### PR TITLE
chore(6924): replace waitForNextUpdate with waitFor

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -480,9 +480,6 @@
     "ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx": {
       "Reselect: Identity function warnings": 1
     },
-    "ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 10
-    },
     "ui/hooks/identity/useAccountSyncing/useAccountSyncing.test.tsx": {
       "MetaMask: Background connection not initialized": 13
     },
@@ -511,8 +508,7 @@
       "Reselect: Input stability warnings": 1
     },
     "ui/hooks/metamask-notifications/useSwitchNotifications.test.tsx": {
-      "MetaMask: Background connection not initialized": 5,
-      "React: Act warnings (component updates not wrapped)": 6
+      "MetaMask: Background connection not initialized": 5
     },
     "ui/hooks/musd/useMusdConversion.test.ts": {
       "error: [MUSD] Transaction creation failed: Error:": 1,
@@ -521,9 +517,6 @@
     },
     "ui/hooks/musd/useMusdCtaVisibility.test.ts": {
       "Reselect: Identity function warnings": 1
-    },
-    "ui/hooks/musd/useMusdGeoBlocking.test.ts": {
-      "React: Act warnings (component updates not wrapped)": 2
     },
     "ui/hooks/rewards/useVipTier.test.ts": {
       "error: Error: fail": 1
@@ -538,7 +531,6 @@
       "React: Act warnings (component updates not wrapped)": 3
     },
     "ui/hooks/useDecodedTransactionData.test.ts": {
-      "React: Act warnings (component updates not wrapped)": 7,
       "error: Unexpected keys \"data\", \"to\", \"chainId\"": 1
     },
     "ui/hooks/useDisplayName.test.ts": {
@@ -550,24 +542,8 @@
     "ui/hooks/useMultichainAccountTotalFiatBalance.test.tsx": {
       "MetaMask: Background connection not initialized": 8
     },
-    "ui/hooks/useTokenDetectionPolling.test.ts": {
-      "Test errors: Uncaught Errors": 4,
-      "error: Error handled by React Router": 4,
-      "error: React Router caught the following": 4
-    },
     "ui/hooks/useTokenInsightsData.test.ts": {
       "React: Act warnings (component updates not wrapped)": 2
-    },
-    "ui/hooks/useTokenListPolling.test.ts": {
-      "Test errors: Uncaught TypeErrors": 3,
-      "error: Error handled by React Router": 3,
-      "error: React Router caught the following": 3
-    },
-    "ui/hooks/useTokenRatesPolling.test.ts": {
-      "Test errors: Uncaught Errors": 1,
-      "Test errors: Uncaught TypeErrors": 3,
-      "error: Error handled by React Router": 4,
-      "error: React Router caught the following": 4
     },
     "ui/hooks/useTokenSearch.test.ts": {
       "error: Error: boom": 1
@@ -637,18 +613,14 @@
       "MetaMask: Background connection not initialized": 14,
       "React: Act warnings (component updates not wrapped)": 2
     },
-    "ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.test.ts": {
-      "React: Act warnings (component updates not wrapped)": 7
-    },
     "ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts": {
       "MetaMask: Background connection not initialized": 32
     },
     "ui/pages/confirmations/components/confirm/info/info.test.tsx": {
-      "MetaMask: Background connection not initialized": 68,
+      "MetaMask: Background connection not initialized": 61,
       "React: Act warnings (component updates not wrapped)": 10,
       "Reselect: Identity function warnings": 1,
-      "Reselect: Input stability warnings": 1,
-      "Test errors: Uncaught Errors": 4
+      "Reselect: Input stability warnings": 1
     },
     "ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.test.tsx": {
       "MetaMask: Background connection not initialized": 23,
@@ -727,12 +699,10 @@
       "React: Act warnings (component updates not wrapped)": 2
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/permission-detail-renderer.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 10,
-      "Test errors: Uncaught Errors": 6
+      "React: Act warnings (component updates not wrapped)": 10
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 13,
-      "Test errors: Uncaught Errors": 12
+      "React: Act warnings (component updates not wrapped)": 13
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.test.tsx": {
       "MetaMask: Background connection not initialized": 4,
@@ -807,14 +777,8 @@
     "ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts": {
       "MetaMask: Background connection not initialized": 60
     },
-    "ui/pages/confirmations/hooks/alerts/transactions/useTokenContractAlert.test.ts": {
-      "React: Act warnings (component updates not wrapped)": 7
-    },
     "ui/pages/confirmations/hooks/alerts/useNetworkAndOriginSwitchingAlerts.test.ts": {
       "MetaMask: Background connection not initialized": 6
-    },
-    "ui/pages/confirmations/hooks/send/alerts/useFirstTimeInteractionSendAlert.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 7
     },
     "ui/pages/confirmations/hooks/send/metrics/useRecipientSelectionMetrics.test.tsx": {
       "error: Unexpected key \"state\" found in": 1

--- a/test/jest/strict-mode.js
+++ b/test/jest/strict-mode.js
@@ -7,6 +7,9 @@
  *
  * Do not register this file in `jest.config.js` setupFilesAfterEnv — enabling
  * StrictMode globally breaks many existing unit tests that assume a single mount.
+ *
+ * NOTE: The `@testing-library/react-hooks` mock remains until remaining direct
+ * imports are removed (see MetaMask-planning#6923 / PR #45062).
  */
 jest.mock('@testing-library/react', () => {
   // eslint-disable-next-line n/global-require -- required inside jest.mock factory
@@ -42,9 +45,18 @@ jest.mock('@testing-library/react', () => {
         wrapper: mockCreateStrictModeWrapper(userWrapper),
       });
     },
+    renderHook(callback, options = {}) {
+      const { wrapper: userWrapper, ...rest } = options;
+
+      return actual.renderHook(callback, {
+        ...rest,
+        wrapper: mockCreateStrictModeWrapper(userWrapper),
+      });
+    },
   };
 });
 
+// Kept until remaining @testing-library/react-hooks imports are removed (#6923).
 jest.mock('@testing-library/react-hooks', () => {
   // eslint-disable-next-line n/global-require -- required inside jest.mock factory
   const React = require('react');

--- a/test/lib/render-helpers-navigate.js
+++ b/test/lib/render-helpers-navigate.js
@@ -1,8 +1,7 @@
 /* eslint-disable no-unused-vars -- ESLint is confused here */
 /* global jest */
 import React, { useMemo, useState } from 'react';
-import { render } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { render, renderHook } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -206,7 +205,7 @@ export function renderHookWithProvider(
  * @template {(...args: any) => any} Hook
  * @template {Parameters<Hook>} HookParams
  * @template {ReturnType<Hook>} HookReturn
- * @template {import('@testing-library/react-hooks').RenderHookResult<HookParams, HookReturn>} RenderHookResult
+ * @template {import('@testing-library/react').RenderHookResult<HookReturn, HookParams>} RenderHookResult
  * @param {Hook} hook - The hook to be rendered.
  * @param [state] - The initial state for the store.
  * @param [pathname] - The initial pathname for the history.

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/hooks/useAssetMetadata.test.ts
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/hooks/useAssetMetadata.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import { AssetType } from '../../../../../../shared/constants/transaction';
 import { useAssetMetadata } from './useAssetMetadata';
@@ -30,33 +31,36 @@ describe('useAssetMetadata', () => {
   it('should return undefined when external services are disabled', async () => {
     (useSelector as jest.Mock).mockReturnValue(false); // allowExternalServices = false
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAssetMetadata(mockSearchQuery, true, mockAbortController, mockChainId),
     );
 
-    await waitForNextUpdate();
-    expect(result.current).toBeUndefined();
-    expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
+      expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
+    });
   });
 
   it('should return undefined when chainId is not provided', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAssetMetadata(mockSearchQuery, true, mockAbortController),
     );
 
-    await waitForNextUpdate();
-    expect(result.current).toBeUndefined();
-    expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
+      expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
+    });
   });
 
   it('should return undefined when search query is empty', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAssetMetadata('', true, mockAbortController, mockChainId),
     );
 
-    await waitForNextUpdate();
-    expect(result.current).toBeUndefined();
-    expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
+      expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
+    });
   });
 
   it('should fetch and return asset metadata when conditions are met', async () => {
@@ -70,61 +74,66 @@ describe('useAssetMetadata', () => {
 
     mockFetchAssetMetadata.mockResolvedValueOnce(mockMetadata);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAssetMetadata(mockSearchQuery, true, mockAbortController, mockChainId),
     );
 
-    await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        ...mockMetadata,
+        chainId: mockChainId,
+        isNative: false,
+        type: AssetType.token,
+        image: 'mock-image-url',
+        balance: '',
+        string: '',
+      });
 
-    expect(result.current).toEqual({
-      ...mockMetadata,
-      chainId: mockChainId,
-      isNative: false,
-      type: AssetType.token,
-      image: 'mock-image-url',
-      balance: '',
-      string: '',
+      expect(mockFetchAssetMetadata).toHaveBeenCalledWith(
+        mockSearchQuery.trim(),
+        mockChainId,
+        mockAbortController.current.signal,
+      );
+      expect(mockGetAssetImageUrl).toHaveBeenCalledWith(
+        mockAssetId,
+        mockChainId,
+      );
     });
-
-    expect(mockFetchAssetMetadata).toHaveBeenCalledWith(
-      mockSearchQuery.trim(),
-      mockChainId,
-      mockAbortController.current.signal,
-    );
-    expect(mockGetAssetImageUrl).toHaveBeenCalledWith(mockAssetId, mockChainId);
   });
 
   it('should return undefined when fetchAssetMetadata returns undefined', async () => {
     mockFetchAssetMetadata.mockResolvedValueOnce(undefined);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAssetMetadata(mockSearchQuery, true, mockAbortController, mockChainId),
     );
 
-    await waitForNextUpdate();
-    expect(result.current).toBeUndefined();
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
 
-    expect(mockFetchAssetMetadata).toHaveBeenCalledWith(
-      mockSearchQuery.trim(),
-      mockChainId,
-      mockAbortController.current.signal,
-    );
+      expect(mockFetchAssetMetadata).toHaveBeenCalledWith(
+        mockSearchQuery.trim(),
+        mockChainId,
+        mockAbortController.current.signal,
+      );
+    });
   });
 
   it('should handle errors gracefully', async () => {
     mockFetchAssetMetadata.mockRejectedValueOnce(new Error('API Error'));
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAssetMetadata(mockSearchQuery, true, mockAbortController, mockChainId),
     );
 
-    await waitForNextUpdate();
-    expect(result.current).toBeUndefined();
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
 
-    expect(mockFetchAssetMetadata).toHaveBeenCalledWith(
-      mockSearchQuery.trim(),
-      mockChainId,
-      mockAbortController.current.signal,
-    );
+      expect(mockFetchAssetMetadata).toHaveBeenCalledWith(
+        mockSearchQuery.trim(),
+        mockChainId,
+        mockAbortController.current.signal,
+      );
+    });
   });
 });

