### PR TITLE
feat(ci): derive orchestrator version from release branch

### DIFF
--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -50,9 +50,15 @@ ensure_mtree() {
   if command -v mtree >/dev/null 2>&1; then
     return
   fi
+  # /usr/bin/mtree on Debian/Ubuntu comes from mtree-netbsd; compare_builds.sh
+  # needs the NetBSD flavour (`mtree -c -k sha256digest -p`). macOS ships it.
   echo "Installing mtree for build comparison..."
   sudo apt-get update -qq
-  sudo apt-get install -y mtree
+  sudo apt-get install -y mtree-netbsd
+  command -v mtree >/dev/null 2>&1 || {
+    echo "::error::mtree still unavailable after installing mtree-netbsd"
+    exit 1
+  }
 }
 
 resolve_last_listed_version() {

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -146,7 +146,9 @@ jobs:
       - build-flask-mv2-webpack
     runs-on: ubuntu-latest
     environment: release-branch
-    timeout-minutes: 45
+    # Publish work is ~10 min; the AMO reviewer step adds two full cold
+    # production builds (main + Flask) for the reproducible-build comparison.
+    timeout-minutes: 90
     env:
       RELEASE_TAG: ${{ needs.validate-branch.outputs.tag }}
       RELEASE_SHA: ${{ needs.validate-branch.outputs.release-sha }}

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -360,9 +360,9 @@ jobs:
             echo "| SHA256SUMS | ✅ Generated |"
             echo "| GitHub Release | ✅ Created |"
             echo "| Firefox Bundle | ✅ Pushed |"
-            if [[ "${{ steps.amo-reviewer-s3.conclusion }}" == "success" ]]; then
+            if [[ "${{ steps.amo-reviewer-s3.outcome }}" == "success" ]]; then
               echo "| AMO reviewer S3 (PRD) | ✅ Published |"
-            elif [[ "${{ steps.amo-reviewer-s3.conclusion }}" == "skipped" ]]; then
+            elif [[ "${{ steps.amo-reviewer-s3.outcome }}" == "skipped" ]]; then
               echo "| AMO reviewer S3 (PRD) | ⏭ Skipped |"
             else
               echo "| AMO reviewer S3 (PRD) | ❌ Failed |"
@@ -370,6 +370,6 @@ jobs:
             echo ""
             echo "**Release:** [${RELEASE_TAG}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG})"
           } >> "${GITHUB_STEP_SUMMARY}"
-          if [[ "${{ steps.amo-reviewer-s3.conclusion }}" == "failure" ]]; then
+          if [[ "${{ steps.amo-reviewer-s3.outcome }}" == "failure" ]]; then
             exit 1
           fi

--- a/.github/workflows/runway-extension-release-and-submit.yml
+++ b/.github/workflows/runway-extension-release-and-submit.yml
@@ -2,33 +2,32 @@ name: Runway extension release and store submit
 
 # INFRA-3735 — Runway single entrypoint for release cut + CWS + AMO store uploads.
 #
-# Phase 0: validate branch, version, optional release_sha, CI, Runway sender (release/*).
+# Phase 0: validate branch, derive version from it, optional release_sha, CI, Runway sender (release/*).
 # Phase 1: workflow_call → publish-release-from-release-head.yml (auto-skipped if release exists at SHA)
 # Phase 2: workflow_call → upload-extension-to-cws.yml (production + flask; CWS pre-flight idempotency)
 # Phase 3: workflow_call → upload-extension-to-amo.yml (flask only; prod AMO triggered independently — no delayed-publish support)
 #
-# Runway contract: version, release_sha, execute_store_phases only.
+# Runway contract: no inputs required. The version is derived from the release/X.Y.Z branch
+# this workflow runs on (the branch is the single source of truth — there is no version input),
+# and all phases run by default. release_sha is an optional integrity check against the Runway
+# record; execute_store_phases=false gives a validation-only run; skip_* are manual break-glass
+# overrides. INFRA-3674 retired the bootstrap execute_store_phases=false default from #44017.
 # Recovery: re-run failed jobs on the same run, or re-dispatch (auto-skip handles completed phases).
-# skip_* inputs are manual break-glass overrides only.
 #
 # workflow_call (not gh workflow run) preserves Runway github.actor for WIF CEL on CWS/AMO.
 
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Release version X.Y.Z — must match release/X.Y.Z branch semver'
-        required: true
-        type: string
       release_sha:
         description: 'Optional integrity check — must match the commit this workflow runs on (Runway record)'
         required: false
         type: string
       execute_store_phases:
