### PR TITLE
fix(ramps): map release-candidate builds to Production API

### DIFF
--- a/shared/lib/ramps/environment.test.ts
+++ b/shared/lib/ramps/environment.test.ts
@@ -24,6 +24,11 @@ describe('getRampsEnvironment', () => {
     expect(getRampsEnvironment()).toBe(RampsEnvironment.Production);
   });
 
+  it('returns Production for METAMASK_ENVIRONMENT=release-candidate', () => {
+    process.env.METAMASK_ENVIRONMENT = 'release-candidate';
+    expect(getRampsEnvironment()).toBe(RampsEnvironment.Production);
+  });
+
   it('returns Development for METAMASK_ENVIRONMENT=development', () => {
     process.env.METAMASK_ENVIRONMENT = 'development';
     expect(getRampsEnvironment()).toBe(RampsEnvironment.Development);

--- a/shared/lib/ramps/environment.ts
+++ b/shared/lib/ramps/environment.ts
@@ -9,7 +9,8 @@ import { RampsEnvironment } from '@metamask/ramps-controller';
  * Build CI emits `METAMASK_ENVIRONMENT` from
  * `shared/constants/build-environment.json`. Release-branch dist builds use
  * `release-candidate` (not the shorthand `rc`), so that value must map to
- * Production or RC Chrome builds incorrectly talk to Staging.
+ * Production or RC Chrome builds incorrectly talk to Staging. `rc` is kept as
+ * a legacy / shorthand alias for the same Production mapping.
  *
  * @returns The ramps environment for API requests.
  */
@@ -18,9 +19,7 @@ export function getRampsEnvironment(): RampsEnvironment {
   switch (metamaskEnvironment) {
     case 'production':
     case 'beta':
-    // Legacy / shorthand — kept for compatibility.
     case 'rc':
-    // Actual value emitted for `release/*` CI builds (`yarn build dist`).
     case 'release-candidate':
       return RampsEnvironment.Production;
     case 'development':

--- a/shared/lib/ramps/environment.ts
+++ b/shared/lib/ramps/environment.ts
@@ -6,6 +6,11 @@ import { RampsEnvironment } from '@metamask/ramps-controller';
  * Lives in `shared` because the UI needs it too: the provider callback URL it
  * builds has to point at the same ramps environment the background talks to.
  *
+ * Build CI emits `METAMASK_ENVIRONMENT` from
+ * `shared/constants/build-environment.json`. Release-branch dist builds use
+ * `release-candidate` (not the shorthand `rc`), so that value must map to
+ * Production or RC Chrome builds incorrectly talk to Staging.
+ *
  * @returns The ramps environment for API requests.
  */
 export function getRampsEnvironment(): RampsEnvironment {
@@ -13,7 +18,10 @@ export function getRampsEnvironment(): RampsEnvironment {
   switch (metamaskEnvironment) {
     case 'production':
     case 'beta':
+    // Legacy / shorthand — kept for compatibility.
     case 'rc':
+    // Actual value emitted for `release/*` CI builds (`yarn build dist`).
+    case 'release-candidate':
       return RampsEnvironment.Production;
     case 'development':
     case 'dev':

--- a/ui/hooks/ramps/utils/getRampCallbackBaseUrl.test.ts
+++ b/ui/hooks/ramps/utils/getRampCallbackBaseUrl.test.ts
@@ -15,10 +15,15 @@ describe('getRampCallbackBaseUrl', () => {
     process.env.METAMASK_ENVIRONMENT = originalEnv;
   });
 
-  it('returns the production URL for the production environment', () => {
-    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.PRODUCTION;
-    expect(getRampCallbackBaseUrl()).toBe(PRODUCTION_CALLBACK);
-  });
+  for (const environment of [
+    ENVIRONMENT.PRODUCTION,
+    ENVIRONMENT.RELEASE_CANDIDATE,
+  ]) {
+    it(`returns the production URL for the ${environment} environment`, () => {
+      process.env.METAMASK_ENVIRONMENT = environment;
+      expect(getRampCallbackBaseUrl()).toBe(PRODUCTION_CALLBACK);
+    });
+  }
 
   // `on-ramp-content.dev-api.cx.metamask.io` does not exist — pointing
   // development at it made providers redirect to a DNS failure page.
@@ -30,7 +35,6 @@ describe('getRampCallbackBaseUrl', () => {
   for (const environment of [
     ENVIRONMENT.OTHER,
     ENVIRONMENT.PULL_REQUEST,
-    ENVIRONMENT.RELEASE_CANDIDATE,
     ENVIRONMENT.STAGING,
     ENVIRONMENT.TESTING,
   ]) {


### PR DESCRIPTION
## **Description**

Release-candidate Extension builds were still calling the **Staging** ramps API (`on-ramp.uat-api…`) because `getRampsEnvironment()` only matched the shorthand `rc`, while CI emits `METAMASK_ENVIRONMENT=release-candidate` for `release/*` `yarn build dist` jobs.

This maps `release-candidate` → `RampsEnvironment.Production` so RC builds automatically use `on-ramp.api.cx.metamask.io` (and the matching callback host).

`rampsEnabled` is unchanged — it still comes from client-config / LaunchDarkly for the build’s RFF environment (`rc`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: TRAM-3718

## **Manual testing steps**

1. Build with `yarn build dist --env release-candidate` (or use a `release/x.y.z` CI dist build).
2. Confirm ramps network requests go to `on-ramp.api.cx.metamask.io` (not `on-ramp.uat-api` / dev).
3. Confirm `pull-request` / `staging` / local `other` builds still default to Staging.
4. Confirm `rampsEnabled` is still driven by remote feature flags (not hardcoded).

## **Screenshots/Recordings**

N/A — env mapping only; no UI change.

### **Before**

N/A — RC builds resolved ramps env to Staging because `release-candidate` fell through the `default` branch.

### **After**

N/A — RC builds resolve ramps env to Production. Covered by unit test `returns Production for METAMASK_ENVIRONMENT=release-candidate`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong env mapping sent RC extension builds to UAT ramps APIs; the fix is small and unit-tested but affects live on-ramp traffic for release builds.
> 
> **Overview**
> **Release-candidate dist builds** were hitting **Staging** ramps endpoints because CI sets `METAMASK_ENVIRONMENT=release-candidate` while `getRampsEnvironment()` only treated `rc` as Production.
> 
> This adds a **`release-candidate`** switch case (alongside existing `rc`) so background and UI callback URLs resolve to **Production** ramps hosts. JSDoc explains the CI/build-environment mismatch.
> 
> Tests cover the new env value in `environment.test.ts` and move **`RELEASE_CANDIDATE`** in `getRampCallbackBaseUrl.test.ts` from the staging expectations to the production callback URL group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b5152d9a262b62505ecbbbdcce998595dd5d2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->