### PR TITLE
fix(streams): call setupLegacyExtensionStreams in onDisconnectDestroyStreams timeout

### DIFF
--- a/app/scripts/streams/provider-stream.ts
+++ b/app/scripts/streams/provider-stream.ts
@@ -341,7 +341,10 @@ export function onDisconnectDestroyStreams(err: unknown) {
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     console.warn(`${lastErr} Resetting the streams.`);
-    setTimeout(setupExtensionStreams, 1000);
+    setTimeout(() => {
+      setupExtensionStreams();
+      setupLegacyExtensionStreams();
+    }, 1000);
   }
 }
 


### PR DESCRIPTION
## **Description**

`onDisconnectDestroyStreams` schedules a 1-second reconnect via `setTimeout` after a port disconnect error. The timeout callback called only `setupExtensionStreams()`, unlike every other reconnect site (`initStreams`, `onMessageSetUpExtensionStreams`) which always calls both `setupExtensionStreams()` and `setupLegacyExtensionStreams()` together.

Two race conditions result:

- **Mode A:** `EXTENSION_MESSAGES.READY` fires before the timeout → `onMessageSetUpExtensionStreams` runs first and sets up both streams; the timeout then calls `setupExtensionStreams` again → duplicate streams, orphaned port.
- **Mode B:** timeout fires first → `extensionStream` is set; when `READY` arrives, `onMessageSetUpExtensionStreams` sees `if (!extensionStream)` → false and skips → `setupLegacyExtensionStreams` is never called → legacy dApp provider permanently broken for the session.

## **Changelog**

CHANGELOG entry: Fixed a bug where legacy dApp provider streams were not re-established after a service worker disconnect recovery.

## **Related issues**

Fixes: #45124

## **Manual testing steps**

1. Open MetaMask with an active dApp connection
2. Force a service worker disconnect (e.g. via chrome://serviceworker-internals → Stop)
3. Verify the dApp provider reconnects correctly (both regular and legacy streams)

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR (not required for external contributors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches content-script stream recovery after service worker disconnect; wrong ordering could still affect dApp connectivity, but the change mirrors existing, tested reconnect behavior.
> 
> **Overview**
> After a service worker disconnect, **`onDisconnectDestroyStreams`** schedules a 1s delayed reconnect. That path previously called only **`setupExtensionStreams()`**, while **`initStreams`** and the **`EXTENSION_MESSAGES.READY`** handler always run **`setupExtensionStreams()`** and **`setupLegacyExtensionStreams()`** together.
> 
> The timeout callback now invokes **both** setup functions, matching the other reconnect paths. That avoids races where **`READY`** and the timeout disagree on whether the extension stream exists—either duplicating streams or skipping legacy provider setup for the rest of the session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3417c482fb1309d9ab28248cef64b5c09b31646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->