### PR TITLE
fix: prevent wallet crash when notification API returns malformed data

### DIFF
--- a/ui/pages/notifications/notifications-list-item-error-boundary.test.tsx
+++ b/ui/pages/notifications/notifications-list-item-error-boundary.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import log from 'loglevel';
+import NotificationsListItemErrorBoundary from './notifications-list-item-error-boundary';
+
+describe('NotificationsListItemErrorBoundary tests', () => {
+  it('should fallback if a notification list item crashes', () => {
+    const mockError = jest.spyOn(log, 'error').mockImplementation(jest.fn());
+    const mockConsoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(jest.fn());
+
+    const MockListItem = () => {
+      throw new Error('Mock Error');
+    };
+
+    const { container } = render(
+      <NotificationsListItemErrorBoundary fallback={() => null}>
+        <MockListItem />
+      </NotificationsListItemErrorBoundary>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockError).toHaveBeenCalled();
+
+    mockError.mockRestore();
+    mockConsoleError.mockRestore();
+  });
+});

--- a/ui/pages/notifications/notifications-list-item-error-boundary.tsx
+++ b/ui/pages/notifications/notifications-list-item-error-boundary.tsx
@@ -1,0 +1,47 @@
+import log from 'loglevel';
+import { Component, ReactNode, ErrorInfo } from 'react';
+
+type ErrorBoundaryProps = { children: ReactNode; fallback: () => ReactNode };
+type ErrorBoundaryState = { hasError: boolean };
+
+/**
+ * Error boundary wrapping a single notification list item.
+ *
+ * Notification API responses are not guaranteed to match the shapes our
+ * notification components expect (e.g. missing `template` or
+ * `payload.data.amount` fields). A single malformed notification would
+ * otherwise throw during render and crash the entire wallet UI, so we catch
+ * the error here and skip rendering that one notification instead.
+ */
+class NotificationsListItemErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    log.error(
+      'NotificationsListItemErrorBoundary - failed to render a notification list item',
+      error,
+      errorInfo,
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // Render the fallback UI
+      return this.props.fallback();
+    }
+
+    return this.props.children;
+  }
+}
+
+export default NotificationsListItemErrorBoundary;

