### PR TITLE
feat: updated the skeleton for search loading state

### DIFF
--- a/ui/pages/discover-search/discover-search-section-skeleton.tsx
+++ b/ui/pages/discover-search/discover-search-section-skeleton.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Skeleton,
+} from '@metamask/design-system-react';
+
+const DISCOVER_SEARCH_SKELETON_ROW_COUNT = 3;
+
+const DiscoverSearchRowSkeleton = ({
+  'data-testid': dataTestId,
+}: {
+  'data-testid': string;
+}) => (
+  <Box
+    className="min-h-[72px] gap-3 px-4 py-3"
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    data-testid={dataTestId}
+  >
+    <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+    <Box
+      className="min-w-0 flex-1 gap-2"
+      flexDirection={BoxFlexDirection.Column}
+    >
+      <Skeleton className="h-4 w-28" />
+      <Skeleton className="h-3 w-36" />
+    </Box>
+    <Box className="shrink-0 gap-2" flexDirection={BoxFlexDirection.Column}>
+      <Skeleton className="h-4 w-16" />
+      <Skeleton className="h-3 w-12" />
+    </Box>
+  </Box>
+);
+
+export const DiscoverSearchSectionSkeleton = ({
+  testIdPrefix,
+}: {
+  testIdPrefix: string;
+}) => (
+  <>
+    {Array.from({ length: DISCOVER_SEARCH_SKELETON_ROW_COUNT }, (_, index) => (
+      <DiscoverSearchRowSkeleton
+        key={index}
+        data-testid={`${testIdPrefix}-skeleton-${index}`}
+      />
+    ))}
+  </>
+);