-        description: 'Run publish + store upload phases after validation'
+        description: 'Run publish + store upload phases after validation. Default true; set false for a validation-only run'
         required: false
         type: boolean
-        default: false
+        default: true
       skip_publish:
         description: 'Manual break-glass — skip Phase 1 (auto-skip also applies when GitHub Release exists at release_sha)'
         required: false
@@ -50,9 +49,11 @@ on:
         type: boolean
         default: false
 
-# One in-flight run per version (Runway must not double-dispatch). Queue, do not cancel.
+# One in-flight run per release branch (Runway must not double-dispatch). Queue, do not cancel.
+# Keyed on github.ref because the branch is 1:1 with the version and is the only version
+# source, matching publish-release-from-release-head.yml.
 concurrency:
-  group: runway-extension-release-and-submit-${{ inputs.version }}
+  group: runway-extension-release-and-submit-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -67,9 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      version: ${{ steps.validate-version.outputs.version }}
+      version: ${{ steps.derive-version.outputs.semver }}
       release_sha: ${{ steps.resolve-sha.outputs.release_sha }}
-      release_tag: ${{ steps.validate-version.outputs.release_tag }}
+      release_tag: v${{ steps.derive-version.outputs.semver }}
       release_exists: ${{ steps.detect-release.outputs.release_exists }}
     steps:
       - name: Checkout repository
@@ -89,26 +90,11 @@ jobs:
             exit 1
           fi
 
-      - name: Validate version input
-        id: validate-version
-        env:
-          VERSION: ${{ inputs.version }}
-          GITHUB_REF: ${{ github.ref }}
-        run: |
-          set -euo pipefail
-          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version: ${VERSION} — expected numeric X.Y.Z"
-            exit 1
-          fi
-          branch_version="${GITHUB_REF#refs/heads/release/}"
-          if [[ "${branch_version}" != "${VERSION}" ]]; then
-            echo "::error::Version input ${VERSION} does not match branch release/${branch_version}"
-            exit 1
-          fi
-          {
-            echo "version=${VERSION}"
-            echo "release_tag=v${VERSION}"
-          } >> "${GITHUB_OUTPUT}"
+      # Same derivation as publish-release-from-release-head.yml, so the orchestrator and the
+      # publish workflow it calls cannot disagree about which version is being released.
+      - name: Derive version from release branch
+        id: derive-version
+        run: .github/scripts/extract-semver.sh
 
       - name: Resolve release SHA
         id: resolve-sha
@@ -128,7 +114,7 @@ jobs:
         id: detect-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.validate-version.outputs.release_tag }}
+          RELEASE_TAG: v${{ steps.derive-version.outputs.semver }}
           RELEASE_SHA: ${{ steps.resolve-sha.outputs.release_sha }}
           EXECUTE_STORE: ${{ inputs.execute_store_phases }}
         run: |
@@ -180,7 +166,7 @@ jobs:
 
       - name: Summary
         env:
-          VERSION: ${{ steps.validate-version.outputs.version }}
+          VERSION: ${{ steps.derive-version.outputs.semver }}
           RELEASE_SHA: ${{ steps.resolve-sha.outputs.release_sha }}
           EXECUTE_STORE: ${{ inputs.execute_store_phases }}
           RELEASE_EXISTS: ${{ steps.detect-release.outputs.release_exists }}


### PR DESCRIPTION
## **Description**

The Runway orchestrator (`runway-extension-release-and-submit.yml`) took a required `version` input that had to equal the `release/X.Y.Z` branch semver. It therefore carried no information the branch did not already provide, added a way for the two to disagree, and Runway does not send it — the first real dispatch would have failed on a missing required input.

This removes the input and derives the version from the branch with `.github/scripts/extract-semver.sh`, the same script `publish-release-from-release-head.yml` uses, so the orchestrator and the publish workflow it calls cannot disagree about which version is being released.

Two follow-on changes fall out of that:

- `execute_store_phases` now defaults to `true`. The `false` default was a bootstrap safety measure from #44017 for merging the orchestrator before Runway was wired; leaving it would mean a Runway dispatch that omits the input validates everything and then does nothing. `false` is still available for a validation-only run.
- `concurrency` is keyed on `github.ref` instead of `inputs.version`, matching `publish-release-from-release-head.yml`. With the input gone the branch is the only version source, and one in-flight run per release branch is the same guarantee as one per version.

