### PR TITLE
fix: reduce horizontal padding on account private key list

### DIFF
--- a/ui/components/multichain-accounts/multichain-private-key-list/multichain-private-key-list.tsx
+++ b/ui/components/multichain-accounts/multichain-private-key-list/multichain-private-key-list.tsx
@@ -360,7 +360,7 @@ const MultichainPrivateKeyList = ({
 
   const renderedPasswordInput = useMemo(
     () => (
-      <Box paddingTop={8} paddingBottom={4}>
+      <Box paddingTop={8} paddingBottom={4} paddingHorizontal={4}>
         <Box>
           <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
             {t('enterYourPassword')}

--- a/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.tsx
@@ -90,26 +90,23 @@ export const MultichainAccountPrivateKeyListPage = ({
       >
         {accountGroupName} / {t('privateKeys')}
       </Header>
-      <Content>
-        <BannerAlert
-          data-testid="backup-state-banner-alert"
-          title={t('revealMultichainPrivateKeysBannerTitle')}
-          paddingTop={2}
-          paddingBottom={2}
-          severity={BannerAlertSeverity.Danger}
-        >
-          {t('revealMultichainPrivateKeysBannerDescription', [learnMoreLink])}
-        </BannerAlert>
-        <Box flexDirection={BoxFlexDirection.Column}>
-          {decodedAccountGroupId ? (
-            <MultichainPrivateKeyList
-              groupId={decodedAccountGroupId}
-              goBack={() => navigate(PREVIOUS_ROUTE)}
-              data-testid="multichain-account-private-key-list"
-            />
-          ) : null}
-        </Box>
-      </Content>
+      <BannerAlert
+        data-testid="backup-state-banner-alert"
+        title={t('revealMultichainPrivateKeysBannerTitle')}
+        severity={BannerAlertSeverity.Danger}
+        marginHorizontal={4}
+      >
+        {t('revealMultichainPrivateKeysBannerDescription', [learnMoreLink])}
+      </BannerAlert>
+      <Box flexDirection={BoxFlexDirection.Column}>
+        {decodedAccountGroupId ? (
+          <MultichainPrivateKeyList
+            groupId={decodedAccountGroupId}
+            goBack={() => navigate(PREVIOUS_ROUTE)}
+            data-testid="multichain-account-private-key-list"
+          />
+        ) : null}
+      </Box>
     </Page>
   );
 };

--- a/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.tsx
@@ -94,6 +94,8 @@ export const MultichainAccountPrivateKeyListPage = ({
         <BannerAlert
           data-testid="backup-state-banner-alert"
           title={t('revealMultichainPrivateKeysBannerTitle')}
+          paddingTop={2}
+          paddingBottom={2}
           severity={BannerAlertSeverity.Danger}
           marginHorizontal={4}
         >

--- a/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.tsx
@@ -90,23 +90,25 @@ export const MultichainAccountPrivateKeyListPage = ({
       >
         {accountGroupName} / {t('privateKeys')}
       </Header>
-      <BannerAlert
-        data-testid="backup-state-banner-alert"
-        title={t('revealMultichainPrivateKeysBannerTitle')}
-        severity={BannerAlertSeverity.Danger}
-        marginHorizontal={4}
-      >
-        {t('revealMultichainPrivateKeysBannerDescription', [learnMoreLink])}
-      </BannerAlert>
-      <Box flexDirection={BoxFlexDirection.Column}>
-        {decodedAccountGroupId ? (
-          <MultichainPrivateKeyList
-            groupId={decodedAccountGroupId}
-            goBack={() => navigate(PREVIOUS_ROUTE)}
-            data-testid="multichain-account-private-key-list"
-          />
-        ) : null}
-      </Box>
+      <Content padding={0}>
+        <BannerAlert
+          data-testid="backup-state-banner-alert"
+          title={t('revealMultichainPrivateKeysBannerTitle')}
+          severity={BannerAlertSeverity.Danger}
+          marginHorizontal={4}
+        >
+          {t('revealMultichainPrivateKeysBannerDescription', [learnMoreLink])}
+        </BannerAlert>
+        <Box flexDirection={BoxFlexDirection.Column}>
+          {decodedAccountGroupId ? (
+            <MultichainPrivateKeyList
+              groupId={decodedAccountGroupId}
+              goBack={() => navigate(PREVIOUS_ROUTE)}
+              data-testid="multichain-account-private-key-list"
+            />
+          ) : null}
+        </Box>
+      </Content>
     </Page>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes the full-width success background state of copying a private key: https://consensyssoftware.atlassian.net/browse/CEUX-1235. Also has the effect of reducing the horizontal margin on the private key list by 4, which keeps it consistent with other account lists.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adjusts horizontal padding on private keys list

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1235

## **Manual testing steps**

1. Go to Account list > Private Keys
2. Check the password screen has correct padding
3. Enter password
4. Check the list screen has correct padding and clicking Copy shows the green bg full width

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://consensyssoftware.atlassian.net/browse/CEUX-1235

### **After**

<img width="521" height="644" alt="image" src="https://github.com/user-attachments/assets/92b87c5f-f17b-4045-a365-6be3348b7286" />



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only spacing changes on the private key reveal flow; no logic, auth, or data handling changes.
> 
> **Overview**
> Fixes **CEUX-1235** by aligning the multichain **Private Keys** screen with other account list pages.
> 
> The page **`Content`** now uses **`padding={0}`** (same pattern as the address list). The danger **banner** gets **`marginHorizontal={4}`**, and the password gate in **`MultichainPrivateKeyList`** adds **`paddingHorizontal={4}`** on its wrapper so copy/reveal UI can span the full content width without double horizontal inset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fed2536ba0bf97fd39046b489d1e1a526f31f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->