### PR TITLE
chore(codeowners): remove onboarding hook security ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -340,4 +340,3 @@ app/scripts/wallet-init/instance-options/storage-service*                @MetaMa
 /shared/lib/deep-links/routes/route*                          @MetaMask/extension-security-team
 /ui/helpers/utils/resolve-deep-link-href*                     @MetaMask/extension-security-team
 /ui/pages/deep-link/                                          @MetaMask/extension-security-team
-/ui/pages/onboarding-flow/hooks/useOnboardingCompletion*      @MetaMask/extension-security-team


### PR DESCRIPTION
## **Description**

Follow-up to #44868 and [this review comment](https://github.com/MetaMask/metamask-extension/pull/44868#discussion_r3693192373).

Removes the dedicated `@MetaMask/extension-security-team` ownership rule for `useOnboardingCompletion*`. The broader ownership rules remain in place. This removal is explicitly approved by a member of the security team in the follow-up request.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Follow-up to #44868.

<!--
## **Manual testing steps**

Not applicable; this changes repository ownership metadata only.
-->

<!--
## **Screenshots/Recordings**

Not applicable; no UI changes.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
