### PR TITLE
fix(e2e): stabilize Tron QR popup clipboard copy in account derivation test

### DIFF
--- a/test/e2e/page-objects/pages/multichain/address-list-modal.ts
+++ b/test/e2e/page-objects/pages/multichain/address-list-modal.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { Driver } from '../../../webdriver/driver';
 import { quoteXPathText } from '../../../../helpers/quoteXPathText';
 
@@ -99,16 +98,19 @@ class AddressListModal {
   async checkQrPopupShowsAddress(expectedAddress: string): Promise<void> {
     console.log(`Check QR popup shows address "${expectedAddress}"`);
     await this.driver.waitForSelector(this.qrModalAddress);
-    const addressElement = await this.driver.findElement(this.qrModalAddress);
-    const displayedAddress = (await addressElement.getText()).replace(
-      /\s+/gu,
-      '',
+    await this.driver.waitUntil(
+      async () => {
+        const addressElement = await this.driver.findElement(
+          this.qrModalAddress,
+        );
+        const displayedAddress = (await addressElement.getText()).replace(
+          /\s+/gu,
+          '',
+        );
+        return displayedAddress === expectedAddress;
+      },
+      { interval: 100, timeout: this.driver.timeout },
     );
-    if (displayedAddress !== expectedAddress) {
-      throw new Error(
-        `Expected QR popup address "${expectedAddress}" but got "${displayedAddress}"`,
-      );
-    }
   }
 
   async checkQuickCopyAddressIsDisplayedForNetwork({
@@ -182,10 +184,7 @@ class AddressListModal {
     expectedAddress: string;
   }): Promise<void> {
     await this.clickCopyButtonForNetwork(networkName);
-    assert.strictEqual(
-      await this.driver.getClipboardContent(),
-      expectedAddress,
-    );
+    await this.driver.waitForClipboardContent(expectedAddress);
   }
 
   async clickQRbutton(addressIndex: number = 0): Promise<void> {
@@ -205,11 +204,9 @@ class AddressListModal {
 
   async clickQrCopyAddressLink(expectedAddress: string): Promise<void> {
     console.log('Click copy address button in QR popup');
+    await this.driver.waitForSelector(this.qrModalCopyButton);
     await this.driver.clickElement(this.qrModalCopyButton);
-    assert.strictEqual(
-      await this.driver.getClipboardContent(),
-      expectedAddress,
-    );
+    await this.driver.waitForClipboardContent(expectedAddress);
   }
 
   async clickQuickCopyButtonForNetwork({
@@ -224,10 +221,7 @@ class AddressListModal {
       this.quickCopyRowByNetworkName(networkName),
     );
     await row.click();
-    assert.strictEqual(
-      await this.driver.getClipboardContent(),
-      expectedAddress,
-    );
+    await this.driver.waitForClipboardContent(expectedAddress);
   }
 
   async getTruncatedAccountAddress(addressIndex: number = 0): Promise<string> {

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1261,6 +1261,30 @@ class Driver {
   }
 
   /**
+   * Waits until the clipboard contains the expected text.
+   * Clipboard writes from the extension are async; reading immediately after
+   * a copy click can race and return stale or empty content.
+   *
+   * @param {string} expectedContent - The expected clipboard text.
+   * @param {object} [options] - Wait options.
+   * @param {number} [options.interval] - Poll interval in milliseconds.
+   * @param {number} [options.timeout] - Maximum wait time in milliseconds.
+   * @returns {Promise<void>}
+   */
+  async waitForClipboardContent(
+    expectedContent,
+    { interval = 100, timeout = this.timeout } = {},
+  ) {
+    await this.waitUntil(
+      async () => {
+        const content = await this.getClipboardContent();
+        return content === expectedContent;
+      },
+      { interval, timeout },
+    );
+  }
+
+  /**
    * Paste a string into a field.
    *
    * @param {string | object} rawLocator  - Element locator


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

PR #45081 skipped the flaky `Shows Account 1 QR popup with address, copy link, and View on Tronscan` case in `test/e2e/tests/tron/account-derivation.spec.ts` after CI failures on #44165 ([run 30556788006](https://github.com/MetaMask/metamask-extension/actions/runs/30556788006)). Both retry attempts failed with an empty clipboard after `AddressListModal.clickQrCopyAddressLink`.

**Root cause:** The page object asserted clipboard content immediately after the copy click. Copy actions use `navigator.clipboard.writeText()`, which is asynchronous, so the test could read the clipboard before the write completed (especially under CI load). A secondary flake was reading the QR modal address before React finished rendering it (empty string).

**Solution:**
- Add `Driver.waitForClipboardContent()` and use it for all clipboard assertions in `AddressListModal`.
- Poll until the QR modal displays the expected address before asserting copy.
- Wait for the QR copy button before clicking.

This keeps the test enabled and addresses the race instead of skipping coverage.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to WPN-685 / #44165. Supersedes skip approach in #45081.

## **Manual testing steps**

1. Run the extension test build: `yarn build:test` (or faster iteration: `yarn start:test`)
2. Run `yarn test:e2e:single test/e2e/tests/tron/account-derivation.spec.ts --browser=chrome`
3. Confirm all six cases pass, including `Shows Account 1 QR popup with address, copy link, and View on Tronscan`
4. Optionally stress the QR case: `E2E_ARGS="--grep QR popup" yarn test:e2e:single test/e2e/tests/tron/account-derivation.spec.ts --browser=chrome --debug=false`

## **Screenshots/Recordings**

N/A — e2e test stabilization only; no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db6aaa53-b99d-4586-921d-bb5d315e67ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db6aaa53-b99d-4586-921d-bb5d315e67ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>