### PR TITLE
fix: Prevent unsigned parameter forwarding to route handlers, and revert forwarding for `batch-sell`, `predict`, `trending`

### DIFF
--- a/shared/lib/deep-links/parse.test.ts
+++ b/shared/lib/deep-links/parse.test.ts
@@ -2,7 +2,7 @@ import log from 'loglevel';
 import { parse } from './parse';
 import { VALID, INVALID, MISSING, verify } from './verify';
 import { type Route, routes } from './routes';
-import { SIG_PARAM, SIG_PARAMS_PARAM } from './constants';
+import { SIG_PARAM } from './constants';
 
 const mockVerify = verify as jest.MockedFunction<typeof verify>;
 const mockRoutes = routes as jest.Mocked<Map<string, Route>>;
@@ -190,27 +190,6 @@ describe('parse', () => {
     // because it is not listed in `sig_params`
     expect(mockHandler).toHaveBeenCalledWith(
       new URLSearchParams([['value', '123']]),
-    );
-  });
-
-  it('passes original query parameters to routes that opt in', async () => {
-    mockRoutes.set('/test', {
-      handler: mockHandler,
-      handlerSearchParams: 'original',
-    } as unknown as Route);
-    mockVerify.mockResolvedValue(VALID);
-
-    const urlStr =
-      `https://example.com/test?marketId=30615&${SIG_PARAMS_PARAM}=marketId` +
-      `&${SIG_PARAM}=signature&utm_source=twitter&_hsenc=value&attributionId=attr`;
-
-    await parse(new URL(urlStr));
-
-    expect(mockHandler).toHaveBeenCalledWith(
-      new URLSearchParams(
-        `marketId=30615&${SIG_PARAMS_PARAM}=marketId&${SIG_PARAM}=signature` +
-          '&utm_source=twitter&_hsenc=value&attributionId=attr',
-      ),
     );
   });
 });

