### PR TITLE
fix(confirmations): cap enforced simulation balance decreases

### DIFF
--- a/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
@@ -252,6 +252,44 @@ describe('Enforced Simulations Utils', () => {
       );
     });
 
+    it('handles missing token balance changes', async () => {
+      options.transactionMeta.simulationData = {
+        nativeBalanceChange: BALANCE_CHANGE_MOCK,
+      } as SimulationData;
+
+      const { updateTransaction } = await enforceSimulations(options);
+
+      const newTransaction = cloneDeep(TRANSACTION_META_MOCK);
+      updateTransaction?.(newTransaction);
+
+      expect(newTransaction.txParams.data).toStrictEqual(
+        expect.stringContaining(
+          remove0x(
+            DELEGATOR_CONTRACTS['1.3.0']['1'].NativeBalanceChangeEnforcer,
+          ).toLowerCase(),
+        ),
+      );
+    });
+
+    it('ignores unsupported token standards', async () => {
+      simulationData.tokenBalanceChanges = [
+        {
+          ...BALANCE_CHANGE_MOCK,
+          address: TOKEN_MOCK,
+          standard: 'unsupported' as SimulationTokenStandard,
+        },
+      ];
+
+      const { updateTransaction } = await enforceSimulations(options);
+
+      const newTransaction = cloneDeep(TRANSACTION_META_MOCK);
+      updateTransaction?.(newTransaction);
+
+      expect(newTransaction.txParams.data).not.toStrictEqual(
+        expect.stringContaining(remove0x(TOKEN_MOCK).toLowerCase()),
+      );
+    });
+
     it('signs delegation if useRealSignature', async () => {
       options.useRealSignature = true;
 
@@ -281,12 +319,25 @@ describe('Enforced Simulations Utils', () => {
       ).rejects.toThrow('No caveats generated for enforced simulations');
     });
 
+    it('throws when simulation data is missing', async () => {
+      const transactionMeta = cloneDeep(TRANSACTION_META_MOCK);
+      transactionMeta.simulationData = undefined;
+
+      await expect(
+        enforceSimulations({
+          ...options,
+          transactionMeta,
+        }),
+      ).rejects.toThrow('No caveats generated for enforced simulations');
+    });
+
     describe('applies slippage', () => {
       it('if decrease', async () => {
         simulationData.tokenBalanceChanges = [
           {
             ...BALANCE_CHANGE_MOCK,
             difference: toHex(100000),
+            previousBalance: toHex(200000),
             address: TOKEN_MOCK,
             standard: SimulationTokenStandard.erc20,
           },
@@ -299,6 +350,50 @@ describe('Enforced Simulations Utils', () => {
 
         expect(newTransaction.txParams.data).toStrictEqual(
           expect.stringContaining(remove0x(toHex(110000)).toLowerCase()),
+        );
+      });
+
+      it('caps an ERC-20 decrease at the previous balance', async () => {
+        simulationData.tokenBalanceChanges = [
+          {
+            ...BALANCE_CHANGE_MOCK,
+            difference: toHex(100000),
+            previousBalance: toHex(105000),
+            address: TOKEN_MOCK,
+            standard: SimulationTokenStandard.erc20,
+          },
+        ];
+
+        const { updateTransaction } = await enforceSimulations(options);
+
+        const newTransaction = cloneDeep(TRANSACTION_META_MOCK);
+        updateTransaction?.(newTransaction);
+
+        expect(newTransaction.txParams.data).toStrictEqual(
+          expect.stringContaining(remove0x(toHex(105000)).toLowerCase()),
+        );
+        expect(newTransaction.txParams.data).toStrictEqual(
+          expect.not.stringContaining(remove0x(toHex(110000)).toLowerCase()),
+        );
+      });
+
+      it('caps a native decrease at the previous balance', async () => {
+        simulationData.nativeBalanceChange = {
+          ...BALANCE_CHANGE_MOCK,
+          difference: toHex(100000),
+          previousBalance: toHex(105000),
+        };
+
+        const { updateTransaction } = await enforceSimulations(options);
+
+        const newTransaction = cloneDeep(TRANSACTION_META_MOCK);
+        updateTransaction?.(newTransaction);
+
+        expect(newTransaction.txParams.data).toStrictEqual(
+          expect.stringContaining(remove0x(toHex(105000)).toLowerCase()),
+        );
+        expect(newTransaction.txParams.data).toStrictEqual(
+          expect.not.stringContaining(remove0x(toHex(110000)).toLowerCase()),
         );
       });
 

--- a/app/scripts/lib/transaction/containers/enforced-simulations.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.ts
@@ -107,8 +107,17 @@ function generateCaveats(
   const { nativeBalanceChange, tokenBalanceChanges = [] } = simulationData;
 
   if (nativeBalanceChange) {
-    const { difference, isDecrease: enforceDecrease } = nativeBalanceChange;
-    const delta = applySlippage(difference, slippage, enforceDecrease);
+    const {
+      difference,
+      isDecrease: enforceDecrease,
+      previousBalance,
+    } = nativeBalanceChange;
+    const delta = applySlippage(
+      difference,
+      slippage,
+      enforceDecrease,
+      previousBalance,
+    );
 
     log('Caveat - Native Balance Change', {
       enforceDecrease,
@@ -136,6 +145,7 @@ function generateCaveats(
       address: token,
       standard,
       id: tokenIdHex,
+      previousBalance,
     } = tokenChange;
 
     const delta = BigInt(difference);
@@ -144,6 +154,7 @@ function generateCaveats(
       difference,
       slippage,
       enforceDecrease,
+      previousBalance,
     );
 
     const tokenId = tokenIdHex ? BigInt(tokenIdHex) : 0n;
@@ -222,8 +233,20 @@ function applySlippage(
   value: Hex,
   slippage: number,
   isDecrease: boolean,
+  previousBalance: Hex,
 ): bigint {
   const valueBN = new BigNumber(value);
   const slippageMultiplier = (100 + (isDecrease ? slippage : -slippage)) / 100;
-  return BigInt(valueBN.mul(slippageMultiplier).toFixed(0));
+  const valueWithSlippage = BigInt(
+    valueBN.mul(slippageMultiplier).toFixed(0),
+  );
+
+  if (!isDecrease) {
+    return valueWithSlippage;
+  }
+
+  const maximumDecrease = BigInt(previousBalance);
+  return valueWithSlippage > maximumDecrease
+    ? maximumDecrease
+    : valueWithSlippage;
 }

--- a/app/scripts/lib/transaction/containers/enforced-simulations.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.ts
@@ -237,9 +237,7 @@ function applySlippage(
 ): bigint {
   const valueBN = new BigNumber(value);
   const slippageMultiplier = (100 + (isDecrease ? slippage : -slippage)) / 100;
-  const valueWithSlippage = BigInt(
-    valueBN.mul(slippageMultiplier).toFixed(0),
-  );
+  const valueWithSlippage = BigInt(valueBN.mul(slippageMultiplier).toFixed(0));
 
   if (!isDecrease) {
     return valueWithSlippage;


### PR DESCRIPTION
## **Description**

Enforced simulations add slippage to simulated balance decreases before encoding balance-change caveats. When a transaction spent almost an entire native or ERC-20 balance, the slippage-adjusted decrease could become greater than the account's starting balance.

The balance-change enforcer calculates the minimum permitted ending balance by subtracting the allowed decrease from the starting balance. An allowed decrease greater than the starting balance caused a Solidity arithmetic-underflow panic. The wrapped transaction simulation consequently returned no gas limit, auto-enabling enforced simulations failed, and the added-protection component remained hidden.

This change caps slippage-adjusted native and ERC-20 decreases at the corresponding pre-transaction balance. This preserves the intended slippage tolerance while ensuring that the enforcer's minimum ending balance cannot fall below zero. Balance increases retain their existing behavior.

Regression tests cover capped and uncapped ERC-20 decreases, capped native decreases, increases, and all existing caveat-generation paths. The focused Jest coverage report for `enforced-simulations.ts` reports 100% statements, branches, functions, and lines.

## **Changelog**

CHANGELOG entry: Fixed enforced simulations failing for transactions that spent nearly the full token or native balance

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Build and load the extension with enforced simulations enabled.
2. On a supported EIP-7702 network, initiate a dapp transaction that decreases a native or ERC-20 balance by enough that the configured slippage would make the permitted decrease greater than the current balance.
3. Open the transaction confirmation and verify the added-protection component appears and remains enabled.
4. Verify the confirmation does not report a wrapped-transaction gas-estimation failure and can proceed normally.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction confirmation enforcement math for EIP-7702 delegations; incorrect capping could weaken protection or still mis-encode caveats, but scope is limited and well-tested.
> 
> **Overview**
> Caps **slippage-adjusted balance decreases** in enforced-simulation caveats so they cannot exceed the simulated **pre-transaction balance** (`previousBalance`). Native and ERC-20 decrease paths pass `previousBalance` into `applySlippage`, which still widens decreases for slippage but now returns `min(slippage-adjusted value, previousBalance)`; increases are unchanged.
> 
> This avoids on-chain balance enforcers computing a minimum ending balance below zero (arithmetic underflow), which could break wrapped-tx gas estimation and block the added-protection UI when a spend nearly empties a wallet.
> 
> Tests cover capped native/ERC-20 decreases, unchanged slippage when under the cap, missing token changes, unsupported standards, and missing simulation data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce3a6b0fecda67b3d3ccbc87a6f16affc7c9e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->