### PR TITLE
fix(stellar): Add Mask for Stellar XLM Spendable balance section

### DIFF
--- a/ui/pages/asset/components/spendable-balance-section.test.tsx
+++ b/ui/pages/asset/components/spendable-balance-section.test.tsx
@@ -10,14 +10,21 @@ jest.mock('../../../hooks/useFiatFormatter', () => ({
   useFiatFormatter: () => (n: number) => `$${n.toFixed(2)}`,
 }));
 
-const store = configureMockStore()({
-  metamask: { currentCurrency: 'usd' },
-  locale: { currentLocale: 'en' },
-});
+const createStore = (privacyMode = false) =>
+  configureMockStore()({
+    metamask: {
+      currentCurrency: 'usd',
+      preferences: { privacyMode },
+    },
+    locale: { currentLocale: 'en' },
+  });
 
-const renderWithProviders = (component: React.ReactElement) =>
+const renderWithProviders = (
+  component: React.ReactElement,
+  { privacyMode = false }: { privacyMode?: boolean } = {},
+) =>
   render(
-    <Provider store={store}>
+    <Provider store={createStore(privacyMode)}>
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
       <I18nContext.Provider value={tEn as any}>
         {component}
@@ -78,5 +85,29 @@ describe('SpendableBalanceSection', () => {
     expect(
       screen.getByText(messages.spendableBalanceBaseReserved.message),
     ).toBeInTheDocument();
+  });
+
+  it('masks balances when privacy mode is enabled', () => {
+    renderWithProviders(<SpendableBalanceSection {...defaultProps} />, {
+      privacyMode: true,
+    });
+
+    const maskedBalance = '•••••••••';
+    expect(
+      screen.getByTestId('spendable-balance-total-balance'),
+    ).toHaveTextContent(maskedBalance);
+    expect(
+      screen.getByTestId('spendable-balance-spendable-balance'),
+    ).toHaveTextContent(maskedBalance);
+    expect(
+      screen.getByTestId('spendable-balance-base-reserved'),
+    ).toHaveTextContent(maskedBalance);
+    expect(
+      screen.getByTestId('spendable-balance-fiat-value'),
+    ).toHaveTextContent(maskedBalance);
+    expect(screen.queryByText('250 XLM')).not.toBeInTheDocument();
+    expect(screen.queryByText('247.5 XLM')).not.toBeInTheDocument();
+    expect(screen.queryByText('2.5 XLM')).not.toBeInTheDocument();
+    expect(screen.queryByText('$105.00')).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/asset/components/spendable-balance-section.tsx
+++ b/ui/pages/asset/components/spendable-balance-section.tsx
@@ -2,12 +2,16 @@ import {
   Box,
   BoxFlexDirection,
   FontWeight,
+  SensitiveText,
   Text,
   TextColor,
   TextVariant,
+  SensitiveTextLength,
 } from '@metamask/design-system-react';
 import React from 'react';
+import { useSelector } from 'react-redux';
 
+import { getPreferences } from '../../../../shared/lib/selectors/preferences';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../hooks/useFiatFormatter';
 
@@ -38,6 +42,7 @@ export function SpendableBalanceSection({
 }: SpendableBalanceSectionProps) {
   const t = useI18nContext();
   const formatFiat = useFiatFormatter();
+  const { privacyMode } = useSelector(getPreferences);
 
   const totalDisplay = `${totalBalance} ${symbol}`;
   const spendableDisplay = `${spendableBalance} ${symbol}`;
@@ -71,13 +76,14 @@ export function SpendableBalanceSection({
           >
             {t('spendableBalanceTotalBalance')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
             data-testid="spendable-balance-total-balance"
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Medium}
           >
             {totalDisplay}
-          </Text>
+          </SensitiveText>
         </Box>
         <Box
           flexDirection={BoxFlexDirection.Column}
@@ -91,12 +97,14 @@ export function SpendableBalanceSection({
           >
             {t('spendableBalanceFiatValue')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodyMd}
             data-testid="spendable-balance-fiat-value"
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Medium}
           >
             {fiatValueDisplay}
-          </Text>
+          </SensitiveText>
         </Box>
       </Box>
       <Box flexDirection={BoxFlexDirection.Row} gap={3}>
@@ -112,13 +120,15 @@ export function SpendableBalanceSection({
           >
             {t('spendableBalance')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodyMd}
             color={TextColor.SuccessDefault}
             data-testid="spendable-balance-spendable-balance"
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Medium}
           >
             {spendableDisplay}
-          </Text>
+          </SensitiveText>
         </Box>
         <Box
           flexDirection={BoxFlexDirection.Column}
@@ -132,13 +142,15 @@ export function SpendableBalanceSection({
           >
             {t('spendableBalanceBaseReserved')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodyMd}
             color={TextColor.SuccessDefault}
             data-testid="spendable-balance-base-reserved"
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Medium}
           >
             {reservedDisplay}
-          </Text>
+          </SensitiveText>
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR hide the spendable amount when privacy mode is on , which align the experience when privacy mode is on 

But since Stellar is not activated, so no UX will be impacted to user

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
this is a screen cap for future version when stellar turn on
<img width="702" height="343" alt="image" src="https://github.com/user-attachments/assets/63606502-2c27-4c79-bc41-91dfdcc75aba" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
