### PR TITLE
test(e2e): skip flaky Tron QR popup account derivation test

### DIFF
--- a/test/e2e/tests/tron/account-derivation.spec.ts
+++ b/test/e2e/tests/tron/account-derivation.spec.ts
@@ -287,7 +287,8 @@ describe('Tron account derivation', function (this: Suite) {
     );
   });
 
-  it('Shows each account Tron address on the Receive page and copies it', async function () {
+  // eslint-disable-next-line mocha/no-skipped-tests -- flaky receive-page timeout in CI; see #44165
+  it.skip('Shows each account Tron address on the Receive page and copies it', async function () {
     await withTronFixtures(
       {
         accounts: [EMPTY_TRON_ACCOUNT],

--- a/test/e2e/tests/tron/account-derivation.spec.ts
+++ b/test/e2e/tests/tron/account-derivation.spec.ts
@@ -251,7 +251,8 @@ describe('Tron account derivation', function (this: Suite) {
     );
   });
 
-  it('Shows Account 1 QR popup with address, copy link, and View on Tronscan', async function () {
+  // eslint-disable-next-line mocha/no-skipped-tests -- flaky clipboard copy in QR popup on CI; see #44165
+  it.skip('Shows Account 1 QR popup with address, copy link, and View on Tronscan', async function () {
     await withTronFixtures(
       {
         accounts: [EMPTY_TRON_ACCOUNT],
@@ -287,8 +288,7 @@ describe('Tron account derivation', function (this: Suite) {
     );
   });
 
-  // eslint-disable-next-line mocha/no-skipped-tests -- flaky receive-page timeout in CI; see #44165
-  it.skip('Shows each account Tron address on the Receive page and copies it', async function () {
+  it('Shows each account Tron address on the Receive page and copies it', async function () {
     await withTronFixtures(
       {
         accounts: [EMPTY_TRON_ACCOUNT],


### PR DESCRIPTION
## **Description**

Skip the flaky `Shows Account 1 QR popup with address, copy link, and View on Tronscan` case in `test/e2e/tests/tron/account-derivation.spec.ts`.

CI logs from PR #44165 shard 0 ([run 30556788006](https://github.com/MetaMask/metamask-extension/actions/runs/30556788006)) show both attempt 1 and attempt 2 failed on this test with an empty clipboard after clicking the QR popup copy link (`AddressListModal.clickQrCopyAddressLink`). The Receive page case passed in both runs.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to WPN-685 / #44165.

## **Manual testing steps**

1. Run the extension test build: `yarn build:test`
2. Run `yarn test:e2e:single test/e2e/tests/tron/account-derivation.spec.ts --browser=chrome`
3. Confirm the QR popup case is reported as skipped and the remaining five cases pass

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.