### PR TITLE
fix: use ds modalheader for latest styles on network picker modal

### DIFF
--- a/test/e2e/page-objects/pages/home-network-filter.ts
+++ b/test/e2e/page-objects/pages/home-network-filter.ts
@@ -8,8 +8,7 @@ class HomeNetworkFilter {
 
   protected readonly driver: Driver;
 
-  private readonly modalCloseButton =
-    '.mm-modal-header button[aria-label="Close"]';
+  private readonly modalCloseButton = 'header button[aria-label="Close"]';
 
   private readonly networksToggle = '[data-testid="sort-by-networks"]';
 

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -19,6 +19,7 @@ import {
   FontWeight,
   IconColor as DsIconColor,
   IconName as DsIconName,
+  ModalHeader,
   Text,
   TextColor,
   TextVariant,
@@ -41,7 +42,6 @@ import {
   Modal,
   ModalContent,
   ModalContentSize,
-  ModalHeader,
   ModalOverlay,
 } from '../../../../component-library';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
@@ -235,6 +235,7 @@ export const NetworkSelectionModal = ({
   footerButton,
   'data-testid': dataTestId,
 }: NetworkSelectionModalProps) => {
+  const t = useI18nContext();
   return (
     <Modal
       isOpen={isOpen}
@@ -252,7 +253,12 @@ export const NetworkSelectionModal = ({
             className: 'flex h-full flex-col overflow-hidden',
           }}
         >
-          <ModalHeader onClose={onClose}>{title}</ModalHeader>
+          <ModalHeader
+            onClose={onClose}
+            closeButtonProps={{ ariaLabel: t('close') }}
+          >
+            {title}
+          </ModalHeader>
           <Box
             className="min-h-0 flex-1 overflow-y-auto"
             flexDirection={BoxFlexDirection.Column}

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -26,29 +26,34 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
         role="dialog"
       >
         <header
-          class="mm-box mm-header-base mm-modal-header mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
+          class="grid grid-cols-[1fr_auto_1fr] items-center px-4 pb-4"
         >
           <div
-            class="mm-box mm-box--width-full"
+            class="col-start-2 col-end-3 w-full"
           >
             <h4
-              class="mm-box mm-text mm-text--heading-sm mm-text--text-align-center mm-box--color-text-default"
+              class="text-default text-s-heading-sm leading-s-heading-sm tracking-s-heading-sm md:text-l-heading-sm md:leading-l-heading-sm md:tracking-l-heading-sm font-bold font-default text-center"
             >
               Select network
             </h4>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--justify-content-flex-end"
-            style="min-width: 0px;"
+            class="col-start-3 justify-self-end"
           >
             <button
               aria-label="Close"
-              class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+              class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
             >
-              <span
-                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
-                style="mask-image: url('./images/icons/close.svg');"
-              />
+              <svg
+                class="inline-block w-6 h-6 text-inherit"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.4 19 5 17.6l5.6-5.6L5 6.4 6.4 5l5.6 5.6L17.6 5 19 6.4 13.4 12l5.6 5.6-1.4 1.4-5.6-5.6z"
+                />
+              </svg>
             </button>
           </div>
         </header>
@@ -510,29 +515,34 @@ exports[`BridgeInputGroup should render source networks 1`] = `
         role="dialog"
       >
         <header
-          class="mm-box mm-header-base mm-modal-header mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
+          class="grid grid-cols-[1fr_auto_1fr] items-center px-4 pb-4"
         >
           <div
-            class="mm-box mm-box--width-full"
+            class="col-start-2 col-end-3 w-full"
           >
             <h4
-              class="mm-box mm-text mm-text--heading-sm mm-text--text-align-center mm-box--color-text-default"
+              class="text-default text-s-heading-sm leading-s-heading-sm tracking-s-heading-sm md:text-l-heading-sm md:leading-l-heading-sm md:tracking-l-heading-sm font-bold font-default text-center"
             >
               Select network
             </h4>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--justify-content-flex-end"
-            style="min-width: 0px;"
+            class="col-start-3 justify-self-end"
           >
             <button
               aria-label="Close"
-              class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+              class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
             >
-              <span
-                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
-                style="mask-image: url('./images/icons/close.svg');"
-              />
+              <svg
+                class="inline-block w-6 h-6 text-inherit"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.4 19 5 17.6l5.6-5.6L5 6.4 6.4 5l5.6 5.6L17.6 5 19 6.4 13.4 12l5.6 5.6-1.4 1.4-5.6-5.6z"
+                />
+              </svg>
             </button>
           </div>
         </header>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates alignment of Select Network header on network picker modal

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updates alignment of Select Network header on network picker modal

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1250

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://consensyssoftware.atlassian.net/browse/CEUX-1250

### **After**

<img width="449" height="261" alt="image" src="https://github.com/user-attachments/assets/400ad2dd-96ac-44db-b3a7-8c786c69e7ec" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only modal header migration with localized close label and test selector updates; no transaction or auth logic changes.
> 
> **Overview**
> **Network selection modals** (home network filter, bridge network picker, and other `NetworkSelectionModal` consumers) now use **`ModalHeader` from `@metamask/design-system-react`** instead of the component-library header, so the **“Select network”** title and close control match current design-system layout (centered title in a grid header, DS close button with inline SVG).
> 
> `NetworkSelectionModal` wires **`closeButtonProps={{ ariaLabel: t('close') }}`** for localized close labeling. E2E **`home-network-filter`** close targeting is updated to **`header button[aria-label="Close"]`** to match the new markup. Bridge prepare **Jest snapshots** are refreshed for the new header DOM/classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111dafacceccb67941b4d03683a092f63512938d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->