### PR TITLE
revert: migrate ReactDOM.render to createRoot

### DIFF
--- a/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch
+++ b/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch
@@ -1,5 +1,5 @@
 diff --git a/rive.js b/rive.js
-index 03eeff276d0495d77ce0c4715160db4b80a5fc87..f8c63241e1e5e39f0aa8c8a82fa062399acc3549 100644
+index 03eeff276d0495d77ce0c4715160db4b80a5fc87..79d6a4b12d62a12a4005e2d7f6f9249ce2ddeb55 100644
 --- a/rive.js
 +++ b/rive.js
 @@ -5418,7 +5418,7 @@ var RiveFile = /** @class */ (function () {
@@ -52,32 +52,3 @@ index 03eeff276d0495d77ce0c4715160db4b80a5fc87..f8c63241e1e5e39f0aa8c8a82fa06239
          }
          // List of animations that should be initialized.
          var startingAnimationNames = mapToStringArray(animations);
-@@ -5749,7 +5749,7 @@ var Rive = /** @class */ (function () {
-             this.eventCleanup();
-         }
-         if (!this.shouldDisableRiveListeners) {
--            var activeStateMachines = (this.animator.stateMachines || [])
-+            var activeStateMachines = ((this.animator && this.animator.stateMachines) || [])
-                 .filter(function (sm) { return sm.playing && _this.runtime.hasListeners(sm.instance); })
-                 .map(function (sm) { return sm.instance; });
-             var touchScrollEnabledOption = this.isTouchScrollEnabled;
-@@ -5941,6 +5941,10 @@ var Rive = /** @class */ (function () {
-         var _a;
-         // Clear the frameRequestId, as we're now rendering a fresh frame
-         this.frameRequestId = null;
-+        // createRoot unmount can cleanup mid-rAF; avoid touching freed animator/runtime
-+        if (!this.animator || !this.artboard || !this.renderer) {
-+            return;
-+        }
-         var before = performance.now();
-         // On the first pass, make sure lastTime has a valid value
-         if (!this.lastRenderTime) {
-@@ -6419,7 +6423,7 @@ var Rive = /** @class */ (function () {
-      */
-     Rive.prototype.stateMachineInputs = function (name) {
-         // If the file's not loaded, early out, nothing to pause
--        if (!this.loaded) {
-+        if (!this.loaded || !this.animator) {
-             return;
-         }
-         var stateMachine = this.animator.stateMachines.find(function (m) { return m.name === name; });

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -34,6 +34,11 @@
       "count": 1
     }
   },
+  "ui/components/app/shield-entry-modal/shield-illustration-animation.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
   "ui/components/app/snaps/snap-ui-address-input/snap-ui-address-input.tsx": {
     "react-hooks/exhaustive-deps": {
       "count": 1
@@ -147,6 +152,11 @@
   "ui/components/ui/jazzicon/jazzicon.component.tsx": {
     "react-hooks/exhaustive-deps": {
       "count": 2
+    }
+  },
+  "ui/components/ui/survey-toast/survey-toast.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
     }
   },
   "ui/contexts/hardware-wallets/HardwareWalletContext.tsx": {
@@ -296,7 +306,7 @@
   },
   "ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-icon-animation.tsx": {
     "react-hooks/exhaustive-deps": {
-      "count": 3
+      "count": 4
     }
   },
   "ui/pages/confirmations/components/confirm/info/approve/hooks/use-is-nft.ts": {
@@ -469,9 +479,14 @@
       "count": 1
     }
   },
+  "ui/pages/settings/debug-tab/debug-content/sentry-test.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
   "ui/pages/shield/transaction-shield/shield-banner-animation.tsx": {
     "react-hooks/exhaustive-deps": {
-      "count": 2
+      "count": 3
     }
   },
   "ui/pages/swaps/awaiting-signatures/awaiting-signatures.js": {

--- a/test/e2e/page-objects/pages/confirmations/confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/confirmation.ts
@@ -272,9 +272,5 @@ class Confirmation {
       timeout: 5000,
     });
   }
-
-  async waitForInlineAlert(): Promise<void> {
-    await this.driver.waitForSelector(this.inlineAlertButton);
-  }
 }
 export default Confirmation;

--- a/test/e2e/page-objects/pages/dialog/confirm-alert.ts
+++ b/test/e2e/page-objects/pages/dialog/confirm-alert.ts
@@ -34,9 +34,7 @@ class ConfirmAlertModal {
   }
 
   async rejectFromAlertModal() {
-    await this.driver.clickElementAndWaitForWindowToClose(
-      this.alertModalCancelButton,
-    );
+    await this.driver.clickElement(this.alertModalCancelButton);
   }
 
   async verifyNetworkDisplay(networkName: string): Promise<void> {

--- a/test/e2e/tests/confirmations/signatures/malicious-signatures.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/malicious-signatures.spec.ts
@@ -61,9 +61,6 @@ describe('Malicious Confirmation Signature - Bad Domain', function (this: Suite)
           SignatureType.SIWE_BadDomain,
         );
 
-        // Alert metrics are only attached once the inline alert has rendered.
-        await confirmation.waitForInlineAlert();
-
         await confirmation.clickFooterCancelButtonAndAndWaitForWindowToClose();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
@@ -131,6 +128,7 @@ describe('Malicious Confirmation Signature - Bad Domain', function (this: Suite)
 
         await alertModal.rejectFromAlertModal();
 
+        await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
         await testDapp.assertUserRejectedRequest();

--- a/test/e2e/tests/survey/survey.spec.ts
+++ b/test/e2e/tests/survey/survey.spec.ts
@@ -7,15 +7,12 @@ import Homepage from '../../page-objects/pages/home/homepage';
 import { login } from '../../page-objects/flows/login.flow';
 
 async function mockSurveys(mockServer: MockttpServer) {
-  // One fetch on home mount (survey 1), one refetch after close when
-  // lastViewedUserSurvey updates (survey 2). The old `.twice()` for survey 1
-  // papered over a wallet bug (#33604) where an unused selected-account
-  // effect dep caused a duplicate mount fetch.
   await mockServer
     .forGet(
       `${ACCOUNTS_PROD_API_BASE_URL}/v1/users/${MOCK_ANALYTICS_ID}/surveys`,
     )
-    .once()
+    // We need to mock this request twice because of a bug on the wallet side (#33604)
+    .twice()
     .thenCallback(() => {
       return {
         statusCode: 200,

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -2009,8 +2009,6 @@ class Driver {
       // performSignIn, getBearerToken, ...) can re-check #isUnlocked after
       // a lock fires mid-flight. No user impact; tracked in #37459.
       'unable to proceed, wallet is locked',
-      // Rive load/cleanup noise (createRoot); not an app regression. See #44516.
-      'Problem loading file; may be corrupt!',
     ]);
 
     const cdpConnection = await this.driver.createCDPConnection('page');

--- a/test/jest/console-baseline-integration.json
+++ b/test/jest/console-baseline-integration.json
@@ -37,7 +37,7 @@
       "warn: ⚠️ React Router Future Flag": 1
     },
     "test/integration/confirmations/transactions/alerts.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 3,
+      "React: Act warnings (component updates not wrapped)": 2,
       "Reselect: Identity function warnings": 1,
       "Reselect: Input stability warnings": 5,
       "error: Error: AggregateError": 1,
@@ -114,19 +114,17 @@
       "warn: ⚠️ React Router Future Flag": 1
     },
     "test/integration/notifications&auth/notifications-toggle.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 6,
+      "React: Act warnings (component updates not wrapped)": 4,
       "React: componentWill* lifecycle deprecations": 1,
       "Reselect: Input stability warnings": 7,
       "warn: ⚠️ React Router Future Flag": 1
     },
     "test/integration/onboarding/import-wallet.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 1,
       "Reselect: Identity function warnings": 1,
       "Reselect: Input stability warnings": 5,
       "warn: ⚠️ React Router Future Flag": 1
     },
     "test/integration/onboarding/wallet-created.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 1,
       "Reselect: Identity function warnings": 1,
       "Reselect: Input stability warnings": 5,
       "warn: ⚠️ React Router Future Flag": 1

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -223,7 +223,8 @@
       "Reselect: Input stability warnings": 1
     },
     "ui/components/app/metametrics-toggle/metametrics-toggle.test.tsx": {
-      "React: componentWill* lifecycle deprecations": 1
+      "React: componentWill* lifecycle deprecations": 1,
+      "error: Error: MetaMetrics context trackEvent was": 3
     },
     "ui/components/app/modals/customize-nonce/customize-nonce.test.js": {
       "React: PropTypes validation failures": 1
@@ -381,6 +382,9 @@
     "ui/components/multichain/app-header/app-header.test.js": {
       "React: Act warnings (component updates not wrapped)": 4,
       "Reselect: Input stability warnings": 3
+    },
+    "ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx": {
+      "React: Act warnings (component updates not wrapped)": 16
     },
     "ui/components/multichain/dapp-connection-control-bar/dapp-bar-network-selector-popover.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 6,
@@ -1002,6 +1006,9 @@
     "ui/pages/settings/sync-accounts/components/enter-verification-code.test.tsx": {
       "Reselect: Identity function warnings": 1
     },
+    "ui/pages/settings/sync-accounts/components/qr-code-scan.test.tsx": {
+      "Reselect: Identity function warnings": 1
+    },
     "ui/pages/settings/sync-accounts/components/sync-error.test.tsx": {
       "Reselect: Identity function warnings": 1
     },
@@ -1013,7 +1020,7 @@
       "Reselect: Identity function warnings": 1
     },
     "ui/pages/shield/plan/shield-payment-modal.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 3
+      "React: Act warnings (component updates not wrapped)": 6
     },
     "ui/pages/shield/plan/shield-plan.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 7,

--- a/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialAnimation.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialAnimation.tsx
@@ -142,6 +142,15 @@ const PerpsTutorialAnimation = ({
     }
   }, [rive, isWasmReady, bufferLoading, buffer]);
 
+  // Cleanup Rive animation resources on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      if (rive) {
+        rive.cleanup();
+      }
+    };
+  }, [rive]);
+
   if (
     !isWasmReady ||
     bufferLoading ||

--- a/ui/components/app/shield-entry-modal/shield-illustration-animation.tsx
+++ b/ui/components/app/shield-entry-modal/shield-illustration-animation.tsx
@@ -68,6 +68,15 @@ const ShieldIllustrationAnimation = ({
     }
   }, [rive, isWasmReady, bufferLoading, buffer]);
 
