### PR TITLE
fix: remove handlerSearchParams bypass from deep links

### DIFF
--- a/shared/lib/deep-links/parse.test.ts
+++ b/shared/lib/deep-links/parse.test.ts
@@ -2,7 +2,7 @@ import log from 'loglevel';
 import { parse } from './parse';
 import { VALID, INVALID, MISSING, verify } from './verify';
 import { type Route, routes } from './routes';
-import { SIG_PARAM, SIG_PARAMS_PARAM } from './constants';
+import { SIG_PARAM } from './constants';
 
 const mockVerify = verify as jest.MockedFunction<typeof verify>;
 const mockRoutes = routes as jest.Mocked<Map<string, Route>>;
@@ -190,27 +190,6 @@ describe('parse', () => {
     // because it is not listed in `sig_params`
     expect(mockHandler).toHaveBeenCalledWith(
       new URLSearchParams([['value', '123']]),
-    );
-  });
-
-  it('passes original query parameters to routes that opt in', async () => {
-    mockRoutes.set('/test', {
-      handler: mockHandler,
-      handlerSearchParams: 'original',
-    } as unknown as Route);
-    mockVerify.mockResolvedValue(VALID);
-
-    const urlStr =
-      `https://example.com/test?marketId=30615&${SIG_PARAMS_PARAM}=marketId` +
-      `&${SIG_PARAM}=signature&utm_source=twitter&_hsenc=value&attributionId=attr`;
-
-    await parse(new URL(urlStr));
-
-    expect(mockHandler).toHaveBeenCalledWith(
-      new URLSearchParams(
-        `marketId=30615&${SIG_PARAMS_PARAM}=marketId&${SIG_PARAM}=signature` +
-          '&utm_source=twitter&_hsenc=value&attributionId=attr',
-      ),
     );
   });
 });