--- a/ui/pages/notifications/notifications-list.test.tsx
+++ b/ui/pages/notifications/notifications-list.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
-import { processNotification } from '@metamask/notification-services-controller/notification-services';
+import {
+  processNotification,
+  TRIGGER_TYPES,
+  type INotification,
+} from '@metamask/notification-services-controller/notification-services';
 import {
   createMockNotificationEthSent,
   createMockNotificationEthReceived,
@@ -108,6 +112,74 @@ describe('NotificationsList', () => {
     expect(screen.queryAllByTestId(/notification-list-item-/u)).toHaveLength(
       mockNotifications.length,
     );
+  });
+
+  it('skips notifications that fail to render instead of crashing the list', () => {
+    // Silence the expected render error logs from the error boundary
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(jest.fn());
+
+    // Malformed API responses observed in the wild (see issue #44088):
+    // a platform notification missing its `template`, and an on-chain
+    // eth_received notification missing `payload.data.amount`.
+    const malformedPlatformNotification = {
+      id: 'poison-1',
+      type: TRIGGER_TYPES.PLATFORM,
+      createdAt: '2026-07-02T00:00:00.000Z',
+      isRead: false,
+    } as unknown as INotification;
+
+    const malformedEthReceivedNotification = {
+      id: 'poison-2',
+      type: TRIGGER_TYPES.ETH_RECEIVED,
+      createdAt: '2026-07-02T00:00:00.000Z',
+      isRead: false,
+      payload: {
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        chain_id: 1,
+        network: 'ethereum-mainnet',
+        data: {
+          kind: 'eth_received',
+          to: '0x1111111111111111111111111111111111111111',
+          from: '0x2222222222222222222222222222222222222222',
+        },
+      },
+    } as unknown as INotification;
+
+    const validNotification = processNotification(
+      createMockNotificationEthSent(),
+    );
+
+    renderWithProvider(
+      <NotificationsList
+        activeTab={TAB_KEYS.ALL}
+        notifications={[
+          validNotification,
+          malformedPlatformNotification,
+          malformedEthReceivedNotification,
+        ]}
+        isLoading={false}
+        isError={false}
+        notificationsCount={0}
+      />,
+      createStore(true),
+    );
+
+    // The list still renders, showing only the valid notification
+    expect(screen.getByTestId('notifications-list')).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`notification-list-item-${validNotification.id}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('notification-list-item-poison-1'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('notification-list-item-poison-2'),
+    ).not.toBeInTheDocument();
+
+    consoleErrorSpy.mockRestore();
   });
 
   ([TAB_KEYS.ALL, TAB_KEYS.WALLET, TAB_KEYS.WEB3] as TAB_KEYS[]).forEach(

--- a/ui/pages/notifications/notifications-list.tsx
+++ b/ui/pages/notifications/notifications-list.tsx
@@ -15,6 +15,7 @@ import { useI18nContext } from '../../hooks/useI18nContext';
 import { NotificationsPlaceholder } from './notifications-list-placeholder';
 import { NotificationsListDisabledNotifications } from './notifications-list-disabled-notifications';
 import { NotificationsListItem } from './notifications-list-item';
+import NotificationsListItemErrorBoundary from './notifications-list-item-error-boundary';
 import { NotificationsListReadAllButton } from './notifications-list-read-all-button';
 
 export type NotificationsListProps = {
@@ -82,7 +83,11 @@ const ErrorContent = () => {
 
 const NotificationItem = (props: { notification: INotification }) => {
   const { notification } = props;
-  return <NotificationsListItem notification={notification} />;
+  return (
+    <NotificationsListItemErrorBoundary fallback={() => null}>
+      <NotificationsListItem notification={notification} />
+    </NotificationsListItemErrorBoundary>
+  );
 };
 
 const NotificationsListStates = ({


### PR DESCRIPTION
## **Description**

The notification API (`https://notification.api.cx.metamask.io/api/v3/notifications`) response is consumed without payload validation. `processAPINotifications` in `@metamask/notification-services-controller` normalises `id`/`createdAt`/`isRead` but passes `payload`/`template` through as-is, so malformed notifications land in UI state unchanged.

The notification components then access nested fields unguarded:

- `platform-notification.tsx` reads `notification.template.image_url` → `Cannot read properties of undefined (reading 'image_url')` when `template` is missing
- `eth-sent-received.tsx` reads `notification.payload.data.amount.eth` → `Cannot read properties of undefined (reading 'eth')` when `amount` is missing

A single malformed notification throws during render, the error propagates to the root error boundary, and the entire wallet UI crashes.

This PR wraps each notification list item in a dedicated error boundary — the same pattern already used for NFT grid items (`NFTGridItemErrorBoundary`) — that logs the error and skips rendering the offending notification. The rest of the list (and the wallet) stays intact.

Tests: a boundary unit test, plus a regression test in `notifications-list.test.tsx` feeding the two exact poison payloads from the issue. Verified the regression test fails with the pre-fix crash (`Cannot read properties of undefined (reading 'eth')`) and passes with the fix.

## **Related issues**

Fixes: #44088

## **Manual testing steps**

1. Set up a proxy and intercept `POST https://notification.api.cx.metamask.io/api/v3/notifications`
2. Return the poison payloads from the issue (a `platform` notification without `template`; an `eth_received` notification whose `payload.data` has no `amount`)
3. Enable notifications and open the notifications page
4. Previously: the wallet crashed with `Cannot read properties of undefined (reading 'image_url')` / `(reading 'eth')`. Now: the malformed notifications are skipped and the rest of the list renders normally

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (`notifications-list.test.tsx` regression test with the issue's poison payloads + `notifications-list-item-error-boundary.test.tsx`; both pass, no console-baseline violations)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CHANGELOG entry: Fixed a crash when the notifications list contains malformed notification data; invalid notifications are now skipped instead of breaking the wallet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only defensive rendering with no auth, payment, or data-persistence changes; worst case is a silently omitted notification row.
> 
> **Overview**
> **Prevents a single bad notification from taking down the whole wallet** by wrapping each list row in `NotificationsListItemErrorBoundary`, which logs the failure and renders nothing for that item instead of letting the error reach the root boundary.
> 
> Adds `notifications-list-item-error-boundary.tsx` (same per-item boundary pattern as `NFTGridItemErrorBoundary`) and wires it in `NotificationItem` inside `notifications-list.tsx`. Tests cover the boundary directly and a list regression with platform notifications missing `template` and `eth_received` payloads missing `payload.data.amount`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bb699a6eaa6993f7d3fa52f954b447dd6cbd34d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->