--- a/ui/components/multichain/networks-form/use-safe-chains.test.ts
+++ b/ui/components/multichain/networks-form/use-safe-chains.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import * as FetchWithCacheModule from '../../../../shared/lib/fetch-with-cache';
 import { renderHookWithProviderTyped } from '../../../../test/lib/render-helpers-navigate';
 import {
@@ -137,15 +138,14 @@ describe('useSafeChains', () => {
   };
 
   it('fetches safe chains when useSafeChainsListValidation is enabled', async () => {
-    const { result, mockFetchWithCache, waitFor } = arrangeAct();
+    const { result, mockFetchWithCache } = arrangeAct();
 
     await waitFor(() => expect(result.current.safeChains).toHaveLength(1));
     expect(mockFetchWithCache).toHaveBeenCalled();
   });
 
   it('reuses cached safe chains across hook mounts', async () => {
-    const { result, mockFetchWithCache, mockState, unmount, waitFor } =
-      arrangeAct();
+    const { result, mockFetchWithCache, mockState, unmount } = arrangeAct();
 
     await waitFor(() => expect(result.current.safeChains).toHaveLength(1));
     unmount();
@@ -169,7 +169,7 @@ describe('useSafeChains', () => {
   });
 
   it('returns an error result when fetching fails', async () => {
-    const { result, mockFetchWithCache, waitFor } = arrangeAct((mocks) => {
+    const { result, mockFetchWithCache } = arrangeAct((mocks) => {
       mocks.mockFetchWithCache.mockRejectedValue(new Error('MOCK ERROR'));
     });
 

--- a/ui/hooks/bridge/useCountdownTimer.test.ts
+++ b/ui/hooks/bridge/useCountdownTimer.test.ts
@@ -1,17 +1,21 @@
 import { act } from '@testing-library/react';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
 import { createBridgeMockStore } from '../../../test/data/bridge/mock-bridge-store';
-import { flushPromises } from '../../../test/lib/timer-helpers';
 import { useCountdownTimer } from './useCountdownTimer';
 
-jest.useFakeTimers();
 const renderUseCountdownTimer = (mockStoreState: object) =>
   renderHookWithProvider(() => useCountdownTimer(), mockStoreState);
 
 describe('useCountdownTimer', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
     jest.clearAllTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   it('returns time remaining', async () => {
@@ -28,15 +32,17 @@ describe('useCountdownTimer', () => {
       }),
     );
 
-    await act(async () => {
-      let i = 0;
-      while (i <= 40) {
-        const secondsLeft = Math.min(41, 40 - i + 1);
-        expect(result.current).toStrictEqual(secondsLeft);
-        i += 10;
+    expect(result.current).toStrictEqual(41);
+
+    for (let elapsedSeconds = 10; elapsedSeconds <= 40; elapsedSeconds += 10) {
+      await act(async () => {
         jest.advanceTimersByTime(10000);
-        await flushPromises();
-      }
+      });
+      expect(result.current).toStrictEqual(41 - elapsedSeconds);
+    }
+
+    await act(async () => {
+      jest.advanceTimersByTime(10000);
     });
     expect(result.current).toStrictEqual(0);
   });

--- a/ui/hooks/bridge/usePrefillFromSearchQuery.test.ts
+++ b/ui/hooks/bridge/usePrefillFromSearchQuery.test.ts
@@ -1,4 +1,5 @@
 import * as bridgeControllerUtils from '@metamask/bridge-controller';
+import { waitFor, act } from '@testing-library/react';
 import { useLocation } from 'react-router-dom';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
 import {
@@ -94,12 +95,14 @@ describe('usePrefillFromSearchQuery', () => {
       '/?' + searchParams.toString(),
     );
 
-    const { waitForNextUpdate, store, result } = renderResult;
+    const { store, result } = renderResult;
 
-    await waitForNextUpdate();
-    expect(result.current.location.search).toBe('?swaps=true');
-    expect(result.current.location.pathname).toBe('/');
-    expect(store).toBeDefined();
+    await waitFor(() => {
+      expect(result.current.location.search).toBe('?swaps=true');
+      expect(result.current.location.pathname).toBe('/');
+      expect(store?.getState().bridge?.fromToken).toBeDefined();
+      expect(store?.getState().bridge?.toToken).toBeDefined();
+    });
     const { fromToken, toToken, fromTokenInputValue } =
       store?.getState().bridge ?? {};
     expect({
@@ -150,16 +153,17 @@ describe('usePrefillFromSearchQuery', () => {
       swaps: 'true',
     });
 
-    const { result, waitForNextUpdate, store } = renderUseBridgeQueryParams(
+    const { result, store } = renderUseBridgeQueryParams(
       mockStoreState,
       // eslint-disable-next-line prefer-template
       '/?' + searchParams.toString(),
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.location.search).toBe('?swaps=true');
-    expect(store).toBeDefined();
+    await waitFor(() => {
+      expect(result.current.location.search).toBe('?swaps=true');
+      expect(store?.getState().bridge?.fromToken).toBeDefined();
+      expect(store?.getState().bridge?.toToken).toBeDefined();
+    });
     const {
       fromToken,
       toToken,
@@ -205,16 +209,16 @@ describe('usePrefillFromSearchQuery', () => {
       swaps: 'true',
     });
 
-    const { result, waitForNextUpdate, store } = renderUseBridgeQueryParams(
+    const { result, store } = renderUseBridgeQueryParams(
       mockStoreState,
       // eslint-disable-next-line prefer-template
       '/?' + searchParams.toString(),
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.location.search).toBe('?swaps=true');
-    expect(store).toBeDefined();
+    await waitFor(() => {
+      expect(result.current.location.search).toBe('?swaps=true');
+      expect(store).toBeDefined();
+    });
     const { fromToken, toToken, fromTokenInputValue } =
       store?.getState().bridge ?? {};
     expect({
@@ -256,16 +260,16 @@ describe('usePrefillFromSearchQuery', () => {
       from: 'eip155:59144/erc20:0x8ac76a51cc950d9822d68b83fe1ad97b32cd580D',
     });
 
-    const { result, waitForNextUpdate, store } = renderUseBridgeQueryParams(
+    const { result, store } = renderUseBridgeQueryParams(
       mockStoreState,
       // eslint-disable-next-line prefer-template
       '/?' + searchParams.toString(),
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.location.search).toBe('');
-    expect(store).toBeDefined();
+    await waitFor(() => {
+      expect(result.current.location.search).toBe('');
+      expect(store?.getState().bridge?.fromToken).toBeDefined();
+    });
     const { fromToken, toToken, fromTokenInputValue } =
       store?.getState().bridge ?? {};
     expect({
@@ -306,16 +310,16 @@ describe('usePrefillFromSearchQuery', () => {
       from: 'eip155:59144/slip44:60',
     });
 
-    const { result, waitForNextUpdate, store } = renderUseBridgeQueryParams(
+    const { result, store } = renderUseBridgeQueryParams(
       mockStoreState,
       // eslint-disable-next-line prefer-template
       '/?' + searchParams.toString(),
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.location.search).toBe('');
-    expect(store).toBeDefined();
+    await waitFor(() => {
+      expect(result.current.location.search).toBe('');
+      expect(store?.getState().bridge?.fromToken).toBeDefined();
+    });
     const { fromToken, toToken, fromTokenInputValue } =
       store?.getState().bridge ?? {};
     expect({
@@ -387,16 +391,16 @@ describe('usePrefillFromSearchQuery', () => {
       to: 'eip155:59144/erc20:0x8ac76a51cc950d9822d68b83fe1ad97b32cd580D',
     });
 
-    const { result, waitForNextUpdate, store } = renderUseBridgeQueryParams(
+    const { result, store } = renderUseBridgeQueryParams(
       mockStoreState,
       // eslint-disable-next-line prefer-template
       '/?' + searchParams.toString(),
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.location.search).toBe('');
-    expect(store).toBeDefined();
+    await waitFor(() => {
+      expect(result.current.location.search).toBe('');
+      expect(store?.getState().bridge?.toToken).toBeDefined();
+    });
     const { fromToken, toToken, fromTokenInputValue } =
       store?.getState().bridge ?? {};
     expect(fromTokenInputValue).toBeUndefined();
@@ -440,16 +444,17 @@ describe('usePrefillFromSearchQuery', () => {
       from: 'eip155:59144/erc20:0x8ac76a51cc950d9822d68b83fe1ad97b32cd580D',
     });
 
-    const { result, waitForNextUpdate, store } = renderUseBridgeQueryParams(
+    const { result, store } = renderUseBridgeQueryParams(
       mockStoreState,
       // eslint-disable-next-line prefer-template
       '/?' + searchParams.toString(),
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.location.search).toBe('');
-    expect(store).toBeDefined();
+    await waitFor(() => {
+      expect(result.current.location.search).toBe('');
+      expect(store?.getState().bridge?.fromToken).toBeDefined();
+      expect(store?.getState().bridge?.fromTokenInputValue).toBeDefined();
+    });
     const { fromToken, toToken, fromTokenInputValue } =
       store?.getState().bridge ?? {};
     expect({
@@ -537,13 +542,15 @@ describe('usePrefillFromSearchQuery', () => {
         from: 'eip155:1/erc20:0x0000000000000000000000000000000000000001',
       });
 
-      const { waitForNextUpdate, store } = renderUseBridgeQueryParams(
+      const { store } = renderUseBridgeQueryParams(
         mockStoreState,
         // eslint-disable-next-line prefer-template
         '/?' + searchParams.toString(),
       );
 
-      await waitForNextUpdate();
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       const { fromToken } = store?.getState().bridge ?? {};
       expect(fromToken?.assetId).not.toBe(
@@ -566,13 +573,15 @@ describe('usePrefillFromSearchQuery', () => {
         to: 'eip155:1/erc20:0x0000000000000000000000000000000000000001',
       });
 
-      const { waitForNextUpdate, store } = renderUseBridgeQueryParams(
+      const { store } = renderUseBridgeQueryParams(
         mockStoreState,
         // eslint-disable-next-line prefer-template
         '/?' + searchParams.toString(),
       );
 
-      await waitForNextUpdate();
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       const { toToken } = store?.getState().bridge ?? {};
       expect(toToken?.assetId).not.toBe(

--- a/ui/hooks/bridge/useTokensWithFiltering.test.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.test.ts
@@ -1,4 +1,5 @@
 import { getNativeAssetForChainId } from '@metamask/bridge-controller';
+import { waitFor } from '@testing-library/react';
 import { AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS } from '@metamask/multichain-network-controller';
 import { SolScope } from '@metamask/keyring-api';
 import { MultichainNetwork } from '@metamask/multichain-transactions-controller';
@@ -76,14 +77,17 @@ describe('useTokensWithFiltering', () => {
       },
     });
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(() => {
+    const { result } = renderHookWithProvider(() => {
       const { filteredTokenListGenerator } = useTokensWithFiltering(
         CHAIN_IDS.MAINNET,
       );
       return filteredTokenListGenerator;
     }, mockStore);
 
-    await waitForNextUpdate();
+    const prevUpdate0 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate0);
+    });
     await flushPromises();
 
     expect(mockFetchTopAssetsList).toHaveBeenCalledTimes(1);
@@ -114,14 +118,17 @@ describe('useTokensWithFiltering', () => {
       },
     });
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(() => {
+    const { result } = renderHookWithProvider(() => {
       const { filteredTokenListGenerator } = useTokensWithFiltering(
         CHAIN_IDS.MAINNET,
       );
       return filteredTokenListGenerator;
     }, mockStore);
 
-    await waitForNextUpdate();
+    const prevUpdate1 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate1);
+    });
     await flushPromises();
 
     expect(mockFetchTopAssetsList).toHaveBeenCalledTimes(1);
@@ -160,14 +167,17 @@ describe('useTokensWithFiltering', () => {
       },
     });
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(() => {
+    const { result } = renderHookWithProvider(() => {
       const { filteredTokenListGenerator } = useTokensWithFiltering(
         MultichainNetwork.Solana,
       );
       return filteredTokenListGenerator;
     }, mockStore);
 
-    await waitForNextUpdate();
+    const prevUpdate2 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate2);
+    });
     await flushPromises();
 
     expect(mockFetchTopAssetsList).toHaveBeenCalledTimes(1);
@@ -195,13 +205,16 @@ describe('useTokensWithFiltering', () => {
       },
     });
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(() => {
+    const { result } = renderHookWithProvider(() => {
       const { filteredTokenListGenerator } = useTokensWithFiltering(
         CHAIN_IDS.POLYGON,
       );
       return filteredTokenListGenerator;
     }, mockStore);
-    await waitForNextUpdate();
+    const prevUpdate3 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate3);
+    });
     await flushPromises();
 
     expect(mockFetchTopAssetsList).toHaveBeenCalledTimes(1);

--- a/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx
+++ b/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import type { Store } from 'redux';
@@ -69,8 +69,14 @@ describe('useGatorPermissionTokenInfo', () => {
     clearTokenInfoCaches();
   });
 
+  async function flushAsyncUpdates() {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
   describe('native token handling', () => {
-    it('should return native token info for native-token-stream permission type', () => {
+    it('should return native token info for native-token-stream permission type', async () => {
       const testStore = createMockStore();
 
       const { result } = renderHook(
@@ -90,9 +96,10 @@ describe('useGatorPermissionTokenInfo', () => {
         chainId: mockChainId,
       });
       expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
+      await flushAsyncUpdates();
     });
 
-    it('should return native token info for native-token-periodic permission type', () => {
+    it('should return native token info for native-token-periodic permission type', async () => {
       const testStore = createMockStore();
 
       const { result } = renderHook(
@@ -111,9 +118,10 @@ describe('useGatorPermissionTokenInfo', () => {
         decimals: 18,
         chainId: mockChainId,
       });
+      await flushAsyncUpdates();
     });
 
-    it('should fallback to CHAIN_ID_TO_CURRENCY_SYMBOL_MAP when network config is missing', () => {
+    it('should fallback to CHAIN_ID_TO_CURRENCY_SYMBOL_MAP when network config is missing', async () => {
       const sepoliaChainId = '0xaa36a7' as Hex; // Sepolia
       const testStore = createMockStore({
         multichainNetworkConfigurationsByChainId: {},
@@ -135,9 +143,10 @@ describe('useGatorPermissionTokenInfo', () => {
         decimals: 18,
         chainId: sepoliaChainId,
       });
+      await flushAsyncUpdates();
     });
 
-    it('should default to ETH when neither network config nor CHAIN_ID_TO_CURRENCY_SYMBOL_MAP has the chain', () => {
+    it('should default to ETH when neither network config nor CHAIN_ID_TO_CURRENCY_SYMBOL_MAP has the chain', async () => {
       const unknownChainId = '0x999999' as Hex;
       const testStore = createMockStore({
         multichainNetworkConfigurationsByChainId: {},
@@ -159,11 +168,12 @@ describe('useGatorPermissionTokenInfo', () => {
         decimals: 18,
         chainId: unknownChainId,
       });
+      await flushAsyncUpdates();
     });
   });
 
   describe('cache layer', () => {
-    it('should return cached token info immediately', () => {
+    it('should return cached token info immediately', async () => {
       const testStore = createMockStore({
         tokensChainsCache: {
           [mockChainId]: {
@@ -194,9 +204,10 @@ describe('useGatorPermissionTokenInfo', () => {
         chainId: mockChainId,
       });
       expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
+      await flushAsyncUpdates();
     });
 
-    it('should return imported token info', () => {
+    it('should return imported token info', async () => {
       const testStore = createMockStore({
         allTokens: {
           [mockChainId]: {
@@ -220,9 +231,10 @@ describe('useGatorPermissionTokenInfo', () => {
 
       expect(result.current.tokenInfo?.symbol).toBe('IMPORTED');
       expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
+      await flushAsyncUpdates();
     });
 
-    it('should prefer cache over imported tokens', () => {
+    it('should prefer cache over imported tokens', async () => {
       const testStore = createMockStore({
         tokensChainsCache: {
           [mockChainId]: {
@@ -254,6 +266,7 @@ describe('useGatorPermissionTokenInfo', () => {
       );
 
       expect(result.current.tokenInfo?.symbol).toBe('CACHED');
+      await flushAsyncUpdates();
     });
   });
 
@@ -269,21 +282,21 @@ describe('useGatorPermissionTokenInfo', () => {
       });
 
       const testStore = createMockStore();
-      const { result, waitForNextUpdate } = renderHook(
+      const { result } = renderHook(
         () => useGatorPermissionTokenInfo(mockTokenAddress, mockChainId),
         { wrapper: createWrapper(testStore) },
       );
 
       expect(result.current.loading).toBe(true);
 
-      await waitForNextUpdate();
-
-      expect(result.current.loading).toBe(false);
-      expect(result.current.tokenInfo?.symbol).toBe('API');
-      expect(mockFetchAssetMetadata).toHaveBeenCalledWith(
-        mockTokenAddress,
-        mockChainId,
-      );
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+        expect(result.current.tokenInfo?.symbol).toBe('API');
+        expect(mockFetchAssetMetadata).toHaveBeenCalledWith(
+          mockTokenAddress,
+          mockChainId,
+        );
+      });
     });
 
     it('should skip API when external services are disabled', async () => {
@@ -297,16 +310,16 @@ describe('useGatorPermissionTokenInfo', () => {
         useExternalServices: false,
       });
 
-      const { result, waitForNextUpdate } = renderHook(
+      const { result } = renderHook(
         () => useGatorPermissionTokenInfo(mockTokenAddress, mockChainId),
         { wrapper: createWrapper(testStore) },
       );
 
-      await waitForNextUpdate();
-
-      expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
-      expect(mockGetTokenStandardAndDetailsByChain).toHaveBeenCalled();
-      expect(result.current.tokenInfo?.symbol).toBe('ONCHAIN');
+      await waitFor(() => {
+        expect(mockFetchAssetMetadata).not.toHaveBeenCalled();
+        expect(mockGetTokenStandardAndDetailsByChain).toHaveBeenCalled();
+        expect(result.current.tokenInfo?.symbol).toBe('ONCHAIN');
+      });
     });
   });
 
@@ -320,16 +333,16 @@ describe('useGatorPermissionTokenInfo', () => {
       });
 
       const testStore = createMockStore();
-      const { result, waitForNextUpdate } = renderHook(
+      const { result } = renderHook(
         () => useGatorPermissionTokenInfo(mockTokenAddress, mockChainId),
         { wrapper: createWrapper(testStore) },
       );
 
-      await waitForNextUpdate();
-
-      expect(result.current.tokenInfo?.symbol).toBe('ONCHAIN');
-      expect(result.current.tokenInfo?.decimals).toBe(6);
-      expect(result.current.error).toBeNull();
+      await waitFor(() => {
+        expect(result.current.tokenInfo?.symbol).toBe('ONCHAIN');
+        expect(result.current.tokenInfo?.decimals).toBe(6);
+        expect(result.current.error).toBeNull();
+      });
     });
 
     it('should parse decimals from decimal string', async () => {
@@ -341,14 +354,14 @@ describe('useGatorPermissionTokenInfo', () => {
       });
 
       const testStore = createMockStore();
-      const { result, waitForNextUpdate } = renderHook(
+      const { result } = renderHook(
         () => useGatorPermissionTokenInfo(mockTokenAddress, mockChainId),
         { wrapper: createWrapper(testStore) },
       );
 
-      await waitForNextUpdate();
-
-      expect(result.current.tokenInfo?.decimals).toBe(6);
+      await waitFor(() => {
+        expect(result.current.tokenInfo?.decimals).toBe(6);
+      });
     });
 
     it('should parse decimals from hex string', async () => {
@@ -360,14 +373,14 @@ describe('useGatorPermissionTokenInfo', () => {
       });
 
       const testStore = createMockStore();
-      const { result, waitForNextUpdate } = renderHook(
+      const { result } = renderHook(
         () => useGatorPermissionTokenInfo(mockTokenAddress, mockChainId),
         { wrapper: createWrapper(testStore) },
       );
 
-      await waitForNextUpdate();
-
-      expect(result.current.tokenInfo?.decimals).toBe(18);
+      await waitFor(() => {
+        expect(result.current.tokenInfo?.decimals).toBe(18);
+      });
     });
 
     it('should use default values when both API and on-chain fail', async () => {
@@ -377,22 +390,22 @@ describe('useGatorPermissionTokenInfo', () => {
       );
 
       const testStore = createMockStore();
-      const { result, waitForNextUpdate } = renderHook(
+      const { result } = renderHook(
         () => useGatorPermissionTokenInfo(mockTokenAddress, mockChainId),
         { wrapper: createWrapper(testStore) },
       );
 
-      await waitForNextUpdate();
-
-      expect(result.current.tokenInfo?.symbol).toBe('Unknown Token');
-      expect(result.current.tokenInfo?.decimals).toBeUndefined();
-      expect(result.current.error).toBeInstanceOf(Error);
-      expect(result.current.error?.message).toBe('On-chain Error');
+      await waitFor(() => {
+        expect(result.current.tokenInfo?.symbol).toBe('Unknown Token');
+        expect(result.current.tokenInfo?.decimals).toBeUndefined();
+        expect(result.current.error).toBeInstanceOf(Error);
+        expect(result.current.error?.message).toBe('On-chain Error');
+      });
     });
   });
 
   describe('edge cases', () => {
-    it('should return default token info when tokenAddress is undefined without permission type', () => {
+    it('should return default token info when tokenAddress is undefined without permission type', async () => {
       const testStore = createMockStore();
       const { result } = renderHook(
         () => useGatorPermissionTokenInfo(undefined, mockChainId),
@@ -404,9 +417,10 @@ describe('useGatorPermissionTokenInfo', () => {
         symbol: 'Unknown Token',
         chainId: mockChainId,
       });
+      await flushAsyncUpdates();
     });
 
-    it('should return default token info when chainId is undefined', () => {
+    it('should return default token info when chainId is undefined', async () => {
       const testStore = createMockStore();
       const { result } = renderHook(
         () => useGatorPermissionTokenInfo(mockTokenAddress, undefined),
@@ -418,9 +432,10 @@ describe('useGatorPermissionTokenInfo', () => {
         symbol: 'Unknown Token',
         chainId: '0x0',
       });
+      await flushAsyncUpdates();
     });
 
-    it('should handle case-insensitive address matching', () => {
+    it('should handle case-insensitive address matching', async () => {
       const upperCaseAddress = mockTokenAddress.toUpperCase();
       const testStore = createMockStore({
         tokensChainsCache: {
@@ -442,6 +457,7 @@ describe('useGatorPermissionTokenInfo', () => {
       );
 
       expect(result.current.tokenInfo?.symbol).toBe('CACHED');
+      await flushAsyncUpdates();
     });
   });
 
@@ -459,27 +475,28 @@ describe('useGatorPermissionTokenInfo', () => {
       const testStore = createMockStore();
 
       // First call
-      const { result: result1, waitForNextUpdate: wait1 } = renderHook(
+      const { result: result1 } = renderHook(
         () => useGatorPermissionTokenInfo(mockTokenAddress, mockChainId),
         { wrapper: createWrapper(testStore) },
       );
 
-      await wait1();
-
-      expect(mockFetchAssetMetadata).toHaveBeenCalledTimes(1);
-      expect(result1.current.tokenInfo?.symbol).toBe('CACHED');
+      await waitFor(() => {
+        expect(mockFetchAssetMetadata).toHaveBeenCalledTimes(1);
+        expect(result1.current.tokenInfo?.symbol).toBe('CACHED');
+      });
 
       // Second call should use cache
-      const { result: result2, waitForNextUpdate: wait2 } = renderHook(
+      const { result: result2 } = renderHook(
         () => useGatorPermissionTokenInfo(mockTokenAddress, mockChainId),
         { wrapper: createWrapper(testStore) },
       );
 
-      await wait2();
+      await waitFor(() => {
+        expect(result2.current.tokenInfo?.symbol).toBe('CACHED');
+      });
 
       // API should still only be called once (reused from cache)
       expect(mockFetchAssetMetadata).toHaveBeenCalledTimes(1);
-      expect(result2.current.tokenInfo?.symbol).toBe('CACHED');
     });
   });
 });

--- a/ui/hooks/gator-permissions/useGatorPermissions.test.tsx
+++ b/ui/hooks/gator-permissions/useGatorPermissions.test.tsx
@@ -210,21 +210,18 @@ describe('useGatorPermissions', () => {
   });
 
   it('should fetch when no cache exists', async () => {
-    const { result, waitForNextUpdate } = renderHook(
-      () => useGatorPermissions(),
-      {
-        wrapper: ({ children }: React.PropsWithChildren) => (
-          <Provider store={store}>{children}</Provider>
-        ),
-      },
-    );
+    const { result } = renderHook(() => useGatorPermissions(), {
+      wrapper: ({ children }: React.PropsWithChildren) => (
+        <Provider store={store}>{children}</Provider>
+      ),
+    });
 
     expect(result.current.loading).toBe(true);
 
-    await waitForNextUpdate();
-
-    expect(mockFetchAndUpdateGatorPermissions).toHaveBeenCalledTimes(1);
-    expect(result.current.loading).toBe(false);
+    await waitFor(() => {
+      expect(mockFetchAndUpdateGatorPermissions).toHaveBeenCalledTimes(1);
+      expect(result.current.loading).toBe(false);
+    });
   });
 
   it('should retry fetch when previous fetch failed', async () => {

--- a/ui/hooks/metamask-notifications/useSwitchNotifications.test.tsx
+++ b/ui/hooks/metamask-notifications/useSwitchNotifications.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import * as ActionsModule from '../../store/actions';
 import * as NotificationSelectorsModule from '../../selectors/metamask-notifications/metamask-notifications';
 import { renderHookWithProviderTyped } from '../../../test/lib/render-helpers-navigate';
@@ -51,23 +51,25 @@ describe('useSwitchAccountNotificationsChange() tests', () => {
       throw new Error('Mock Error');
     });
 
-    const act = async (testEnableOrDisable: boolean) => {
+    const runChange = async (testEnableOrDisable: boolean) => {
       const hook = renderHookWithProviderTyped(
         () => useSwitchAccountNotificationsChange(),
         {},
       );
-      try {
-        await hook.result.current.onChange(['0x1'], testEnableOrDisable);
-      } catch {
-        // onChange rethrows after setting error state — expected here
-      }
+      await act(async () => {
+        try {
+          await hook.result.current.onChange(['0x1'], testEnableOrDisable);
+        } catch {
+          // onChange rethrows after setting error state — expected here
+        }
+      });
       return hook.result.current.error;
     };
 
-    const enableError = await act(true);
+    const enableError = await runChange(true);
     expect(enableError).toBeDefined();
 
-    const disableError = await act(false);
+    const disableError = await runChange(false);
     expect(disableError).toBeDefined();
   });
 });
@@ -124,7 +126,13 @@ describe('useAccountSettingsProps() tests', () => {
       {},
     );
 
-    await hook.result.current.update(['0x1', '0x2']);
+    await waitFor(() => {
+      expect(mocks.mockCheckAccountsPresence).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      await hook.result.current.update(['0x1', '0x2']);
+    });
     await waitFor(() => {
       expect(mocks.mockCheckAccountsPresence).toHaveBeenCalledWith([
         '0x1',

--- a/ui/hooks/musd/useMusdGeoBlocking.test.ts
+++ b/ui/hooks/musd/useMusdGeoBlocking.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import { useMusdGeoBlocking } from './useMusdGeoBlocking';
 
 jest.mock('react-redux', () => ({
@@ -32,147 +33,136 @@ describe('useMusdGeoBlocking', () => {
   });
 
   it('exposes expected return shape', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useMusdGeoBlocking(),
-    );
+    const { result } = renderHook(() => useMusdGeoBlocking());
 
-    await waitForNextUpdate();
-
-    expect(result.current).toEqual(
-      expect.objectContaining({
-        isBlocked: expect.any(Boolean),
-        userCountry: expect.any(String),
-        isLoading: false,
-        error: null,
-        blockedRegions: BLOCKED_REGIONS,
-        blockedMessage: null,
-        refreshGeolocation: expect.any(Function),
-      }),
-    );
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          isBlocked: expect.any(Boolean),
+          userCountry: expect.any(String),
+          isLoading: false,
+          error: null,
+          blockedRegions: BLOCKED_REGIONS,
+          blockedMessage: null,
+          refreshGeolocation: expect.any(Function),
+        }),
+      );
+    });
   });
 
-  it('reports isBlocked as false while geolocation is still loading', () => {
+  it('reports isBlocked as false while geolocation is still loading', async () => {
     isGeoBlocked.mockReturnValue(true);
 
-    const { result } = renderHook(() => useMusdGeoBlocking());
+    const { result, unmount } = renderHook(() => useMusdGeoBlocking());
 
     expect(result.current.isLoading).toBe(true);
     expect(result.current.isBlocked).toBe(false);
+
+    // Flush the resolved geolocation request so setState is not outside act.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    unmount();
   });
 
   it('calls the GeolocationController on mount', async () => {
-    const { waitForNextUpdate } = renderHook(() => useMusdGeoBlocking());
+    renderHook(() => useMusdGeoBlocking());
 
-    await waitForNextUpdate();
-
-    expect(submitRequestToBackground).toHaveBeenCalledWith('getGeolocation');
+    await waitFor(() => {
+      expect(submitRequestToBackground).toHaveBeenCalledWith('getGeolocation');
+    });
   });
 
   it('sets userCountry from the controller response', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useMusdGeoBlocking(),
-    );
+    const { result } = renderHook(() => useMusdGeoBlocking());
 
-    await waitForNextUpdate();
-
-    expect(result.current.userCountry).toBe('US');
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.error).toBeNull();
+    await waitFor(() => {
+      expect(result.current.userCountry).toBe('US');
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
   });
 
   it('delegates blocking decision to isGeoBlocked', async () => {
     isGeoBlocked.mockReturnValue(true);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useMusdGeoBlocking(),
-    );
+    const { result } = renderHook(() => useMusdGeoBlocking());
 
-    await waitForNextUpdate();
-
-    expect(isGeoBlocked).toHaveBeenCalledWith('US', BLOCKED_REGIONS);
-    expect(result.current.isBlocked).toBe(true);
+    await waitFor(() => {
+      expect(isGeoBlocked).toHaveBeenCalledWith('US', BLOCKED_REGIONS);
+      expect(result.current.isBlocked).toBe(true);
+    });
   });
 
   it('shows blocked message when user is geo-blocked', async () => {
     isGeoBlocked.mockReturnValue(true);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useMusdGeoBlocking(),
-    );
+    const { result } = renderHook(() => useMusdGeoBlocking());
 
-    await waitForNextUpdate();
-
-    expect(result.current.blockedMessage).toBe(
-      'mUSD conversion is not available in your region.',
-    );
+    await waitFor(() => {
+      expect(result.current.blockedMessage).toBe(
+        'mUSD conversion is not available in your region.',
+      );
+    });
   });
 
   it('returns null blockedMessage when user is not blocked', async () => {
     isGeoBlocked.mockReturnValue(false);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useMusdGeoBlocking(),
-    );
+    const { result } = renderHook(() => useMusdGeoBlocking());
 
-    await waitForNextUpdate();
-
-    expect(result.current.blockedMessage).toBeNull();
+    await waitFor(() => {
+      expect(result.current.blockedMessage).toBeNull();
+    });
   });
 
   it('treats an UNKNOWN response as an unknown country (userCountry=null)', async () => {
     submitRequestToBackground.mockResolvedValue('UNKNOWN');
     isGeoBlocked.mockReturnValue(true);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useMusdGeoBlocking(),
-    );
+    const { result } = renderHook(() => useMusdGeoBlocking());
 
-    await waitForNextUpdate();
-
-    expect(result.current.userCountry).toBeNull();
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.isBlocked).toBe(true);
+    await waitFor(() => {
+      expect(result.current.userCountry).toBeNull();
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isBlocked).toBe(true);
+    });
   });
 
   it('sets error and keeps userCountry null when the background call throws', async () => {
     submitRequestToBackground.mockRejectedValue(new Error('Background error'));
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useMusdGeoBlocking(),
-    );
+    const { result } = renderHook(() => useMusdGeoBlocking());
 
-    await waitForNextUpdate();
-
-    expect(result.current.error).toBe('Background error');
-    expect(result.current.userCountry).toBeNull();
-    expect(result.current.isLoading).toBe(false);
+    await waitFor(() => {
+      expect(result.current.error).toBe('Background error');
+      expect(result.current.userCountry).toBeNull();
+      expect(result.current.isLoading).toBe(false);
+    });
   });
 
   it('fails closed (isBlocked=true) after a background failure', async () => {
     isGeoBlocked.mockReturnValue(true);
     submitRequestToBackground.mockRejectedValue(new Error('Background error'));
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useMusdGeoBlocking(),
-    );
+    const { result } = renderHook(() => useMusdGeoBlocking());
 
-    await waitForNextUpdate();
-
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.userCountry).toBeNull();
-    expect(result.current.isBlocked).toBe(true);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.userCountry).toBeNull();
+      expect(result.current.isBlocked).toBe(true);
+    });
   });
 
   it('allows manual refresh via refreshGeolocation', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useMusdGeoBlocking(),
-    );
+    const { result } = renderHook(() => useMusdGeoBlocking());
 
-    await waitForNextUpdate();
-    expect(submitRequestToBackground).toHaveBeenCalledTimes(1);
-    expect(submitRequestToBackground).toHaveBeenLastCalledWith(
-      'getGeolocation',
-    );
+    await waitFor(() => {
+      expect(submitRequestToBackground).toHaveBeenCalledTimes(1);
+      expect(submitRequestToBackground).toHaveBeenLastCalledWith(
+        'getGeolocation',
+      );
+    });
 
     submitRequestToBackground.mockResolvedValue('DE');
 

--- a/ui/hooks/perps/usePerpsMarketFills.test.ts
+++ b/ui/hooks/perps/usePerpsMarketFills.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import type { OrderFill } from '@metamask/perps-controller';
 import {
   usePerpsMarketFills,
@@ -69,17 +70,17 @@ describe('usePerpsMarketFills', () => {
 
   describe('initialization', () => {
     it('returns empty fills and not loading once REST resolves', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current).toEqual(
-        expect.objectContaining({
-          fills: [],
-          isInitialLoading: false,
-        }),
-      );
+      await waitFor(() => {
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            fills: [],
+            isInitialLoading: false,
+          }),
+        );
+      });
     });
 
     it('is loading when REST is in-flight even if WS already resolved', () => {
@@ -98,12 +99,12 @@ describe('usePerpsMarketFills', () => {
     it('is not loading when REST resolved even if WS is still loading', async () => {
       setLiveFills([], true);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.isInitialLoading).toBe(false);
+      await waitFor(() => {
+        expect(result.current.isInitialLoading).toBe(false);
+      });
     });
 
     it('reports isInitialLoading when REST is in-flight', async () => {
@@ -123,13 +124,14 @@ describe('usePerpsMarketFills', () => {
       setLiveFills([], true);
       setRestFillsResponse([]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
 
       expect(result.current.isInitialLoading).toBe(true);
-      await waitForNextUpdate();
-      expect(result.current.isInitialLoading).toBe(false);
+      await waitFor(() => {
+        expect(result.current.isInitialLoading).toBe(false);
+      });
     });
   });
 
@@ -137,17 +139,17 @@ describe('usePerpsMarketFills', () => {
     it('fetches fills via perpsGetOrderFills on mount', async () => {
       setRestFillsResponse([makeFill({ orderId: 'rest-1', timestamp: 2000 })]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-        'perpsGetOrderFills',
-        [{ aggregateByTime: false, startTime: expect.any(Number) }],
-      );
-      expect(result.current.fills).toHaveLength(1);
-      expect(result.current.fills[0].orderId).toBe('rest-1');
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'perpsGetOrderFills',
+          [{ aggregateByTime: false, startTime: expect.any(Number) }],
+        );
+        expect(result.current.fills).toHaveLength(1);
+        expect(result.current.fills[0].orderId).toBe('rest-1');
+      });
     });
 
     it('keeps fills empty when REST API returns an error', async () => {
@@ -155,24 +157,24 @@ describe('usePerpsMarketFills', () => {
         new Error('Network error'),
       );
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.fills).toEqual([]);
-      expect(result.current.isInitialLoading).toBe(false);
+      await waitFor(() => {
+        expect(result.current.fills).toEqual([]);
+        expect(result.current.isInitialLoading).toBe(false);
+      });
     });
 
     it('keeps fills empty when REST API returns null', async () => {
       setRestFillsResponse(null);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.fills).toEqual([]);
+      await waitFor(() => {
+        expect(result.current.fills).toEqual([]);
+      });
     });
   });
 
@@ -184,13 +186,15 @@ describe('usePerpsMarketFills', () => {
         makeFill({ orderId: 'btc-2', symbol: 'BTC', timestamp: 1000 }),
       ]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.fills).toHaveLength(2);
-      expect(result.current.fills.every((f) => f.symbol === 'BTC')).toBe(true);
+      await waitFor(() => {
+        expect(result.current.fills).toHaveLength(2);
+        expect(result.current.fills.every((f) => f.symbol === 'BTC')).toBe(
+          true,
+        );
+      });
     });
 
     it('only includes live fills matching the requested symbol', async () => {
@@ -199,13 +203,13 @@ describe('usePerpsMarketFills', () => {
         makeFill({ orderId: 'live-eth', symbol: 'ETH', timestamp: 4000 }),
       ]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.fills).toHaveLength(1);
-      expect(result.current.fills[0].orderId).toBe('live-btc');
+      await waitFor(() => {
+        expect(result.current.fills).toHaveLength(1);
+        expect(result.current.fills[0].orderId).toBe('live-btc');
+      });
     });
 
     it('returns empty when no fills match the symbol', async () => {
@@ -213,12 +217,12 @@ describe('usePerpsMarketFills', () => {
         makeFill({ orderId: 'eth-1', symbol: 'ETH', timestamp: 1000 }),
       ]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'SOL' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.fills).toEqual([]);
+      await waitFor(() => {
+        expect(result.current.fills).toEqual([]);
+      });
     });
   });
 
@@ -227,12 +231,12 @@ describe('usePerpsMarketFills', () => {
       setRestFillsResponse([makeFill({ orderId: 'rest-1', timestamp: 1000 })]);
       setLiveFills([makeFill({ orderId: 'live-1', timestamp: 2000 })]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.fills).toHaveLength(2);
+      await waitFor(() => {
+        expect(result.current.fills).toHaveLength(2);
+      });
     });
 
     it('deduplicates fills sharing orderId/timestamp/size/price', async () => {
@@ -246,12 +250,12 @@ describe('usePerpsMarketFills', () => {
       setRestFillsResponse([makeFill(shared)]);
       setLiveFills([makeFill(shared)]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.fills).toHaveLength(1);
+      await waitFor(() => {
+        expect(result.current.fills).toHaveLength(1);
+      });
     });
 
     it('prefers live fill data over REST for the same dedup key', async () => {
@@ -265,13 +269,13 @@ describe('usePerpsMarketFills', () => {
       setRestFillsResponse([makeFill({ ...shared, pnl: '0' })]);
       setLiveFills([makeFill({ ...shared, pnl: '100' })]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.fills).toHaveLength(1);
-      expect(result.current.fills[0].pnl).toBe('100');
+      await waitFor(() => {
+        expect(result.current.fills).toHaveLength(1);
+        expect(result.current.fills[0].pnl).toBe('100');
+      });
     });
   });
 
@@ -283,14 +287,14 @@ describe('usePerpsMarketFills', () => {
         makeFill({ orderId: 'mid', timestamp: 2000 }),
       ]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.fills.map((f) => f.timestamp)).toEqual([
-        3000, 2000, 1000,
-      ]);
+      await waitFor(() => {
+        expect(result.current.fills.map((f) => f.timestamp)).toEqual([
+          3000, 2000, 1000,
+        ]);
+      });
     });
   });
 
@@ -298,22 +302,23 @@ describe('usePerpsMarketFills', () => {
     it('clears stale fills and re-fetches for the new account', async () => {
       setRestFillsResponse([makeFill({ orderId: 'a-1', timestamp: 1000 })]);
 
-      const { result, waitForNextUpdate, rerender } = renderHook(
+      const { result, rerender } = renderHook(
         ({ address }: { address: string }) => {
           mockGetSelectedInternalAccount.mockReturnValue({ address });
           return usePerpsMarketFills({ symbol: 'BTC' });
         },
         { initialProps: { address: '0xaaa' } },
       );
-      await waitForNextUpdate();
-      expect(result.current.fills[0].orderId).toBe('a-1');
+      await waitFor(() => {
+        expect(result.current.fills[0].orderId).toBe('a-1');
+      });
 
       setRestFillsResponse([makeFill({ orderId: 'b-1', timestamp: 2000 })]);
       rerender({ address: '0xbbb' });
-      await waitForNextUpdate();
-
-      expect(result.current.fills[0].orderId).toBe('b-1');
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(2);
+      await waitFor(() => {
+        expect(result.current.fills[0].orderId).toBe('b-1');
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(2);
+      });
     });
 
     it('discards stale REST response when account changes before fetch completes', async () => {
@@ -324,7 +329,7 @@ describe('usePerpsMarketFills', () => {
         }),
       );
 
-      const { result, waitForNextUpdate, rerender } = renderHook(
+      const { result, rerender } = renderHook(
         ({ address }: { address: string }) => {
           mockGetSelectedInternalAccount.mockReturnValue({ address });
           return usePerpsMarketFills({ symbol: 'BTC' });
@@ -334,7 +339,10 @@ describe('usePerpsMarketFills', () => {
 
       setRestFillsResponse([makeFill({ orderId: 'b-1', timestamp: 2000 })]);
       rerender({ address: '0xbbb' });
-      await waitForNextUpdate();
+      const prevUpdate0 = result.current;
+      await waitFor(() => {
+        expect(result.current).not.toBe(prevUpdate0);
+      });
 
       await act(async () => {
         resolveFirstFetch([makeFill({ orderId: 'stale-a', timestamp: 500 })]);
@@ -351,11 +359,10 @@ describe('usePerpsMarketFills', () => {
       setRestFillsResponse([fill]);
 
       // First render — populates cache
-      const { waitForNextUpdate: waitFirst } = renderHook(() =>
-        usePerpsMarketFills({ symbol: 'BTC' }),
-      );
-      await waitFirst();
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+      renderHook(() => usePerpsMarketFills({ symbol: 'BTC' }));
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+      });
 
       // Second render (e.g. re-navigation) — cache is warm, no additional REST call
       const { result: result2 } = renderHook(() =>
@@ -399,7 +406,7 @@ describe('usePerpsMarketFills', () => {
     });
 
     it('re-fetches after TTL expires', async () => {
-      jest.useFakeTimers();
+      // Control TTL via Date.now only — fake timers break promise flushing with waitFor/act.
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
 
       try {
@@ -407,10 +414,10 @@ describe('usePerpsMarketFills', () => {
           makeFill({ orderId: 'fresh-1', timestamp: 1000 }),
         ]);
 
-        const { waitForNextUpdate: waitFirst } = renderHook(() =>
-          usePerpsMarketFills({ symbol: 'BTC' }),
-        );
-        await waitFirst();
+        renderHook(() => usePerpsMarketFills({ symbol: 'BTC' }));
+        await act(async () => {
+          await Promise.resolve();
+        });
         expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
         mockSubmitRequestToBackground.mockClear();
 
@@ -420,11 +427,10 @@ describe('usePerpsMarketFills', () => {
           makeFill({ orderId: 'stale-1', timestamp: 2000 }),
         ]);
 
-        const { waitForNextUpdate: waitSecond } = renderHook(() =>
-          usePerpsMarketFills({ symbol: 'BTC' }),
-        );
-        await waitSecond();
-
+        renderHook(() => usePerpsMarketFills({ symbol: 'BTC' }));
+        await act(async () => {
+          await Promise.resolve();
+        });
         expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
           'perpsGetOrderFills',
@@ -432,51 +438,50 @@ describe('usePerpsMarketFills', () => {
         );
       } finally {
         nowSpy.mockRestore();
-        jest.useRealTimers();
       }
     });
 
     it('re-fetches for a different account even when cache is warm', async () => {
       setRestFillsResponse([makeFill({ orderId: 'abc-1', timestamp: 1000 })]);
 
-      const { waitForNextUpdate: waitFirst } = renderHook(() =>
-        usePerpsMarketFills({ symbol: 'BTC' }),
-      );
-      await waitFirst();
+      renderHook(() => usePerpsMarketFills({ symbol: 'BTC' }));
+      await act(async () => {
+        await Promise.resolve();
+      });
       mockSubmitRequestToBackground.mockClear();
 
       // Different address — cache scope includes address
       mockGetSelectedInternalAccount.mockReturnValue({ address: '0xdef' });
       setRestFillsResponse([makeFill({ orderId: 'def-1', timestamp: 2000 })]);
 
-      const { result: result2, waitForNextUpdate: waitSecond } = renderHook(
-        () => usePerpsMarketFills({ symbol: 'BTC' }),
+      const { result: result2 } = renderHook(() =>
+        usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitSecond();
-
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
-      expect(result2.current.fills[0].orderId).toBe('def-1');
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+        expect(result2.current.fills[0].orderId).toBe('def-1');
+      });
     });
 
     it('re-fetches when mainnet vs testnet scope changes even when cache is warm', async () => {
       setRestFillsResponse([makeFill({ orderId: 'main-1', timestamp: 1000 })]);
 
-      const { waitForNextUpdate: waitFirst } = renderHook(() =>
-        usePerpsMarketFills({ symbol: 'BTC' }),
-      );
-      await waitFirst();
+      renderHook(() => usePerpsMarketFills({ symbol: 'BTC' }));
+      await act(async () => {
+        await Promise.resolve();
+      });
       mockSubmitRequestToBackground.mockClear();
 
       mockSelectPerpsIsTestnet.mockReturnValue(true);
       setRestFillsResponse([makeFill({ orderId: 'test-1', timestamp: 2000 })]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
-      expect(result.current.fills[0].orderId).toBe('test-1');
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+        expect(result.current.fills[0].orderId).toBe('test-1');
+      });
     });
 
     it('excludes live fills while scope is transitioning to prevent mixing env data', async () => {
@@ -486,12 +491,12 @@ describe('usePerpsMarketFills', () => {
       setRestFillsResponse([
         makeFill({ orderId: 'main-rest', timestamp: 1000 }),
       ]);
-      const {
-        result,
-        waitForNextUpdate: waitFirst,
-        rerender,
-      } = renderHook(() => usePerpsMarketFills({ symbol: 'BTC' }));
-      await waitFirst();
+      const { result, rerender } = renderHook(() =>
+        usePerpsMarketFills({ symbol: 'BTC' }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       // Switch to testnet with an in-flight REST request
       mockSelectPerpsIsTestnet.mockReturnValue(true);
@@ -529,22 +534,21 @@ describe('usePerpsMarketFills', () => {
     it('re-fetches after clearPerpsMarketFillsModuleCache', async () => {
       setRestFillsResponse([makeFill({ orderId: 'first', timestamp: 1000 })]);
 
-      const { waitForNextUpdate: waitFirst } = renderHook(() =>
-        usePerpsMarketFills({ symbol: 'BTC' }),
-      );
-      await waitFirst();
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+      renderHook(() => usePerpsMarketFills({ symbol: 'BTC' }));
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+      });
 
       clearPerpsMarketFillsModuleCache();
       setRestFillsResponse([makeFill({ orderId: 'second', timestamp: 2000 })]);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
-      await waitForNextUpdate();
-
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(2);
-      expect(result.current.fills[0].orderId).toBe('second');
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(2);
+        expect(result.current.fills[0].orderId).toBe('second');
+      });
     });
   });
 });

--- a/ui/hooks/perps/usePerpsMarketInfo.test.ts
+++ b/ui/hooks/perps/usePerpsMarketInfo.test.ts
@@ -62,44 +62,42 @@ describe('usePerpsMarketInfo', () => {
     ];
     mockSubmitRequestToBackground.mockResolvedValue(markets);
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(
-      () => usePerpsMarketInfo('BTC'),
-      { metamask: defaultPerpsMetamask },
-    );
+    const { result } = renderHookWithProvider(() => usePerpsMarketInfo('BTC'), {
+      metamask: defaultPerpsMetamask,
+    });
 
-    await waitForNextUpdate();
-
-    expect(result.current).toBeDefined();
-    expect(result.current?.name).toBe('BTC');
-    expect(result.current?.szDecimals).toBe(5);
+    await waitFor(() => {
+      expect(result.current).toBeDefined();
+      expect(result.current?.name).toBe('BTC');
+      expect(result.current?.szDecimals).toBe(5);
+    });
   });
 
   it('matches symbol case-insensitively', async () => {
     const markets = [makeMarketInfo({ name: 'HYPE' })];
     mockSubmitRequestToBackground.mockResolvedValue(markets);
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(
+    const { result } = renderHookWithProvider(
       () => usePerpsMarketInfo('hype'),
       { metamask: defaultPerpsMetamask },
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current?.name).toBe('HYPE');
+    await waitFor(() => {
+      expect(result.current?.name).toBe('HYPE');
+    });
   });
 
   it('returns undefined when the symbol is not in the market list', async () => {
     const markets = [makeMarketInfo({ name: 'BTC' })];
     mockSubmitRequestToBackground.mockResolvedValue(markets);
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(
-      () => usePerpsMarketInfo('SOL'),
-      { metamask: defaultPerpsMetamask },
-    );
+    const { result } = renderHookWithProvider(() => usePerpsMarketInfo('SOL'), {
+      metamask: defaultPerpsMetamask,
+    });
 
-    await waitForNextUpdate();
-
-    expect(result.current).toBeUndefined();
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
+    });
   });
 
   it('returns undefined and does not throw when the fetch rejects', async () => {
@@ -247,23 +245,24 @@ describe('usePerpsMarketInfo', () => {
     const markets = [makeMarketInfo({ name: 'BTC' })];
     mockSubmitRequestToBackground.mockResolvedValue(markets);
 
-    const { unmount, waitForNextUpdate } = renderHookWithProvider(
+    const { unmount } = renderHookWithProvider(
       () => usePerpsMarketInfo('BTC'),
       { metamask: defaultPerpsMetamask },
     );
 
-    await waitForNextUpdate();
-    expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+    });
 
     clearPerpsMarketInfoModuleCache();
     unmount();
 
-    const { waitForNextUpdate: wait2 } = renderHookWithProvider(
-      () => usePerpsMarketInfo('BTC'),
-      { metamask: defaultPerpsMetamask },
-    );
+    renderHookWithProvider(() => usePerpsMarketInfo('BTC'), {
+      metamask: defaultPerpsMetamask,
+    });
 
-    await wait2();
-    expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/ui/hooks/perps/usePerpsMaxSlippage.test.ts
+++ b/ui/hooks/perps/usePerpsMaxSlippage.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import { PERPS_EVENT_VALUE } from '../../../shared/constants/perps-events';
 import { PERPS_SLIPPAGE_DEFAULT_BPS } from '../../components/app/perps/constants/slippageConfig';
 import { usePerpsMaxSlippage } from './usePerpsMaxSlippage';
@@ -32,30 +33,26 @@ describe('usePerpsMaxSlippage', () => {
   it('falls back to the documented default when no value is stored', async () => {
     setMaxSlippageResponse(undefined);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePerpsMaxSlippage(),
-    );
-    await waitForNextUpdate();
-
-    expect(result.current.maxSlippageBps).toBe(PERPS_SLIPPAGE_DEFAULT_BPS);
-    expect(result.current.maxSlippageSource).toBe(
-      PERPS_EVENT_VALUE.MAX_SLIPPAGE_SOURCE.DEFAULT,
-    );
-    expect(result.current.isLoading).toBe(false);
+    const { result } = renderHook(() => usePerpsMaxSlippage());
+    await waitFor(() => {
+      expect(result.current.maxSlippageBps).toBe(PERPS_SLIPPAGE_DEFAULT_BPS);
+      expect(result.current.maxSlippageSource).toBe(
+        PERPS_EVENT_VALUE.MAX_SLIPPAGE_SOURCE.DEFAULT,
+      );
+      expect(result.current.isLoading).toBe(false);
+    });
   });
 
   it('resolves a persisted user-configured max slippage value', async () => {
     setMaxSlippageResponse(200);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePerpsMaxSlippage(),
-    );
-    await waitForNextUpdate();
-
-    expect(result.current.maxSlippageBps).toBe(200);
-    expect(result.current.maxSlippageSource).toBe(
-      PERPS_EVENT_VALUE.MAX_SLIPPAGE_SOURCE.USER_CONFIGURED,
-    );
+    const { result } = renderHook(() => usePerpsMaxSlippage());
+    await waitFor(() => {
+      expect(result.current.maxSlippageBps).toBe(200);
+      expect(result.current.maxSlippageSource).toBe(
+        PERPS_EVENT_VALUE.MAX_SLIPPAGE_SOURCE.USER_CONFIGURED,
+      );
+    });
   });
 
   it('falls back to the default when the controller read rejects', async () => {
@@ -77,10 +74,11 @@ describe('usePerpsMaxSlippage', () => {
   it('persists a new max slippage value and updates the resolved source', async () => {
     setMaxSlippageResponse(undefined);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePerpsMaxSlippage(),
-    );
-    await waitForNextUpdate();
+    const { result } = renderHook(() => usePerpsMaxSlippage());
+    const prevUpdate0 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate0);
+    });
 
     await act(async () => {
       await result.current.setMaxSlippage(150);

--- a/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.test.ts
+++ b/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import { getCurrentChainId } from '../../../shared/lib/selectors/networks';
@@ -81,23 +82,23 @@ describe('usePerpsMetamaskFeeDiscountBips', () => {
   it('returns the discount in basis points when > 0', async () => {
     setDiscountResponse(5000);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
     );
-    await waitForNextUpdate();
-
-    expect(result.current).toBe(5000);
+    await waitFor(() => {
+      expect(result.current).toBe(5000);
+    });
   });
 
   it('caps the discount at 10000 bips (100%)', async () => {
     setDiscountResponse(12000);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
     );
-    await waitForNextUpdate();
-
-    expect(result.current).toBe(10000);
+    await waitFor(() => {
+      expect(result.current).toBe(10000);
+    });
   });
 
   it('returns undefined when bips is exactly 0', async () => {
@@ -188,25 +189,26 @@ describe('usePerpsMetamaskFeeDiscountBips', () => {
   it('calls rewardsGetPerpsDiscountForAccount with the CAIP-10 id and the original MM fee bips', async () => {
     setDiscountResponse(2500);
 
-    const { waitForNextUpdate } = renderHook(() =>
+    renderHook(() =>
       usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
     );
-    await waitForNextUpdate();
-
-    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-      'rewardsGetPerpsDiscountForAccount',
-      [TEST_CAIP_ACCOUNT_ID, ORIGINAL_METAMASK_FEE_BIPS],
-    );
+    await waitFor(() => {
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'rewardsGetPerpsDiscountForAccount',
+        [TEST_CAIP_ACCOUNT_ID, ORIGINAL_METAMASK_FEE_BIPS],
+      );
+    });
   });
 
   it('caches a non-null discount across rerenders for the same address', async () => {
     setDiscountResponse(2000);
 
-    const { waitForNextUpdate, rerender, result } = renderHook(() =>
+    const { rerender, result } = renderHook(() =>
       usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
     );
-    await waitForNextUpdate();
-    expect(result.current).toBe(2000);
+    await waitFor(() => {
+      expect(result.current).toBe(2000);
+    });
 
     // Force a re-render — the effect deps (selectedAddress, currentChainId)
     // haven't changed, so the effect shouldn't re-fire. Even if it did, the
@@ -227,8 +229,9 @@ describe('usePerpsMetamaskFeeDiscountBips', () => {
     const first = renderHook(() =>
       usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
     );
-    await first.waitForNextUpdate();
-    expect(first.result.current).toBe(3000);
+    await waitFor(() => {
+      expect(first.result.current).toBe(3000);
+    });
     first.unmount();
 
     // Second mount with the same address: should hit the cache and not call
@@ -250,22 +253,24 @@ describe('usePerpsMetamaskFeeDiscountBips', () => {
   it('refetches when the chain changes for the same address (cache is keyed by CAIP account id)', async () => {
     setDiscountResponse(2000);
 
-    const { rerender, result, waitForNextUpdate } = renderHook(
+    const { rerender, result } = renderHook(
       ({ chainId }: { chainId: string }) => {
         setSelectors({ chainId });
         return usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS);
       },
       { initialProps: { chainId: TEST_CHAIN_ID } },
     );
-    await waitForNextUpdate();
-    expect(result.current).toBe(2000);
+    await waitFor(() => {
+      expect(result.current).toBe(2000);
+    });
 
     // Switch to a different chain for the same address. The CAIP account id
     // changes, so the cache must miss and the background must be called again.
     setDiscountResponse(4000);
     rerender({ chainId: '0x1' });
-    await waitForNextUpdate();
-    expect(result.current).toBe(4000);
+    await waitFor(() => {
+      expect(result.current).toBe(4000);
+    });
 
     const discountCalls = mockSubmitRequestToBackground.mock.calls.filter(
       (call) => call[0] === 'rewardsGetPerpsDiscountForAccount',
@@ -287,7 +292,7 @@ describe('usePerpsMetamaskFeeDiscountBips', () => {
       },
       { initialProps: { chainId: TEST_CHAIN_ID } },
     );
-    // Flush the initial null lookup. `waitForNextUpdate` would hang here
+    // Flush the initial null lookup. a waitFor on result.current would hang here
     // because the hook stays at its initial `undefined` value — there's no
     // state change to await.
     await act(async () => {
@@ -309,15 +314,16 @@ describe('usePerpsMetamaskFeeDiscountBips', () => {
   it('resets to undefined immediately when the account switches before the new fetch resolves', async () => {
     // First account resolves to 5000.
     setDiscountResponse(5000);
-    const { rerender, result, waitForNextUpdate } = renderHook(
+    const { rerender, result } = renderHook(
       ({ address }: { address: string }) => {
         setSelectors({ address });
         return usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS);
       },
       { initialProps: { address: TEST_ADDRESS } },
     );
-    await waitForNextUpdate();
-    expect(result.current).toBe(5000);
+    await waitFor(() => {
+      expect(result.current).toBe(5000);
+    });
 
     // Switch to a new address. New fetch is deliberately never resolved.
     mockSubmitRequestToBackground.mockReturnValue(new Promise(() => undefined));

--- a/ui/hooks/perps/usePerpsOrderFees.test.ts
+++ b/ui/hooks/perps/usePerpsOrderFees.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import type { FeeCalculationResult } from '@metamask/perps-controller';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
@@ -128,24 +129,24 @@ describe('usePerpsOrderFees', () => {
     const feeResult = makeFeeResult({ feeRate: 0.001 });
     setBackgroundResponses({ feeResponse: feeResult, discountBips: null });
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.feeRate).toBe(0.001);
-    expect(result.current.protocolFeeRate).toBe(0.00025);
-    expect(result.current.metamaskFeeRate).toBe(0.001);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.hasError).toBe(false);
-    expect(result.current.feeResult).toEqual(feeResult);
+    await waitFor(() => {
+      expect(result.current.feeRate).toBe(0.001);
+      expect(result.current.protocolFeeRate).toBe(0.00025);
+      expect(result.current.metamaskFeeRate).toBe(0.001);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasError).toBe(false);
+      expect(result.current.feeResult).toEqual(feeResult);
+    });
   });
 
   it('calls perpsCalculateFees with the correct params', async () => {
     setBackgroundResponses({ feeResponse: makeFeeResult() });
 
-    const { waitForNextUpdate } = renderHook(() =>
+    renderHook(() =>
       usePerpsOrderFees({
         symbol: 'HYPE',
         orderType: 'limit',
@@ -154,12 +155,12 @@ describe('usePerpsOrderFees', () => {
       }),
     );
 
-    await waitForNextUpdate();
-
-    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-      'perpsCalculateFees',
-      [{ orderType: 'limit', isMaker: true, amount: '100', symbol: 'HYPE' }],
-    );
+    await waitFor(() => {
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'perpsCalculateFees',
+        [{ orderType: 'limit', isMaker: true, amount: '100', symbol: 'HYPE' }],
+      );
+    });
   });
 
   it('falls back to base rates when the RPC call fails', async () => {
@@ -251,22 +252,24 @@ describe('usePerpsOrderFees', () => {
       return Promise.resolve(null);
     });
 
-    const { result, waitForNextUpdate, rerender } = renderHook(
+    const { result, rerender } = renderHook(
       ({ symbol }: { symbol: string }) =>
         usePerpsOrderFees({ symbol, orderType: 'market' }),
       { initialProps: { symbol: 'BTC' } },
     );
 
-    await waitForNextUpdate();
-    expect(result.current.feeRate).toBe(0.001);
+    await waitFor(() => {
+      expect(result.current.feeRate).toBe(0.001);
+    });
 
     rerender({ symbol: 'ETH' });
     // Keep the previous result visible while the replacement request loads.
     expect(result.current.feeRate).toBe(0.001);
     expect(result.current.isLoading).toBe(true);
 
-    await waitForNextUpdate();
-    expect(result.current.feeRate).toBe(0.0008);
+    await waitFor(() => {
+      expect(result.current.feeRate).toBe(0.0008);
+    });
   });
 
   it('retains the previous rate while order type fees are refetched', async () => {
@@ -291,7 +294,7 @@ describe('usePerpsOrderFees', () => {
       return Promise.resolve(null);
     });
 
-    const { result, waitForNextUpdate, rerender } = renderHook(
+    const { result, rerender } = renderHook(
       ({ orderType, isMaker }: FeeProps) =>
         usePerpsOrderFees({ symbol: 'BTC', orderType, isMaker }),
       {
@@ -302,8 +305,9 @@ describe('usePerpsOrderFees', () => {
       },
     );
 
-    await waitForNextUpdate();
-    expect(result.current.feeRate).toBe(0.00145);
+    await waitFor(() => {
+      expect(result.current.feeRate).toBe(0.00145);
+    });
 
     rerender({ orderType: 'limit', isMaker: true });
 
@@ -332,7 +336,7 @@ describe('usePerpsOrderFees', () => {
       return Promise.resolve(null);
     });
 
-    const { result, waitForNextUpdate, rerender } = renderHook(
+    const { result, rerender } = renderHook(
       ({ symbol }: { symbol: string }) =>
         usePerpsOrderFees({ symbol, orderType: 'market' }),
       { initialProps: { symbol: 'BTC' } },
@@ -346,10 +350,10 @@ describe('usePerpsOrderFees', () => {
     expect(result.current.feeRate).toBe(0.00145);
 
     rerender({ symbol: 'ETH' });
-    await waitForNextUpdate();
-
-    expect(result.current.hasError).toBe(false);
-    expect(result.current.feeRate).toBe(0.001);
+    await waitFor(() => {
+      expect(result.current.hasError).toBe(false);
+      expect(result.current.feeRate).toBe(0.001);
+    });
   });
 
   describe('discount surface', () => {
@@ -359,12 +363,12 @@ describe('usePerpsOrderFees', () => {
         discountBips: 5000,
       });
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.metamaskFeeRateDiscountPercentage).toBe(50);
+      await waitFor(() => {
+        expect(result.current.metamaskFeeRateDiscountPercentage).toBe(50);
+      });
     });
 
     it('caps the discount at 100% (10000 bips)', async () => {
@@ -373,12 +377,12 @@ describe('usePerpsOrderFees', () => {
         discountBips: 12000,
       });
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.metamaskFeeRateDiscountPercentage).toBe(100);
+      await waitFor(() => {
+        expect(result.current.metamaskFeeRateDiscountPercentage).toBe(100);
+      });
     });
 
     it('is undefined when discountBips is 0', async () => {
@@ -387,12 +391,14 @@ describe('usePerpsOrderFees', () => {
         discountBips: 0,
       });
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.metamaskFeeRateDiscountPercentage).toBeUndefined();
+      await waitFor(() => {
+        expect(
+          result.current.metamaskFeeRateDiscountPercentage,
+        ).toBeUndefined();
+      });
     });
 
     it('is undefined when the rewards controller returns null', async () => {
@@ -401,12 +407,14 @@ describe('usePerpsOrderFees', () => {
         discountBips: null,
       });
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.metamaskFeeRateDiscountPercentage).toBeUndefined();
+      await waitFor(() => {
+        expect(
+          result.current.metamaskFeeRateDiscountPercentage,
+        ).toBeUndefined();
+      });
     });
 
     it('is undefined and skips the lookup when no account is selected', async () => {
@@ -416,12 +424,14 @@ describe('usePerpsOrderFees', () => {
         discountBips: 5000,
       });
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.metamaskFeeRateDiscountPercentage).toBeUndefined();
+      await waitFor(() => {
+        expect(
+          result.current.metamaskFeeRateDiscountPercentage,
+        ).toBeUndefined();
+      });
       const calledMethods = mockSubmitRequestToBackground.mock.calls.map(
         (call) => call[0],
       );
@@ -434,15 +444,15 @@ describe('usePerpsOrderFees', () => {
         discountBips: 0,
       });
 
-      const { waitForNextUpdate } = renderHook(() =>
+      renderHook(() =>
         usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
       );
-      await waitForNextUpdate();
-
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-        'rewardsGetPerpsDiscountForAccount',
-        [TEST_CAIP_ACCOUNT_ID, 10],
-      );
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'rewardsGetPerpsDiscountForAccount',
+          [TEST_CAIP_ACCOUNT_ID, 10],
+        );
+      });
     });
 
     it('caches a non-null discount across rerenders for the same address', async () => {
@@ -451,16 +461,20 @@ describe('usePerpsOrderFees', () => {
         discountBips: 2000,
       });
 
-      const { waitForNextUpdate, rerender } = renderHook(
+      const { rerender } = renderHook(
         ({ symbol }: { symbol: string }) =>
           usePerpsOrderFees({ symbol, orderType: 'market' }),
         { initialProps: { symbol: 'BTC' } },
       );
 
-      await waitForNextUpdate();
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       rerender({ symbol: 'ETH' });
-      await waitForNextUpdate();
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       const discountCalls = mockSubmitRequestToBackground.mock.calls.filter(
         (call) => call[0] === 'rewardsGetPerpsDiscountForAccount',
@@ -481,27 +495,27 @@ describe('usePerpsOrderFees', () => {
         discountBips: 5000,
       });
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsOrderFees({
           symbol: 'BTC',
           orderType: 'market',
           amount: '100',
         }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.metamaskFeeRateDiscountPercentage).toBe(50);
-      expect(result.current.metamaskFeeRate).toBeCloseTo(0.0005, 10);
-      expect(result.current.feeRate).toBeCloseTo(0.00095, 10);
-      expect(result.current.undiscountedFeeRate).toBe(0.00145);
-      expect(result.current.protocolFeeRate).toBe(0.00045);
-      expect(result.current.feeResult).toEqual({
-        feeRate: 0.00095,
-        protocolFeeRate: 0.00045,
-        metamaskFeeRate: 0.0005,
-        feeAmount: 0.095,
-        protocolFeeAmount: 0.045,
-        metamaskFeeAmount: 0.05,
+      await waitFor(() => {
+        expect(result.current.metamaskFeeRateDiscountPercentage).toBe(50);
+        expect(result.current.metamaskFeeRate).toBeCloseTo(0.0005, 10);
+        expect(result.current.feeRate).toBeCloseTo(0.00095, 10);
+        expect(result.current.undiscountedFeeRate).toBe(0.00145);
+        expect(result.current.protocolFeeRate).toBe(0.00045);
+        expect(result.current.feeResult).toEqual({
+          feeRate: 0.00095,
+          protocolFeeRate: 0.00045,
+          metamaskFeeRate: 0.0005,
+          feeAmount: 0.095,
+          protocolFeeAmount: 0.045,
+          metamaskFeeAmount: 0.05,
+        });
       });
     });
 
@@ -515,15 +529,17 @@ describe('usePerpsOrderFees', () => {
         discountBips: 0,
       });
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.metamaskFeeRateDiscountPercentage).toBeUndefined();
-      expect(result.current.metamaskFeeRate).toBe(0.001);
-      expect(result.current.feeRate).toBe(0.00145);
-      expect(result.current.undiscountedFeeRate).toBe(0.00145);
+      await waitFor(() => {
+        expect(
+          result.current.metamaskFeeRateDiscountPercentage,
+        ).toBeUndefined();
+        expect(result.current.metamaskFeeRate).toBe(0.001);
+        expect(result.current.feeRate).toBe(0.00145);
+        expect(result.current.undiscountedFeeRate).toBe(0.00145);
+      });
     });
 
     it('swallows a thrown discount lookup (no error state surfaced)', async () => {
@@ -537,13 +553,15 @@ describe('usePerpsOrderFees', () => {
         return Promise.resolve(null);
       });
 
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
       );
-      await waitForNextUpdate();
-
-      expect(result.current.metamaskFeeRateDiscountPercentage).toBeUndefined();
-      expect(result.current.hasError).toBe(false);
+      await waitFor(() => {
+        expect(
+          result.current.metamaskFeeRateDiscountPercentage,
+        ).toBeUndefined();
+        expect(result.current.hasError).toBe(false);
+      });
     });
   });
 });

--- a/ui/hooks/subscription/useSubscription.test.ts
+++ b/ui/hooks/subscription/useSubscription.test.ts
@@ -375,15 +375,15 @@ describe('useShieldRewards', () => {
       );
     });
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(
+    const { result } = renderHookWithProvider(
       () => useShieldRewards(),
       shieldState,
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.isRewardsSeason).toBe(false);
-    expect(result.current.pending).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isRewardsSeason).toBe(false);
+      expect(result.current.pending).toBe(false);
+    });
   });
 
   // useShieldRewards now hard-returns disabled state without invoking
@@ -399,12 +399,15 @@ describe('useShieldRewards', () => {
       throw new Error('Network error');
     });
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(
+    const { result } = renderHookWithProvider(
       () => useShieldRewards(),
       shieldState,
     );
 
-    await waitForNextUpdate();
+    const prevUpdate0 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate0);
+    });
 
     // seasonError triggers the error fallback, returning default values
     expect(result.current.isRewardsSeason).toBe(false);
@@ -431,12 +434,15 @@ describe('useShieldRewards', () => {
       throw new Error('Points estimation failed: 500');
     });
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(
+    const { result } = renderHookWithProvider(
       () => useShieldRewards(),
       stateWithKeyrings,
     );
 
-    await waitForNextUpdate();
+    const prevUpdate1 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate1);
+    });
 
     // Points estimation error is caught gracefully, returning null values
     expect(result.current.pointsMonthly).toBeNull();

--- a/ui/hooks/useAlerts.test.ts
+++ b/ui/hooks/useAlerts.test.ts
@@ -1,3 +1,4 @@
+import { act } from '@testing-library/react';
 import { renderHookWithProvider } from '../../test/lib/render-helpers-navigate';
 import {
   Alert,
@@ -341,12 +342,16 @@ describe('useAlerts', () => {
   describe('setAlertConfirmed', () => {
     it('dismisses alert confirmation', () => {
       const result = renderAndReturnResult();
-      result.current.setAlertConfirmed(fromAlertKeyMock, false);
+      act(() => {
+        result.current.setAlertConfirmed(fromAlertKeyMock, false);
+      });
       expect(result.current.isAlertConfirmed(fromAlertKeyMock)).toBe(false);
     });
     it('confirms an alert', () => {
       const result = renderAndReturnResult(ownerId2Mock);
-      result.current.setAlertConfirmed(fromAlertKeyMock, true);
+      act(() => {
+        result.current.setAlertConfirmed(fromAlertKeyMock, true);
+      });
       expect(result.current.isAlertConfirmed(fromAlertKeyMock)).toBe(true);
     });
   });

--- a/ui/hooks/useAsync.test.ts
+++ b/ui/hooks/useAsync.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import {
   useAsyncResult,
   useAsyncResultOrThrow,
@@ -44,17 +45,17 @@ describe('useAsyncCallback', () => {
 
   it('updates when asyncFn changes', async () => {
     let counter = 0;
-    const { result, rerender, waitForNextUpdate } = renderHook(
-      ({ fn }) => useAsyncCallback(fn),
-      { initialProps: { fn: async () => `count: ${counter}` } },
-    );
+    const { result, rerender } = renderHook(({ fn }) => useAsyncCallback(fn), {
+      initialProps: { fn: async () => `count: ${counter}` },
+    });
 
     // Execute with counter=0
     act(() => {
       result.current[0]();
     });
-    await waitForNextUpdate();
-    expect(result.current[1]).toEqual(successState('count: 0'));
+    await waitFor(() => {
+      expect(result.current[1]).toEqual(successState('count: 0'));
+    });
 
     // Change counter and function, execute again
     counter = 1;
@@ -62,14 +63,13 @@ describe('useAsyncCallback', () => {
     act(() => {
       result.current[0]();
     });
-    await waitForNextUpdate();
-    expect(result.current[1]).toEqual(successState('count: 1'));
+    await waitFor(() => {
+      expect(result.current[1]).toEqual(successState('count: 1'));
+    });
   });
 
   it('transitions through states correctly for success', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useAsyncCallback(async () => 'test'),
-    );
+    const { result } = renderHook(() => useAsyncCallback(async () => 'test'));
 
     // Execute and check pending state
     act(() => {
@@ -78,26 +78,28 @@ describe('useAsyncCallback', () => {
     expect(result.current[1]).toEqual(RESULT_PENDING);
 
     // Wait for completion and check success state
-    await waitForNextUpdate();
-    expect(result.current[1]).toEqual(successState('test'));
+    await waitFor(() => {
+      expect(result.current[1]).toEqual(successState('test'));
+    });
   });
 
   it('handles errors correctly', async () => {
     const error = new Error('Custom test error');
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAsyncCallback(() => Promise.reject(error)),
     );
 
     act(() => {
       result.current[0]();
     });
-    await waitForNextUpdate();
-    expect(result.current[1]).toEqual(errorState(error));
+    await waitFor(() => {
+      expect(result.current[1]).toEqual(errorState(error));
+    });
   });
 
   it('handles rapid consecutive executions', async () => {
     const executionLog: string[] = [];
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAsyncCallback(async () => {
         executionLog.push('executed');
         await new Promise((resolve) => setTimeout(resolve, 10));
@@ -113,9 +115,10 @@ describe('useAsyncCallback', () => {
     });
 
     expect(result.current[1]).toEqual(RESULT_PENDING);
-    await waitForNextUpdate();
-    expect(result.current[1]).toEqual(successState('test'));
-    expect(executionLog.length).toBe(3);
+    await waitFor(() => {
+      expect(result.current[1]).toEqual(successState('test'));
+      expect(executionLog.length).toBe(3);
+    });
   });
 
   it('handles race conditions with dependency changes', async () => {
@@ -161,14 +164,17 @@ describe('useAsyncCallback', () => {
     ];
 
     for (const error of errors) {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useAsyncCallback(() => Promise.reject(error)),
       );
 
       act(() => {
         result.current[0]();
       });
-      await waitForNextUpdate();
+      const prevUpdate0 = result.current;
+      await waitFor(() => {
+        expect(result.current).not.toBe(prevUpdate0);
+      });
       const state = result.current[1];
 
       expect(state.error).toBe(error);
@@ -177,7 +183,7 @@ describe('useAsyncCallback', () => {
 
   it('recovers from errors on re-execution', async () => {
     let shouldFail = true;
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAsyncCallback(async () => {
         if (shouldFail) {
           shouldFail = false;
@@ -191,15 +197,17 @@ describe('useAsyncCallback', () => {
     act(() => {
       result.current[0]();
     });
-    await waitForNextUpdate();
-    expect(result.current[1].status).toBe('error');
+    await waitFor(() => {
+      expect(result.current[1].status).toBe('error');
+    });
 
     // Second execution succeeds
     act(() => {
       result.current[0]();
     });
-    await waitForNextUpdate();
-    expect(result.current[1]).toEqual(successState('success'));
+    await waitFor(() => {
+      expect(result.current[1]).toEqual(successState('success'));
+    });
   });
 
   it('preserves state during execution phases', async () => {
@@ -228,7 +236,7 @@ describe('useAsyncCallback', () => {
 describe('useAsyncResult', () => {
   it('handles immediate execution with correct state transitions', async () => {
     const { promise, resolve } = createControlledPromise<string>();
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAsyncResult(async () => await promise),
     );
 
@@ -239,15 +247,16 @@ describe('useAsyncResult', () => {
     act(() => {
       resolve('test');
     });
-    await waitForNextUpdate();
-    expect(result.current).toEqual(successState('test'));
+    await waitFor(() => {
+      expect(result.current).toEqual(successState('test'));
+    });
   });
 
   it('handles async errors with stack trace preservation', async () => {
     const error = new Error('Async error');
     const { promise, reject } = createControlledPromise<string>();
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAsyncResult(async () => {
         await promise;
         throw error;
@@ -257,7 +266,10 @@ describe('useAsyncResult', () => {
     act(() => {
       reject(error);
     });
-    await waitForNextUpdate();
+    const prevUpdate1 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate1);
+    });
 
     if (result.current.status === 'error') {
       expect(result.current.error).toBe(error);
@@ -271,12 +283,13 @@ describe('useAsyncResult', () => {
 describe('useAsyncResultOrThrow', () => {
   it('throws errors for error boundaries to catch', async () => {
     const error = new Error('Boundary error');
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAsyncResultOrThrow(() => Promise.reject(error)),
     );
 
-    await waitForNextUpdate();
-    expect(() => result.current).toThrow(error);
+    await waitFor(() => {
+      expect(() => result.current).toThrow(error);
+    });
   });
 
   it('preserves error properties when throwing', async () => {
@@ -284,11 +297,13 @@ describe('useAsyncResultOrThrow', () => {
     const error = new Error('Context error') as CustomError;
     error.code = 'CUSTOM_CODE';
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useAsyncResultOrThrow(() => Promise.reject(error)),
     );
 
-    await waitForNextUpdate();
+    await waitFor(() => {
+      expect(() => result.current).toThrow(error);
+    });
     try {
       Object.prototype.toString.call(result.current);
       fail('Should have thrown');

--- a/ui/hooks/useDecodedTransactionData.test.ts
+++ b/ui/hooks/useDecodedTransactionData.test.ts
@@ -1,4 +1,4 @@
-import { act } from 'react-dom/test-utils';
+import { waitFor } from '@testing-library/react';
 import {
   TransactionParams,
   TransactionStatus,
@@ -32,15 +32,15 @@ async function runHook({
   to,
   chainId,
 }: { data?: Hex; to?: Hex; chainId?: Hex } = {}) {
-  const response = renderHook(() =>
+  const { result } = renderHook(() =>
     useDecodedTransactionData({ data, to, chainId }),
   );
 
-  await act(() => {
-    // Ignore
+  await waitFor(() => {
+    expect(result.current.pending).toBe(false);
   });
 
-  return response.result.current;
+  return result.current;
 }
 
 describe('useDecodedTransactionData', () => {
@@ -145,8 +145,8 @@ describe('useDecodedTransactionDataValue', () => {
       },
     );
 
-    await act(() => {
-      // Ignore
+    await waitFor(() => {
+      expect(result.current.decodeResponse.pending).toBe(false);
     });
 
     expect(result.current).toEqual({
@@ -191,8 +191,8 @@ describe('useDecodedTransactionDataValue', () => {
       useDecodedTransactionDataValue(transactionMeta),
     );
 
-    await act(() => {
-      // Ignore
+    await waitFor(() => {
+      expect(result.current.decodeResponse.pending).toBe(false);
     });
 
     expect(result.current).toEqual({
@@ -238,8 +238,8 @@ describe('useDecodedTransactionDataValue', () => {
       useDecodedTransactionDataValue(transactionMeta),
     );
 
-    await act(() => {
-      // Ignore
+    await waitFor(() => {
+      expect(result.current.decodeResponse.pending).toBe(false);
     });
 
     expect(result.current).toEqual({

--- a/ui/hooks/useEventFragment.test.js
+++ b/ui/hooks/useEventFragment.test.js
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import {
   finalizeEventFragment,
@@ -38,14 +39,19 @@ describe('useEventFragment', () => {
           id: 'testid',
         }),
       );
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useEventFragment(undefined, {
           successEvent: 'success',
           failureEvent: 'failure',
           persist: true,
         }),
       );
-      await waitForNextUpdate();
+      const prevUpdate0 = result.current;
+      await waitFor(() => {
+        if (Object.is(result.current, prevUpdate0)) {
+          throw new Error('Waiting for next update');
+        }
+      });
       value = result.current;
     });
 
@@ -92,14 +98,15 @@ describe('useEventFragment', () => {
           id: 'testid',
         }),
       );
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useEventFragment(undefined, {
           successEvent: 'success',
           failureEvent: 'failure',
         }),
       );
-      await waitForNextUpdate();
-      expect(createEventFragment).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(createEventFragment).toHaveBeenCalledTimes(1);
+      });
       const returnValue = result.current;
       expect(returnValue.fragment).toMatchObject({
         id: 'testid',
@@ -176,14 +183,19 @@ describe('useEventFragment', () => {
           id: 'testid',
         }),
       );
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useEventFragment(undefined, {
           successEvent: 'success',
           failureEvent: 'failure',
           persist: true,
         }),
       );
-      await waitForNextUpdate();
+      const prevUpdate1 = result.current;
+      await waitFor(() => {
+        if (Object.is(result.current, prevUpdate1)) {
+          throw new Error('Waiting for next update');
+        }
+      });
       value = result.current;
     });
 

--- a/ui/hooks/useMetametrics.test.tsx
+++ b/ui/hooks/useMetametrics.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import type { Store } from 'redux';
@@ -45,24 +46,21 @@ describe('useMetametrics', () => {
       },
     });
 
-    const { result, waitForNextUpdate } = renderHook(
-      () => useEnableMetametrics(),
-      {
-        wrapper: ({ children }: React.PropsWithChildren) => (
-          <Provider store={store}>{children}</Provider>
-        ),
-      },
-    );
+    const { result } = renderHook(() => useEnableMetametrics(), {
+      wrapper: ({ children }: React.PropsWithChildren) => (
+        <Provider store={store}>{children}</Provider>
+      ),
+    });
 
     act(() => {
       result.current.enableMetametrics();
     });
 
-    await waitForNextUpdate();
-
-    expect(actions.setParticipateInMetaMetrics).toHaveBeenCalledWith(true);
-    expect(store.dispatch).toHaveBeenCalled();
-    expect(result.current.loading).toBe(false);
+    await waitFor(() => {
+      expect(actions.setParticipateInMetaMetrics).toHaveBeenCalledWith(true);
+      expect(store.dispatch).toHaveBeenCalled();
+      expect(result.current.loading).toBe(false);
+    });
   });
 
   it('should disable MetaMetrics', async () => {
@@ -73,22 +71,19 @@ describe('useMetametrics', () => {
       },
     });
 
-    const { result, waitForNextUpdate } = renderHook(
-      () => useDisableMetametrics(),
-      {
-        wrapper: ({ children }: React.PropsWithChildren) => (
-          <Provider store={store}>{children}</Provider>
-        ),
-      },
-    );
+    const { result } = renderHook(() => useDisableMetametrics(), {
+      wrapper: ({ children }: React.PropsWithChildren) => (
+        <Provider store={store}>{children}</Provider>
+      ),
+    });
 
     act(() => {
       result.current.disableMetametrics();
     });
 
-    await waitForNextUpdate();
-
-    expect(actions.setParticipateInMetaMetrics).toHaveBeenCalledWith(false);
-    expect(result.current.loading).toBe(false);
+    await waitFor(() => {
+      expect(actions.setParticipateInMetaMetrics).toHaveBeenCalledWith(false);
+      expect(result.current.loading).toBe(false);
+    });
   });
 });

--- a/ui/hooks/useTokenDetectionPolling.test.ts
+++ b/ui/hooks/useTokenDetectionPolling.test.ts
@@ -16,6 +16,48 @@ jest.mock('../store/actions', () => ({
   }),
   tokenDetectionStopPollingByPollingToken: jest.fn(),
 }));
+
+const getBaseState = (
+  overrides: Record<string, unknown> = {},
+  enabledNetworkMap: Record<string, Record<string, boolean>> = {
+    eip155: {
+      '0x1': true,
+      '0x89': true,
+    },
+  },
+) => ({
+  metamask: {
+    isUnlocked: true,
+    completedOnboarding: true,
+    useTokenDetection: true,
+    selectedNetworkClientId: 'selectedNetworkClientId',
+    enabledNetworkMap,
+    multichainNetworkConfigurationsByChainId:
+      AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
+    selectedMultichainNetworkChainId: 'eip155:1',
+    isEvmSelected: true,
+    networkConfigurationsByChainId: {
+      '0x1': {
+        chainId: '0x1',
+        rpcEndpoints: [
+          {
+            networkClientId: 'selectedNetworkClientId',
+          },
+        ],
+      },
+      '0x89': {
+        chainId: '0x89',
+        rpcEndpoints: [
+          {
+            networkClientId: 'selectedNetworkClientId2',
+          },
+        ],
+      },
+    },
+    ...overrides,
+  },
+});
+
 let originalPortfolioView: string | undefined;
 
 describe('useTokenDetectionPolling', () => {
@@ -35,46 +77,9 @@ describe('useTokenDetectionPolling', () => {
 
   it('should poll token detection for chain IDs when enabled and stop on dismount', async () => {
     process.env.PORTFOLIO_VIEW = 'true';
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: true,
-        useTokenDetection: true,
-        selectedNetworkClientId: 'selectedNetworkClientId',
-        enabledNetworkMap: {
-          eip155: {
-            '0x1': true,
-            '0x89': true,
-          },
-        },
-        multichainNetworkConfigurationsByChainId:
-          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        selectedMultichainNetworkChainId: 'eip155:1',
-        isEvmSelected: true,
-        networkConfigurationsByChainId: {
-          '0x1': {
-            chainId: '0x1',
-            rpcEndpoints: [
-              {
-                networkClientId: 'selectedNetworkClientId',
-              },
-            ],
-          },
-          '0x89': {
-            chainId: '0x89',
-            rpcEndpoints: [
-              {
-                networkClientId: 'selectedNetworkClientId2',
-              },
-            ],
-          },
-        },
-      },
-    };
-
     const { unmount } = renderHookWithProvider(
       () => useTokenDetectionPolling(),
-      state,
+      getBaseState(),
     );
 
     // Should poll each chain
@@ -91,18 +96,10 @@ describe('useTokenDetectionPolling', () => {
   });
 
   it('should not poll if onboarding is not completed', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: false,
-        useTokenDetection: true,
-        networkConfigurationsByChainId: {
-          '0x1': {},
-        },
-      },
-    };
-
-    renderHookWithProvider(() => useTokenDetectionPolling(), state);
+    renderHookWithProvider(
+      () => useTokenDetectionPolling(),
+      getBaseState({ completedOnboarding: false }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenDetectionStartPolling).toHaveBeenCalledTimes(0);
@@ -110,18 +107,10 @@ describe('useTokenDetectionPolling', () => {
   });
 
   it('should not poll when locked', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: false,
-        completedOnboarding: true,
-        useTokenDetection: true,
-        networkConfigurationsByChainId: {
-          '0x1': {},
-        },
-      },
-    };
-
-    renderHookWithProvider(() => useTokenDetectionPolling(), state);
+    renderHookWithProvider(
+      () => useTokenDetectionPolling(),
+      getBaseState({ isUnlocked: false }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenDetectionStartPolling).toHaveBeenCalledTimes(0);
@@ -129,18 +118,10 @@ describe('useTokenDetectionPolling', () => {
   });
 
   it('should not poll when token detection is disabled', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: true,
-        useTokenDetection: false,
-        networkConfigurationsByChainId: {
-          '0x1': {},
-        },
-      },
-    };
-
-    renderHookWithProvider(() => useTokenDetectionPolling(), state);
+    renderHookWithProvider(
+      () => useTokenDetectionPolling(),
+      getBaseState({ useTokenDetection: false }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenDetectionStartPolling).toHaveBeenCalledTimes(0);
@@ -148,18 +129,10 @@ describe('useTokenDetectionPolling', () => {
   });
 
   it('should not poll when no chains are provided', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: true,
-        useTokenDetection: true,
-        networkConfigurationsByChainId: {
-          '0x1': {},
-        },
-      },
-    };
-
-    renderHookWithProvider(() => useTokenDetectionPolling(), state);
+    renderHookWithProvider(
+      () => useTokenDetectionPolling(),
+      getBaseState({}, { eip155: {} }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenDetectionStartPolling).toHaveBeenCalledTimes(0);

--- a/ui/hooks/useTokenDetectionPolling.ts
+++ b/ui/hooks/useTokenDetectionPolling.ts
@@ -15,7 +15,11 @@ const useTokenDetectionPolling = () => {
   const isUnlocked = useSelector(getIsUnlocked);
   const enabledChainIds = useSelector(getEnabledChainIds);
 
-  const enabled = completedOnboarding && isUnlocked && useTokenDetection;
+  const enabled =
+    completedOnboarding &&
+    isUnlocked &&
+    useTokenDetection &&
+    enabledChainIds.length > 0;
 
   useMultiPolling({
     startPolling: tokenDetectionStartPolling,

--- a/ui/hooks/useTokenListPolling.test.ts
+++ b/ui/hooks/useTokenListPolling.test.ts
@@ -18,6 +18,39 @@ jest.mock('../store/actions', () => ({
   tokenListStopPollingByPollingToken: jest.fn(),
 }));
 
+const getBaseState = (
+  overrides: Record<string, unknown> = {},
+  enabledNetworkMap: Record<string, Record<string, boolean>> = {
+    eip155: {
+      '0x1': true,
+    },
+  },
+) => ({
+  metamask: {
+    isUnlocked: true,
+    completedOnboarding: true,
+    useExternalServices: true,
+    useTokenDetection: true,
+    selectedNetworkClientId: 'selectedNetworkClientId',
+    enabledNetworkMap,
+    networkConfigurationsByChainId: {
+      '0x1': {
+        chainId: '0x1',
+        rpcEndpoints: [
+          {
+            networkClientId: 'selectedNetworkClientId',
+          },
+        ],
+      },
+    },
+    multichainNetworkConfigurationsByChainId:
+      AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
+    selectedMultichainNetworkChainId: BtcScope.Mainnet,
+    isEvmSelected: true,
+    ...overrides,
+  },
+});
+
 describe('useTokenListPolling', () => {
   beforeEach(() => {
     mockPromises = [];
@@ -25,38 +58,9 @@ describe('useTokenListPolling', () => {
   });
 
   it('should poll the selected network when enabled, and stop on dismount', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: true,
-        useExternalServices: true,
-        useTokenDetection: true,
-        selectedNetworkClientId: 'selectedNetworkClientId',
-        enabledNetworkMap: {
-          eip155: {
-            '0x1': true,
-          },
-        },
-        networkConfigurationsByChainId: {
-          '0x1': {
-            chainId: '0x1',
-            rpcEndpoints: [
-              {
-                networkClientId: 'selectedNetworkClientId',
-              },
-            ],
-          },
-        },
-        multichainNetworkConfigurationsByChainId:
-          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        selectedMultichainNetworkChainId: BtcScope.Mainnet,
-        isEvmSelected: true,
-      },
-    };
-
     const { unmount } = renderHookWithProvider(
       () => useTokenListPolling(),
-      state,
+      getBaseState(),
     );
 
     // Should poll each chain
@@ -73,24 +77,10 @@ describe('useTokenListPolling', () => {
   });
 
   it('should not poll before onboarding is completed', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: false,
-        useExternalServices: true,
-        useTokenDetection: true,
-        networkConfigurationsByChainId: {
-          '0x1': {},
-          '0x89': {},
-        },
-        multichainNetworkConfigurationsByChainId:
-          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        selectedMultichainNetworkChainId: BtcScope.Mainnet,
-        isEvmSelected: true,
-      },
-    };
-
-    renderHookWithProvider(() => useTokenListPolling(), state);
+    renderHookWithProvider(
+      () => useTokenListPolling(),
+      getBaseState({ completedOnboarding: false }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenListStartPolling).toHaveBeenCalledTimes(0);
@@ -98,24 +88,10 @@ describe('useTokenListPolling', () => {
   });
 
   it('should not poll when locked', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: false,
-        completedOnboarding: true,
-        useExternalServices: true,
-        useTokenDetection: true,
-        networkConfigurationsByChainId: {
-          '0x1': {},
-          '0x89': {},
-        },
-        multichainNetworkConfigurationsByChainId:
-          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        selectedMultichainNetworkChainId: BtcScope.Mainnet,
-        isEvmSelected: true,
-      },
-    };
-
-    renderHookWithProvider(() => useTokenListPolling(), state);
+    renderHookWithProvider(
+      () => useTokenListPolling(),
+      getBaseState({ isUnlocked: false }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenListStartPolling).toHaveBeenCalledTimes(0);
@@ -124,25 +100,13 @@ describe('useTokenListPolling', () => {
 
   it('should not poll when disabled', async () => {
     // disabled when detection, petnames, and simulations are all disabled
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: true,
-        useExternalServices: true,
+    renderHookWithProvider(
+      () => useTokenListPolling(),
+      getBaseState({
         useTokenDetection: false,
         useTransactionSimulations: false,
-        networkConfigurationsByChainId: {
-          '0x1': {},
-          '0x89': {},
-        },
-        multichainNetworkConfigurationsByChainId:
-          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        selectedMultichainNetworkChainId: BtcScope.Mainnet,
-        isEvmSelected: true,
-      },
-    };
-
-    renderHookWithProvider(() => useTokenListPolling(), state);
+      }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenListStartPolling).toHaveBeenCalledTimes(0);

--- a/ui/hooks/useTokenRatesPolling.test.ts
+++ b/ui/hooks/useTokenRatesPolling.test.ts
@@ -18,6 +18,47 @@ jest.mock('../store/actions', () => ({
   tokenRatesStopPollingByPollingToken: jest.fn(),
 }));
 
+const getBaseState = (
+  overrides: Record<string, unknown> = {},
+  enabledNetworkMap: Record<string, Record<string, boolean>> = {
+    eip155: {
+      '0x1': true,
+      '0x89': true,
+    },
+  },
+) => ({
+  metamask: {
+    isUnlocked: true,
+    completedOnboarding: true,
+    useCurrencyRateCheck: true,
+    selectedNetworkClientId: 'selectedNetworkClientId',
+    enabledNetworkMap,
+    networkConfigurationsByChainId: {
+      '0x1': {
+        chainId: '0x1',
+        rpcEndpoints: [
+          {
+            networkClientId: 'selectedNetworkClientId',
+          },
+        ],
+      },
+      '0x89': {
+        chainId: '0x89',
+        rpcEndpoints: [
+          {
+            networkClientId: 'selectedNetworkClientId2',
+          },
+        ],
+      },
+    },
+    multichainNetworkConfigurationsByChainId:
+      AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
+    selectedMultichainNetworkChainId: BtcScope.Mainnet,
+    isEvmSelected: true,
+    ...overrides,
+  },
+});
+
 let originalPortfolioView: string | undefined;
 describe('useTokenRatesPolling', () => {
   beforeEach(() => {
@@ -35,46 +76,9 @@ describe('useTokenRatesPolling', () => {
   });
 
   it('should poll token rates when enabled and stop on dismount', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: true,
-        useCurrencyRateCheck: true,
-        selectedNetworkClientId: 'selectedNetworkClientId',
-        enabledNetworkMap: {
-          eip155: {
-            '0x1': true,
-            '0x89': true,
-          },
-        },
-        networkConfigurationsByChainId: {
-          '0x1': {
-            chainId: '0x1',
-            rpcEndpoints: [
-              {
-                networkClientId: 'selectedNetworkClientId',
-              },
-            ],
-          },
-          '0x89': {
-            chainId: '0x89',
-            rpcEndpoints: [
-              {
-                networkClientId: 'selectedNetworkClientId2',
-              },
-            ],
-          },
-        },
-        multichainNetworkConfigurationsByChainId:
-          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        selectedMultichainNetworkChainId: BtcScope.Mainnet,
-        isEvmSelected: true,
-      },
-    };
-
     const { unmount } = renderHookWithProvider(
       () => useTokenRatesPolling(),
-      state,
+      getBaseState(),
     );
 
     // Should poll each chain
@@ -90,23 +94,10 @@ describe('useTokenRatesPolling', () => {
   });
 
   it('should not poll if onboarding is not completed', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: false,
-        useCurrencyRateCheck: true,
-        networkConfigurationsByChainId: {
-          '0x1': {},
-          '0x89': {},
-        },
-        multichainNetworkConfigurationsByChainId:
-          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        selectedMultichainNetworkChainId: BtcScope.Mainnet,
-        isEvmSelected: true,
-      },
-    };
-
-    renderHookWithProvider(() => useTokenRatesPolling(), state);
+    renderHookWithProvider(
+      () => useTokenRatesPolling(),
+      getBaseState({ completedOnboarding: false }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenRatesStartPolling).toHaveBeenCalledTimes(0);
@@ -114,23 +105,10 @@ describe('useTokenRatesPolling', () => {
   });
 
   it('should not poll when locked', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: false,
-        completedOnboarding: true,
-        useCurrencyRateCheck: true,
-        networkConfigurationsByChainId: {
-          '0x1': {},
-          '0x89': {},
-        },
-        multichainNetworkConfigurationsByChainId:
-          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        selectedMultichainNetworkChainId: BtcScope.Mainnet,
-        isEvmSelected: true,
-      },
-    };
-
-    renderHookWithProvider(() => useTokenRatesPolling(), state);
+    renderHookWithProvider(
+      () => useTokenRatesPolling(),
+      getBaseState({ isUnlocked: false }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenRatesStartPolling).toHaveBeenCalledTimes(0);
@@ -138,23 +116,10 @@ describe('useTokenRatesPolling', () => {
   });
 
   it('should not poll when rate checking is disabled', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: true,
-        useCurrencyRateCheck: false,
-        networkConfigurationsByChainId: {
-          '0x1': {},
-          '0x89': {},
-        },
-        multichainNetworkConfigurationsByChainId:
-          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        selectedMultichainNetworkChainId: BtcScope.Mainnet,
-        isEvmSelected: true,
-      },
-    };
-
-    renderHookWithProvider(() => useTokenRatesPolling(), state);
+    renderHookWithProvider(
+      () => useTokenRatesPolling(),
+      getBaseState({ useCurrencyRateCheck: false }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenRatesStartPolling).toHaveBeenCalledTimes(0);
@@ -162,20 +127,10 @@ describe('useTokenRatesPolling', () => {
   });
 
   it('should not poll when no chains are provided', async () => {
-    const state = {
-      metamask: {
-        isUnlocked: true,
-        completedOnboarding: true,
-        useCurrencyRateCheck: true,
-        networkConfigurationsByChainId: {},
-        multichainNetworkConfigurationsByChainId:
-          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        selectedMultichainNetworkChainId: BtcScope.Mainnet,
-        isEvmSelected: true,
-      },
-    };
-
-    renderHookWithProvider(() => useTokenRatesPolling(), state);
+    renderHookWithProvider(
+      () => useTokenRatesPolling(),
+      getBaseState({}, { eip155: {} }),
+    );
 
     await Promise.all(mockPromises);
     expect(tokenRatesStartPolling).toHaveBeenCalledTimes(0);

--- a/ui/hooks/useTokenRatesPolling.ts
+++ b/ui/hooks/useTokenRatesPolling.ts
@@ -16,7 +16,11 @@ const useTokenRatesPolling = () => {
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
   const enabledChainIds = useSelector(getEnabledChainIds);
 
-  const enabled = completedOnboarding && isUnlocked && useCurrencyRateCheck;
+  const enabled =
+    completedOnboarding &&
+    isUnlocked &&
+    useCurrencyRateCheck &&
+    enabledChainIds.length > 0;
 
   useMultiPolling({
     startPolling: tokenRatesStartPolling,

--- a/ui/pages/bridge/hooks/useExternalAccountResolution.test.tsx
+++ b/ui/pages/bridge/hooks/useExternalAccountResolution.test.tsx
@@ -2,6 +2,20 @@ import { createBridgeMockStore } from '../../../../test/data/bridge/mock-bridge-
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { useExternalAccountResolution } from './useExternalAccountResolution';
 
+jest.mock('../../../ducks/domains', () => {
+  const actual = jest.requireActual('../../../ducks/domains');
+  return {
+    // Required for Babel/Jest default-export interop so the DNS reducer stays registered.
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Jest ESM interop flag
+    __esModule: true,
+    ...actual,
+    default: actual.default,
+    // Prevent async lookups from clearing preloaded DNS resolutions during render.
+    initializeDomainSlice: () => () => undefined,
+    lookupDomainName: () => async () => undefined,
+  };
+});
+
 const renderUseExternalAccountResolution = (
   searchQuery: string,
   isDestinationSolana: boolean,
@@ -24,8 +38,7 @@ describe('useExternalAccountResolution', () => {
 
   it('returns null when search query is not a valid address', () => {
     const { result } = renderUseExternalAccountResolution('0x123', false);
-    expect(result.all.length).toBe(1);
-    expect(result.all[0]).toBeNull();
+    expect(result.current).toBeNull();
   });
 
   it('returns null when search query is an internal account', () => {
@@ -33,8 +46,7 @@ describe('useExternalAccountResolution', () => {
       '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
       false,
     );
-    expect(result.all.length).toBe(1);
-    expect(result.all[0]).toBeNull();
+    expect(result.current).toBeNull();
   });
 
   it('returns external account when ENS search query is resolved', () => {
@@ -49,8 +61,7 @@ describe('useExternalAccountResolution', () => {
         },
       },
     });
-    expect(result.all.length).toBe(2);
-    expect(result.all[0]).toStrictEqual({
+    expect(result.current).toStrictEqual({
       address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7ba',
       isExternal: true,
       type: 'any:account',
@@ -64,7 +75,6 @@ describe('useExternalAccountResolution', () => {
         DNS: {},
       },
     });
-    expect(result.all.length).toBe(2);
-    expect(result.all[0]).toBeNull();
+    expect(result.current).toBeNull();
   });
 });

--- a/ui/pages/bridge/hooks/useGasIncludedSupport.test.ts
+++ b/ui/pages/bridge/hooks/useGasIncludedSupport.test.ts
@@ -222,12 +222,14 @@ describe.each([
                         } as never);
 
                         // Render the hook
-                        const { result, waitForNextUpdate } =
-                          renderUseGasIncludedSupport();
+                        const { result } = renderUseGasIncludedSupport();
 
                         await waitFor(async () => {
                           if (!isNonEvmChainId(validFromToken.chainId)) {
-                            await waitForNextUpdate();
+                            const prevUpdate0 = result.current;
+                            await waitFor(() => {
+                              expect(result.current).not.toBe(prevUpdate0);
+                            });
                           }
                         });
 

--- a/ui/pages/bridge/hooks/useGasIncludedSupport.test.ts
+++ b/ui/pages/bridge/hooks/useGasIncludedSupport.test.ts
@@ -224,14 +224,14 @@ describe.each([
                         // Render the hook
                         const { result } = renderUseGasIncludedSupport();
 
-                        await waitFor(async () => {
-                          if (!isNonEvmChainId(validFromToken.chainId)) {
-                            const prevUpdate0 = result.current;
-                            await waitFor(() => {
-                              expect(result.current).not.toBe(prevUpdate0);
-                            });
-                          }
-                        });
+                        // EVM paths fetch sentinel flags async; capture prev outside
+                        // waitFor so retries do not re-snapshot the baseline value.
+                        if (!isNonEvmChainId(validFromToken.chainId)) {
+                          const prevUpdate0 = result.current;
+                          await waitFor(() => {
+                            expect(result.current).not.toBe(prevUpdate0);
+                          });
+                        }
 
                         // HW + 7702 is not supported
                         if (isUsingHardwareWallet) {

--- a/ui/pages/confirmations/components/confirm/info/approve/hooks/use-is-nft.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/approve/hooks/use-is-nft.test.ts
@@ -1,4 +1,5 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
+import { waitFor } from '@testing-library/react';
 import { TokenStandard } from '../../../../../../../../shared/constants/transaction';
 import {
   CONTRACT_INTERACTION_SENDER_ADDRESS,
@@ -33,20 +34,20 @@ describe('useIsNFT', () => {
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
     }) as TransactionMeta;
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(
+    const { result } = renderHookWithProvider(
       () => useIsNFT(transactionMeta),
       mockState,
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.isNFT).toMatchInlineSnapshot(`true`);
-    expect(mockGetTokenStandardAndDetailsByChain).toHaveBeenCalledWith(
-      transactionMeta.txParams.to,
-      transactionMeta.txParams.from,
-      undefined,
-      transactionMeta.chainId,
-    );
+    await waitFor(() => {
+      expect(result.current.isNFT).toMatchInlineSnapshot(`true`);
+      expect(mockGetTokenStandardAndDetailsByChain).toHaveBeenCalledWith(
+        transactionMeta.txParams.to,
+        transactionMeta.txParams.from,
+        undefined,
+        transactionMeta.chainId,
+      );
+    });
   });
 
   it('identifies fungible in token with greater than 0 decimals', async () => {
@@ -60,13 +61,14 @@ describe('useIsNFT', () => {
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
     }) as TransactionMeta;
 
-    const { result, waitForNextUpdate } = renderHookWithProvider(
+    const { result } = renderHookWithProvider(
       () => useIsNFT(transactionMeta),
       mockState,
     );
 
-    await waitForNextUpdate();
-
+    await waitFor(() => {
+      expect(result.current.isNFT).toBe(false);
+    });
     expect(result.current.isNFT).toMatchInlineSnapshot(`false`);
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.test.ts
@@ -1,4 +1,4 @@
-import { act } from 'react-dom/test-utils';
+import { waitFor } from '@testing-library/react';
 import {
   TransactionParams,
   TransactionStatus,
@@ -28,16 +28,16 @@ async function runHook(
   state: Record<string, unknown>,
   { data, to }: { data?: Hex; to?: Hex } = {},
 ) {
-  const response = renderHookWithConfirmContextProvider(
+  const { result } = renderHookWithConfirmContextProvider(
     () => useDecodedTransactionData({ data, to }),
     state,
   );
 
-  await act(() => {
-    // Ignore
+  await waitFor(() => {
+    expect(result.current.pending).toBe(false);
   });
 
-  return response.result.current;
+  return result.current;
 }
 
 describe('useDecodedTransactionData', () => {

--- a/ui/pages/confirmations/components/confirm/info/info.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.test.tsx
@@ -138,6 +138,26 @@ const normalizeTippyIds = (container: HTMLElement): HTMLElement => {
   return clone;
 };
 
+/**
+ * Asserts that a render callback throws, while suppressing React's
+ * "The above error occurred in ..." console.error noise so it does not
+ * pollute the console baseline.
+ *
+ * @param render - Render callback that is expected to throw.
+ * @param expectedError - Expected error message or matcher.
+ */
+function expectRenderToThrow(render: () => void, expectedError: string): void {
+  const consoleError = jest
+    .spyOn(console, 'error')
+    .mockImplementation(() => undefined);
+
+  try {
+    expect(render).toThrow(expectedError);
+  } finally {
+    consoleError.mockRestore();
+  }
+}
+
 describe('Info', () => {
   const mockedAssetDetails = jest.mocked(useAssetDetails);
   const mockedUseParams = jest.mocked(useParams);
@@ -188,7 +208,8 @@ describe('Info', () => {
 
     const state = getMockTypedSignPermissionConfirmState();
     const mockStore = configureMockStore([])(state);
-    expect(() => renderWithConfirmContext(<Info />, mockStore)).toThrow(
+    expectRenderToThrow(
+      () => renderWithConfirmContext(<Info />, mockStore),
       'Invalid eth_signTypedData_v4 request - Advanced Permission type: native-token-stream not enabled',
     );
   });
@@ -199,7 +220,8 @@ describe('Info', () => {
 
     const state = getMockTypedSignPermissionConfirmState();
     const mockStore = configureMockStore([])(state);
-    expect(() => renderWithConfirmContext(<Info />, mockStore)).toThrow(
+    expectRenderToThrow(
+      () => renderWithConfirmContext(<Info />, mockStore),
       'Invalid eth_signTypedData_v4 request - Advanced Permission type: native-token-stream not enabled',
     );
   });

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/permission-detail-renderer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/permission-detail-renderer.test.tsx
@@ -32,6 +32,26 @@ const mockFetchErc20DecimalsOrThrow =
     typeof fetchErc20DecimalsOrThrow
   >;
 
+/**
+ * Asserts that a render callback throws, while suppressing React's
+ * "The above error occurred in ..." console.error noise so it does not
+ * pollute the console baseline.
+ *
+ * @param render - Render callback that is expected to throw.
+ * @param expectedError - Expected error message or matcher.
+ */
+function expectRenderToThrow(render: () => void, expectedError: string): void {
+  const consoleError = jest
+    .spyOn(console, 'error')
+    .mockImplementation(() => undefined);
+
+  try {
+    expect(render).toThrow(expectedError);
+  } finally {
+    consoleError.mockRestore();
+  }
+}
+
 const getMockStore = (permission?: DecodedPermission) => {
   const state = getMockTypedSignPermissionConfirmState(permission);
   return configureMockStore([])(state);
@@ -440,54 +460,60 @@ describe('PermissionDetailRenderer', () => {
 
   describe('error handling', () => {
     it('throws if throwIfUnknown is true on unknown permission type', () => {
-      expect(() =>
-        renderWithConfirmContext(
-          <PermissionDetailRenderer
-            permission={{ type: 'invalid', data: {} }}
-            expiry={null}
-            chainId="0x1"
-            origin="https://example.com"
-            ownerId="test-id"
-          />,
-          getMockStore(),
-        ),
-      ).toThrow('Unknown permission type: invalid');
+      expectRenderToThrow(
+        () =>
+          renderWithConfirmContext(
+            <PermissionDetailRenderer
+              permission={{ type: 'invalid', data: {} }}
+              expiry={null}
+              chainId="0x1"
+              origin="https://example.com"
+              ownerId="test-id"
+            />,
+            getMockStore(),
+          ),
+        'Unknown permission type: invalid',
+      );
     });
 
     it('throws when startTime is missing for periodic types', () => {
-      expect(() =>
-        renderWithConfirmContext(
-          <PermissionDetailRenderer
-            permission={{
-              type: 'native-token-periodic',
-              data: { periodAmount: '0x1', periodDuration: 86400 },
-            }}
-            expiry={null}
-            chainId="0x1"
-            origin="https://example.com"
-            ownerId="test-id"
-          />,
-          getMockStore(),
-        ),
-      ).toThrow('Start time is required');
+      expectRenderToThrow(
+        () =>
+          renderWithConfirmContext(
+            <PermissionDetailRenderer
+              permission={{
+                type: 'native-token-periodic',
+                data: { periodAmount: '0x1', periodDuration: 86400 },
+              }}
+              expiry={null}
+              chainId="0x1"
+              origin="https://example.com"
+              ownerId="test-id"
+            />,
+            getMockStore(),
+          ),
+        'Start time is required',
+      );
     });
 
     it('throws when startTime is missing for stream types', () => {
-      expect(() =>
-        renderWithConfirmContext(
-          <PermissionDetailRenderer
-            permission={{
-              type: 'native-token-stream',
-              data: { amountPerSecond: '0x1' },
-            }}
-            expiry={null}
-            chainId="0x1"
-            origin="https://example.com"
-            ownerId="test-id"
-          />,
-          getMockStore(),
-        ),
-      ).toThrow('Start time is required');
+      expectRenderToThrow(
+        () =>
+          renderWithConfirmContext(
+            <PermissionDetailRenderer
+              permission={{
+                type: 'native-token-stream',
+                data: { amountPerSecond: '0x1' },
+              }}
+              expiry={null}
+              chainId="0x1"
+              origin="https://example.com"
+              ownerId="test-id"
+            />,
+            getMockStore(),
+          ),
+        'Start time is required',
+      );
     });
   });
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission.test.tsx
@@ -24,6 +24,26 @@ jest.mock('../../../../../utils/token', () => ({
   fetchErc20DecimalsOrThrow: jest.fn().mockResolvedValue(18),
 }));
 
+/**
+ * Asserts that a render callback throws, while suppressing React's
+ * "The above error occurred in ..." console.error noise so it does not
+ * pollute the console baseline.
+ *
+ * @param render - Render callback that is expected to throw.
+ * @param expectedError - Expected error message or matcher.
+ */
+function expectRenderToThrow(render: () => void, expectedError: string): void {
+  const consoleError = jest
+    .spyOn(console, 'error')
+    .mockImplementation(() => undefined);
+
+  try {
+    expect(render).toThrow(expectedError);
+  } finally {
+    consoleError.mockRestore();
+  }
+}
+
 describe('TypedSignPermissionInfo', () => {
   describe('permission section fields', () => {
     const permission = {
@@ -66,9 +86,10 @@ describe('TypedSignPermissionInfo', () => {
       } as unknown as DecodedPermission);
 
       const mockStore = configureMockStore([])(state);
-      expect(() =>
-        renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
-      ).toThrow('Unknown permission type: invalid');
+      expectRenderToThrow(
+        () => renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
+        'Unknown permission type: invalid',
+      );
     });
 
     it('throws an error when decodedPermission is not defined', () => {
@@ -78,9 +99,10 @@ describe('TypedSignPermissionInfo', () => {
       )[0].decodedPermission = undefined;
 
       const mockStore = configureMockStore([])(state);
-      expect(() =>
-        renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
-      ).toThrow('Decoded permission is undefined');
+      expectRenderToThrow(
+        () => renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
+        'Decoded permission is undefined',
+      );
     });
   });
 
@@ -130,9 +152,10 @@ describe('TypedSignPermissionInfo', () => {
         permissionWithoutStartTime as DecodedPermission,
       );
       const mockStore = configureMockStore([])(state);
-      expect(() =>
-        renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
-      ).toThrow('Start time is required');
+      expectRenderToThrow(
+        () => renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
+        'Start time is required',
+      );
     });
 
     it('renders native token periodic permission without expiry', () => {
@@ -208,9 +231,10 @@ describe('TypedSignPermissionInfo', () => {
         permissionWithoutStartTime as DecodedPermission,
       );
       const mockStore = configureMockStore([])(state);
-      expect(() =>
-        renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
-      ).toThrow('Start time is required');
+      expectRenderToThrow(
+        () => renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
+        'Start time is required',
+      );
     });
 
     it('renders native token stream permission without initial amount', () => {
@@ -328,9 +352,10 @@ describe('TypedSignPermissionInfo', () => {
         permissionWithoutStartTime as DecodedPermission,
       );
       const mockStore = configureMockStore([])(state);
-      expect(() =>
-        renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
-      ).toThrow('Start time is required');
+      expectRenderToThrow(
+        () => renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
+        'Start time is required',
+      );
     });
 
     it('renders ERC20 token periodic permission without expiry', () => {
@@ -403,9 +428,10 @@ describe('TypedSignPermissionInfo', () => {
         permissionWithoutStartTime as DecodedPermission,
       );
       const mockStore = configureMockStore([])(state);
-      expect(() =>
-        renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
-      ).toThrow('Start time is required');
+      expectRenderToThrow(
+        () => renderWithConfirmContext(<TypedSignPermissionInfo />, mockStore),
+        'Start time is required',
+      );
     });
 
     it('renders ERC20 token stream permission without initial amount', () => {

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
@@ -1,5 +1,5 @@
 import { Hex } from '@metamask/utils';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import {
   SimulationData,
   SimulationTokenStandard,
@@ -114,14 +114,18 @@ describe('useBalanceChanges', () => {
 
   describe('pending states', () => {
     it('returns pending=true if no simulation data', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result, unmount } = renderHook(() =>
         useBalanceChanges({
           chainId: CHAIN_ID_MOCK,
           simulationData: undefined,
         }),
       );
       expect(result.current).toEqual({ pending: true, value: [] });
-      await waitForNextUpdate();
+      // Flush useAsync settlement so setResult does not fire outside act.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      unmount();
     });
 
     it('returns pending=true while fetching token decimals', async () => {
@@ -138,14 +142,16 @@ describe('useBalanceChanges', () => {
           },
         ],
       };
-      const { result, unmount, waitForNextUpdate } = renderHook(() =>
+      const { result, unmount } = renderHook(() =>
         useBalanceChanges({ chainId: CHAIN_ID_MOCK, simulationData }),
       );
 
-      await waitForNextUpdate();
-
-      expect(result.current).toEqual({ pending: true, value: [] });
-      unmount();
+      await waitFor(() => {
+        expect(result.current).toEqual({ pending: true, value: [] });
+      });
+      act(() => {
+        unmount();
+      });
     });
 
     it('returns pending=true while fetching token fiat rates', async () => {
@@ -162,14 +168,16 @@ describe('useBalanceChanges', () => {
           },
         ],
       };
-      const { result, unmount, waitForNextUpdate } = renderHook(() =>
+      const { result, unmount } = renderHook(() =>
         useBalanceChanges({ chainId: CHAIN_ID_MOCK, simulationData }),
       );
 
-      await waitForNextUpdate();
-
-      expect(result.current).toEqual({ pending: true, value: [] });
-      unmount();
+      await waitFor(() => {
+        expect(result.current).toEqual({ pending: true, value: [] });
+      });
+      act(() => {
+        unmount();
+      });
     });
   });
 
@@ -187,7 +195,7 @@ describe('useBalanceChanges', () => {
     };
 
     it('maps token balance changes correctly', async () => {
-      const { result, waitForNextUpdate } = setupHook([
+      const { result } = setupHook([
         {
           ...dummyBalanceChange,
           difference: '0x11',
@@ -197,7 +205,10 @@ describe('useBalanceChanges', () => {
         },
       ]);
 
-      await waitForNextUpdate();
+      const prevUpdate0 = result.current;
+      await waitFor(() => {
+        expect(result.current).not.toBe(prevUpdate0);
+      });
 
       const changes = result.current.value;
       expect(changes).toEqual([
@@ -217,7 +228,7 @@ describe('useBalanceChanges', () => {
     });
 
     it('handles multiple token balance changes', async () => {
-      const { result, waitForNextUpdate } = setupHook([
+      const { result } = setupHook([
         {
           ...dummyBalanceChange,
           difference: DIFFERENCE_1_MOCK,
@@ -234,7 +245,10 @@ describe('useBalanceChanges', () => {
         },
       ]);
 
-      await waitForNextUpdate();
+      const prevUpdate1 = result.current;
+      await waitFor(() => {
+        expect(result.current).not.toBe(prevUpdate1);
+      });
 
       const changes = result.current.value;
       expect(changes).toHaveLength(2);
@@ -245,7 +259,7 @@ describe('useBalanceChanges', () => {
     });
 
     it('handles non-ERC20 tokens', async () => {
-      const { result, waitForNextUpdate } = setupHook([
+      const { result } = setupHook([
         {
           ...dummyBalanceChange,
           difference: '0x1',
@@ -256,25 +270,25 @@ describe('useBalanceChanges', () => {
         },
       ]);
 
-      await waitForNextUpdate();
-
-      expect(result.current.value).toEqual([
-        {
-          asset: {
-            chainId: CHAIN_ID_MOCK,
-            address: NFT_TOKEN_ADDRESS_MOCK,
-            standard: TokenStandard.ERC721,
-            tokenId: TOKEN_ID_1_MOCK,
+      await waitFor(() => {
+        expect(result.current.value).toEqual([
+          {
+            asset: {
+              chainId: CHAIN_ID_MOCK,
+              address: NFT_TOKEN_ADDRESS_MOCK,
+              standard: TokenStandard.ERC721,
+              tokenId: TOKEN_ID_1_MOCK,
+            },
+            amount: new BigNumber('-1'),
+            fiatAmount: FIAT_UNAVAILABLE,
+            usdAmount: FIAT_UNAVAILABLE,
           },
-          amount: new BigNumber('-1'),
-          fiatAmount: FIAT_UNAVAILABLE,
-          usdAmount: FIAT_UNAVAILABLE,
-        },
-      ]);
+        ]);
+      });
     });
 
     it('uses default decimals when token details not found', async () => {
-      const { result, waitForNextUpdate } = setupHook([
+      const { result } = setupHook([
         {
           ...dummyBalanceChange,
           difference: DIFFERENCE_1_MOCK,
@@ -284,13 +298,13 @@ describe('useBalanceChanges', () => {
         },
       ]);
 
-      await waitForNextUpdate();
-
-      expect(result.current.value[0].amount.decimalPlaces()).toBe(18);
+      await waitFor(() => {
+        expect(result.current.value[0].amount.decimalPlaces()).toBe(18);
+      });
     });
 
     it('uses default decimals when token details are not valid numbers', async () => {
-      const { result, waitForNextUpdate } = setupHook([
+      const { result } = setupHook([
         {
           ...dummyBalanceChange,
           difference: DIFFERENCE_1_MOCK,
@@ -300,16 +314,16 @@ describe('useBalanceChanges', () => {
         },
       ]);
 
-      await waitForNextUpdate();
-
-      expect(result.current.value[0].amount.decimalPlaces()).toBe(18);
+      await waitFor(() => {
+        expect(result.current.value[0].amount.decimalPlaces()).toBe(18);
+      });
     });
 
     it('handles token fiat rate with more than 15 significant digits', async () => {
       mockFetchTokenExchangeRates.mockResolvedValue({
         [ERC20_TOKEN_ADDRESS_1_MOCK]: 0.1234567890123456,
       });
-      const { result, waitForNextUpdate } = setupHook([
+      const { result } = setupHook([
         {
           ...dummyBalanceChange,
           difference: DIFFERENCE_1_MOCK,
@@ -319,9 +333,9 @@ describe('useBalanceChanges', () => {
         },
       ]);
 
-      await waitForNextUpdate();
-
-      expect(result.current.value[0].fiatAmount).toBe(-0.002098765413209875);
+      await waitFor(() => {
+        expect(result.current.value[0].fiatAmount).toBe(-0.002098765413209875);
+      });
     });
   });
 
@@ -339,13 +353,16 @@ describe('useBalanceChanges', () => {
     };
 
     it('maps native balance change correctly', async () => {
-      const { result, waitForNextUpdate } = setupHook({
+      const { result } = setupHook({
         ...dummyBalanceChange,
         difference: DIFFERENCE_ETH_MOCK,
         isDecrease: true,
       });
 
-      await waitForNextUpdate();
+      const prevUpdate2 = result.current;
+      await waitFor(() => {
+        expect(result.current).not.toBe(prevUpdate2);
+      });
 
       const changes = result.current.value;
       expect(changes).toEqual([
@@ -363,34 +380,35 @@ describe('useBalanceChanges', () => {
 
     it('handles native fiat rate with more than 15 significant digits', async () => {
       mockSelectConversionRateByChainId.mockReturnValue(0.1234567890123456);
-      const { result, waitForNextUpdate } = setupHook({
+      const { result } = setupHook({
         ...dummyBalanceChange,
         difference: DIFFERENCE_ETH_MOCK,
         isDecrease: true,
       });
 
-      await waitForNextUpdate();
-
-      expect(result.current.value[0].fiatAmount).toBe(-663.3337769927953);
+      await waitFor(() => {
+        expect(result.current.value[0].fiatAmount).toBe(-663.3337769927953);
+      });
     });
 
     it('handles unavailable native fiat rate', async () => {
       mockSelectConversionRateByChainId.mockReturnValue(undefined);
-      const { result, waitForNextUpdate } = setupHook({
+      const { result } = setupHook({
         ...dummyBalanceChange,
         difference: DIFFERENCE_ETH_MOCK,
         isDecrease: true,
       });
 
-      await waitForNextUpdate();
-
-      expect(result.current.value[0].fiatAmount).toBe(FIAT_UNAVAILABLE);
+      await waitFor(() => {
+        expect(result.current.value[0].fiatAmount).toBe(FIAT_UNAVAILABLE);
+      });
     });
 
     it('handles no native balance change', async () => {
-      const { result, waitForNextUpdate } = setupHook(undefined);
-      await waitForNextUpdate();
-      expect(result.current.value).toEqual([]);
+      const { result } = setupHook(undefined);
+      await waitFor(() => {
+        expect(result.current.value).toEqual([]);
+      });
     });
   });
 
@@ -411,11 +429,14 @@ describe('useBalanceChanges', () => {
         },
       ],
     };
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useBalanceChanges({ chainId: CHAIN_ID_MOCK, simulationData }),
     );
 
-    await waitForNextUpdate();
+    const prevUpdate3 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate3);
+    });
 
     const changes = result.current.value;
     expect(changes).toHaveLength(2);

--- a/ui/pages/confirmations/hooks/alerts/transactions/useTokenContractAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useTokenContractAlert.test.ts
@@ -1,3 +1,4 @@
+import { act, waitFor } from '@testing-library/react';
 import { ApprovalType } from '@metamask/controller-utils';
 import {
   TransactionMeta,
@@ -14,6 +15,12 @@ import {
   TokenStandAndDetails,
 } from '../../../../../store/actions';
 import { useTokenContractAlert } from './useTokenContractAlert';
+
+async function flushAsyncUpdates() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
 
 jest.mock('../../../../../hooks/useI18nContext', () => ({
   useI18nContext: jest.fn(),
@@ -81,9 +88,11 @@ describe('useTokenContractAlert', () => {
   });
 
   describe('when no confirmation exists', () => {
-    it('returns no alerts', () => {
+    it('returns no alerts', async () => {
       const { result } = runHook();
       expect(result.current).toEqual([]);
+      // Confirm-context providers can settle async work after the sync assert.
+      await flushAsyncUpdates();
     });
   });
 
@@ -103,9 +112,11 @@ describe('useTokenContractAlert', () => {
         },
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      expect(result.current).toEqual([]);
+      // Approvals skip the token-contract lookup path.
+      await waitFor(() => {
+        expect(result.current).toEqual([]);
+      });
+      expect(mockGetTokenStandardAndDetailsByChain).not.toHaveBeenCalled();
     });
   });
 
@@ -125,8 +136,10 @@ describe('useTokenContractAlert', () => {
         },
       });
 
-      // Wait for async resolution
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await waitFor(() => {
+        expect(mockGetTokenStandardAndDetailsByChain).toHaveBeenCalled();
+      });
+      await flushAsyncUpdates();
 
       expect(result.current).toEqual([]);
     });
@@ -148,10 +161,9 @@ describe('useTokenContractAlert', () => {
         },
       });
 
-      // Wait for async resolution
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      expect(result.current).toHaveLength(1);
+      await waitFor(() => {
+        expect(result.current).toHaveLength(1);
+      });
       expect(result.current[0]).toEqual(
         expect.objectContaining({
           key: 'tokenContractAddress',
@@ -177,10 +189,9 @@ describe('useTokenContractAlert', () => {
         },
       });
 
-      // Wait for async resolution
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      expect(result.current).toHaveLength(1);
+      await waitFor(() => {
+        expect(result.current).toHaveLength(1);
+      });
       expect(result.current[0]).toEqual(
         expect.objectContaining({
           key: 'tokenContractAddress',
@@ -204,10 +215,9 @@ describe('useTokenContractAlert', () => {
         },
       });
 
-      // Wait for async resolution
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      expect(result.current[0].message).toBe('smartContractAddressWarning');
+      await waitFor(() => {
+        expect(result.current[0]?.message).toBe('smartContractAddressWarning');
+      });
     });
 
     it('calls getTokenStandardAndDetailsByChain with correct params', async () => {
@@ -226,15 +236,15 @@ describe('useTokenContractAlert', () => {
         },
       });
 
-      // Wait for async resolution
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      expect(mockGetTokenStandardAndDetailsByChain).toHaveBeenCalledWith(
-        TOKEN_CONTRACT_ADDRESS,
-        undefined,
-        undefined,
-        '0x5',
-      );
+      await waitFor(() => {
+        expect(mockGetTokenStandardAndDetailsByChain).toHaveBeenCalledWith(
+          TOKEN_CONTRACT_ADDRESS,
+          undefined,
+          undefined,
+          '0x5',
+        );
+      });
+      await flushAsyncUpdates();
     });
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/useAddEthereumChainAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useAddEthereumChainAlerts.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import { Severity } from '../../../../helpers/constants/design-system';
 import * as confirmContext from '../../context/confirm';
 import * as safeChains from '../../../../components/multichain/networks-form/use-safe-chains';
@@ -25,7 +26,10 @@ const mockJsonRpcRequest = jest.fn();
 
 const renderHookWithWait = async () => {
   const hookResult = renderHook(() => useAddEthereumChainAlerts());
-  await hookResult.waitForNextUpdate();
+  const prevUpdate0 = hookResult.result.current;
+  await waitFor(() => {
+    expect(hookResult.result.current).not.toBe(prevUpdate0);
+  });
   return hookResult;
 };
 

--- a/ui/pages/confirmations/hooks/gas/useGaslessSupportedSmartTransactions.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useGaslessSupportedSmartTransactions.test.ts
@@ -1,4 +1,4 @@
-import { act } from 'react-dom/test-utils';
+import { waitFor } from '@testing-library/react';
 import { Hex } from '@metamask/utils';
 import { getIsSmartTransaction } from '../../../../../shared/lib/selectors';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
@@ -31,8 +31,8 @@ async function runHook() {
     ),
   );
 
-  await act(async () => {
-    // Intentionally empty
+  await waitFor(() => {
+    expect(result.current.pending).toBe(false);
   });
 
   return result.current;
@@ -98,7 +98,7 @@ describe('useGaslessSupportedSmartTransactions', () => {
   it('returns pending = true while sendBundleSupported is being fetched', async () => {
     getIsSmartTransactionMock.mockReturnValue(true);
     // Simulate pending by not resolving the Promise yet
-    let resolvePromise: (value: boolean) => void;
+    let resolvePromise: (value: boolean) => void = () => undefined;
     const pendingPromise = new Promise<boolean>((resolve) => {
       resolvePromise = resolve;
     });
@@ -106,7 +106,7 @@ describe('useGaslessSupportedSmartTransactions', () => {
       pendingPromise as Promise<boolean>,
     );
 
-    const { result, waitForNextUpdate } = renderHookWithConfirmContextProvider(
+    const { result } = renderHookWithConfirmContextProvider(
       useGaslessSupportedSmartTransactions,
       getMockConfirmStateForTransaction(
         genUnapprovedContractInteractionConfirmation({
@@ -118,16 +118,14 @@ describe('useGaslessSupportedSmartTransactions', () => {
     // Initially pending
     expect(result.current.pending).toBe(true);
 
-    // Resolve and wait for next update
-    await act(async () => {
-      resolvePromise(true);
-      await waitForNextUpdate();
-    });
-
-    expect(result.current).toStrictEqual({
-      isSmartTransaction: true,
-      isSupported: true,
-      pending: false,
+    // Resolve and wait for the async result to settle
+    resolvePromise(true);
+    await waitFor(() => {
+      expect(result.current).toStrictEqual({
+        isSmartTransaction: true,
+        isSupported: true,
+        pending: false,
+      });
     });
   });
 
@@ -141,8 +139,8 @@ describe('useGaslessSupportedSmartTransactions', () => {
       ),
     );
 
-    await act(async () => {
-      // Wait for useAsyncResult to settle
+    await waitFor(() => {
+      expect(result.current.pending).toBe(false);
     });
 
     expect(result.current).toStrictEqual({

--- a/ui/pages/confirmations/hooks/musd/useMerklClaimAmount.test.ts
+++ b/ui/pages/confirmations/hooks/musd/useMerklClaimAmount.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import {
   TransactionMeta,
   TransactionStatus,
@@ -88,13 +89,13 @@ describe('useMerklClaimAmount', () => {
   it('computes full claim amount when nothing claimed on-chain', async () => {
     mockGetClaimedAmount.mockResolvedValue(null);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useMerklClaimAmount(buildMockTransaction()),
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.pending).toBe(false);
+    await waitFor(() => {
+      expect(result.current.pending).toBe(false);
+    });
     // 10.5 MUSD
     expect(result.current.displayClaimAmount).toBe('10.5');
     expect(result.current.fiatDisplayValue).toBe('$10.50');
@@ -104,13 +105,13 @@ describe('useMerklClaimAmount', () => {
     // 5.5 MUSD already claimed
     mockGetClaimedAmount.mockResolvedValue('5500000');
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useMerklClaimAmount(buildMockTransaction()),
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.pending).toBe(false);
+    await waitFor(() => {
+      expect(result.current.pending).toBe(false);
+    });
     // 10.5 - 5.5 = 5.0
     expect(result.current.displayClaimAmount).toBe('5');
     expect(result.current.fiatDisplayValue).toBe('$5.00');
@@ -119,14 +120,14 @@ describe('useMerklClaimAmount', () => {
   it('returns zero when all claimed', async () => {
     mockGetClaimedAmount.mockResolvedValue('10500000');
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useMerklClaimAmount(buildMockTransaction()),
     );
 
-    await waitForNextUpdate();
-
-    expect(result.current.pending).toBe(false);
-    expect(result.current.displayClaimAmount).toBe('0');
+    await waitFor(() => {
+      expect(result.current.pending).toBe(false);
+      expect(result.current.displayClaimAmount).toBe('0');
+    });
   });
 
   it('returns undefined for non-musdClaim transactions', () => {
@@ -143,11 +144,14 @@ describe('useMerklClaimAmount', () => {
   it('handles contract call errors gracefully', async () => {
     mockGetClaimedAmount.mockRejectedValue(new Error('RPC error'));
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useMerklClaimAmount(buildMockTransaction()),
     );
 
-    await waitForNextUpdate();
+    const prevUpdate0 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate0);
+    });
 
     // Falls back to 0 claimed, so full amount is claimable
     expect(result.current.pending).toBe(false);

--- a/ui/pages/confirmations/hooks/send/alerts/useFirstTimeInteractionSendAlert.test.tsx
+++ b/ui/pages/confirmations/hooks/send/alerts/useFirstTimeInteractionSendAlert.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import { NameType } from '@metamask/name-controller';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
@@ -11,6 +11,12 @@ import { getExperience } from '../../../../../../shared/constants/verification';
 import { useSendContext } from '../../../context/send';
 import { checkFirstTimeInteraction } from '../../../../../store/actions';
 import { useFirstTimeInteractionSendAlert } from './useFirstTimeInteractionSendAlert';
+
+async function flushAsyncUpdates() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -58,7 +64,7 @@ describe('useFirstTimeInteractionSendAlert', () => {
     mockCheckFirstTimeInteraction.mockResolvedValue(true);
   });
 
-  it('returns null when there is no recipient', () => {
+  it('returns null when there is no recipient', async () => {
     mockUseSendContext.mockReturnValue({
       to: undefined,
       toResolved: undefined,
@@ -68,9 +74,10 @@ describe('useFirstTimeInteractionSendAlert', () => {
 
     const { result } = renderHook(() => useFirstTimeInteractionSendAlert());
     expect(result.current).toBeNull();
+    await flushAsyncUpdates();
   });
 
-  it('returns null when there is no from address', () => {
+  it('returns null when there is no from address', async () => {
     mockUseSendContext.mockReturnValue({
       to: MOCK_TO,
       toResolved: MOCK_TO,
@@ -80,40 +87,44 @@ describe('useFirstTimeInteractionSendAlert', () => {
 
     const { result } = renderHook(() => useFirstTimeInteractionSendAlert());
     expect(result.current).toBeNull();
+    await flushAsyncUpdates();
   });
 
-  it('returns null when recipient is an internal account', () => {
+  it('returns null when recipient is an internal account', async () => {
     mockUseSelector.mockReturnValue([{ address: MOCK_TO.toLowerCase() }]);
 
     const { result } = renderHook(() => useFirstTimeInteractionSendAlert());
     expect(result.current).toBeNull();
+    await flushAsyncUpdates();
   });
 
   it('returns alert when it is a first-time interaction', async () => {
     mockCheckFirstTimeInteraction.mockResolvedValue(true);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useFirstTimeInteractionSendAlert(),
-    );
+    const { result } = renderHook(() => useFirstTimeInteractionSendAlert());
 
-    await waitForNextUpdate();
-
-    expect(result.current).not.toBeNull();
-    expect(result.current?.key).toBe('firstTimeInteraction');
-    expect(result.current?.title).toBe('sendAlertNewAddressTitle');
-    expect(result.current?.acknowledgeButtonLabel).toBe('continue');
-    expect(result.current?.message).toBeDefined();
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+      expect(result.current?.key).toBe('firstTimeInteraction');
+      expect(result.current?.title).toBe('sendAlertNewAddressTitle');
+      expect(result.current?.acknowledgeButtonLabel).toBe('continue');
+      expect(result.current?.message).toBeDefined();
+    });
   });
 
   it('returns null for a returning address (not first-time)', async () => {
     mockCheckFirstTimeInteraction.mockResolvedValue(false);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useFirstTimeInteractionSendAlert(),
-    );
+    const { result } = renderHook(() => useFirstTimeInteractionSendAlert());
 
     try {
-      await waitForNextUpdate({ timeout: 100 });
+      const prevUpdate0 = result.current;
+      await waitFor(
+        () => {
+          expect(result.current).not.toBe(prevUpdate0);
+        },
+        { timeout: 100 },
+      );
     } catch {
       // No update expected
     }
@@ -124,12 +135,16 @@ describe('useFirstTimeInteractionSendAlert', () => {
   it('returns null when API returns undefined', async () => {
     mockCheckFirstTimeInteraction.mockResolvedValue(undefined);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useFirstTimeInteractionSendAlert(),
-    );
+    const { result } = renderHook(() => useFirstTimeInteractionSendAlert());
 
     try {
-      await waitForNextUpdate({ timeout: 100 });
+      const prevUpdate1 = result.current;
+      await waitFor(
+        () => {
+          expect(result.current).not.toBe(prevUpdate1);
+        },
+        { timeout: 100 },
+      );
     } catch {
       // No update expected
     }
@@ -137,7 +152,7 @@ describe('useFirstTimeInteractionSendAlert', () => {
     expect(result.current).toBeNull();
   });
 
-  it('returns null when recipient is a verified address', () => {
+  it('returns null when recipient is a verified address', async () => {
     mockUseTrustSignal.mockReturnValue({
       state: TrustSignalDisplayState.Verified,
       label: 'Verified',
@@ -145,9 +160,10 @@ describe('useFirstTimeInteractionSendAlert', () => {
 
     const { result } = renderHook(() => useFirstTimeInteractionSendAlert());
     expect(result.current).toBeNull();
+    await flushAsyncUpdates();
   });
 
-  it('returns null when trust signal is loading', () => {
+  it('returns null when trust signal is loading', async () => {
     mockUseTrustSignal.mockReturnValue({
       state: TrustSignalDisplayState.Loading,
       label: null,
@@ -155,16 +171,18 @@ describe('useFirstTimeInteractionSendAlert', () => {
 
     const { result } = renderHook(() => useFirstTimeInteractionSendAlert());
     expect(result.current).toBeNull();
+    await flushAsyncUpdates();
   });
 
-  it('returns null when recipient is a first-party contract', () => {
+  it('returns null when recipient is a first-party contract', async () => {
     mockGetExperience.mockReturnValue('metamask' as never);
 
     const { result } = renderHook(() => useFirstTimeInteractionSendAlert());
     expect(result.current).toBeNull();
+    await flushAsyncUpdates();
   });
 
-  it('calls useTrustSignal with correct arguments', () => {
+  it('calls useTrustSignal with correct arguments', async () => {
     renderHook(() => useFirstTimeInteractionSendAlert());
 
     expect(mockUseTrustSignal).toHaveBeenCalledWith(
@@ -172,31 +190,31 @@ describe('useFirstTimeInteractionSendAlert', () => {
       NameType.ETHEREUM_ADDRESS,
       '0x1',
     );
+    await flushAsyncUpdates();
   });
 
   it('calls checkFirstTimeInteraction with correct arguments', async () => {
-    const { waitForNextUpdate } = renderHook(() =>
-      useFirstTimeInteractionSendAlert(),
-    );
+    renderHook(() => useFirstTimeInteractionSendAlert());
 
-    await waitForNextUpdate();
-
-    expect(mockCheckFirstTimeInteraction).toHaveBeenCalledWith({
-      from: MOCK_FROM,
-      to: MOCK_TO,
-      chainId: 1,
+    await waitFor(() => {
+      expect(mockCheckFirstTimeInteraction).toHaveBeenCalledWith({
+        from: MOCK_FROM,
+        to: MOCK_TO,
+        chainId: 1,
+      });
     });
   });
 
   it('resets when recipient changes', async () => {
     mockCheckFirstTimeInteraction.mockResolvedValue(true);
 
-    const { result, waitForNextUpdate, rerender } = renderHook(() =>
+    const { result, rerender } = renderHook(() =>
       useFirstTimeInteractionSendAlert(),
     );
 
-    await waitForNextUpdate();
-    expect(result.current).not.toBeNull();
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+    });
 
     const newRecipient = '0x111122223333444455556666777788889999aaaa';
     mockCheckFirstTimeInteraction.mockResolvedValue(false);
@@ -210,7 +228,13 @@ describe('useFirstTimeInteractionSendAlert', () => {
     rerender();
 
     try {
-      await waitForNextUpdate({ timeout: 100 });
+      const prevUpdate2 = result.current;
+      await waitFor(
+        () => {
+          expect(result.current).not.toBe(prevUpdate2);
+        },
+        { timeout: 100 },
+      );
     } catch {
       // No update expected
     }
@@ -227,23 +251,21 @@ describe('useFirstTimeInteractionSendAlert', () => {
     } as unknown as ReturnType<typeof useSendContext>);
     mockCheckFirstTimeInteraction.mockResolvedValue(true);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useFirstTimeInteractionSendAlert(),
-    );
+    const { result } = renderHook(() => useFirstTimeInteractionSendAlert());
 
-    await waitForNextUpdate();
-
-    expect(mockCheckFirstTimeInteraction).toHaveBeenCalledWith({
-      from: MOCK_FROM,
-      to: MOCK_TO,
-      chainId: 1,
+    await waitFor(() => {
+      expect(mockCheckFirstTimeInteraction).toHaveBeenCalledWith({
+        from: MOCK_FROM,
+        to: MOCK_TO,
+        chainId: 1,
+      });
+      expect(mockUseTrustSignal).toHaveBeenCalledWith(
+        MOCK_TO,
+        NameType.ETHEREUM_ADDRESS,
+        '0x1',
+      );
+      expect(result.current).not.toBeNull();
     });
-    expect(mockUseTrustSignal).toHaveBeenCalledWith(
-      MOCK_TO,
-      NameType.ETHEREUM_ADDRESS,
-      '0x1',
-    );
-    expect(result.current).not.toBeNull();
   });
 
   it('returns null while name resolution is pending (toResolved is not a hex address)', async () => {

--- a/ui/pages/confirmations/hooks/send/alerts/useTokenContractSendAlert.test.ts
+++ b/ui/pages/confirmations/hooks/send/alerts/useTokenContractSendAlert.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useSendContext } from '../../../context/send';
 import { useSendType } from '../useSendType';
@@ -65,29 +66,31 @@ describe('useTokenContractSendAlert', () => {
   it('returns alert when address is a token contract', async () => {
     mockGetTokenStandard.mockResolvedValue({ standard: 'ERC20' } as never);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useTokenContractSendAlert(),
-    );
+    const { result } = renderHook(() => useTokenContractSendAlert());
 
-    await waitForNextUpdate();
-
-    expect(result.current).toStrictEqual({
-      key: 'tokenContract',
-      title: 'smartContractAddress',
-      message: 'smartContractAddressWarning',
+    await waitFor(() => {
+      expect(result.current).toStrictEqual({
+        key: 'tokenContract',
+        title: 'smartContractAddress',
+        message: 'smartContractAddressWarning',
+      });
     });
   });
 
   it('returns null when address is not a token contract', async () => {
     mockGetTokenStandard.mockResolvedValue({} as never);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useTokenContractSendAlert(),
-    );
+    const { result } = renderHook(() => useTokenContractSendAlert());
 
     // Wait for the async check to settle
     try {
-      await waitForNextUpdate({ timeout: 100 });
+      const prevUpdate0 = result.current;
+      await waitFor(
+        () => {
+          expect(result.current).not.toBe(prevUpdate0);
+        },
+        { timeout: 100 },
+      );
     } catch {
       // No update expected - that's fine
     }
@@ -113,12 +116,11 @@ describe('useTokenContractSendAlert', () => {
   it('resets when recipient changes', async () => {
     mockGetTokenStandard.mockResolvedValue({ standard: 'ERC20' } as never);
 
-    const { result, waitForNextUpdate, rerender } = renderHook(() =>
-      useTokenContractSendAlert(),
-    );
+    const { result, rerender } = renderHook(() => useTokenContractSendAlert());
 
-    await waitForNextUpdate();
-    expect(result.current).not.toBeNull();
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+    });
 
     mockGetTokenStandard.mockResolvedValue({} as never);
     mockUseSendContext.mockReturnValue({
@@ -130,7 +132,13 @@ describe('useTokenContractSendAlert', () => {
     rerender();
 
     try {
-      await waitForNextUpdate({ timeout: 100 });
+      const prevUpdate1 = result.current;
+      await waitFor(
+        () => {
+          expect(result.current).not.toBe(prevUpdate1);
+        },
+        { timeout: 100 },
+      );
     } catch {
       // No update expected - that's fine
     }

--- a/ui/pages/confirmations/hooks/send/useRecipientValidation.test.ts
+++ b/ui/pages/confirmations/hooks/send/useRecipientValidation.test.ts
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 
 import mockState from '../../../../../test/data/mock-state.json';
 import {
@@ -36,6 +36,8 @@ describe('useRecipientValidation', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Ensure real timers are active; the debouncing suite toggles fake timers.
+    jest.useRealTimers();
     mockUseI18nContext.mockReturnValue(mockT);
     mockUseSendAlerts.mockReturnValue({
       alerts: [],
@@ -333,6 +335,17 @@ describe('useRecipientValidation', () => {
     });
 
     afterEach(() => {
+      // Flush and clear pending timers before restoring real timers so later
+      // tests (lodash debounce + waitFor) are not stuck on fake timers.
+      // RTL's waitFor schedules its own timers while fake timers are active.
+      act(() => {
+        try {
+          jest.runOnlyPendingTimers();
+        } catch {
+          // Ignore if no fake timers are installed
+        }
+      });
+      jest.clearAllTimers();
       jest.useRealTimers();
     });
 
@@ -378,7 +391,9 @@ describe('useRecipientValidation', () => {
 
       expect(mockValidateName).not.toHaveBeenCalled();
 
-      jest.advanceTimersByTime(500);
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
 
       await waitFor(() => {
         expect(mockValidateName).toHaveBeenCalledTimes(1);
@@ -415,7 +430,9 @@ describe('useRecipientValidation', () => {
       const { result, rerender } = renderHook();
 
       // Advance timers to trigger the debounced validation
-      jest.advanceTimersByTime(500);
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
 
       await waitFor(() => {
         expect(mockValidateName).toHaveBeenCalledWith(
@@ -434,19 +451,24 @@ describe('useRecipientValidation', () => {
       rerender();
 
       // Now resolve the original validation (for chainId 0x1)
-      if (resolveValidation) {
-        resolveValidation({
+      await act(async () => {
+        resolveValidation?.({
           resolvedLookup: '0xOldChainResult',
           protocol: 'ens',
         });
-      }
-
-      // Wait for any state updates
-      await jest.advanceTimersByTimeAsync(100);
+        await Promise.resolve();
+      });
 
       // The result from chainId 0x1 should be discarded
       // because chainId has changed to 0x89
       expect(result.current.recipientResolvedLookup).toBeUndefined();
+
+      // Flush the debounce scheduled for the new chainId so its setResult
+      // does not fire outside act during afterEach timer cleanup.
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+        await Promise.resolve();
+      });
     });
   });
 

--- a/ui/pages/confirmations/hooks/useLedgerConnection.test.ts
+++ b/ui/pages/confirmations/hooks/useLedgerConnection.test.ts
@@ -1,6 +1,7 @@
 import type { KeyringObject } from '@metamask/keyring-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
+import { act } from '@testing-library/react';
 import { cloneDeep } from 'lodash';
 import {
   HardwareTransportStates,
@@ -16,6 +17,12 @@ import { flushPromises } from '../../../../test/lib/timer-helpers';
 import * as appActions from '../../../ducks/app/app';
 import { attemptLedgerTransportCreation } from '../../../store/actions';
 import useLedgerConnection from './useLedgerConnection';
+
+async function flushAsyncUpdates() {
+  await act(async () => {
+    await flushPromises();
+  });
+}
 
 jest.mock('../../../store/actions', () => ({
   ...jest.requireActual('../../../store/actions'),
@@ -115,7 +122,7 @@ describe('useLedgerConnection', () => {
 
       renderHookWithConfirmContextProvider(useLedgerConnection, state);
 
-      await flushPromises();
+      await flushAsyncUpdates();
 
       expect(spyOnSetLedgerWebHidConnectedStatus).toHaveBeenCalledWith(
         WebHIDConnectedStatuses.connected,
@@ -137,7 +144,7 @@ describe('useLedgerConnection', () => {
 
       renderHookWithConfirmContextProvider(useLedgerConnection, state);
 
-      await flushPromises();
+      await flushAsyncUpdates();
 
       expect(spyOnSetLedgerWebHidConnectedStatus).toHaveBeenCalledWith(
         WebHIDConnectedStatuses.notConnected,
@@ -160,7 +167,7 @@ describe('useLedgerConnection', () => {
 
       renderHookWithConfirmContextProvider(useLedgerConnection, state);
 
-      await flushPromises();
+      await flushAsyncUpdates();
 
       expect(spyOnSetLedgerTransportStatus).toHaveBeenCalledWith(
         HardwareTransportStates.verified,
@@ -181,7 +188,7 @@ describe('useLedgerConnection', () => {
 
       renderHookWithConfirmContextProvider(useLedgerConnection, state);
 
-      await flushPromises();
+      await flushAsyncUpdates();
 
       expect(spyOnSetLedgerTransportStatus).toHaveBeenCalledWith(
         HardwareTransportStates.unknownFailure,
@@ -204,7 +211,7 @@ describe('useLedgerConnection', () => {
 
       renderHookWithConfirmContextProvider(useLedgerConnection, state);
 
-      await flushPromises();
+      await flushAsyncUpdates();
 
       expect(spyOnSetLedgerTransportStatus).toHaveBeenCalledWith(
         HardwareTransportStates.deviceOpenFailure,
@@ -227,7 +234,7 @@ describe('useLedgerConnection', () => {
 
       renderHookWithConfirmContextProvider(useLedgerConnection, state);
 
-      await flushPromises();
+      await flushAsyncUpdates();
 
       expect(spyOnSetLedgerTransportStatus).toHaveBeenCalledWith(
         HardwareTransportStates.verified,
@@ -250,7 +257,7 @@ describe('useLedgerConnection', () => {
 
       renderHookWithConfirmContextProvider(useLedgerConnection, state);
 
-      await flushPromises();
+      await flushAsyncUpdates();
 
       expect(spyOnSetLedgerTransportStatus).toHaveBeenCalledWith(
         HardwareTransportStates.unknownFailure,
@@ -269,7 +276,9 @@ describe('useLedgerConnection', () => {
       state,
     );
 
-    unmount();
+    act(() => {
+      unmount();
+    });
 
     expect(spyOnSetLedgerTransportStatus).toHaveBeenCalledWith(
       HardwareTransportStates.none,
@@ -292,7 +301,7 @@ describe('useLedgerConnection', () => {
 
       renderHookWithConfirmContextProvider(useLedgerConnection, state);
 
-      await flushPromises();
+      await flushAsyncUpdates();
 
       expect(spyOnSetLedgerWebHidConnectedStatus).not.toHaveBeenCalled();
       expect(spyOnSetLedgerTransportStatus).not.toHaveBeenCalled();
@@ -314,7 +323,7 @@ describe('useLedgerConnection', () => {
 
       renderHookWithConfirmContextProvider(useLedgerConnection, tempState);
 
-      await flushPromises();
+      await flushAsyncUpdates();
 
       expect(spyOnSetLedgerWebHidConnectedStatus).not.toHaveBeenCalled();
       expect(spyOnSetLedgerTransportStatus).not.toHaveBeenCalled();

--- a/ui/pages/snaps/snap-view/hooks/useUpdate.test.ts
+++ b/ui/pages/snaps/snap-view/hooks/useUpdate.test.ts
@@ -1,4 +1,5 @@
 import { act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import { renderHookWithProviderTyped } from '../../../../../test/lib/render-helpers-navigate';
 import { createMockUIMessenger } from '../../../../../test/lib/mock-ui-messenger';
 import type { UIMessenger } from '../../../../messengers/ui-messenger';
@@ -52,7 +53,7 @@ describe('useUpdate', () => {
       'SnapController:installSnaps': callMock,
     });
 
-    const { result, waitForNextUpdate } = renderHook({
+    const { result } = renderHook({
       state: {
         metamask: {
           ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
@@ -78,7 +79,10 @@ describe('useUpdate', () => {
     act(() => update({}));
     expect(callMock).toHaveBeenCalledWith('MetaMask', {});
 
-    await waitForNextUpdate();
+    const prevUpdate0 = result.current;
+    await waitFor(() => {
+      expect(result.current).not.toBe(prevUpdate0);
+    });
 
     const [, approvalId] = result.current;
     expect(approvalId).toBe('approval-id-123');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Replaces deprecated `waitForNextUpdate` with `waitFor` from `@testing-library/react` across hook unit tests, and updates `renderHookWithProvider` to use `@testing-library/react` as well.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6924

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are overwhelmingly test-only; the only runtime edits are defensive guards on token detection/rates polling when no enabled chains.
> 
> **Overview**
> Migrates hook unit tests from deprecated **`waitForNextUpdate`** (and mixed **`@testing-library/react-hooks`** usage) to **`waitFor`**, **`act`**, and **`renderHook`** from **`@testing-library/react`**, including shared **`renderHookWithProviderTyped`** in `render-helpers-navigate.js`.
> 
> **Test harness:** `test/jest/strict-mode.js` now also wraps **`renderHook`** from `@testing-library/react` in StrictMode (with a note that the react-hooks mock stays until #6923). Several suites add **`act`** for state updates, **`flushAsyncUpdates`** / promise flushes, and **`expectRenderToThrow`** helpers that mute React error-boundary **`console.error`** noise in confirmation tests. **`test/jest/console-baseline-unit.json`** is trimmed to match fewer Act/uncaught-error counts.
> 
> **Behavior-aligned fixes:** **`useTokenDetectionPolling`** and **`useTokenRatesPolling`** only enable polling when **`enabledChainIds.length > 0`**, with polling tests refactored via shared **`getBaseState`** helpers. Bridge **`useExternalAccountResolution`** tests mock DNS slice init so ENS resolutions stay stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4096f035c44c8efce5ea3b3042383f392801f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->