### PR TITLE
fix: add timeout and subscription cleanup to PPOM confirmation waits

### DIFF
--- a/app/scripts/lib/ppom/ppom-util.test.ts
+++ b/app/scripts/lib/ppom/ppom-util.test.ts
@@ -33,7 +33,9 @@ import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import { isSnapPreinstalled } from '../../../../shared/lib/snaps/snaps';
 import { RootMessenger } from '../messenger';
 import {
+  CONFIRMATION_WAIT_TIMEOUT,
   generateSecurityAlertId,
+  SecurityAlertTimeoutError,
   updateSecurityAlertResponse,
   validateRequestWithPPOM,
 } from './ppom-util';
@@ -250,6 +252,35 @@ describe('PPOM Utils', () => {
           source: SecurityAlertSource.Local,
         },
       );
+    });
+
+    it('does not update response again if waiting for the confirmation timed out', async () => {
+      updateSecurityAlertResponseMock.mockRejectedValueOnce(
+        new SecurityAlertTimeoutError('Timed out waiting for transaction'),
+      );
+
+      await validateRequestWithPPOM({
+        ...validateRequestWithPPOMOptionsBase,
+        ppomController,
+      });
+
+      expect(updateSecurityAlertResponseMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves if the error response update also fails', async () => {
+      updateSecurityAlertResponseMock
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('Update failed'))
+        .mockRejectedValueOnce(new Error('Update failed again'));
+
+      await expect(
+        validateRequestWithPPOM({
+          ...validateRequestWithPPOMOptionsBase,
+          ppomController,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(updateSecurityAlertResponseMock).toHaveBeenCalledTimes(3);
     });
 
     it('updates error response if controller throws', async () => {
@@ -983,6 +1014,89 @@ describe('PPOM Utils', () => {
       expect(
         transactionController.updateSecurityAlertResponse,
       ).toHaveBeenCalledWith(TRANSACTION_ID_MOCK, SECURITY_ALERT_RESPONSE_MOCK);
+    });
+
+    it('rejects and unsubscribes if transaction is never added before timeout', async () => {
+      jest.useFakeTimers();
+
+      try {
+        const transactionController = createTransactionControllerMock({
+          transactions: [],
+        } as unknown as TransactionController['state']);
+
+        const messenger = createMessengerMock();
+        const unsubscribeSpy = jest.spyOn(messenger, 'unsubscribe');
+
+        const updatePromise = updateSecurityAlertResponse({
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          appStateController: {} as any,
+          method: 'eth_sendTransaction',
+          messenger,
+          securityAlertId: SECURITY_ALERT_ID_MOCK,
+          securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          signatureController: {} as any,
+          transactionController,
+        });
+
+        jest.advanceTimersByTime(CONFIRMATION_WAIT_TIMEOUT);
+
+        await expect(updatePromise).rejects.toThrow(
+          `Timed out waiting for transaction with security alert ID: ${SECURITY_ALERT_ID_MOCK}`,
+        );
+
+        expect(unsubscribeSpy).toHaveBeenCalledWith(
+          'TransactionController:unapprovedTransactionAdded',
+          expect.any(Function),
+        );
+
+        expect(
+          transactionController.updateSecurityAlertResponse,
+        ).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('rejects and unsubscribes if signature request never appears before timeout', async () => {
+      jest.useFakeTimers();
+
+      try {
+        const appStateController = createAppStateControllerMock();
+        const signatureController = createSignatureControllerMock({});
+
+        const messenger = createMessengerMock();
+        const unsubscribeSpy = jest.spyOn(messenger, 'unsubscribe');
+
+        const updatePromise = updateSecurityAlertResponse({
+          appStateController,
+          method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
+          messenger,
+          securityAlertId: SECURITY_ALERT_ID_MOCK,
+          securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
+          signatureController,
+          transactionController: {} as unknown as TransactionController,
+        });
+
+        jest.advanceTimersByTime(CONFIRMATION_WAIT_TIMEOUT);
+
+        await expect(updatePromise).rejects.toThrow(
+          `Timed out waiting for signature request with security alert ID: ${SECURITY_ALERT_ID_MOCK}`,
+        );
+
+        expect(unsubscribeSpy).toHaveBeenCalledWith(
+          'SignatureController:stateChange',
+          expect.any(Function),
+        );
+
+        expect(
+          appStateController.addSignatureSecurityAlertResponse,
+        ).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/app/scripts/lib/ppom/ppom-util.ts
+++ b/app/scripts/lib/ppom/ppom-util.ts
@@ -53,6 +53,15 @@ const SECURITY_ALERT_RESPONSE_ERROR = {
   reason: BlockaidReason.errored,
 };
 
+export const CONFIRMATION_WAIT_TIMEOUT = 60_000;
+
+export class SecurityAlertTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SecurityAlertTimeoutError';
+  }
+}
+
 type PPOMRequest = JsonRpcRequest & {
   delegationMock?: Hex;
   origin?: string;
@@ -101,11 +110,22 @@ export async function validateRequestWithPPOM({
   } catch (error: unknown) {
     log('Error', error);
 
-    await updateSecurityResponse(
-      request.method,
-      securityAlertId,
-      handlePPOMError(error, 'Error validating JSON RPC using PPOM: '),
-    );
+    if (error instanceof SecurityAlertTimeoutError) {
+      // The confirmation never appeared (e.g. it was rejected while PPOM was
+      // still validating), so there is nothing left to update and waiting for
+      // it again would only time out a second time.
+      return;
+    }
+
+    try {
+      await updateSecurityResponse(
+        request.method,
+        securityAlertId,
+        handlePPOMError(error, 'Error validating JSON RPC using PPOM: '),
+      );
+    } catch (updateError: unknown) {
+      log('Error updating security alert response after failure', updateError);
+    }
   }
 }
 
@@ -371,7 +391,7 @@ async function waitForTransactionMetadata(
   const transactionFilter = (meta: TransactionMeta) =>
     meta.securityAlertResponse?.securityAlertId === securityAlertId;
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const transactionMeta =
       transactionController.state.transactions.find(transactionFilter);
 
@@ -380,12 +400,27 @@ async function waitForTransactionMetadata(
       return;
     }
 
-    const callback = (event: TransactionMeta) => {
+    const timeoutId = setTimeout(() => {
+      messenger.unsubscribe(
+        'TransactionController:unapprovedTransactionAdded',
+        callback,
+      );
+
+      reject(
+        new SecurityAlertTimeoutError(
+          `Timed out waiting for transaction with security alert ID: ${securityAlertId}`,
+        ),
+      );
+    }, CONFIRMATION_WAIT_TIMEOUT);
+
+    function callback(event: TransactionMeta) {
       if (!transactionFilter(event)) {
         return;
       }
 
       log('Found transaction metadata', event);
+
+      clearTimeout(timeoutId);
 
       messenger.unsubscribe(
         'TransactionController:unapprovedTransactionAdded',
@@ -393,7 +428,7 @@ async function waitForTransactionMetadata(
       );
 
       resolve(event);
-    };
+    }
 
     log('Waiting for transaction metadata', securityAlertId);
 
@@ -415,7 +450,7 @@ async function waitForSignatureRequest(
         request.securityAlertResponse?.securityAlertId === securityAlertId,
     );
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const signatureRequest = signatureFilter(signatureController.state);
 
     if (signatureRequest) {
@@ -423,7 +458,17 @@ async function waitForSignatureRequest(
       return;
     }
 
-    const callback = (state: SignatureControllerState) => {
+    const timeoutId = setTimeout(() => {
+      messenger.unsubscribe('SignatureController:stateChange', callback);
+
+      reject(
+        new SecurityAlertTimeoutError(
+          `Timed out waiting for signature request with security alert ID: ${securityAlertId}`,
+        ),
+      );
+    }, CONFIRMATION_WAIT_TIMEOUT);
+
+    function callback(state: SignatureControllerState) {
       const request = signatureFilter(state);
 
       if (!request) {
@@ -432,10 +477,12 @@ async function waitForSignatureRequest(
 
       log('Found signature request', request);
 
+      clearTimeout(timeoutId);
+
       messenger.unsubscribe('SignatureController:stateChange', callback);
 
       resolve(request);
-    };
+    }
 
     log('Waiting for signature request', securityAlertId);
 


### PR DESCRIPTION
## **Description**

`waitForTransactionMetadata` and `waitForSignatureRequest` in `app/scripts/lib/ppom/ppom-util.ts` returned promises that could only resolve — no timeout, no rejection path, and no unsubscribe if the awaited confirmation never appears.

`validateRequestWithPPOM` calls `updateSecurityAlertResponse` twice per request (loading + final result). If the user rejects the confirmation while PPOM validation is in flight (a 2–10s API call), the second call subscribes to `TransactionController:unapprovedTransactionAdded` / `SignatureController:stateChange` for a confirmation that no longer exists — the subscription leaks for the rest of the service-worker session. The signature variant is worse: the leaked callback executes on **every** subsequent signature state change, so N rejected signatures degrade every future signature event.

This PR:
- Adds a 60s timeout to both waits; on timeout they unsubscribe and reject with a dedicated `SecurityAlertTimeoutError`
- Clears the timer and unsubscribes on the resolve path (as before)
- `validateRequestWithPPOM` recognises the timeout error and skips the error-response update — the confirmation is gone, so waiting for it again would just time out a second time — and guards the fallback update so a failure there can't become an unhandled rejection

## **Related issues**

Fixes: #45129

## **Manual testing steps**

1. Connect a dApp and trigger `eth_sendTransaction` or `eth_signTypedData_v4`
2. Reject the confirmation while the security check is still loading
3. Repeat several times
4. Messenger subscription count no longer grows; previously each rejection leaked one subscription permanently

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (`ppom-util.test.ts`: timeout rejection + unsubscribe for both waits, timeout-skip and guarded-fallback behavior in `validateRequestWithPPOM` — 28/28 pass)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CHANGELOG entry: Fixed a resource leak where rejecting a transaction or signature confirmation while the security check was still running permanently leaked internal event subscriptions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async error paths and messenger subscription lifecycle for PPOM security updates; behavior on rejected confirmations improves but timeouts could affect edge cases where confirmations appear slowly.
> 
> **Overview**
> Fixes a **subscription leak** when users reject a transaction or signature while PPOM/security validation is still running: waits for the confirmation to attach security results could hang forever and never unsubscribe.
> 
> **`waitForTransactionMetadata`** and **`waitForSignatureRequest`** now use a **60s** `CONFIRMATION_WAIT_TIMEOUT`. On timeout they unsubscribe from messenger events and reject with **`SecurityAlertTimeoutError`**; on success they clear the timer as before.
> 
> **`validateRequestWithPPOM`** treats that timeout as expected (confirmation gone) and **skips** a follow-up errored security update that would wait again. Other failures still attempt the error response update inside a **try/catch** so a failed update cannot surface as an unhandled rejection.
> 
> Tests cover timeout rejection/unsubscribe for both paths and the new error-handling behavior in `validateRequestWithPPOM`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa8e8d051b919e3cf45c14872e8c8eac9e11dbee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->