+  // Stop animation on unmount
+  useEffect(() => {
+    return () => {
+      if (rive) {
+        rive.cleanup();
+      }
+    };
+  }, []);
+
   // Don't render Rive component until WASM and buffer are ready to avoid errors
   if (
     !isWasmReady ||

--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -27,7 +27,6 @@ import {
 import { getURLHost } from '../../../helpers/utils/util';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getCurrentNetwork, getOriginOfCurrentTab } from '../../../selectors';
-import { getIsUnlocked } from '../../../ducks/metamask/base-selectors';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../shared/constants/network';
 import {
   hidePermittedNetworkToast,
@@ -97,7 +96,6 @@ const MemoizedStorageErrorToast = memo(StorageErrorToast);
 
 export function ToastMaster() {
   const location = useLocation();
-  const isUnlocked = useSelector(getIsUnlocked);
 
   // Check if storage error toast should be shown (needed for conditional rendering on other screens)
   // The selector includes all conditions: flag is true, onboarding complete, and unlocked
@@ -113,9 +111,7 @@ export function ToastMaster() {
     return (
       <ToastContainer>
         <MemoizedStorageErrorToast />
-        {/* SurveyToast must not mount while locked: `/` can flash before /unlock
-            and would consume the first survey mock/API response. */}
-        {isUnlocked ? <MemoizedSurveyToast /> : null}
+        <MemoizedSurveyToast />
         <MemoizedPrivacyPolicyToast />
         <MemoizedPermittedNetworkToast />
         <MemoizedInfuraSwitchToast />

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.test.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.test.tsx
@@ -173,35 +173,6 @@ describe('GlobalMenuDrawer', () => {
     expect(queryByTestId('global-menu-drawer')).not.toBeInTheDocument();
   });
 
-  it('opens in fullscreen when app-root-layout is present', async () => {
-    getEnvironmentType.mockReturnValue('fullscreen');
-    const app = document.createElement('div');
-    app.className = 'app';
-    const rootLayout = document.createElement('div');
-    rootLayout.setAttribute('data-testid', 'app-root-layout');
-    // Intentionally omit max-w-[ classes so only the stable test id matches.
-    app.appendChild(rootLayout);
-    document.body.appendChild(app);
-
-    const { getByTestId } = renderWithProvider(
-      <GlobalMenuDrawer
-        isOpen
-        onClose={() => undefined}
-        data-testid="global-menu-drawer"
-      >
-        <span>Content</span>
-      </GlobalMenuDrawer>,
-      configureStore(mockState),
-      '/',
-    );
-
-    await waitFor(() => {
-      expect(getByTestId('drawer-close-button')).toBeInTheDocument();
-    });
-
-    app.remove();
-  });
-
   it('networks item navigates to the dedicated networks page', async () => {
     const store = configureStore({
       ...mockState,

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
@@ -160,6 +160,7 @@ export const GlobalMenuDrawer = ({
       return;
     }
 
+    // Same root layout for both: walk up from anchor or find in .app (the content container)
     const findRootLayout = (): HTMLElement | null => {
       if (
         rootLayoutRef.current &&
@@ -167,19 +168,43 @@ export const GlobalMenuDrawer = ({
       ) {
         return rootLayoutRef.current;
       }
-      const el = document.querySelector<HTMLElement>(
-        '[data-testid="app-root-layout"]',
-      );
-      if (el) {
-        rootLayoutRef.current = el;
+      let found: HTMLElement | null = null;
+      if (anchorElement) {
+        let current: HTMLElement | null = anchorElement;
+        while (current && current !== document.body) {
+          const parent: HTMLElement | null = current.parentElement;
+          if (
+            parent instanceof HTMLElement &&
+            parent.className.includes('max-w-[') &&
+            parent.classList.contains('flex') &&
+            parent.classList.contains('flex-col')
+          ) {
+            found = parent;
+            break;
+          }
+          current = parent;
+        }
       }
-      return el;
+      if (!found) {
+        found =
+          (Array.from(appContainer.children).find(
+            (child) =>
+              child instanceof HTMLElement &&
+              child.className.includes('max-w-[') &&
+              child.classList.contains('flex') &&
+              child.classList.contains('flex-col'),
+          ) as HTMLElement) || null;
+      }
+      if (found) {
+        rootLayoutRef.current = found;
+      }
+      return found;
     };
 
     const updatePosition = () => {
       const rootLayout = findRootLayout();
       if (!rootLayout) {
-        return false;
+        return;
       }
 
       const rootLayoutRect = rootLayout.getBoundingClientRect();
@@ -215,63 +240,20 @@ export const GlobalMenuDrawer = ({
       }
 
       setContainerElement(appContainer);
-      return true;
     };
 
-    let positionRetryFrame: number | null = null;
-    let positionRetryIsRaf = false;
     if (isOpen) {
-      // createRoot can run this layout effect a frame before RootLayout is
-      // queryable; retry briefly instead of leaving hasPosition stuck false.
-      // After the first rAF attempt we fall back to setTimeout because
-      // requestAnimationFrame is throttled in Firefox/geckodriver test
-      // contexts (extension popup running in a non-visible browsing context),
-      // which would leave hasPosition stuck false for up to 10+ seconds.
-      let attempts = 0;
-      const MAX_POSITION_ATTEMPTS = 20;
-      const tryUpdatePosition = () => {
-        positionRetryFrame = null;
-        if (updatePosition()) {
-          return;
-        }
-        attempts += 1;
-        if (attempts < MAX_POSITION_ATTEMPTS) {
-          if (attempts === 1) {
-            // One rAF retry so we don't skip the normal paint-synchronised
-            // path in production.
-            positionRetryIsRaf = true;
-            positionRetryFrame = requestAnimationFrame(tryUpdatePosition);
-          } else {
-            // Subsequent retries: use setTimeout so we are not blocked by
-            // rAF throttling in headless / background extension contexts.
-            positionRetryIsRaf = false;
-            positionRetryFrame = setTimeout(
-              tryUpdatePosition,
-              50,
-            ) as unknown as number;
-          }
-        }
-      };
-      tryUpdatePosition();
+      updatePosition();
     }
 
     const handleResize = () => {
       if (resizeTimeoutRef.current) {
         clearTimeout(resizeTimeoutRef.current);
       }
-      resizeTimeoutRef.current = setTimeout(() => {
-        updatePosition();
-      }, 100);
+      resizeTimeoutRef.current = setTimeout(updatePosition, 100);
     };
     window.addEventListener('resize', handleResize);
     return () => {
-      if (positionRetryFrame !== null) {
-        if (positionRetryIsRaf) {
-          cancelAnimationFrame(positionRetryFrame);
-        } else {
-          clearTimeout(positionRetryFrame);
-        }
-      }
       if (resizeTimeoutRef.current) {
         clearTimeout(resizeTimeoutRef.current);
       }

--- a/ui/components/ui/status-icon/status-icon.test.tsx
+++ b/ui/components/ui/status-icon/status-icon.test.tsx
@@ -7,6 +7,7 @@ jest.mock('@rive-app/react-canvas', () => ({
     rive: null,
     RiveComponent: () => <div data-testid="rive-component" />,
   }),
+  useStateMachineInput: () => null,
 }));
 
 jest.mock('../../../hooks/useTheme', () => ({

--- a/ui/components/ui/status-icon/status-icon.tsx
+++ b/ui/components/ui/status-icon/status-icon.tsx
@@ -1,4 +1,4 @@
-import { useRive } from '@rive-app/react-canvas';
+import { useRive, useStateMachineInput } from '@rive-app/react-canvas';
 import React, { useEffect } from 'react';
 import cn from 'clsx';
 import { ThemeType } from '../../../../shared/constants/preferences';
@@ -23,22 +23,20 @@ export function StatusIcon({ state, className }: Props) {
     stateMachines: riveFile ? stateMachine : undefined,
     autoplay: true,
   });
+  const darkInput = useStateMachineInput(rive, stateMachine, 'Dark');
 
   useEffect(() => {
-    if (!rive) {
+    if (!darkInput) {
       return;
     }
 
     try {
-      const inputs = rive.stateMachineInputs(stateMachine);
-      const darkInput = inputs?.find((input) => input.name === 'Dark');
-      if (darkInput) {
-        darkInput.value = isDark;
-      }
+      // eslint-disable-next-line react-hooks/immutability
+      darkInput.value = isDark;
     } catch {
       // Rive WASM runtime may have been cleaned up
     }
-  }, [rive, isDark]);
+  }, [rive, darkInput, isDark]);
 
   useEffect(() => {
     if (!rive) {
@@ -54,7 +52,11 @@ export function StatusIcon({ state, className }: Props) {
     }
   }, [rive, state]);
 
-  // useRive owns instance cleanup on unmount / instance change.
+  useEffect(() => {
+    return () => {
+      rive?.cleanup();
+    };
+  }, [rive]);
 
   if (fileStatus !== 'success') {
     return null;

--- a/ui/components/ui/survey-toast/survey-toast.test.tsx
+++ b/ui/components/ui/survey-toast/survey-toast.test.tsx
@@ -51,17 +51,14 @@ const surveyData = {
   },
 };
 
-const createStore = (
-  options: { metametricsEnabled?: boolean; isUnlocked?: boolean } = {},
-) =>
+const createStore = (options = { metametricsEnabled: true }) =>
   mockStore({
     user: { basicFunctionality: true },
     metamask: {
       lastViewedUserSurvey: 2,
       useExternalServices: true,
       consentDecisionMade: true,
-      optedIn: options.metametricsEnabled ?? true,
-      isUnlocked: options.isUnlocked ?? true,
+      optedIn: options.metametricsEnabled,
       analyticsId: '0x123',
       internalAccounts: {
         selectedAccount: '0x123',
@@ -70,9 +67,8 @@ const createStore = (
     },
   });
 
-const renderComponent = (
-  options: { metametricsEnabled?: boolean; isUnlocked?: boolean } = {},
-) => renderWithProvider(<SurveyToast />, createStore(options));
+const renderComponent = (options = { metametricsEnabled: true }) =>
+  renderWithProvider(<SurveyToast />, createStore(options));
 
 describe('SurveyToast', () => {
   beforeEach(() => {
@@ -168,16 +164,5 @@ describe('SurveyToast', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('survey-toast')).toBeNull();
     });
-  });
-
-  it('does not fetch surveys while the wallet is locked', async () => {
-    mockFetchWithCache.mockResolvedValue({ surveys: surveyData.valid });
-
-    await act(async () => {
-      renderComponent({ isUnlocked: false });
-    });
-
-    expect(mockFetchWithCache).not.toHaveBeenCalled();
-    expect(screen.queryByTestId('survey-toast')).toBeNull();
   });
 });

--- a/ui/components/ui/survey-toast/survey-toast.tsx
+++ b/ui/components/ui/survey-toast/survey-toast.tsx
@@ -15,7 +15,7 @@ import {
   getCompletedMetaMetricsOnboarding,
   getOptedIn,
 } from '../../../selectors';
-import { getIsUnlocked } from '../../../ducks/metamask/base-selectors';
+import { getSelectedInternalAccount } from '../../../../shared/lib/selectors/accounts';
 import { ACCOUNTS_API_BASE_URL } from '../../../../shared/constants/accounts';
 import { setLastViewedUserSurvey } from '../../../store/actions';
 import { Toast } from '../../multichain';
@@ -39,7 +39,7 @@ export function SurveyToast() {
     getCompletedMetaMetricsOnboarding,
   );
   const basicFunctionality = useSelector(getUseExternalServices);
-  const isUnlocked = useSelector(getIsUnlocked);
+  const internalAccount = useSelector(getSelectedInternalAccount);
   const analyticsId = useSelector(getAnalyticsId);
   const isMetaMetricsEnabled = completedMetaMetricsOnboarding && isOptedIn;
 
@@ -49,15 +49,7 @@ export function SurveyToast() {
   );
 
   useEffect(() => {
-    // ToastMaster can mount on `/` while the wallet is still locked (e.g. the
-    // brief DEFAULT_ROUTE flash before redirecting to /unlock). Fetching then
-    // burns the first survey response before the home screen ever sees it.
-    if (
-      !isUnlocked ||
-      !basicFunctionality ||
-      !analyticsId ||
-      !isMetaMetricsEnabled
-    ) {
+    if (!basicFunctionality || !analyticsId || !isMetaMetricsEnabled) {
       return undefined;
     }
 
@@ -102,12 +94,12 @@ export function SurveyToast() {
       controller.abort();
     };
   }, [
-    isUnlocked,
+    internalAccount?.address,
     lastViewedUserSurvey,
     basicFunctionality,
     analyticsId,
     isMetaMetricsEnabled,
-    surveyUrl,
+    dispatch,
   ]);
 
   function handleActionClick() {

--- a/ui/contexts/rive-wasm/index.tsx
+++ b/ui/contexts/rive-wasm/index.tsx
@@ -22,13 +22,6 @@ export const useRiveWasmReady = () => {
   const [isWasmReady, setIsWasmReady] = useState(false);
 
   const result = useAsyncResult(async () => {
-    // E2E/unit builds: skip Rive WASM. createRoot unmount can free the
-    // runtime mid-frame and crash the UI before `.controller-loaded` is set
-    // (see MetaMask/metamask-extension#44516).
-    if (process.env.IN_TEST) {
-      return false;
-    }
-
     if (isWasmReady) {
       return true;
     }
@@ -56,8 +49,8 @@ export const useRiveWasmReady = () => {
 
   return {
     isWasmReady,
-    loading: process.env.IN_TEST ? false : result.pending,
-    error: process.env.IN_TEST ? undefined : result.error,
+    loading: result.pending,
+    error: result.error,
   };
 };
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,6 +1,8 @@
 import log from 'loglevel';
-import React, { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
+import React from 'react';
+// TODO: https://github.com/MetaMask/MetaMask-planning/issues/6925
+// eslint-disable-next-line react/no-deprecated
+import { render } from 'react-dom';
 import browser from 'webextension-polyfill';
 import { isInternalAccountInPermittedAccountIds } from '@metamask/chain-agnostic-permission';
 
@@ -66,30 +68,6 @@ export {
 } from './helpers/utils/display-critical-error';
 
 log.setLevel(global.METAMASK_DEBUG ? 'debug' : 'warn', false);
-
-const reactRoots = new WeakMap();
-
-function renderUi(element, container) {
-  let root = reactRoots.get(container);
-  if (!root) {
-    root = createRoot(container);
-    reactRoots.set(container, root);
-  }
-  root.render(element);
-}
-
-function wrapWithStrictModeIfDevelopment(element) {
-  // Dev-only StrictMode, matching `withStrictMode` in `ui/pages/index.js`.
-  // Skip when IN_TEST so E2E builds don't double-mount effects.
-  const isDevelopment =
-    process.env.NODE_ENV === 'development' && !process.env.IN_TEST;
-
-  if (isDevelopment) {
-    return <StrictMode>{element}</StrictMode>;
-  }
-
-  return element;
-}
 
 /**
  * @type {PromiseWithResolvers<ReturnType<typeof configureStore>>}
@@ -271,12 +249,7 @@ async function startApp(metamaskState, opts) {
   // `submitRequestToBackground` with it.
   const uiMessenger = createUIMessenger();
   trace({ name: TraceName.FirstRender, parentContext: traceContext }, () =>
-    renderUi(
-      wrapWithStrictModeIfDevelopment(
-        <Root store={store} uiMessenger={uiMessenger} />,
-      ),
-      opts.container,
-    ),
+    render(<Root store={store} uiMessenger={uiMessenger} />, opts.container),
   );
 
   return store;

--- a/ui/layouts/root-layout.tsx
+++ b/ui/layouts/root-layout.tsx
@@ -10,10 +10,7 @@ export const RootLayout = () => {
   const showBottomNav = useBottomNavBar();
 
   return (
-    <div
-      className={cn('w-full h-full flex flex-col', width)}
-      data-testid="app-root-layout"
-    >
+    <div className={cn('w-full h-full flex flex-col', width)}>
       <div className="flex-1 min-h-0 overflow-y-auto flex flex-col">
         <Outlet />
       </div>

--- a/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-icon-animation.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-icon-animation.tsx
@@ -223,10 +223,15 @@ const ShieldIconAnimation = ({
     // it's intended to trigger the animation when the theme changes
   }, [theme]);
 
+  // Stop animation on unmount or when rive instance changes
   useEffect(() => {
     return () => {
+      if (rive) {
+        rive.cleanup();
+      }
       isInitializedRef.current = false;
     };
+    // it's intended to stop the animation when the component unmounts
   }, []);
 
   // Don't render Rive component until WASM and buffer are ready to avoid errors

--- a/ui/pages/hardware-wallets/swap/generic-hardware-wallet-animation.tsx
+++ b/ui/pages/hardware-wallets/swap/generic-hardware-wallet-animation.tsx
@@ -145,6 +145,9 @@ const GenericHardwareWalletAnimation = ({
 
   useEffect(() => {
     return () => {
+      if (rive) {
+        rive.cleanup();
+      }
       isInitializedRef.current = false;
       lastInputNameRef.current = undefined;
     };

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -153,7 +153,6 @@ import { GlobalMenuRouteTransition } from './global-menu-route-transition';
 
 // Begin Lazy Routes
 const OnboardingFlow = mmLazy(() => import('../onboarding-flow/index.ts'));
-
 const Lock = mmLazy(() => import('../lock/index.ts'));
 const UnlockPage = mmLazy(() => import('../unlock-page/index.ts'));
 const RestoreVaultPage = mmLazy(() => import('../keychains/restore-vault.tsx'));

--- a/ui/pages/settings/debug-tab/debug-content/debug-content.tsx
+++ b/ui/pages/settings/debug-tab/debug-content/debug-content.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { ONBOARDING_REVIEW_SRP_ROUTE } from '../../../../helpers/constants/routes';
 
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   perpsToggleTestnet,
   resetOnboarding,
@@ -38,32 +39,15 @@ import SentryTest from './sentry-test';
 import { BackupAndSyncDevSettings } from './backup-and-sync';
 import MigrateToSplitStateTest from './migrate-to-split-state-test';
 
-const PAGE_CRASH_ERROR_MESSAGE =
-  'Unable to find value of key "debug" for locale "en"';
-
-type PageCrashTriggerProps = {
-  shouldCrash: boolean;
-};
-
-// Throws during render when armed. Prefer this over flushSync + locale
-// corruption: createRoot can batch the locale update such that the error
-// page never mounts for E2E.
-const PageCrashTrigger = ({ shouldCrash }: PageCrashTriggerProps) => {
-  if (shouldCrash) {
-    throw new Error(PAGE_CRASH_ERROR_MESSAGE);
-  }
-
-  return null;
-};
-
 const DebugContent = () => {
+  const t = useI18nContext();
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const [shouldCrashPage, setShouldCrashPage] = useState(false);
-  const triggerPageCrash = useCallback(() => {
-    setShouldCrashPage(true);
-  }, []);
+  // This translation call is only required for the "Generate Page Crash" test button.
+  // The crash mechanism works by setting 'debug' to undefined in the locale,
+  // which causes this t() call to throw an error that triggers the error boundary.
+  t('debug');
 
   const [hasResetAnnouncements, setHasResetAnnouncements] = useState(false);
   const [hasResetOnboarding, setHasResetOnboarding] = useState(false);
@@ -228,7 +212,6 @@ const DebugContent = () => {
 
   return (
     <div className="settings-page__body">
-      <PageCrashTrigger shouldCrash={shouldCrashPage} />
       <Text className="settings-page__security-tab-sub-header__bold">
         States
       </Text>
@@ -266,7 +249,7 @@ const DebugContent = () => {
       </div>
 
       <BackupAndSyncDevSettings />
-      <SentryTest triggerPageCrash={triggerPageCrash} />
+      <SentryTest />
       <hr />
       <MigrateToSplitStateTest />
       <hr />

--- a/ui/pages/settings/debug-tab/debug-content/sentry-test.tsx
+++ b/ui/pages/settings/debug-tab/debug-content/sentry-test.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useCallback, ReactElement } from 'react';
+import { flushSync } from 'react-dom';
+import { useSelector } from 'react-redux';
 import {
   Box,
   Button,
@@ -18,15 +20,19 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { trace, TraceName } from '../../../../../shared/lib/trace';
 
+import { setCurrentLocale } from '../../../../store/actions';
+import { FALLBACK_LOCALE, fetchLocale } from '../../../../../shared/lib/i18n';
+import { getCurrentLocale } from '../../../../ducks/locale/locale';
+import { useDispatch } from '../../../../store/hooks';
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-type SentryTestProps = {
-  triggerPageCrash: () => void;
-};
+const SentryTest = () => {
+  const currentLocale: string =
+    useSelector(getCurrentLocale) || FALLBACK_LOCALE;
 
-const SentryTest = ({ triggerPageCrash }: SentryTestProps) => {
   return (
     <>
       <Text className="settings-page__security-tab-sub-header__bold">
@@ -38,7 +44,7 @@ const SentryTest = ({ triggerPageCrash }: SentryTestProps) => {
         <CaptureUIError />
         <CaptureBackgroundError />
         <GenerateTrace />
-        <GeneratePageCrash triggerPageCrash={triggerPageCrash} />
+        <GeneratePageCrash currentLocale={currentLocale} />
       </div>
     </>
   );
@@ -175,14 +181,20 @@ function GenerateTrace() {
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function GeneratePageCrash({
-  triggerPageCrash,
-}: {
-  triggerPageCrash: () => void;
-}) {
-  const handleClick = useCallback(async () => {
-    triggerPageCrash();
-  }, [triggerPageCrash]);
+function GeneratePageCrash({ currentLocale }: { currentLocale: string }) {
+  const dispatch = useDispatch();
+  const handleClick = async () => {
+    const localeMessages = await fetchLocale(currentLocale);
+    flushSync(() => {
+      dispatch(
+        setCurrentLocale(currentLocale, {
+          ...localeMessages,
+          // @ts-expect-error - remove a language string in this page to trigger a page crash
+          debug: undefined,
+        }),
+      );
+    });
+  };
 
   return (
     <TestButton
@@ -224,15 +236,13 @@ function TestButton({
       await onClick();
     } catch (error) {
       hasError = true;
-      // Always rethrow so "Generate * Error" buttons still produce an unhandled
-      // rejection for Sentry. expectError only controls the success checkmark.
       throw error;
     } finally {
       if (expectError || !hasError) {
         setIsComplete(true);
       }
     }
-  }, [onClick, expectError]);
+  }, [onClick]);
 
   return (
     <Box

--- a/ui/pages/shield/transaction-shield/shield-banner-animation.tsx
+++ b/ui/pages/shield/transaction-shield/shield-banner-animation.tsx
@@ -131,10 +131,15 @@ const ShieldBannerAnimation = ({
     // it's intended to trigger the animation when the isInactive changes
   }, [isInactive]);
 
+  // Stop animation on unmount or when rive instance changes
   useEffect(() => {
     return () => {
+      if (rive) {
+        rive.cleanup();
+      }
       isInitializedRef.current = false;
     };
+    // it's intended to stop the animation when the component unmounts
   }, []);
 
   // Don't render Rive component until WASM and buffer are ready to avoid errors

--- a/yarn.lock
+++ b/yarn.lock
@@ -11751,8 +11751,8 @@ __metadata:
 
 "@rive-app/canvas@patch:@rive-app/canvas@patch%3A@rive-app/canvas@patch%253A@rive-app/canvas@npm%25253A2.31.5%2523~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%253A%253Aversion=2.31.5&hash=1ed092%23~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch%3A%3Aversion=2.31.5&hash=19c5d0#~/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch":
   version: 2.31.5
-  resolution: "@rive-app/canvas@patch:@rive-app/canvas@patch%3A@rive-app/canvas@patch%253A@rive-app/canvas@npm%25253A2.31.5%2523~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%253A%253Aversion=2.31.5&hash=1ed092%23~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch%3A%3Aversion=2.31.5&hash=19c5d0#~/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch::version=2.31.5&hash=b24ae4"
-  checksum: 10/d19b98ca38f2183c8c69893264f5b152faf3a7f984b6565f9ca347e99c2f272fa644c7ba2f5c999e907230bba5b38db315f2206ab4d057b06fe4ac1319799fe6
+  resolution: "@rive-app/canvas@patch:@rive-app/canvas@patch%3A@rive-app/canvas@patch%253A@rive-app/canvas@npm%25253A2.31.5%2523~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%253A%253Aversion=2.31.5&hash=1ed092%23~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch%3A%3Aversion=2.31.5&hash=19c5d0#~/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch::version=2.31.5&hash=410688"
+  checksum: 10/96e2414409aae7b87bbd06bbd643a8daa13c9a20444e0ca336328ba2a85aade5cad351076b1fb843d61627d1e2d7d7ee9cf943d1b198d800119024e3735d83dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Reverts #44530 (`796685ce7b753f36d8dd7a21a4f911337f508547`) in full. This restores the legacy `ReactDOM.render` bootstrap and removes the companion changes introduced for the `createRoot` migration, including rendering-test updates, Rive cleanup changes, portal adjustments, E2E workarounds, and the related patch/lockfile updates.

#44530 is currently the tip of `main`. Since it landed, consecutive merge-queue runs have failed in unrelated UI E2E areas, primarily with selector timeouts and stale-element errors. Similar flakes existed before #44530, so this revert does not assert that the migration originated every failure; it restores the prior rendering baseline while we determine whether `createRoot` is amplifying their frequency.

Validation performed locally:

- `yarn lint:changed:fix` (passes with three pre-existing warnings)
- Focused unit tests for the global menu drawer, status icon, and survey toast (19 tests passed)
- Confirmed the resulting source tree exactly matches #44530's parent commit

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Reverts: #44530

## **Manual testing steps**

1. Build and load the extension in Chrome.
2. Complete onboarding or unlock an existing wallet, and verify the home screen renders normally.
3. Open the global menu drawer and navigate through Settings, verifying the extension shell remains interactive.
4. Connect to a test dapp and initiate a confirmation, verifying the confirmation screen and status icon render normally.
5. Reload both the popup and a fullscreen extension page, verifying neither displays a blank screen or crashes.

<!--
## **Screenshots/Recordings**

Not applicable; this PR restores the previous rendering implementation without an intended visual change.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Reverts the extension-wide React 18 root API and changes survey fetch timing and Rive teardown/WASM loading, which can affect startup stability, E2E flakes, and home-screen survey behavior.
> 
> **Overview**
> Reverts the **`createRoot`** UI bootstrap (#44530) and restores legacy **`ReactDOM.render`** in `ui/index.js`, dropping the `createRoot` root cache and dev **`StrictMode`** wrapper.
> 
> **Rive / animations:** Re-enables Rive WASM loading in test builds, trims the `@rive-app/canvas` patch (fewer createRoot-specific runtime guards), and adds explicit **`rive.cleanup()`** on unmount across Shield, Perps, hardware-wallet, and status-icon animations; **`StatusIcon`** switches theme input handling to **`useStateMachineInput`**.
> 
> **Shell / surveys:** **`GlobalMenuDrawer`** again finds the root layout via `max-w-[` / flex classes (no `app-root-layout` test id or position-retry loop). **`SurveyToast`** / **`ToastMaster`** no longer gate survey fetch on wallet unlock; the survey effect keys off selected account address instead. E2E survey mocking goes back to **`.twice()`** for the duplicate-fetch behavior (#33604).
> 
> **Tests / tooling:** Confirmation E2E drops inline-alert wait and adjusts alert-modal reject flow; debug **page crash** test uses locale **`debug: undefined`** + **`flushSync`** again instead of a render-time throw. Jest console baselines and eslint suppressions are updated for the reverted behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091b597e0fac3885854bdee893117b526883b7cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->