### PR TITLE
fix: add autoscroll to notifications page

### DIFF
--- a/ui/pages/settings/notifications-tab/notification-section-sub-page.tsx
+++ b/ui/pages/settings/notifications-tab/notification-section-sub-page.tsx
@@ -112,7 +112,7 @@ export const NotificationSectionSubPage = ({
     <Box
       flexDirection={BoxFlexDirection.Column}
       alignItems={BoxAlignItems.Stretch}
-      className="h-full min-h-0"
+      className="h-full min-h-0 overflow-y-auto"
       paddingTop={3}
       paddingHorizontal={4}
       gap={6}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds autoscroll to the notifications Wallet Activity container so that it scrolls and doesn't push the settings side tab bar down

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds autoscroll to the notifications Wallet Activity container

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1221

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://consensyssoftware.atlassian.net/browse/CEUX-1221

### **After**

<img width="800" height="769" alt="image" src="https://github.com/user-attachments/assets/9c4ac239-8903-4ec5-97fa-4ca4e5be3514" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class change on a settings layout wrapper with no logic, data, or security impact.
> 
> **Overview**
> Adds **`overflow-y-auto`** to the main `Box` wrapper in `notification-section-sub-page.tsx` (alongside the existing `h-full min-h-0` classes).
> 
> Long notification section content (e.g. Wallet Activity) now scrolls inside that panel instead of growing the page and pushing the settings sidebar down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197c4b88a3d9d50a9d3f32df013da073ab4b9b4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->