--- a/ui/pages/discover-search/discover-search.tsx
+++ b/ui/pages/discover-search/discover-search.tsx
@@ -138,7 +138,10 @@ export const DiscoverSearchPage = () => {
   const showAllEmpty = !allLoading && !hasAnyPreview;
 
   const renderAllTabSkeleton = () => (
-    <Box flexDirection={BoxFlexDirection.Column} data-testid="discover-search-loading">
+    <Box
+      flexDirection={BoxFlexDirection.Column}
+      data-testid="discover-search-loading"
+    >
       <DiscoverSearchSectionHeader
         title={t('perpsFilterCrypto')}
         showViewAll={false}

--- a/ui/pages/discover-search/discover-search.tsx
+++ b/ui/pages/discover-search/discover-search.tsx
@@ -11,10 +11,7 @@ import {
   BoxJustifyContent,
   ButtonIcon,
   ButtonIconSize,
-  Icon,
-  IconColor,
   IconName,
-  IconSize,
   Text,
   TextAlign,
   TextColor,
@@ -39,24 +36,7 @@ import { buildAssetRoutePath } from '../../../shared/lib/asset-route';
 import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
 import { DiscoverAssetRow } from './discover-asset-row';
 import { DiscoverSearchSectionHeader } from './discover-search-section-header';
-
-const LoadingState = ({ label }: { label: string }) => (
-  <Box
-    flexDirection={BoxFlexDirection.Column}
-    alignItems={BoxAlignItems.Center}
-    justifyContent={BoxJustifyContent.Center}
-    padding={6}
-    aria-label={label}
-    data-testid="discover-search-loading"
-  >
-    <Icon
-      className="animate-spin"
-      name={IconName.Loading}
-      color={IconColor.IconMuted}
-      size={IconSize.Lg}
-    />
-  </Box>
-);
+import { DiscoverSearchSectionSkeleton } from './discover-search-section-skeleton';
 
 const EmptyState = ({ message }: { message: string }) => (
   <Box
@@ -157,13 +137,42 @@ export const DiscoverSearchPage = () => {
   const showAllLoading = allLoading && !hasAnyPreview;
   const showAllEmpty = !allLoading && !hasAnyPreview;
 
+  const renderAllTabSkeleton = () => (
+    <Box flexDirection={BoxFlexDirection.Column} data-testid="discover-search-loading">
+      <DiscoverSearchSectionHeader
+        title={t('perpsFilterCrypto')}
+        showViewAll={false}
+        data-testid="discover-section-crypto"
+      />
+      <DiscoverSearchSectionSkeleton testIdPrefix="discover-crypto-preview" />
+
+      {isPerpsAvailable ? (
+        <>
+          <DiscoverSearchSectionHeader
+            title={t('perps')}
+            showViewAll={false}
+            data-testid="discover-section-perps"
+          />
+          <DiscoverSearchSectionSkeleton testIdPrefix="discover-perps" />
+        </>
+      ) : null}
+
+      <DiscoverSearchSectionHeader
+        title={t('perpsFilterStocks')}
+        showViewAll={false}
+        data-testid="discover-section-stocks"
+      />
+      <DiscoverSearchSectionSkeleton testIdPrefix="discover-stocks-preview" />
+    </Box>
+  );
+
   const renderAssetList = (
     items: TrendingAsset[],
     isLoading: boolean,
     testIdPrefix: string,
   ) => {
     if (isLoading && items.length === 0) {
-      return <LoadingState label={t('loading')} />;
+      return <DiscoverSearchSectionSkeleton testIdPrefix={testIdPrefix} />;
     }
     if (items.length === 0) {
       return <EmptyState message={t('discoverSearchNoResults')} />;
@@ -180,7 +189,7 @@ export const DiscoverSearchPage = () => {
 
   const renderPerpsList = (items: PerpsMarketData[], isLoading: boolean) => {
     if (isLoading && items.length === 0) {
-      return <LoadingState label={t('loading')} />;
+      return <DiscoverSearchSectionSkeleton testIdPrefix="discover-perps" />;
     }
     if (items.length === 0) {
       return <EmptyState message={t('discoverSearchNoResults')} />;
@@ -198,7 +207,7 @@ export const DiscoverSearchPage = () => {
 
   const allTabContent = (() => {
     if (showAllLoading) {
-      return <LoadingState label={t('loading')} />;
+      return renderAllTabSkeleton();
     }
     if (showAllEmpty) {
       return <EmptyState message={t('discoverSearchNoResults')} />;


### PR DESCRIPTION
This PR improves the Discover Search experience by adding polished loading and empty states.

Adds section-level skeleton loading states so Crypto, Perps, and Stocks each render three placeholder rows while results are loading.
Adds a dedicated no-results state for searched queries, including suggested popular assets.
Keeps the loading UI colocated in a reusable Discover Search skeleton component.

[Figma](https://www.figma.com/design/gb2U5v8Q7ZkFRNwtElGAkp/Discover-search-on-extension?node-id=37-3325&m=dev)
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added search skeleton

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build and run the extension.
2. Enable the extensionUXSearch feature flag.
3. Open the extension and click the Search entry point in the app header.
4. Verify the Discover Search page opens correctly.
5. Enter a search query and verify loading sections show skeleton rows.
6. Verify each loading section shows three skeleton rows.
7. Search for a term with no results.
8. Verify the no-results empty state appears with popular asset suggestions.
9. Click a suggested popular asset and verify it navigates to the asset detail page.
10. Switch between All, Crypto, Perps, and Stocks tabs and verify loading, results, and empty states render correctly.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/5fcfadc8-2bf9-4dcb-b61b-4a48de434c56


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only loading UI swap with no data, routing, or search logic changes; main review note is keeping `data-testid` expectations aligned for any tests that asserted the old spinner.
> 
> **Overview**
> **Replaces the centered loading spinner** on Discover Search with **section-shaped skeleton placeholders** that mirror real asset/perps rows (avatar + two text columns).
> 
> Adds `DiscoverSearchSectionSkeleton`, which renders **three skeleton rows** per section with configurable `data-testid` prefixes. The **All** tab initial load uses `renderAllTabSkeleton`: section headers for Crypto, optional Perps, and Stocks, each followed by skeleton rows—still keyed by `discover-search-loading`.
> 
> Per-tab and per-section loading paths in `renderAssetList` / `renderPerpsList` now show the same skeleton component instead of the removed inline `LoadingState`. Unused `Icon` imports are dropped from `discover-search.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6e10d4212f74bf63dea0b7f8ed59ca416373cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->