### PR TITLE
fix(analytics): seed cachedAnalyticsId before init() geolocation await

### DIFF
--- a/app/scripts/messenger-client-init/analytics-controller-init.ts
+++ b/app/scripts/messenger-client-init/analytics-controller-init.ts
@@ -51,15 +51,26 @@ export const AnalyticsControllerInit: MessengerClientInitFunction<
   );
   configureOptOutSegmentEnrichment(enrichmentContext);
 
+  const platformAdapter = createPlatformAdapter(enrichmentContext);
+
   const controller = new AnalyticsController({
     messenger: controllerMessenger,
-    platformAdapter: createPlatformAdapter(enrichmentContext),
+    platformAdapter,
     state: persisted as AnalyticsControllerState,
     isAnonymousEventsFeatureEnabled: true,
     isEventQueuePersistenceEnabled: true,
     isPreConsentQueueEnabled: true,
     isGeolocationEnabled: true,
   });
+
+  // Eagerly seed cachedAnalyticsId so track/view payloads have a valid userId
+  // before init() completes. When isGeolocationEnabled is true, init() awaits
+  // a geolocation network request before calling onSetupCompleted — creating a
+  // window where events fire with userId: undefined. Calling it here is safe
+  // and idempotent; init() will call it again once geolocation resolves.
+  // See: https://github.com/MetaMask/metamask-extension/issues/45125
+  platformAdapter.onSetupCompleted(persisted.analyticsId);
+
   controller.init();
 
   configureAnalytics({


### PR DESCRIPTION
## **Description**

`@metamask/analytics-controller@2.0.0` made `init()` asynchronous (breaking change). When `isGeolocationEnabled: true`, `init()` awaits a geolocation network request before calling `platformAdapter.onSetupCompleted()` which sets `cachedAnalyticsId` in the platform adapter.

Because `controller.init()` is not awaited (the `MessengerClientInitFunction` type is synchronous), any analytics event fired during geolocation resolution sends Segment payloads with `userId: undefined`. This silently corrupts analytics data for all opted-in returning users on every startup.

**Fix:** Extract `platformAdapter` and call `onSetupCompleted` immediately after controller construction to seed `cachedAnalyticsId` before any events fire. `init()` calls it again once geolocation resolves safe and idempotent (same value).

## **Changelog**

CHANGELOG entry: Fixed a bug causing Segment analytics events to be sent with `userId: undefined` for opted-in users during extension startup.

## **Related issues**

Fixes: #45125

## **Manual testing steps**

1. Ensure analytics is opted in (returning user)
2. Restart the extension
3. Verify Segment track/view payloads contain the correct `userId` immediately after startup, before geolocation resolves

## **Screenshots/Recordings**

N/A silent data corruption, no visible UI change.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR (not required for external contributors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted analytics bootstrap change using an existing idempotent API; no auth or data-model changes.
> 
> **Overview**
> Fixes opted-in users sending Segment **track**/**page** events with **`userId: undefined`** during extension startup after `@metamask/analytics-controller` 2.x made **`init()`** async.
> 
> **`analytics-controller-init`** now keeps a **`platformAdapter`** reference and calls **`onSetupCompleted(persisted.analyticsId)`** right after **`AnalyticsController`** construction, before **`controller.init()`**. With **`isGeolocationEnabled: true`**, **`init()`** used to await geolocation before seeding the adapter’s **`cachedAnalyticsId`**, while **`init()`** is not awaited—so early events missed **`userId`**. The early call is idempotent; **`init()`** still invokes **`onSetupCompleted`** after geolocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6815b76c4593c464438f9326888a4df8ecc27afb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->