### PR TITLE
chore: tweak toast ui

### DIFF
--- a/ui/components/multichain/toast/index.scss
+++ b/ui/components/multichain/toast/index.scss
@@ -42,6 +42,7 @@
 
   [role=status] {
     justify-content: flex-start;
+    margin-block: 0;
   }
 }
 

--- a/ui/components/ui/toast/toast.tsx
+++ b/ui/components/ui/toast/toast.tsx
@@ -1,5 +1,10 @@
 import React, { type CSSProperties } from 'react';
-import { toast, ToastBar, Toaster as ToasterBase } from 'react-hot-toast';
+import {
+  type Toast,
+  toast,
+  ToastBar,
+  Toaster as ToasterBase,
+} from 'react-hot-toast';
 import {
   ButtonIcon,
   ButtonIconSize,
@@ -14,6 +19,10 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { StatusIcon } from '../status-icon/status-icon';
 
 export { toast } from 'react-hot-toast';
+
+export type ToastWithClose = Toast & {
+  onClose?: () => void;
+};
 
 const statusMap = {
   loading: 'loading',
@@ -67,7 +76,11 @@ export function Toaster() {
                 ariaLabel={t('close')}
                 iconName={IconName.Close}
                 size={ButtonIconSize.Sm}
-                onClick={() => toast.dismiss(item.id)}
+                className="self-start"
+                onClick={() => {
+                  (item as ToastWithClose).onClose?.();
+                  toast.dismiss(item.id);
+                }}
               />
             </>
           )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adjust the toast UI, alignment and adding an optional `onClose` prop, part of breaking down #45122

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1af70a8025a132a7807d8fb16c9dccc2c09e5f82. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->