### PR TITLE
fix: add network search to the network manager

### DIFF
--- a/ui/components/multichain/network-manager/components/custom-networks/custom-networks.tsx
+++ b/ui/components/multichain/network-manager/components/custom-networks/custom-networks.tsx
@@ -39,8 +39,14 @@ import {
 } from '../../../../../selectors';
 import { hideModal } from '../../../../../store/actions';
 import { useDispatch } from '../../../../../store/hooks';
+import { searchNetworks } from '../../utils/search-networks';
 
-export const CustomNetworks = React.memo(() => {
+type CustomNetworksProps = {
+  searchQuery?: string;
+};
+
+export const CustomNetworks = React.memo((props: CustomNetworksProps) => {
+  const { searchQuery = '' } = props;
   const t = useI18nContext();
   const [, setSearchParams] = useSearchParams();
   const dispatch = useDispatch();
@@ -135,14 +141,17 @@ export const CustomNetworks = React.memo(() => {
 
   // Memoize the rendered network lists with filtering
   const renderedCustomNetworks = useMemo(() => {
-    const filteredNetworks = orderedNetworks.filter((network) => {
-      // If EVM network is selected, only show EVM networks
-      if (isEvmNetworkSelected) {
-        return network.isEvm;
-      }
-      // If non-EVM network is selected, only show non-EVM networks
-      return !network.isEvm;
-    });
+    const filteredNetworks = searchNetworks(
+      orderedNetworks.filter((network) => {
+        // If EVM network is selected, only show EVM networks
+        if (isEvmNetworkSelected) {
+          return network.isEvm;
+        }
+        // If non-EVM network is selected, only show non-EVM networks
+        return !network.isEvm;
+      }),
+      searchQuery,
+    );
 
     return filteredNetworks.length > 0 ? (
       <Box paddingBottom={2}>
@@ -163,18 +172,22 @@ export const CustomNetworks = React.memo(() => {
     orderedNetworks,
     isEvmNetworkSelected,
     generateMultichainNetworkListItem,
+    searchQuery,
     t,
   ]);
 
   const renderedTestNetworks = useMemo(() => {
-    const filteredTestNetworks = orderedTestNetworks.filter((network) => {
-      // If EVM network is selected, only show EVM networks
-      if (isEvmNetworkSelected) {
-        return network.isEvm;
-      }
-      // If non-EVM network is selected, only show non-EVM networks
-      return !network.isEvm;
-    });
+    const filteredTestNetworks = searchNetworks(
+      orderedTestNetworks.filter((network) => {
+        // If EVM network is selected, only show EVM networks
+        if (isEvmNetworkSelected) {
+          return network.isEvm;
+        }
+        // If non-EVM network is selected, only show non-EVM networks
+        return !network.isEvm;
+      }),
+      searchQuery,
+    );
 
     return filteredTestNetworks.map((network) =>
       generateMultichainNetworkListItem(network),
@@ -183,6 +196,7 @@ export const CustomNetworks = React.memo(() => {
     orderedTestNetworks,
     isEvmNetworkSelected,
     generateMultichainNetworkListItem,
+    searchQuery,
   ]);
 
   // Memoize the padding value to prevent unnecessary re-renders

--- a/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
+++ b/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
@@ -63,6 +63,7 @@ import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../../sel
 import { isEvmChainId } from '../../../../../../shared/lib/asset-utils';
 import { useIsNetworkGasSponsored } from '../../../../../hooks/useIsNetworkGasSponsored';
 import { useDispatch } from '../../../../../store/hooks';
+import { searchNetworks } from '../../utils/search-networks';
 
 const AdditionalNetwork = ({ network }: { network: FeaturedNetwork }) => {
   const t = useI18nContext();
@@ -123,7 +124,11 @@ const AdditionalNetwork = ({ network }: { network: FeaturedNetwork }) => {
   );
 };
 
-const DefaultNetworks = memo(() => {
+type DefaultNetworksProps = {
+  searchQuery?: string;
+};
+
+const DefaultNetworks = memo(({ searchQuery = '' }: DefaultNetworksProps) => {
   const t = useI18nContext();
   const dispatch = useDispatch();
   const orderedNetworksList = useSelector(getOrderedNetworksList);
@@ -309,7 +314,7 @@ const DefaultNetworks = memo(() => {
       });
     };
 
-    const filteredNetworks = getFilteredNetworks();
+    const filteredNetworks = searchNetworks(getFilteredNetworks(), searchQuery);
 
     return filteredNetworks.map((network) => {
       const networkChainId = network.chainId; // eip155:59144
@@ -382,39 +387,46 @@ const DefaultNetworks = memo(() => {
     enabledChainIds,
     useExternalServices,
     selectedNonEvmChainId,
+    searchQuery,
   ]);
 
   // Memoize the additional network list items
   const additionalNetworkListItems = useMemo(() => {
-    return featuredNetworksNotYetEnabled.map((network) => (
-      <AdditionalNetwork
-        key={`additionnal-network-${network.chainId}`}
-        network={network}
-      ></AdditionalNetwork>
-    ));
-  }, [featuredNetworksNotYetEnabled]);
+    return searchNetworks(featuredNetworksNotYetEnabled, searchQuery).map(
+      (network) => (
+        <AdditionalNetwork
+          key={`additionnal-network-${network.chainId}`}
+          network={network}
+        ></AdditionalNetwork>
+      ),
+    );
+  }, [featuredNetworksNotYetEnabled, searchQuery]);
 
   return (
     <>
       <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
-        <Box
-          className="network-manager__all-popular-networks"
-          data-testid="network-manager-select-all"
-        >
-          <NetworkListItem
-            name={t('allPopularNetworks')}
-            onClick={selectAllDefaultNetworks}
-            iconSrc={IconName.Global}
-            iconSize={IconSize.Xl}
-            selected={isAllPopularNetworksSelected}
-            focus={false}
-          />
-        </Box>
+        {searchQuery === '' && (
+          <Box
+            className="network-manager__all-popular-networks"
+            data-testid="network-manager-select-all"
+          >
+            <NetworkListItem
+              name={t('allPopularNetworks')}
+              onClick={selectAllDefaultNetworks}
+              iconSrc={IconName.Global}
+              iconSize={IconSize.Xl}
+              selected={isAllPopularNetworksSelected}
+              focus={false}
+            />
+          </Box>
+        )}
         {networkListItems}
-        <>
-          <AdditionalNetworksInfo />
-          {additionalNetworkListItems}
-        </>
+        {(searchQuery === '' || additionalNetworkListItems.length > 0) && (
+          <>
+            <AdditionalNetworksInfo />
+            {additionalNetworkListItems}
+          </>
+        )}
       </Box>
     </>
   );

--- a/ui/components/multichain/network-manager/network-manager.test.tsx
+++ b/ui/components/multichain/network-manager/network-manager.test.tsx
@@ -314,6 +314,32 @@ describe('NetworkManager Component', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders a network search field and filters the popular networks list', () => {
+    renderNetworkManager();
+
+    const searchBox = screen.getByPlaceholderText(messages.search.message);
+
+    expect(screen.getByText('Optimism')).toBeInTheDocument();
+    expect(screen.getByText('Arbitrum')).toBeInTheDocument();
+
+    fireEvent.change(searchBox, { target: { value: 'Optimism' } });
+
+    expect(screen.getByText('Optimism')).toBeInTheDocument();
+    expect(screen.queryByText('Arbitrum')).not.toBeInTheDocument();
+
+    // The select-all row is hidden while searching
+    expect(
+      screen.queryByText(messages.allPopularNetworks.message),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(searchBox, { target: { value: '' } });
+
+    expect(screen.getByText('Arbitrum')).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.allPopularNetworks.message),
+    ).toBeInTheDocument();
+  });
+
   it('keeps the current route when dismissed outside from token management', () => {
     renderNetworkManagerWithLocationDisplay(TOKEN_MANAGEMENT_ROUTE);
 

--- a/ui/components/multichain/network-manager/network-tabs.tsx
+++ b/ui/components/multichain/network-manager/network-tabs.tsx
@@ -4,6 +4,7 @@ import { ModalHeader, ModalBody, Box } from '../../component-library';
 import { Tab, Tabs } from '../../ui/tabs';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useDispatch } from '../../../store/hooks';
+import NetworkListSearch from '../network-list-menu/network-list-search/network-list-search';
 import { CustomNetworks } from './components/custom-networks';
 import { DefaultNetworks } from './components/default-networks';
 
@@ -24,6 +25,8 @@ export const NetworkTabs = ({
   const dispatch = useDispatch();
   const t = useI18nContext();
   const [activeTab, setActiveTab] = useState(initialTab);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [, setFocusSearch] = useState(false);
   const handleClose = useCallback(() => {
     if (onClose) {
       onClose();
@@ -43,6 +46,11 @@ export const NetworkTabs = ({
         </ModalHeader>
       ) : null}
       <ModalBody style={{ padding: 0 }}>
+        <NetworkListSearch
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          setFocusSearch={setFocusSearch}
+        />
         <Tabs
           style={{ padding: 0 }}
           activeTab={activeTab}
@@ -61,14 +69,14 @@ export const NetworkTabs = ({
             name={t('networkTabPopular')}
             className="flex-1"
           >
-            <DefaultNetworks />
+            <DefaultNetworks searchQuery={searchQuery} />
           </Tab>
           <Tab
             tabKey="custom-networks"
             name={t('networkTabCustom')}
             className="flex-1"
           >
-            <CustomNetworks />
+            <CustomNetworks searchQuery={searchQuery} />
           </Tab>
         </Tabs>
       </ModalBody>

--- a/ui/components/multichain/network-manager/utils/search-networks.ts
+++ b/ui/components/multichain/network-manager/utils/search-networks.ts
@@ -1,0 +1,23 @@
+import Fuse from 'fuse.js';
+
+/**
+ * Filters a list of networks by a user-provided search query, using the same
+ * fuzzy-matching behavior as the network list menu search.
+ *
+ * @param networks - The networks to filter.
+ * @param query - The user-provided search query.
+ * @returns The networks matching the query, in their original order.
+ */
+export function searchNetworks<Item>(networks: Item[], query: string): Item[] {
+  return query === ''
+    ? networks
+    : new Fuse(networks, {
+        threshold: 0.2,
+        location: 0,
+        distance: 100,
+        maxPatternLength: 32,
+        minMatchCharLength: 1,
+        shouldSort: false, // Maintain network order instead of ordering by search score
+        keys: ['name', 'chainId', 'nativeCurrency'],
+      }).search(query);
+}


### PR DESCRIPTION
## **Description**

The network manager (the network picker opened from the tokens view) has no search field, while the dApp-connection network list (`network-list-menu`) has had one — with many networks configured, finding one means scrolling the whole Popular/Custom lists. Regression noted in 13.28.0 when the network manager replaced the searchable list in this context.

This adds search to the network manager for feature parity:

- Reuses the existing `NetworkListSearch` component, rendered above the Popular/Custom tabs in `network-tabs.tsx`, so one query filters whichever tab is active
- New `searchNetworks` util mirrors the exact Fuse.js options `network-list-menu` uses (threshold 0.2, order-preserving, matching name/chainId/nativeCurrency)
- `DefaultNetworks`: filters both the enabled-networks list and the "additional networks" list; hides the "All popular networks" select-all row and the additional-networks header while a query is active so results read as a flat list
- `CustomNetworks`: filters both the custom networks and testnet sections

## **Related issues**

Fixes: #42280

## **Manual testing steps**

1. Open the network picker from the tokens view (not connected to any dApp)
2. A search field now appears above the Popular/Custom tabs
3. Type a network name — both tabs filter; clearing the query restores the full list

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (network-manager.test.tsx: search field renders, filters the popular list, hides/restores the select-all row — 25/25 pass; `yarn lint:changed` and `yarn lint:tsc` clean)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CHANGELOG entry: Added network search to the network selector opened from the tokens view

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering and list visibility in the network picker; no changes to network enablement, RPC, or auth flows.
> 
> **Overview**
> Restores **search in the network manager** opened from the tokens view so users can filter long Popular/Custom lists without scrolling.
> 
> `NetworkTabs` now renders the existing **`NetworkListSearch`** above the tabs and keeps a shared **`searchQuery`** that is passed into **`DefaultNetworks`** and **`CustomNetworks`**. Both tabs filter their lists through a new **`searchNetworks`** helper that uses the same Fuse.js settings as the dApp **`network-list-menu`** (name, chainId, nativeCurrency; order preserved).
> 
> On the Popular tab, **“All popular networks”** is hidden while a query is active, and the additional-networks block only shows when the query is empty or there are matching addable networks. A **`network-manager.test.tsx`** case covers filtering and select-all visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b223a627b8a0d0f26eb8add59f43b15850d40148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->