### PR TITLE
perf(deep-links): defer interstitial preference read

### DIFF
--- a/app/scripts/lib/deep-links/deep-link-router.ts
+++ b/app/scripts/lib/deep-links/deep-link-router.ts
@@ -188,9 +188,8 @@ export class DeepLinkRouter extends EventEmitter<{
           source: 'intercepted',
           signatureStatus: parsed.signature,
           requestOrigin,
-          skipDeepLinkInterstitial: Boolean(
-            this.getState().preferences?.skipDeepLinkInterstitial,
-          ),
+          getSkipDeepLinkInterstitial: () =>
+            Boolean(this.getState().preferences?.skipDeepLinkInterstitial),
         });
 
         if (shouldShowInterstitial) {

--- a/app/scripts/lib/deep-links/deep-link.router.test.ts
+++ b/app/scripts/lib/deep-links/deep-link.router.test.ts
@@ -77,6 +77,9 @@ describe('DeepLinkRouter', () => {
   let router: DeepLinkRouter;
 
   beforeEach(() => {
+    getState.mockReturnValue({
+      preferences: { skipDeepLinkInterstitial: false },
+    } as unknown as ReturnType<MetaMaskController['getState']>);
     router = new DeepLinkRouter({
       getExtensionURL: new ExtensionPlatform().getExtensionURL,
       getState,
@@ -156,6 +159,8 @@ describe('DeepLinkRouter', () => {
           tabId,
           url,
         } as browser.WebRequest.OnBeforeRequestDetailsType);
+
+        expect(getState).toHaveBeenCalledTimes(signed ? 1 : 0);
         expect(browser.tabs.update).toHaveBeenCalledWith(tabId, {
           url: 'chrome-extension://extension-id/home.html#link?u=%2Fexternal-route%3Fquery%3Dparam',
         });
@@ -234,6 +239,7 @@ describe('DeepLinkRouter', () => {
             initiator: 'https://metamask.io',
           }),
           expectedUrl: `${EXTENSION_HOME}#internal-route?one=two`,
+          readsPreferences: false,
         },
         {
           name: 'signed links initiated from app.metamask.io (Chrome initiator)',
@@ -242,6 +248,7 @@ describe('DeepLinkRouter', () => {
             initiator: 'https://app.metamask.io',
           }),
           expectedUrl: `${EXTENSION_HOME}#internal-route?one=two`,
+          readsPreferences: false,
         },
         {
           name: 'signed links initiated from metamask.io (Firefox originUrl)',
@@ -250,6 +257,7 @@ describe('DeepLinkRouter', () => {
             originUrl: 'https://metamask.io/portfolio/assets',
           }),
           expectedUrl: `${EXTENSION_HOME}#internal-route?one=two`,
+          readsPreferences: false,
         },
         {
           name: 'unsigned links from a trusted origin',
@@ -258,6 +266,7 @@ describe('DeepLinkRouter', () => {
             initiator: 'https://metamask.io',
           }),
           expectedUrl: `${EXTENSION_HOME}#internal-route?query=param`,
+          readsPreferences: false,
         },
         {
           name: 'signed links from an untrusted origin (shows interstitial)',
@@ -266,14 +275,17 @@ describe('DeepLinkRouter', () => {
             initiator: 'https://evil.com',
           }),
           expectedUrl: `${EXTENSION_HOME}#link?u=%2Ftest-route`, // we are redirecting to #link interstitial page
+          readsPreferences: true,
         },
       ];
 
       it.each(interstitialTestCases)(
         'handles interstitial for $name',
-        async ({ parsed, requestDetails, expectedUrl }) => {
+        async ({ parsed, requestDetails, expectedUrl, readsPreferences }) => {
           parseMock.mockResolvedValue(parsed);
           await onBeforeRequest?.(requestDetails);
+
+          expect(getState).toHaveBeenCalledTimes(readsPreferences ? 1 : 0);
           expect(browser.tabs.update).toHaveBeenCalledWith(
             requestDetails.tabId,
             { url: expectedUrl },

--- a/shared/lib/deep-links/security-policy.test.ts
+++ b/shared/lib/deep-links/security-policy.test.ts
@@ -8,14 +8,17 @@ describe('shouldShowDeepLinkInterstitial', () => {
       'https://app.metamask.io',
     ]) {
       it(`allows the explicitly trusted web origin ${requestOrigin} to bypass the interstitial`, () => {
+        const getSkipDeepLinkInterstitial = jest.fn(() => false);
+
         const result = shouldShowDeepLinkInterstitial({
           source: 'intercepted',
           requestOrigin,
           signatureStatus: MISSING,
-          skipDeepLinkInterstitial: false,
+          getSkipDeepLinkInterstitial,
         });
 
         expect(result).toBe(false);
+        expect(getSkipDeepLinkInterstitial).not.toHaveBeenCalled();
       });
     }
 
@@ -24,7 +27,7 @@ describe('shouldShowDeepLinkInterstitial', () => {
         source: 'intercepted',
         requestOrigin: 'https://portfolio.metamask.io',
         signatureStatus: MISSING,
-        skipDeepLinkInterstitial: false,
+        getSkipDeepLinkInterstitial: () => false,
       });
 
       expect(result).toBe(true);
@@ -34,7 +37,7 @@ describe('shouldShowDeepLinkInterstitial', () => {
       const result = shouldShowDeepLinkInterstitial({
         source: 'intercepted',
         signatureStatus: VALID,
-        skipDeepLinkInterstitial: true,
+        getSkipDeepLinkInterstitial: () => true,
       });
 
       expect(result).toBe(false);
@@ -44,7 +47,7 @@ describe('shouldShowDeepLinkInterstitial', () => {
       const result = shouldShowDeepLinkInterstitial({
         source: 'intercepted',
         signatureStatus: VALID,
-        skipDeepLinkInterstitial: false,
+        getSkipDeepLinkInterstitial: () => false,
       });
 
       expect(result).toBe(true);
@@ -52,13 +55,16 @@ describe('shouldShowDeepLinkInterstitial', () => {
 
     for (const signatureStatus of [MISSING, INVALID]) {
       it(`shows the interstitial for a ${signatureStatus} signature even when the user opted out`, () => {
+        const getSkipDeepLinkInterstitial = jest.fn(() => true);
+
         const result = shouldShowDeepLinkInterstitial({
           source: 'intercepted',
           signatureStatus,
-          skipDeepLinkInterstitial: true,
+          getSkipDeepLinkInterstitial,
         });
 
         expect(result).toBe(true);
+        expect(getSkipDeepLinkInterstitial).not.toHaveBeenCalled();
       });
     }
   });

--- a/shared/lib/deep-links/security-policy.ts
+++ b/shared/lib/deep-links/security-policy.ts
@@ -25,7 +25,11 @@ type InterceptedDeepLinkContext = {
   source: 'intercepted';
   requestOrigin?: string;
   signatureStatus: SignatureStatus;
-  skipDeepLinkInterstitial: boolean;
+  /**
+   * Reads the local interstitial preference. This remains lazy because reading
+   * controller state is unnecessary for trusted origins or invalid links.
+   */
+  getSkipDeepLinkInterstitial: () => boolean;
 };
 
 type DeferredDeepLinkContext = {
@@ -47,7 +51,8 @@ export type DeepLinkInterstitialContext =
  *
  * This function must remain synchronous. In particular, asset reputation,
  * product configuration, feature flags, and other remote data must never
- * influence this decision.
+ * influence this decision. The intercepted preference getter is evaluated
+ * only for valid signatures from untrusted origins.
  *
  * @param context - The trusted inputs available for the relevant deep-link
  * flow.
@@ -64,5 +69,7 @@ export function shouldShowDeepLinkInterstitial(
     return false;
   }
 
-  return context.signatureStatus !== VALID || !context.skipDeepLinkInterstitial;
+  return (
+    context.signatureStatus !== VALID || !context.getSkipDeepLinkInterstitial()
+  );
 }


### PR DESCRIPTION
## **Description**

Follow-up to #44868 and [this review comment](https://github.com/MetaMask/metamask-extension/pull/44868#discussion_r3693149351).

The centralized deep-link policy currently receives the interstitial preference eagerly, so `MetaMaskController.getState()` runs for every parsed intercepted link—even when trusted-origin or invalid-signature paths do not need it. This changes the intercepted policy input to a synchronous lazy getter and invokes it only for valid signatures from untrusted origins. Navigation behavior is unchanged, and focused tests assert that the preference remains unread on the other paths.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Follow-up to #44868.

<!--
## **Manual testing steps**

Not applicable; this is an internal state-read optimization with unchanged navigation behavior and focused automated coverage.
-->

<!--
## **Screenshots/Recordings**

Not applicable; no UI changes.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