--- a/shared/lib/deep-links/parse.ts
+++ b/shared/lib/deep-links/parse.ts
@@ -36,19 +36,10 @@ export async function parse<Options extends ParseOptions = { verify: true }>(
   let destination: Destination;
   try {
     const canonicalUrl = new URL(canonicalize(url));
-    const canonicalSearchParams = new URLSearchParams(
-      canonicalUrl.searchParams,
-    );
     // canonicalize does not remove sig_params, as it is needed for verification
-    // but canonical route handlers should not receive it.
-    canonicalSearchParams.delete(SIG_PARAMS_PARAM);
-
-    const handlerSearchParams =
-      route.handlerSearchParams === 'original'
-        ? new URLSearchParams(url.searchParams)
-        : canonicalSearchParams;
-
-    destination = route.handler(handlerSearchParams);
+    // but we do not want to pass it to the route handler, so we remove it
+    canonicalUrl.searchParams.delete(SIG_PARAMS_PARAM);
+    destination = route.handler(canonicalUrl.searchParams);
   } catch (error) {
     // tab may have closed in the meantime, the searchParams may have
     // been rejected by the handler, etc.

--- a/shared/lib/deep-links/routes/batch-sell.test.ts
+++ b/shared/lib/deep-links/routes/batch-sell.test.ts
@@ -3,10 +3,6 @@ import { HomeQueryParams } from './home';
 import { DEFAULT_ROUTE } from './route';
 
 describe('batch-sell deep link route', () => {
-  it('forwards only signature-covered query parameters', () => {
-    expect(batchSell.handlerSearchParams).toBe('canonical');
-  });
-
   it('opens the default route with QR modal params for the batch sell deeplink', () => {
     const params = new URLSearchParams();
 

--- a/shared/lib/deep-links/routes/batch-sell.test.ts
+++ b/shared/lib/deep-links/routes/batch-sell.test.ts
@@ -3,8 +3,8 @@ import { HomeQueryParams } from './home';
 import { DEFAULT_ROUTE } from './route';
 
 describe('batch-sell deep link route', () => {
-  it('uses original query parameters in the QR deeplink', () => {
-    expect(batchSell.handlerSearchParams).toBe('original');
+  it('forwards only signature-covered query parameters', () => {
+    expect(batchSell.handlerSearchParams).toBe('canonical');
   });
 
   it('opens the default route with QR modal params for the batch sell deeplink', () => {

--- a/shared/lib/deep-links/routes/batch-sell.ts
+++ b/shared/lib/deep-links/routes/batch-sell.ts
@@ -8,7 +8,6 @@ import { Route } from './route';
 export const batchSell = new Route({
   pathname: '/batch-sell',
   getTitle: (_: URLSearchParams) => 'deepLink_theBatchSellPage',
-  handlerSearchParams: 'original',
   handler: function handler(params: URLSearchParams) {
     const deeplinkUrl = new URL('/batch-sell', DEEP_LINK_ORIGIN);
     params.forEach((value, key) => deeplinkUrl.searchParams.append(key, value));

--- a/shared/lib/deep-links/routes/predict.test.ts
+++ b/shared/lib/deep-links/routes/predict.test.ts
@@ -3,8 +3,8 @@ import { HomeQueryParams } from './home';
 import { DEFAULT_ROUTE } from './route';
 
 describe('predict deep link route', () => {
-  it('uses original query parameters in the QR deeplink', () => {
-    expect(predict.handlerSearchParams).toBe('original');
+  it('forwards only signature-covered query parameters', () => {
+    expect(predict.handlerSearchParams).toBe('canonical');
   });
 
   it('opens the default route with QR modal params and preserves every query parameter in the encoded deeplink', () => {

--- a/shared/lib/deep-links/routes/predict.test.ts
+++ b/shared/lib/deep-links/routes/predict.test.ts
@@ -3,14 +3,8 @@ import { HomeQueryParams } from './home';
 import { DEFAULT_ROUTE } from './route';
 
 describe('predict deep link route', () => {
-  it('forwards only signature-covered query parameters', () => {
-    expect(predict.handlerSearchParams).toBe('canonical');
-  });
-
-  it('opens the default route with QR modal params and preserves every query parameter in the encoded deeplink', () => {
-    const params = new URLSearchParams(
-      'marketId=30615&sig_params=marketId&sig=signature&utm_source=twitter&_hsenc=value&attributionId=attr',
-    );
+  it('opens the default route with QR modal params and includes query parameters in the encoded deeplink', () => {
+    const params = new URLSearchParams('marketId=30615');
 
     const destination = predict.handler(params);
 
@@ -20,8 +14,6 @@ describe('predict deep link route', () => {
       (destination as { query: URLSearchParams }).query.get(
         HomeQueryParams.PredictDeeplinkUrl,
       ),
-    ).toBe(
-      'https://link.metamask.io/predict?marketId=30615&sig_params=marketId&sig=signature&utm_source=twitter&_hsenc=value&attributionId=attr',
-    );
+    ).toBe('https://link.metamask.io/predict?marketId=30615');
   });
 });

--- a/shared/lib/deep-links/routes/predict.ts
+++ b/shared/lib/deep-links/routes/predict.ts
@@ -8,7 +8,6 @@ import { Route } from './route';
 export const predict = new Route({
   pathname: '/predict',
   getTitle: (_: URLSearchParams) => 'deepLink_thePredictPage',
-  handlerSearchParams: 'original',
   handler: function handler(params: URLSearchParams) {
     const deeplinkUrl = new URL('/predict', DEEP_LINK_ORIGIN);
     params.forEach((value, key) => deeplinkUrl.searchParams.append(key, value));

--- a/shared/lib/deep-links/routes/route.test.ts
+++ b/shared/lib/deep-links/routes/route.test.ts
@@ -33,15 +33,6 @@ describe('Route', () => {
     expect(route.handler).toBe(mockHandler);
   });
 
-  it('defaults handlerSearchParams to canonical', () => {
-    expect(route.handlerSearchParams).toBe('canonical');
-  });
-
-  it('assigns handlerSearchParams from options', () => {
-    route = new Route({ ...options, handlerSearchParams: 'original' });
-    expect(route.handlerSearchParams).toBe('original');
-  });
-
   it('should call getTitle with URLSearchParams', () => {
     const params = new URLSearchParams({ foo: 'bar' });
     route.getTitle(params);

--- a/shared/lib/deep-links/routes/route.ts
+++ b/shared/lib/deep-links/routes/route.ts
@@ -31,8 +31,6 @@ export type Destination =
       redirectTo: URL;
     };
 
-export type HandlerSearchParams = 'canonical' | 'original';
-
 export type RouteOptions = {
   /**
    * The pathname of the route.
@@ -50,11 +48,6 @@ export type RouteOptions = {
    * @throws if the handler fails to process the params
    */
   handler: (params: URLSearchParams) => Destination;
-  /**
-   * Controls which search params are passed to the route handler.
-   * Defaults to canonical params, which removes unsigned params for signed links.
-   */
-  handlerSearchParams?: HandlerSearchParams;
 };
 
 export const SWAP_ROUTE = `${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`;
@@ -80,15 +73,9 @@ export class Route {
    */
   public readonly handler: RouteOptions['handler'];
 
-  /**
-   * @see {@link RouteOptions.handlerSearchParams}
-   */
-  public readonly handlerSearchParams: HandlerSearchParams;
-
   constructor(options: RouteOptions) {
     this.pathname = options.pathname.toLowerCase();
     this.getTitle = options.getTitle;
     this.handler = options.handler;
-    this.handlerSearchParams = options.handlerSearchParams ?? 'canonical';
   }
 }

--- a/shared/lib/deep-links/routes/trending.test.ts
+++ b/shared/lib/deep-links/routes/trending.test.ts
@@ -3,10 +3,6 @@ import { DEFAULT_ROUTE } from './route';
 import { trending } from './trending';
 
 describe('trending deep link route', () => {
-  it('forwards only signature-covered query parameters', () => {
-    expect(trending.handlerSearchParams).toBe('canonical');
-  });
-
   it('opens the default route with QR modal params for the trending deeplink', () => {
     const params = new URLSearchParams();
 
@@ -21,7 +17,7 @@ describe('trending deep link route', () => {
     ).toBe('https://link.metamask.io/trending');
   });
 
-  it('preserves the original query parameters in the QR deeplink', () => {
+  it('includes query parameters in the QR deeplink', () => {
     const params = new URLSearchParams({ tab: 'crypto' });
 
     const destination = trending.handler(params);

--- a/shared/lib/deep-links/routes/trending.test.ts
+++ b/shared/lib/deep-links/routes/trending.test.ts
@@ -3,8 +3,8 @@ import { DEFAULT_ROUTE } from './route';
 import { trending } from './trending';
 
 describe('trending deep link route', () => {
-  it('uses original query parameters in the QR deeplink', () => {
-    expect(trending.handlerSearchParams).toBe('original');
+  it('forwards only signature-covered query parameters', () => {
+    expect(trending.handlerSearchParams).toBe('canonical');
   });
 
   it('opens the default route with QR modal params for the trending deeplink', () => {

--- a/shared/lib/deep-links/routes/trending.ts
+++ b/shared/lib/deep-links/routes/trending.ts
@@ -8,7 +8,6 @@ import { Route } from './route';
 export const trending = new Route({
   pathname: '/trending',
   getTitle: (_: URLSearchParams) => 'deepLink_theTrendingPage',
-  handlerSearchParams: 'original',
   handler: function handler(params: URLSearchParams) {
     const deeplinkUrl = new URL('/trending', DEEP_LINK_ORIGIN);
     params.forEach((value, key) => deeplinkUrl.searchParams.append(key, value));


### PR DESCRIPTION
## **Description**

Three deep-link routes forwarded query parameters that the link's signature never covered into the QR-code destination they generate. This removes those three opt-ins **and** the mechanism that made opting out possible.

> [!IMPORTANT]
> **This drops params.** Any `batch-sell`, `predict`, or `trending` link relying on unsigned params (attribution/UTM tags, extra query params) stops having them forwarded into the generated QR deeplink. That is the intended effect. A link that needs a param forwarded should list it in `sig_params` so it is signed, not restore the opt-out.

**Commits**

- **`c840905`** — deletes `handlerSearchParams: 'original'` from `batch-sell`, `predict`, and `trending`, the three routes on `main` that still set it.
- **`8136baf`** — removes the escape hatch itself: the `HandlerSearchParams` type, the `RouteOptions.handlerSearchParams` option, the `Route` class field and its default, and the branch in `parse.ts`. Handlers now always receive canonicalized params with `sig_params` stripped. Authored by @davidmurdoch, cherry-picked from #45106.

### Why

[ADR-0011 "Deep linking into wallet"](https://github.com/MetaMask/decisions/blob/main/decisions/core/0011-deep-linking-into-wallet.md) grants a signed deep link the reduced-friction *trusted flow* on one condition:

> This is acceptable from a security perspective **if the deep link includes a signature in its query parameters, which is verified on the client side before redirecting the user.**

The guarantee therefore extends exactly as far as the signature covers. [`canonicalize.ts`](https://github.com/MetaMask/metamask-extension/blob/main/shared/lib/deep-links/canonicalize.ts) signs *only* the params named in the link's own `sig_params` list. Params outside that list can be appended without invalidating the signature: the link still verifies as `VALID`.

Before this PR, [`parse.ts`](https://github.com/MetaMask/metamask-extension/blob/main/shared/lib/deep-links/parse.ts) let a route opt out via `handlerSearchParams: 'original'`, handing its handler the raw query rather than the canonical one. All three routes then appended every inbound param into a reconstructed URL passed to `createHomeQrCodeDestination` — so attacker-appended params on an otherwise-valid signed link reached that destination unfiltered.

The handlers still append every param they are given. Containment is not in the routes but in `parse.ts`, which decides what to hand them.

<details>
<summary>The three code paths</summary>

`canonicalize.ts` — only `sig_params`-named keys are signed:

```js
const allowedParams = sigParams.split(',');
for (const allowedParam of allowedParams) {
  const values = url.searchParams.getAll(allowedParam);
  ...
}
```

`parse.ts` — the removed branch:

```js
const handlerSearchParams =
  route.handlerSearchParams === 'original'
    ? new URLSearchParams(url.searchParams)   // includes unsigned params
    : canonicalSearchParams;                  // signature-covered only
```

Each route handler — wholesale append, no allowlist:

```js
const deeplinkUrl = new URL('/predict', DEEP_LINK_ORIGIN);
params.forEach((value, key) => deeplinkUrl.searchParams.append(key, value));
```

</details>

### Coverage

`'canonical'` was already the `Route` default and `'original'` an opt-in, so removing it per route was a one-line deletion. After this PR the option does not exist at all, which makes the coverage check below structurally empty rather than merely passing:

```bash
git grep -n "andlerSearchParams" -- shared/lib/deep-links/
```

Any future hit is a reintroduction of the mechanism, not a route taking an existing opt-out.

## **Changelog**

CHANGELOG entry: Fixed deep links to exclude unsigned parameters from the QR code destinations generated for `batch-sell`, `predict`, and `trending`

## **Related issues**

Context: #44324, #45087, #45106

## **Manual testing steps**

1. Generate a signed deep link for `/predict` (or `/batch-sell`, `/trending`) whose `sig_params` covers only its intended params.
2. Append an extra query param that is *not* listed in `sig_params`.
3. Open the link and confirm it still verifies as validly signed — the signature covers only the `sig_params` set.
4. Confirm the appended param is no longer forwarded into the deeplink URL handed to `createHomeQrCodeDestination`. Before this change it was forwarded verbatim; after, only signature-covered params are.
5. Open *unsigned* `/predict`, `/trending`, and `/batch-sell` links and confirm their QR modals still open with their query parameters included — canonicalization only constrains signed links.

## **Automated testing**

`yarn jest shared/lib/deep-links` — **20 suites, 186 tests passed** at `8136baf`.

- **192 on `main` → 186 here**, because six tests asserted on the removed option and have no successor: one in `parse.test.ts`, two in `route.test.ts`, one each in the three route tests.
- **Regression coverage survives** in `parse.test.ts`: the `sig_params=value&value=123&foo=bar` case asserts the signed `value` reaches the handler and the unsigned `foo` does not. That test fails if the bypass is reintroduced.

## **Screenshots/Recordings**

N/A — no user-visible UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes deep-link security boundaries: unsigned query params can no longer reach handlers or QR destinations on affected routes; attribution/unsigned params must be included in `sig_params` to be forwarded.
> 
> **Overview**
> **Removes the `handlerSearchParams` opt-in** so deep link route handlers always receive **canonicalized** query params (signature-covered keys only), with `sig_params` stripped—no route can request the raw URL query anymore.
> 
> `parse.ts` now deletes `sig_params` on the canonical URL and passes those search params to every handler. **`batch-sell`**, **`predict`**, and **`trending`** no longer set `handlerSearchParams: 'original'`, so unsigned extras (e.g. UTM/tracking) are **not** copied into the QR deeplink URLs those handlers build. Tests were updated to drop coverage of the removed option; signed-link filtering is still asserted in `parse.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8136baf883cb56a9a894ee4f41f196a4eae2ad93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