`release_sha` is unchanged and stays optional: it is an integrity check against the Runway record, not a version source. The `skip_*` break-glass inputs are unchanged.

### Also here: the AMO reviewer artifact publish has never worked

`Publish AMO reviewer artifacts to S3` has reported `✅ Published` in every release since it merged (#43785) while uploading nothing. `prd-va-mmc-extension-submission-amo-reviewer-source` currently holds **zero objects**. Two independent causes, both fixed here:

- **The step could never report failure.** It is `continue-on-error: true`, and the summary branched on `steps.amo-reviewer-s3.conclusion`, which is always `success` once `continue-on-error` is applied. The `⏭ Skipped` and `❌ Failed` branches were unreachable and the `exit 1` guard never fired. All three references now use `.outcome`.
- **`apt-get install -y mtree` installs a package that does not exist on Ubuntu.** `/usr/bin/mtree` comes from `mtree-netbsd`, which is the NetBSD flavour `compare_builds.sh` needs for `mtree -c -k sha256digest -p`. Verified in `ubuntu:24.04`: it installs from the default repos, and the exact invocations return 0 on identical trees and non-zero on a modified file.

The run history behind this: v13.39.0 through v13.41.0 died instantly at "Prepare all required actions" because `aws-actions/configure-aws-credentials` was not on the org actions allowlist — 0 seconds, nothing packaged, nothing uploaded. That allowlist entry exists now, so v13.42.0 got one step further and failed with `E: Unable to locate package mtree` (exit 100), which skipped the AWS credential and upload steps. The Firefox bundle script push in the same job is unaffected and has succeeded in all of those releases.

- **The job had no time budget for what this step does.** `timeout-minutes` was 45 while the publish job already spends ~9 minutes on Sentry, attestations and the release itself, and packaging adds two full cold production MV2 builds (main and Flask) for the reproducible-build comparison. Raised to 90.

The upload leg itself was reviewed against the platform side and matches: the `amo-reviewer-publisher` trust policy pins `sub=repo:MetaMask/metamask-extension:environment:release-branch`, `ref` under `refs/heads/release/*` and `job_workflow_ref` to this workflow file, all of which this job satisfies; the role's `s3:PutObject` grant on `reviewer-source/*` covers the keys the script writes; the bucket is `AES256` so no KMS grant is needed; and the object names match what the amo-submission Lambda reads. Note for future refactors: moving this step into a different workflow file would break the `job_workflow_ref` condition, and the role has no `ListBucket`/`GetObject`, so an S3 pre-flight check is not possible with these permissions.

Still unproven: because packaging has never completed in CI, the reproducible-build comparison in `compare_builds.sh` has never executed there. The build command it runs is character-identical to this workflow's own (`yarn webpack:lavamoat:build:mv2 [--type flask] --zip --env production`), `TZ=UTC` is set on both sides, and the comparison keys on content digests only, so checkout-vs-archive mtime differences are irrelevant. The next release is the first real test.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3674](https://consensyssoftware.atlassian.net/browse/INFRA-3674)

## **Manual testing steps**

CI-only change; no extension build or UI is involved.

Orchestrator version derivation, verifiable by dispatch:

1. On a `release/X.Y.Z` branch, dispatch **Runway extension release and store submit** with `execute_store_phases=false` (validation-only, cuts nothing and uploads nothing).
2. Confirm Phase 0's summary reports `Version: X.Y.Z` matching the branch, with no `version` input in the dispatch form.
3. Dispatch the same workflow from a non-release branch and confirm Phase 0 fails at **Validate branch ref**.
4. A human dispatch fails at Phase 0's Runway sender check, so end-to-end verification of the default `execute_store_phases=true` path requires a Runway-initiated dispatch on a real release branch.

AMO reviewer artifacts, only exercisable by a real release:

5. After the next production release, open the **Publish release** job summary. The `AMO reviewer S3 (PRD)` row can no longer be a false `✅ Published` — if packaging or upload fails it now reads `❌ Failed` and the job goes red.
6. Confirm four objects appear under `s3://prd-va-mmc-extension-submission-amo-reviewer-source/reviewer-source/X.Y.Z/` (production and Flask source zips plus their approval notes).
7. If the job does go red at that step, re-run failed jobs rather than re-dispatching: the tag and release creation ahead of it are idempotent and skip when already correct.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

[INFRA-3674]: https://consensyssoftware.atlassian.net/browse/INFRA-3674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

