### PR TITLE
feat: added no search result update for header search

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3500,6 +3500,14 @@
     "message": "No results found",
     "description": "Empty state when Discover search returns no matching assets."
   },
+  "discoverSearchNoResultsFor": {
+    "message": "No results found for “$1”",
+    "description": "Empty state title when Discover search returns no matching assets for a user query."
+  },
+  "discoverSearchPopularAssets": {
+    "message": "Check out other popular assets",
+    "description": "Empty state subtitle prompting users to open popular assets when Discover search has no results."
+  },
   "discoverSearchVol": {
     "message": "vol",
     "description": "Abbreviated label for volume in Discover search result rows."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3500,6 +3500,14 @@
     "message": "No results found",
     "description": "Empty state when Discover search returns no matching assets."
   },
+  "discoverSearchNoResultsFor": {
+    "message": "No results found for “$1”",
+    "description": "Empty state title when Discover search returns no matching assets for a user query."
+  },
+  "discoverSearchPopularAssets": {
+    "message": "Check out other popular assets",
+    "description": "Empty state subtitle prompting users to open popular assets when Discover search has no results."
+  },
   "discoverSearchVol": {
     "message": "vol",
     "description": "Abbreviated label for volume in Discover search result rows."

--- a/ui/pages/discover-search/discover-no-results-state.tsx
+++ b/ui/pages/discover-search/discover-no-results-state.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import {
+  AvatarNetwork,
+  AvatarNetworkSize,
   AvatarToken,
   AvatarTokenSize,
+  BadgeWrapper,
   Box,
   BoxFlexDirection,
   ButtonBase,
@@ -13,6 +16,11 @@ import {
 } from '@metamask/design-system-react';
 import type { CaipAssetType } from '@metamask/utils';
 
+import {
+  CHAIN_IDS,
+  CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
+} from '../../../shared/constants/network';
+import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
 import { ThemeType } from '../../../shared/constants/preferences';
 import { getCaipAssetImageUrl } from '../../../shared/lib/asset-utils';
 import { useI18nContext } from '../../hooks/useI18nContext';
@@ -21,23 +29,31 @@ import { useTheme } from '../../hooks/useTheme';
 const POPULAR_ASSETS: {
   assetId: CaipAssetType;
   name: string;
+  networkName: string;
+  networkImage: string;
   symbol: string;
 }[] = [
   {
     assetId: 'eip155:1/slip44:60' as CaipAssetType,
     name: 'Ethereum',
+    networkName: 'Ethereum',
+    networkImage: CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[CHAIN_IDS.MAINNET],
     symbol: 'ETH',
   },
   {
     assetId:
       'bip122:000000000019d6689c085ae165831e93/slip44:0' as CaipAssetType,
     name: 'Bitcoin',
+    networkName: 'Bitcoin',
+    networkImage: CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[MultichainNetworks.BITCOIN],
     symbol: 'BTC',
   },
   {
     assetId:
       'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501' as CaipAssetType,
     name: 'Solana',
+    networkName: 'Solana',
+    networkImage: CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[MultichainNetworks.SOLANA],
     symbol: 'SOL',
   },
 ];
@@ -72,8 +88,12 @@ export const DiscoverNoResultsState = ({
           aria-hidden="true"
           data-testid="discover-search-no-results-illustration"
         />
-        <Box className="flex w-64 flex-col items-center gap-1">
-          <Text variant={TextVariant.BodyMd} textAlign={TextAlign.Center}>
+        <Box className="flex w-full flex-col items-center gap-1">
+          <Text
+            variant={TextVariant.BodyMd}
+            textAlign={TextAlign.Center}
+            className="whitespace-nowrap"
+          >
             {t('discoverSearchNoResultsFor', [query])}
           </Text>
           <Text
@@ -86,28 +106,45 @@ export const DiscoverNoResultsState = ({
         </Box>
       </Box>
       <Box className="flex w-full items-center justify-center gap-2">
-        {POPULAR_ASSETS.map(({ assetId, name, symbol }) => (
-          <ButtonBase
-            key={assetId}
-            className="h-10 rounded-full bg-muted px-3 hover:bg-muted-hover active:bg-pressed"
-            data-testid={`discover-search-popular-asset-${symbol.toLowerCase()}`}
-            onClick={() => onAssetPress(assetId)}
-          >
-            <Box
-              className="items-center gap-3"
-              flexDirection={BoxFlexDirection.Row}
+        {POPULAR_ASSETS.map(
+          ({ assetId, name, networkImage, networkName, symbol }) => (
+            <ButtonBase
+              key={assetId}
+              className="rounded-full bg-muted px-3 py-2 hover:bg-muted-hover active:bg-pressed"
+              data-testid={`discover-search-popular-asset-${symbol.toLowerCase()}`}
+              onClick={() => onAssetPress(assetId)}
             >
-              <AvatarToken
-                name={name}
-                src={getCaipAssetImageUrl(assetId)}
-                size={AvatarTokenSize.Md}
-              />
-              <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-                {symbol}
-              </Text>
-            </Box>
-          </ButtonBase>
-        ))}
+              <Box
+                className="items-center gap-3"
+                flexDirection={BoxFlexDirection.Row}
+              >
+                <BadgeWrapper
+                  badge={
+                    <AvatarNetwork
+                      name={networkName}
+                      src={networkImage}
+                      size={AvatarNetworkSize.Xs}
+                      className="rounded-md border-2 border-background-default bg-background-default"
+                      data-testid={`discover-search-popular-asset-${symbol.toLowerCase()}-network`}
+                    />
+                  }
+                >
+                  <AvatarToken
+                    name={name}
+                    src={getCaipAssetImageUrl(assetId)}
+                    size={AvatarTokenSize.Md}
+                  />
+                </BadgeWrapper>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                >
+                  {symbol}
+                </Text>
+              </Box>
+            </ButtonBase>
+          ),
+        )}
       </Box>
     </Box>
   );

--- a/ui/pages/discover-search/discover-no-results-state.tsx
+++ b/ui/pages/discover-search/discover-no-results-state.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import {
+  AvatarToken,
+  AvatarTokenSize,
+  Box,
+  BoxFlexDirection,
+  ButtonBase,
+  FontWeight,
+  Text,
+  TextAlign,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import type { CaipAssetType } from '@metamask/utils';
+
+import { ThemeType } from '../../../shared/constants/preferences';
+import { getCaipAssetImageUrl } from '../../../shared/lib/asset-utils';
+import { useI18nContext } from '../../hooks/useI18nContext';
+import { useTheme } from '../../hooks/useTheme';
+
+const POPULAR_ASSETS: {
+  assetId: CaipAssetType;
+  name: string;
+  symbol: string;
+}[] = [
+  {
+    assetId: 'eip155:1/slip44:60' as CaipAssetType,
+    name: 'Ethereum',
+    symbol: 'ETH',
+  },
+  {
+    assetId:
+      'bip122:000000000019d6689c085ae165831e93/slip44:0' as CaipAssetType,
+    name: 'Bitcoin',
+    symbol: 'BTC',
+  },
+  {
+    assetId:
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501' as CaipAssetType,
+    name: 'Solana',
+    symbol: 'SOL',
+  },
+];
+
+type DiscoverNoResultsStateProps = {
+  query: string;
+  onAssetPress: (assetId: CaipAssetType) => void;
+};
+
+export const DiscoverNoResultsState = ({
+  query,
+  onAssetPress,
+}: DiscoverNoResultsStateProps) => {
+  const t = useI18nContext();
+  const theme = useTheme();
+  const activityIcon =
+    theme === ThemeType.dark
+      ? './images/empty-state-activity-dark.png'
+      : './images/empty-state-activity-light.png';
+
+  return (
+    <Box
+      className="flex h-full flex-col items-center justify-center gap-4 px-4 pt-[60px] text-center"
+      data-testid="discover-search-no-results"
+    >
+      <Box className="flex flex-col items-center gap-[18px]">
+        <img
+          src={activityIcon}
+          alt=""
+          width={72}
+          height={72}
+          aria-hidden="true"
+          data-testid="discover-search-no-results-illustration"
+        />
+        <Box className="flex w-64 flex-col items-center gap-1">
+          <Text variant={TextVariant.BodyMd} textAlign={TextAlign.Center}>
+            {t('discoverSearchNoResultsFor', [query])}
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
+            textAlign={TextAlign.Center}
+          >
+            {t('discoverSearchPopularAssets')}
+          </Text>
+        </Box>
+      </Box>
+      <Box className="flex w-full items-center justify-center gap-2">
+        {POPULAR_ASSETS.map(({ assetId, name, symbol }) => (
+          <ButtonBase
+            key={assetId}
+            className="h-10 rounded-full bg-muted px-3 hover:bg-muted-hover active:bg-pressed"
+            data-testid={`discover-search-popular-asset-${symbol.toLowerCase()}`}
+            onClick={() => onAssetPress(assetId)}
+          >
+            <Box
+              className="items-center gap-3"
+              flexDirection={BoxFlexDirection.Row}
+            >
+              <AvatarToken
+                name={name}
+                src={getCaipAssetImageUrl(assetId)}
+                size={AvatarTokenSize.Md}
+              />
+              <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+                {symbol}
+              </Text>
+            </Box>
+          </ButtonBase>
+        ))}
+      </Box>
+    </Box>
+  );
+};

--- a/ui/pages/discover-search/discover-no-results-state.tsx
+++ b/ui/pages/discover-search/discover-no-results-state.tsx
@@ -88,11 +88,11 @@ export const DiscoverNoResultsState = ({
           aria-hidden="true"
           data-testid="discover-search-no-results-illustration"
         />
-        <Box className="flex w-full flex-col items-center gap-1">
+        <Box className="flex w-full max-w-full flex-col items-center gap-1 overflow-hidden">
           <Text
             variant={TextVariant.BodyMd}
             textAlign={TextAlign.Center}
-            className="whitespace-nowrap"
+            className="max-w-full truncate"
           >
             {t('discoverSearchNoResultsFor', [query])}
           </Text>

--- a/ui/pages/discover-search/discover-search.test.tsx
+++ b/ui/pages/discover-search/discover-search.test.tsx
@@ -131,7 +131,6 @@ describe('DiscoverSearchPage', () => {
     expect(
       screen.getByText(messages.networkNameEthereum.message),
     ).toBeInTheDocument();
-    expect(screen.getByText('Stock1')).toBeInTheDocument();
   });
 
   it('switches to Crypto tab when View all is clicked', () => {

--- a/ui/pages/discover-search/discover-search.test.tsx
+++ b/ui/pages/discover-search/discover-search.test.tsx
@@ -11,6 +11,7 @@ import { DiscoverSearchPage } from './discover-search';
 
 const mockNavigate = jest.fn();
 const mockRunCloseTransition = jest.fn((callback: () => void) => callback());
+const mockUseDiscoverSearch = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -22,47 +23,68 @@ jest.mock('../routes/global-menu-route-transition', () => ({
 }));
 
 jest.mock('../../hooks/discover-search/useDiscoverSearch', () => ({
-  useDiscoverSearch: () => ({
-    crypto: {
-      items: [
-        {
-          assetId: 'eip155:1/slip44:60',
-          name: 'Ethereum',
-          symbol: 'ETH',
-          decimals: 18,
-          price: '2500',
-          marketCap: 20_000_000_000,
-          aggregatedUsdVolume: 126_000_000,
-          priceChangePct: { h24: '0.02' },
-        },
-      ],
-      isLoading: false,
-      error: null,
-    },
-    perps: {
-      items: [],
-      isLoading: false,
-      error: null,
-    },
-    stocks: {
-      items: [
-        {
-          assetId: 'eip155:1/erc20:0xstock',
-          name: 'Stock1',
-          symbol: 'STK1',
-          decimals: 18,
-          price: '406.78',
-          marketCap: 20_000_000_000,
-          aggregatedUsdVolume: 126_000_000,
-          priceChangePct: { h24: '9.4' },
-        },
-      ],
-      isLoading: false,
-      error: null,
-    },
-    isDebouncing: false,
-  }),
+  useDiscoverSearch: () => mockUseDiscoverSearch(),
 }));
+
+const getDefaultDiscoverSearchResult = () => ({
+  crypto: {
+    items: [
+      {
+        assetId: 'eip155:1/slip44:60',
+        name: 'Ethereum',
+        symbol: 'ETH',
+        decimals: 18,
+        price: '2500',
+        marketCap: 20_000_000_000,
+        aggregatedUsdVolume: 126_000_000,
+        priceChangePct: { h24: '0.02' },
+      },
+    ],
+    isLoading: false,
+    error: null,
+  },
+  perps: {
+    items: [],
+    isLoading: false,
+    error: null,
+  },
+  stocks: {
+    items: [
+      {
+        assetId: 'eip155:1/erc20:0xstock',
+        name: 'Stock1',
+        symbol: 'STK1',
+        decimals: 18,
+        price: '406.78',
+        marketCap: 20_000_000_000,
+        aggregatedUsdVolume: 126_000_000,
+        priceChangePct: { h24: '9.4' },
+      },
+    ],
+    isLoading: false,
+    error: null,
+  },
+  isDebouncing: false,
+});
+
+const getEmptyDiscoverSearchResult = () => ({
+  crypto: {
+    items: [],
+    isLoading: false,
+    error: null,
+  },
+  perps: {
+    items: [],
+    isLoading: false,
+    error: null,
+  },
+  stocks: {
+    items: [],
+    isLoading: false,
+    error: null,
+  },
+  isDebouncing: false,
+});
 
 jest.mock('../../selectors/perps/feature-flags', () => ({
   getIsPerpsExperienceAvailable: () => false,
@@ -74,6 +96,7 @@ describe('DiscoverSearchPage', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
     mockRunCloseTransition.mockClear();
+    mockUseDiscoverSearch.mockReturnValue(getDefaultDiscoverSearchResult());
   });
 
   const renderPage = ({ currentCurrency = 'usd' } = {}) => {
@@ -140,6 +163,31 @@ describe('DiscoverSearchPage', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(
       '/asset/eip155:1/eip155%3A1%2Fslip44%3A60',
+    );
+  });
+
+  it('renders no-results search design and opens popular assets', () => {
+    mockUseDiscoverSearch.mockReturnValue(getEmptyDiscoverSearchResult());
+    renderPage();
+
+    fireEvent.change(screen.getByTestId('discover-search-input'), {
+      target: { value: 'erwerwqer' },
+    });
+
+    expect(
+      screen.getByText('No results found for “erwerwqer”'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Check out other popular assets'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('discover-search-no-results-illustration'),
+    ).toHaveAttribute('src', './images/empty-state-activity-light.png');
+
+    fireEvent.click(screen.getByTestId('discover-search-popular-asset-btc'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/asset/bip122:000000000019d6689c085ae165831e93/bip122%3A000000000019d6689c085ae165831e93%2Fslip44%3A0',
     );
   });
 });

--- a/ui/pages/discover-search/discover-search.test.tsx
+++ b/ui/pages/discover-search/discover-search.test.tsx
@@ -183,6 +183,15 @@ describe('DiscoverSearchPage', () => {
     expect(
       screen.getByTestId('discover-search-no-results-illustration'),
     ).toHaveAttribute('src', './images/empty-state-activity-light.png');
+    expect(
+      screen.getByTestId('discover-search-popular-asset-eth-network'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('discover-search-popular-asset-btc-network'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('discover-search-popular-asset-sol-network'),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('discover-search-popular-asset-btc'));
 

--- a/ui/pages/discover-search/discover-search.test.tsx
+++ b/ui/pages/discover-search/discover-search.test.tsx
@@ -167,18 +167,22 @@ describe('DiscoverSearchPage', () => {
   });
 
   it('renders no-results search design and opens popular assets', () => {
+    const searchQuery = 'erwerwqer';
+
     mockUseDiscoverSearch.mockReturnValue(getEmptyDiscoverSearchResult());
     renderPage();
 
     fireEvent.change(screen.getByTestId('discover-search-input'), {
-      target: { value: 'erwerwqer' },
+      target: { value: searchQuery },
     });
 
     expect(
-      screen.getByText('No results found for “erwerwqer”'),
+      screen.getByText(
+        messages.discoverSearchNoResultsFor.message.replace('$1', searchQuery),
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText('Check out other popular assets'),
+      screen.getByText(messages.discoverSearchPopularAssets.message),
     ).toBeInTheDocument();
     expect(
       screen.getByTestId('discover-search-no-results-illustration'),

--- a/ui/pages/discover-search/discover-search.tsx
+++ b/ui/pages/discover-search/discover-search.tsx
@@ -22,7 +22,7 @@ import {
   TextFieldSize,
   TextVariant,
 } from '@metamask/design-system-react';
-import { isCaipAssetType } from '@metamask/utils';
+import { isCaipAssetType, type CaipAssetType } from '@metamask/utils';
 
 import { MarketRow } from '../../components/app/perps/market-row';
 import { Tab, Tabs } from '../../components/ui/tabs';
@@ -76,6 +76,24 @@ const EmptyState = ({ message }: { message: string }) => (
     </Text>
   </Box>
 );
+
+type DiscoverAllEmptyStateProps = {
+  noResultsMessage: string;
+  onAssetPress: (assetId: CaipAssetType) => void;
+  query: string;
+};
+
+const DiscoverAllEmptyState = ({
+  noResultsMessage,
+  onAssetPress,
+  query,
+}: DiscoverAllEmptyStateProps) => {
+  if (query) {
+    return <DiscoverNoResultsState query={query} onAssetPress={onAssetPress} />;
+  }
+
+  return <EmptyState message={noResultsMessage} />;
+};
 
 /**
  * Discover search page: search + All / Crypto / Perps / Stock tabs.
@@ -134,19 +152,6 @@ export const DiscoverSearchPage = () => {
 
   const trimmedSearchQuery = searchQuery.trim();
 
-  const renderEmptyState = useCallback(() => {
-    if (trimmedSearchQuery) {
-      return (
-        <DiscoverNoResultsState
-          query={trimmedSearchQuery}
-          onAssetPress={(assetId) => navigate(buildAssetRoutePath(assetId))}
-        />
-      );
-    }
-
-    return <EmptyState message={t('discoverSearchNoResults')} />;
-  }, [navigate, t, trimmedSearchQuery]);
-
   const previewCrypto = useMemo(
     () => cryptoSection.items.slice(0, DISCOVER_SEARCH_PREVIEW_COUNT),
     [cryptoSection.items],
@@ -182,7 +187,7 @@ export const DiscoverSearchPage = () => {
       return <LoadingState label={t('loading')} />;
     }
     if (items.length === 0) {
-      return renderEmptyState();
+      return <EmptyState message={t('discoverSearchNoResults')} />;
     }
     return items.map((asset) => (
       <DiscoverAssetRow
@@ -199,7 +204,7 @@ export const DiscoverSearchPage = () => {
       return <LoadingState label={t('loading')} />;
     }
     if (items.length === 0) {
-      return renderEmptyState();
+      return <EmptyState message={t('discoverSearchNoResults')} />;
     }
     return items.map((market) => (
       <MarketRow
@@ -217,7 +222,13 @@ export const DiscoverSearchPage = () => {
       return <LoadingState label={t('loading')} />;
     }
     if (showAllEmpty) {
-      return renderEmptyState();
+      return (
+        <DiscoverAllEmptyState
+          noResultsMessage={t('discoverSearchNoResults')}
+          onAssetPress={(assetId) => navigate(buildAssetRoutePath(assetId))}
+          query={trimmedSearchQuery}
+        />
+      );
     }
     return (
       <Box flexDirection={BoxFlexDirection.Column}>

--- a/ui/pages/discover-search/discover-search.tsx
+++ b/ui/pages/discover-search/discover-search.tsx
@@ -38,6 +38,7 @@ import { getIsPerpsExperienceAvailable } from '../../selectors/perps/feature-fla
 import { buildAssetRoutePath } from '../../../shared/lib/asset-route';
 import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
 import { DiscoverAssetRow } from './discover-asset-row';
+import { DiscoverNoResultsState } from './discover-no-results-state';
 import { DiscoverSearchSectionHeader } from './discover-search-section-header';
 
 const LoadingState = ({ label }: { label: string }) => (
@@ -131,6 +132,21 @@ export const DiscoverSearchPage = () => {
     setActiveTab(tab);
   }, []);
 
+  const trimmedSearchQuery = searchQuery.trim();
+
+  const renderEmptyState = useCallback(() => {
+    if (trimmedSearchQuery) {
+      return (
+        <DiscoverNoResultsState
+          query={trimmedSearchQuery}
+          onAssetPress={(assetId) => navigate(buildAssetRoutePath(assetId))}
+        />
+      );
+    }
+
+    return <EmptyState message={t('discoverSearchNoResults')} />;
+  }, [navigate, t, trimmedSearchQuery]);
+
   const previewCrypto = useMemo(
     () => cryptoSection.items.slice(0, DISCOVER_SEARCH_PREVIEW_COUNT),
     [cryptoSection.items],
@@ -166,7 +182,7 @@ export const DiscoverSearchPage = () => {
       return <LoadingState label={t('loading')} />;
     }
     if (items.length === 0) {
-      return <EmptyState message={t('discoverSearchNoResults')} />;
+      return renderEmptyState();
     }
     return items.map((asset) => (
       <DiscoverAssetRow
@@ -183,7 +199,7 @@ export const DiscoverSearchPage = () => {
       return <LoadingState label={t('loading')} />;
     }
     if (items.length === 0) {
-      return <EmptyState message={t('discoverSearchNoResults')} />;
+      return renderEmptyState();
     }
     return items.map((market) => (
       <MarketRow
@@ -201,7 +217,7 @@ export const DiscoverSearchPage = () => {
       return <LoadingState label={t('loading')} />;
     }
     if (showAllEmpty) {
-      return <EmptyState message={t('discoverSearchNoResults')} />;
+      return renderEmptyState();
     }
     return (
       <Box flexDirection={BoxFlexDirection.Column}>


### PR DESCRIPTION
This PR is to add no result state for Header search

[Figma](https://www.figma.com/design/gb2U5v8Q7ZkFRNwtElGAkp/Discover-search-on-extension?node-id=37-3325&m=dev)
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build and run the extension.
2. Enable the extensionUXSearch feature flag.
3. Open the extension and click the Search entry point in the app header.
4. Verify the Discover Search page opens correctly.
5. Type a random wrong string in search bar like "abcdefgh" check the correct no result state is there

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="1014" height="876" alt="Screenshot 2026-08-03 at 5 58 11 PM" src="https://github.com/user-attachments/assets/86943bf5-a602-43a5-8273-4281daf8a274" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only empty state and navigation to existing asset detail routes; no auth, data, or search API changes.
> 
> **Overview**
> When **Discover Search** (header entry) has no matches on the **All** tab and the user has entered a non-empty query, the generic “No results found” line is replaced with a **designed empty state**: theme-aware illustration, **“No results found for “{query}””**, a prompt to try popular assets, and tappable **ETH / BTC / SOL** chips that navigate via existing asset routes.
> 
> If the All tab is empty but there is **no** search text, behavior stays the same generic empty message. **Crypto / Perps / Stocks** tabs still use the simple empty state. New copy is added in **en** and **en_GB**; tests mock `useDiscoverSearch` and cover the no-results UI and popular-asset navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bba4fb64d59cbbec3ff9a5218ae5e8f816d23470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->