--- a/shared/lib/deep-links/parse.ts
+++ b/shared/lib/deep-links/parse.ts
@@ -36,19 +36,10 @@ export async function parse<Options extends ParseOptions = { verify: true }>(
   let destination: Destination;
   try {
     const canonicalUrl = new URL(canonicalize(url));
-    const canonicalSearchParams = new URLSearchParams(
-      canonicalUrl.searchParams,
-    );
     // canonicalize does not remove sig_params, as it is needed for verification
-    // but canonical route handlers should not receive it.
-    canonicalSearchParams.delete(SIG_PARAMS_PARAM);
-
-    const handlerSearchParams =
-      route.handlerSearchParams === 'original'
-        ? new URLSearchParams(url.searchParams)
-        : canonicalSearchParams;
-
-    destination = route.handler(handlerSearchParams);
+    // but we do not want to pass it to the route handler, so we remove it
+    canonicalUrl.searchParams.delete(SIG_PARAMS_PARAM);
+    destination = route.handler(canonicalUrl.searchParams);
   } catch (error) {
     // tab may have closed in the meantime, the searchParams may have
     // been rejected by the handler, etc.

--- a/shared/lib/deep-links/routes/batch-sell.test.ts
+++ b/shared/lib/deep-links/routes/batch-sell.test.ts
@@ -3,10 +3,6 @@ import { HomeQueryParams } from './home';
 import { DEFAULT_ROUTE } from './route';
 
 describe('batch-sell deep link route', () => {
-  it('uses original query parameters in the QR deeplink', () => {
-    expect(batchSell.handlerSearchParams).toBe('original');
-  });
-
   it('opens the default route with QR modal params for the batch sell deeplink', () => {
     const params = new URLSearchParams();
 

--- a/shared/lib/deep-links/routes/batch-sell.ts
+++ b/shared/lib/deep-links/routes/batch-sell.ts
@@ -8,7 +8,6 @@ import { Route } from './route';
 export const batchSell = new Route({
   pathname: '/batch-sell',
   getTitle: (_: URLSearchParams) => 'deepLink_theBatchSellPage',
-  handlerSearchParams: 'original',
   handler: function handler(params: URLSearchParams) {
     const deeplinkUrl = new URL('/batch-sell', DEEP_LINK_ORIGIN);
     params.forEach((value, key) => deeplinkUrl.searchParams.append(key, value));

--- a/shared/lib/deep-links/routes/predict.test.ts
+++ b/shared/lib/deep-links/routes/predict.test.ts
@@ -3,14 +3,8 @@ import { HomeQueryParams } from './home';
 import { DEFAULT_ROUTE } from './route';
 
 describe('predict deep link route', () => {
-  it('uses original query parameters in the QR deeplink', () => {
-    expect(predict.handlerSearchParams).toBe('original');
-  });
-
-  it('opens the default route with QR modal params and preserves every query parameter in the encoded deeplink', () => {
-    const params = new URLSearchParams(
-      'marketId=30615&sig_params=marketId&sig=signature&utm_source=twitter&_hsenc=value&attributionId=attr',
-    );
+  it('opens the default route with QR modal params and includes query parameters in the encoded deeplink', () => {
+    const params = new URLSearchParams('marketId=30615');
 
     const destination = predict.handler(params);
 
@@ -20,8 +14,6 @@ describe('predict deep link route', () => {
       (destination as { query: URLSearchParams }).query.get(
         HomeQueryParams.PredictDeeplinkUrl,
       ),
-    ).toBe(
-      'https://link.metamask.io/predict?marketId=30615&sig_params=marketId&sig=signature&utm_source=twitter&_hsenc=value&attributionId=attr',
-    );
+    ).toBe('https://link.metamask.io/predict?marketId=30615');
   });
 });

--- a/shared/lib/deep-links/routes/predict.ts
+++ b/shared/lib/deep-links/routes/predict.ts
@@ -8,7 +8,6 @@ import { Route } from './route';
 export const predict = new Route({
   pathname: '/predict',
   getTitle: (_: URLSearchParams) => 'deepLink_thePredictPage',
-  handlerSearchParams: 'original',
   handler: function handler(params: URLSearchParams) {
     const deeplinkUrl = new URL('/predict', DEEP_LINK_ORIGIN);
     params.forEach((value, key) => deeplinkUrl.searchParams.append(key, value));

--- a/shared/lib/deep-links/routes/route.test.ts
+++ b/shared/lib/deep-links/routes/route.test.ts
@@ -33,15 +33,6 @@ describe('Route', () => {
     expect(route.handler).toBe(mockHandler);
   });
 
-  it('defaults handlerSearchParams to canonical', () => {
-    expect(route.handlerSearchParams).toBe('canonical');
-  });
-
-  it('assigns handlerSearchParams from options', () => {
-    route = new Route({ ...options, handlerSearchParams: 'original' });
-    expect(route.handlerSearchParams).toBe('original');
-  });
-
   it('should call getTitle with URLSearchParams', () => {
     const params = new URLSearchParams({ foo: 'bar' });
     route.getTitle(params);

--- a/shared/lib/deep-links/routes/route.ts
+++ b/shared/lib/deep-links/routes/route.ts
@@ -31,8 +31,6 @@ export type Destination =
       redirectTo: URL;
     };
 
-export type HandlerSearchParams = 'canonical' | 'original';
-
 export type RouteOptions = {
   /**
    * The pathname of the route.
@@ -50,11 +48,6 @@ export type RouteOptions = {
    * @throws if the handler fails to process the params
    */
   handler: (params: URLSearchParams) => Destination;
-  /**
-   * Controls which search params are passed to the route handler.
-   * Defaults to canonical params, which removes unsigned params for signed links.
-   */
-  handlerSearchParams?: HandlerSearchParams;
 };
 
 export const SWAP_ROUTE = `${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`;
@@ -80,15 +73,9 @@ export class Route {
    */
   public readonly handler: RouteOptions['handler'];
 
-  /**
-   * @see {@link RouteOptions.handlerSearchParams}
-   */
-  public readonly handlerSearchParams: HandlerSearchParams;
-
   constructor(options: RouteOptions) {
     this.pathname = options.pathname.toLowerCase();
     this.getTitle = options.getTitle;
     this.handler = options.handler;
-    this.handlerSearchParams = options.handlerSearchParams ?? 'canonical';
   }
 }

--- a/shared/lib/deep-links/routes/trending.test.ts
+++ b/shared/lib/deep-links/routes/trending.test.ts
@@ -3,10 +3,6 @@ import { DEFAULT_ROUTE } from './route';
 import { trending } from './trending';
 
 describe('trending deep link route', () => {
-  it('uses original query parameters in the QR deeplink', () => {
-    expect(trending.handlerSearchParams).toBe('original');
-  });
-
   it('opens the default route with QR modal params for the trending deeplink', () => {
     const params = new URLSearchParams();
 
@@ -21,7 +17,7 @@ describe('trending deep link route', () => {
     ).toBe('https://link.metamask.io/trending');
   });
 
-  it('preserves the original query parameters in the QR deeplink', () => {
+  it('includes query parameters in the QR deeplink', () => {
     const params = new URLSearchParams({ tab: 'crypto' });
 
     const destination = trending.handler(params);

--- a/shared/lib/deep-links/routes/trending.ts
+++ b/shared/lib/deep-links/routes/trending.ts
@@ -8,7 +8,6 @@ import { Route } from './route';
 export const trending = new Route({
   pathname: '/trending',
   getTitle: (_: URLSearchParams) => 'deepLink_theTrendingPage',
-  handlerSearchParams: 'original',
   handler: function handler(params: URLSearchParams) {
     const deeplinkUrl = new URL('/trending', DEEP_LINK_ORIGIN);
     params.forEach((value, key) => deeplinkUrl.searchParams.append(key, value));


### PR DESCRIPTION
## **Description**

[PR #43153](https://github.com/MetaMask/metamask-extension/pull/43153) introduced `handlerSearchParams` as a route-level escape hatch that allowed selected deep-link handlers to receive the original query string instead of canonicalized parameters.

This change removes the `HandlerSearchParams` type, route option, parser branch, and all route opt-ins. Deep-link handlers now always receive canonicalized search parameters after `sig_params` is removed. This prevents signed deep links from forwarding unsigned parameters or signature metadata to route handlers.

The QR-code handoff added by the original PR remains in place for predict, trending, and batch-sell deep links.

## **Changelog**

CHANGELOG entry: Fixed deep links to exclude unverified parameters from QR code destinations

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Build and run the extension.
2. Open a signed `/predict` deep link containing `marketId`, `sig_params`, `sig`, and an unsigned `utm_source` parameter.
3. Verify the Home QR modal opens, then scan the QR code and confirm its URL contains the canonical `marketId` parameter but excludes `sig_params`, `sig`, and the unsigned `utm_source` parameter.
4. Open unsigned `/predict`, `/trending`, and `/batch-sell` deep links and verify their QR modals still open with their query parameters included.

## **Automated testing**

- `yarn test:unit shared/lib/deep-links` — 20 suites and 186 tests passed.
- Repository formatting check passed for all changed files.

<!--
## **Screenshots/Recordings**

### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
