### PR TITLE
fix: Monad send native reduced amount ux glitch

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.test.ts
@@ -193,6 +193,27 @@ describe('useMaxValueRefresher', () => {
     expect(updateEditableParamsMock).not.toHaveBeenCalled();
   });
 
+  it('does not update transaction value when gas estimation has failed', () => {
+    // Simulates a tx that reverted on-chain during gas estimation (e.g. a
+    // chain-enforced minimum balance being breached by a "send max" attempt).
+    // The resulting gas is an unreliable fallback, not a real cost, so the
+    // hook must not use it to shrink the value further.
+    const transactionMeta = merge({}, baseTransactionMeta, {
+      simulationFails: {
+        reason: 'execution reverted',
+        debug: {},
+      },
+    });
+
+    useConfirmContextMock.mockReturnValue({
+      currentConfirmation: transactionMeta,
+    } as unknown as ReturnType<typeof useConfirmContext>);
+
+    renderHook(() => useMaxValueRefresher());
+
+    expect(updateEditableParamsMock).not.toHaveBeenCalled();
+  });
+
   it('does not update transaction value for token transfer transactions', () => {
     const tokenTransferMeta = merge({}, baseTransactionMeta, {
       type: TransactionType.tokenMethodTransfer,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
@@ -83,7 +83,8 @@ export const useMaxValueRefresher = () => {
   useEffect(() => {
     if (
       !isMaxValueMode ||
-      transactionMeta.type !== TransactionType.simpleSend
+      transactionMeta.type !== TransactionType.simpleSend ||
+      transactionMeta.simulationFails
     ) {
       return;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When sending "Max MON" (native token) on Monad, the tx will show failure - going under the 10 MON minimum reserve - which is expected. The issue is that when this happens, the `amount` sent shown in the tx preview changes. This is because the predicted failure causes more gas consumption predicted, making the sent MON amount decrease by a seemingly-random amount.

Solution: Skip the step that refreshes the amount when done on the basis of a failing/reverting tx.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: send MAX native reduced amount ux glitch- #45080

## **Related issues**

Fixes:  https://github.com/MetaMask/metamask-extension/issues/44994

## **Manual testing steps**

Fix:
1. Go on Monad network.
2. Select "send" for MON.
3. Click the "max" button and don't edit the amount after that.
4. Click "next" to reach tx confirmation.
5. Check that send amount is consistent with was was pre-filled when clicking the "max" button. Check that the blocking alert is about a 10 MON minimum reserve (expected behavior).

Non-Reg:
1. Perform the same test for another Network.
2. Validate that even when editing the gas during tx confirmation, the "send max" behavior is preserve (sent amount refreshed based on <balance>-<gasEstimate>).

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="300" alt="image" src="https://github.com/user-attachments/assets/7e50fc4b-b66b-441b-a47b-c74b2c7c21ec" />


### **After**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ebe0831f-7364-44c0-b325-1b9dc7431100" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in send-max confirmation logic with a focused unit test; no auth, payments, or broad behavioral changes beyond failed-simulation max sends.
> 
> **Overview**
> Fixes a confirmation UX bug where **send max** native transfers could show a **shrinking send amount** after the tx is predicted to fail (e.g. Monad’s minimum balance reserve).
> 
> `useMaxValueRefresher` now **bails out** when `transactionMeta.simulationFails` is set, so it no longer subtracts inflated/fallback gas from balance and dispatches `updateEditableParams` for the value. A unit test covers the `simulationFails` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7ee0fe0476d6729ed5821e590fb05cf10e0d8aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->