### PR TITLE
test(ramps): QA Chrome build with rampsEnabled + prod API

### DIFF
--- a/shared/lib/ramps/environment.test.ts
+++ b/shared/lib/ramps/environment.test.ts
@@ -24,6 +24,16 @@ describe('getRampsEnvironment', () => {
     expect(getRampsEnvironment()).toBe(RampsEnvironment.Production);
   });
 
+  it('returns Production for METAMASK_ENVIRONMENT=release-candidate', () => {
+    process.env.METAMASK_ENVIRONMENT = 'release-candidate';
+    expect(getRampsEnvironment()).toBe(RampsEnvironment.Production);
+  });
+
+  it('returns Production for METAMASK_ENVIRONMENT=pull-request', () => {
+    process.env.METAMASK_ENVIRONMENT = 'pull-request';
+    expect(getRampsEnvironment()).toBe(RampsEnvironment.Production);
+  });
+
   it('returns Development for METAMASK_ENVIRONMENT=development', () => {
     process.env.METAMASK_ENVIRONMENT = 'development';
     expect(getRampsEnvironment()).toBe(RampsEnvironment.Development);
@@ -36,6 +46,16 @@ describe('getRampsEnvironment', () => {
 
   it('returns Staging for METAMASK_ENVIRONMENT=testing', () => {
     process.env.METAMASK_ENVIRONMENT = 'testing';
+    expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
+  });
+
+  it('returns Staging for METAMASK_ENVIRONMENT=staging', () => {
+    process.env.METAMASK_ENVIRONMENT = 'staging';
+    expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
+  });
+
+  it('returns Staging for METAMASK_ENVIRONMENT=other', () => {
+    process.env.METAMASK_ENVIRONMENT = 'other';
     expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
   });
 

--- a/shared/lib/ramps/environment.ts
+++ b/shared/lib/ramps/environment.ts
@@ -6,6 +6,11 @@ import { RampsEnvironment } from '@metamask/ramps-controller';
  * Lives in `shared` because the UI needs it too: the provider callback URL it
  * builds has to point at the same ramps environment the background talks to.
  *
+ * Build system emits `METAMASK_ENVIRONMENT` values from
+ * `shared/constants/build-environment.json` (e.g. `release-candidate`,
+ * `pull-request`). Those must be mapped here — matching only shorthand values
+ * like `rc` never fires for real CI builds.
+ *
  * @returns The ramps environment for API requests.
  */
 export function getRampsEnvironment(): RampsEnvironment {
@@ -13,13 +18,22 @@ export function getRampsEnvironment(): RampsEnvironment {
   switch (metamaskEnvironment) {
     case 'production':
     case 'beta':
+    // Legacy / shorthand — kept for compatibility.
     case 'rc':
+    // Actual value emitted for release/* CI builds.
+    case 'release-candidate':
+    // PR CI builds: keep remote feature flags on `dev` (where `rampsEnabled`
+    // is on) while pointing the ramps API + callback host at Production.
+    case 'pull-request':
       return RampsEnvironment.Production;
     case 'development':
     case 'dev':
       return RampsEnvironment.Development;
     case 'test':
     case 'testing':
+    // `staging` = main-branch dist builds; `other` = local `yarn dist`.
+    case 'staging':
+    case 'other':
     default:
       return RampsEnvironment.Staging;
   }

--- a/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.test.tsx
+++ b/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.test.tsx
@@ -122,7 +122,9 @@ beforeEach(() => {
 });
 
 describe('useRampsNavigation goToBuy', () => {
-  it('flag off → opens Portfolio (no modal, no geolocation lookup)', async () => {
+  // TEST PR: getIsRampsEnabled is forced on, so a remote `false` still takes
+  // the in-app path (geolocation lookup) rather than Portfolio fallback.
+  it('remote flag false still uses in-app path when QA force-on is active', async () => {
     const { result, getModalName } = run(
       buildState({
         remoteFeatureFlags: {
@@ -132,8 +134,7 @@ describe('useRampsNavigation goToBuy', () => {
       }),
     );
     await goToBuy(result);
-    expect(openTab).toHaveBeenCalled();
-    expect(mockGetGeolocation).not.toHaveBeenCalled();
+    expect(mockGetGeolocation).toHaveBeenCalled();
     expect(getModalName()).toBeNull();
   });
 

--- a/ui/selectors/ramps-feature-flags.test.ts
+++ b/ui/selectors/ramps-feature-flags.test.ts
@@ -6,19 +6,22 @@ import {
 const mk = (flags = {}) => ({ metamask: { remoteFeatureFlags: flags } });
 
 describe('ramps feature-flag selectors', () => {
-  // TEST PR: getIsRampsEnabled is forced on for prod-ramps QA.
+  // TEMP QA: getIsRampsEnabled is forced on for prod-ramps QA.
   it('getIsRampsEnabled is forced on for this QA branch', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(getIsRampsEnabled(mk() as any)).toBe(true);
   });
+
   it('getIsRampsEnabled stays on even when remote flag is false', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(getIsRampsEnabled(mk({ rampsEnabled: false }) as any)).toBe(true);
   });
+
   it('getIsRampsServiceDisruptionActive defaults to false', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(getIsRampsServiceDisruptionActive(mk() as any)).toBe(false);
   });
+
   it('getIsRampsServiceDisruptionActive reads the flag', () => {
     expect(
       getIsRampsServiceDisruptionActive(

--- a/ui/selectors/ramps-feature-flags.test.ts
+++ b/ui/selectors/ramps-feature-flags.test.ts
@@ -6,46 +6,14 @@ import {
 const mk = (flags = {}) => ({ metamask: { remoteFeatureFlags: flags } });
 
 describe('ramps feature-flag selectors', () => {
-  it('getIsRampsEnabled defaults to false', () => {
+  // TEST PR: getIsRampsEnabled is forced on for prod-ramps QA.
+  it('getIsRampsEnabled is forced on for this QA branch', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(getIsRampsEnabled(mk() as any)).toBe(false);
+    expect(getIsRampsEnabled(mk() as any)).toBe(true);
   });
-  it('getIsRampsEnabled reads the flag', () => {
+  it('getIsRampsEnabled stays on even when remote flag is false', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(getIsRampsEnabled(mk({ rampsEnabled: true }) as any)).toBe(true);
-  });
-  it('getIsRampsEnabled reads a version-gated flag', () => {
-    expect(
-      getIsRampsEnabled(
-        mk({
-          rampsEnabled: { enabled: true, minimumVersion: '0.0.0' },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any,
-      ),
-    ).toBe(true);
-  });
-  it('getIsRampsEnabled is false when the minimum version is not met', () => {
-    expect(
-      getIsRampsEnabled(
-        mk({
-          rampsEnabled: { enabled: true, minimumVersion: '9999.0.0' },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any,
-      ),
-    ).toBe(false);
-  });
-  it('getIsRampsEnabled reads a progressive rollout wrapped flag', () => {
-    expect(
-      getIsRampsEnabled(
-        mk({
-          rampsEnabled: {
-            name: 'rollout',
-            value: { enabled: true, minimumVersion: '0.0.0' },
-          },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any,
-      ),
-    ).toBe(true);
+    expect(getIsRampsEnabled(mk({ rampsEnabled: false }) as any)).toBe(true);
   });
   it('getIsRampsServiceDisruptionActive defaults to false', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ui/selectors/ramps-feature-flags.ts
+++ b/ui/selectors/ramps-feature-flags.ts
@@ -1,19 +1,19 @@
 import { createSelector } from 'reselect';
 import { getRemoteFeatureFlags } from '../../shared/lib/selectors/remote-feature-flags';
-import { getBooleanFeatureFlag } from '../../shared/lib/remote-feature-flag-utils';
 
 /**
  * Selector to determine if the ramps feature is enabled.
- * Supports version-gated and progressive rollout flag formats, e.g.
- * `{ enabled: true, minimumVersion: '13.41.0' }` or
- * `{ name: 'rollout', value: { enabled: true, minimumVersion: '13.41.0' } }`.
  *
- * @param state - The root Redux state object.
+ * TEST PR (`test/tram-3718-prod-ramps-qa`): force ON so QA does not depend on
+ * client-config `rc`/`prod` (where `rampsEnabled` is currently false).
+ *
+ * @param _state - The root Redux state object.
  * @returns Boolean indicating whether ramps feature is enabled.
  */
 export const getIsRampsEnabled = createSelector(
   getRemoteFeatureFlags,
-  (flags) => getBooleanFeatureFlag(flags?.rampsEnabled, false),
+  // TEST PR override — always enable native ramps for this QA branch.
+  (_flags) => true,
 );
 
 /**

--- a/ui/selectors/ramps-feature-flags.ts
+++ b/ui/selectors/ramps-feature-flags.ts
@@ -4,15 +4,17 @@ import { getRemoteFeatureFlags } from '../../shared/lib/selectors/remote-feature
 /**
  * Selector to determine if the ramps feature is enabled.
  *
- * TEST PR (`test/tram-3718-prod-ramps-qa`): force ON so QA does not depend on
- * client-config `rc`/`prod` (where `rampsEnabled` is currently false).
+ * TEMP QA (`test/tram-3718-prod-ramps-qa`): forced ON. Client-config currently
+ * has `rampsEnabled` enabled for `dev` but disabled for `rc`/`prod`. Forcing
+ * here keeps native ramps usable while this branch points the ramps API at
+ * Production. Do not merge this override to `main`.
  *
  * @param _state - The root Redux state object.
  * @returns Boolean indicating whether ramps feature is enabled.
  */
 export const getIsRampsEnabled = createSelector(
   getRemoteFeatureFlags,
-  // TEST PR override — always enable native ramps for this QA branch.
+  // TEMP QA override — always enable native ramps for this branch.
   (_flags) => true,
 );
 


### PR DESCRIPTION
## Summary
- Temporary **test PR** stacked on [#44948](https://github.com/MetaMask/metamask-extension/pull/44948) (`tram-3718-orders`) for Chrome QA.
- Force `getIsRampsEnabled` **ON** (client-config has `rampsEnabled` off for `rc`/`prod`).
- Map `pull-request` / `release-candidate` / `staging` / `other` → **ramps Production** (`on-ramp.api.cx.metamask.io`).

## Not for merge
Do not merge. Close after QA. Revert these overrides before any production path.

## Test plan
- [ ] Install Chrome zip from this PR's Main CI `build-dist-webpack` artifact
- [ ] Confirm native Buy is available (`rampsEnabled` forced on)
- [ ] Confirm network calls go to `on-ramp.api.cx.metamask.io` (not uat/dev)
- [ ] Exercise Buy → Activity / toasts from parent PR


Made with [Cursor](https://cursor.com)