### PR TITLE
fix: gate token rates controller on onboarding completion

### DIFF
--- a/app/scripts/messenger-client-init/assets/token-rates-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/token-rates-controller-init.test.ts
@@ -16,6 +16,7 @@ import {
   getTokenRatesControllerMessenger,
   TokenRatesControllerInitMessenger,
 } from '../messengers/assets';
+import { OnboardingControllerGetStateAction } from '../../controllers/onboarding';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 import { TokenRatesControllerInit } from './token-rates-controller-init';
 
@@ -48,24 +49,52 @@ function buildControllerMock(
  *
  * Notice that we also mock the getController method to return the
  * stubbed PreferencesController.
+ *
+ * @param options - Test configuration options.
+ * @param options.useCurrencyRateCheck - Whether the currency rate check preference is enabled (default: true).
+ * @param options.completedOnboarding - Whether onboarding is completed (default: true).
  */
-function buildInitRequestMock(): jest.Mocked<
-  MessengerClientInitRequest<
-    TokenRatesControllerMessenger,
-    TokenRatesControllerInitMessenger
-  >
-> {
+function buildInitRequestMock(
+  options: {
+    useCurrencyRateCheck?: boolean;
+    completedOnboarding?: boolean;
+  } = {},
+): {
+  requestMock: jest.Mocked<
+    MessengerClientInitRequest<
+      TokenRatesControllerMessenger,
+      TokenRatesControllerInitMessenger
+    >
+  >;
+  preferencesGetStateMock: jest.Mock;
+  onboardingGetStateMock: jest.Mock;
+} {
+  const { useCurrencyRateCheck = true, completedOnboarding = true } = options;
+
   const baseControllerMessenger = new Messenger<
     MockAnyNamespace,
-    PreferencesControllerGetStateAction | ActionConstraint,
+    | PreferencesControllerGetStateAction
+    | OnboardingControllerGetStateAction
+    | ActionConstraint,
     never
   >({
     namespace: MOCK_ANY_NAMESPACE,
   });
 
+  const preferencesGetStateMock = jest
+    .fn()
+    .mockReturnValue({ useCurrencyRateCheck });
+  const onboardingGetStateMock = jest
+    .fn()
+    .mockReturnValue({ completedOnboarding });
+
   baseControllerMessenger.registerActionHandler(
     'PreferencesController:getState',
-    jest.fn().mockReturnValue({ useCurrencyRateCheck: true }),
+    preferencesGetStateMock,
+  );
+  baseControllerMessenger.registerActionHandler(
+    'OnboardingController:getState',
+    onboardingGetStateMock,
   );
 
   const requestMock = {
@@ -81,7 +110,7 @@ function buildInitRequestMock(): jest.Mocked<
   // @ts-expect-error Incomplete mock, just includes properties used by code-under-test.
   requestMock.getMessengerClient.mockReturnValue(buildControllerMock());
 
-  return requestMock;
+  return { requestMock, preferencesGetStateMock, onboardingGetStateMock };
 }
 
 describe('TokenRatesControllerInit', () => {
@@ -92,16 +121,176 @@ describe('TokenRatesControllerInit', () => {
   });
 
   it('returns controller instance', () => {
-    const requestMock = buildInitRequestMock();
+    const { requestMock } = buildInitRequestMock();
     expect(
       TokenRatesControllerInit(requestMock).messengerClient,
     ).toBeInstanceOf(TokenRatesController);
   });
 
   it('initializes with correct messenger and state', () => {
-    const requestMock = buildInitRequestMock();
+    const { requestMock } = buildInitRequestMock();
     TokenRatesControllerInit(requestMock);
 
     expect(tokenRatesControllerClassMock).toHaveBeenCalled();
+  });
+
+  it('initializes the controller enabled when onboarding is completed and useCurrencyRateCheck is enabled', () => {
+    const { requestMock } = buildInitRequestMock({
+      useCurrencyRateCheck: true,
+      completedOnboarding: true,
+    });
+    TokenRatesControllerInit(requestMock);
+
+    expect(tokenRatesControllerClassMock).toHaveBeenCalledWith(
+      expect.objectContaining({ disabled: false }),
+    );
+  });
+
+  it('initializes the controller disabled during onboarding even when useCurrencyRateCheck is enabled', () => {
+    const { requestMock } = buildInitRequestMock({
+      useCurrencyRateCheck: true,
+      completedOnboarding: false,
+    });
+    TokenRatesControllerInit(requestMock);
+
+    expect(tokenRatesControllerClassMock).toHaveBeenCalledWith(
+      expect.objectContaining({ disabled: true }),
+    );
+  });
+
+  it('initializes the controller disabled when useCurrencyRateCheck is disabled', () => {
+    const { requestMock } = buildInitRequestMock({
+      useCurrencyRateCheck: false,
+      completedOnboarding: true,
+    });
+    TokenRatesControllerInit(requestMock);
+
+    expect(tokenRatesControllerClassMock).toHaveBeenCalledWith(
+      expect.objectContaining({ disabled: true }),
+    );
+  });
+
+  describe('enable/disable subscriptions', () => {
+    /**
+     * Build an init request whose `initMessenger.subscribe` is replaced with a
+     * jest mock so tests can capture and invoke the registered handlers
+     * directly, bypassing the messenger's namespace-prefixed publish
+     * restriction.
+     *
+     * @param options - Test configuration options.
+     * @param options.useCurrencyRateCheck - Whether the currency rate check preference is enabled.
+     * @param options.completedOnboarding - Whether onboarding is completed.
+     */
+    function setupSubscriptionTest(options: {
+      useCurrencyRateCheck?: boolean;
+      completedOnboarding?: boolean;
+    }) {
+      const { requestMock, preferencesGetStateMock, onboardingGetStateMock } =
+        buildInitRequestMock(options);
+      const subscribeMock = jest.fn();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (requestMock.initMessenger as any).subscribe = subscribeMock;
+
+      const { messengerClient } = TokenRatesControllerInit(requestMock);
+
+      const getHandler = (event: string) => {
+        const subscription = subscribeMock.mock.calls.find(
+          ([subscribedEvent]) => subscribedEvent === event,
+        );
+        if (!subscription) {
+          throw new Error(`No subscription found for ${event}`);
+        }
+        return subscription[1];
+      };
+
+      return {
+        messengerClient,
+        preferencesGetStateMock,
+        onboardingGetStateMock,
+        getHandler,
+      };
+    }
+
+    it('enables the controller when onboarding completes with useCurrencyRateCheck enabled', () => {
+      const { messengerClient, onboardingGetStateMock, getHandler } =
+        setupSubscriptionTest({
+          useCurrencyRateCheck: true,
+          completedOnboarding: false,
+        });
+      const onOnboardingStateChange = getHandler(
+        'OnboardingController:stateChange',
+      );
+
+      // Simulate onboarding completing
+      onboardingGetStateMock.mockReturnValue({ completedOnboarding: true });
+      onOnboardingStateChange(true);
+
+      expect(messengerClient.enable).toHaveBeenCalled();
+      expect(messengerClient.disable).not.toHaveBeenCalled();
+    });
+
+    it('keeps the controller disabled when onboarding completes with useCurrencyRateCheck disabled', () => {
+      const {
+        messengerClient,
+        preferencesGetStateMock,
+        onboardingGetStateMock,
+        getHandler,
+      } = setupSubscriptionTest({
+        useCurrencyRateCheck: true,
+        completedOnboarding: false,
+      });
+      const onPreferencesStateChange = getHandler(
+        'PreferencesController:stateChange',
+      );
+      const onOnboardingStateChange = getHandler(
+        'OnboardingController:stateChange',
+      );
+
+      // Simulate the user turning basic functionality off during onboarding,
+      // then completing onboarding (matching the flow in issue #43998).
+      preferencesGetStateMock.mockReturnValue({ useCurrencyRateCheck: false });
+      onPreferencesStateChange({ useCurrencyRateCheck: false });
+      onboardingGetStateMock.mockReturnValue({ completedOnboarding: true });
+      onOnboardingStateChange(true);
+
+      expect(messengerClient.enable).not.toHaveBeenCalled();
+      expect(messengerClient.disable).toHaveBeenCalled();
+    });
+
+    it('does not enable the controller when useCurrencyRateCheck turns on during onboarding', () => {
+      const { messengerClient, preferencesGetStateMock, getHandler } =
+        setupSubscriptionTest({
+          useCurrencyRateCheck: false,
+          completedOnboarding: false,
+        });
+      const onPreferencesStateChange = getHandler(
+        'PreferencesController:stateChange',
+      );
+
+      preferencesGetStateMock.mockReturnValue({ useCurrencyRateCheck: true });
+      onPreferencesStateChange({ useCurrencyRateCheck: true });
+
+      expect(messengerClient.enable).not.toHaveBeenCalled();
+      expect(messengerClient.disable).toHaveBeenCalled();
+    });
+
+    it('toggles the controller when useCurrencyRateCheck changes after onboarding', () => {
+      const { messengerClient, preferencesGetStateMock, getHandler } =
+        setupSubscriptionTest({
+          useCurrencyRateCheck: true,
+          completedOnboarding: true,
+        });
+      const onPreferencesStateChange = getHandler(
+        'PreferencesController:stateChange',
+      );
+
+      preferencesGetStateMock.mockReturnValue({ useCurrencyRateCheck: false });
+      onPreferencesStateChange({ useCurrencyRateCheck: false });
+      expect(messengerClient.disable).toHaveBeenCalled();
+
+      preferencesGetStateMock.mockReturnValue({ useCurrencyRateCheck: true });
+      onPreferencesStateChange({ useCurrencyRateCheck: true });
+      expect(messengerClient.enable).toHaveBeenCalled();
+    });
   });
 });

--- a/app/scripts/messenger-client-init/assets/token-rates-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/token-rates-controller-init.ts
@@ -5,6 +5,7 @@ import {
 } from '@metamask/assets-controllers';
 import { MessengerClientInitFunction } from '../types';
 import { TokenRatesControllerInitMessenger } from '../messengers/assets';
+import type { OnboardingControllerState } from '../../controllers/onboarding';
 import { previousValueComparator } from '../../lib/util';
 
 /**
@@ -22,27 +23,61 @@ export const TokenRatesControllerInit: MessengerClientInitFunction<
 > = (request) => {
   const { controllerMessenger, initMessenger, persistedState } = request;
   const preferencesState = initMessenger.call('PreferencesController:getState');
+  const { completedOnboarding } = initMessenger.call(
+    'OnboardingController:getState',
+  );
 
   const messengerClient = new TokenRatesController({
     messenger: controllerMessenger,
     state: persistedState.TokenRatesController,
     tokenPricesService: new CodefiTokenPricesServiceV2(),
-    disabled: !preferencesState.useCurrencyRateCheck,
+    // Keep the controller disabled until onboarding has completed: while
+    // enabled it fetches token prices in response to
+    // `TokensController:stateChange` events, and during onboarding the user
+    // has not yet confirmed the basic functionality preference. This mirrors
+    // the `completedOnboarding` gating in the UI polling hooks
+    // (see `useTokenRatesPolling`).
+    disabled: !preferencesState.useCurrencyRateCheck || !completedOnboarding,
   });
+
+  const updateEnabledState = () => {
+    const { useCurrencyRateCheck } = initMessenger.call(
+      'PreferencesController:getState',
+    );
+    const { completedOnboarding: isOnboardingCompleted } = initMessenger.call(
+      'OnboardingController:getState',
+    );
+    if (useCurrencyRateCheck && isOnboardingCompleted) {
+      messengerClient.enable();
+    } else {
+      messengerClient.disable();
+    }
+  };
 
   initMessenger.subscribe(
     'PreferencesController:stateChange',
     previousValueComparator((prevState, currState) => {
       const { useCurrencyRateCheck: prevUseCurrencyRateCheck } = prevState;
       const { useCurrencyRateCheck: currUseCurrencyRateCheck } = currState;
-      if (currUseCurrencyRateCheck && !prevUseCurrencyRateCheck) {
-        messengerClient.enable();
-      } else if (!currUseCurrencyRateCheck && prevUseCurrencyRateCheck) {
-        messengerClient.disable();
+      if (currUseCurrencyRateCheck !== prevUseCurrencyRateCheck) {
+        updateEnabledState();
       }
 
       return true;
     }, preferencesState),
+  );
+
+  // When onboarding completes, re-evaluate the enabled state so price
+  // requests start (or stay stopped) based on the preference the user chose
+  // during onboarding.
+  initMessenger.subscribe(
+    'OnboardingController:stateChange',
+    (isOnboardingCompleted: boolean) => {
+      if (isOnboardingCompleted) {
+        updateEnabledState();
+      }
+    },
+    (state: OnboardingControllerState) => state.completedOnboarding,
   );
 
   return {

--- a/app/scripts/messenger-client-init/messengers/assets/token-rates-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/token-rates-controller-messenger.ts
@@ -5,6 +5,10 @@ import {
 } from '@metamask/messenger';
 import { TokenRatesControllerMessenger } from '@metamask/assets-controllers';
 import {
+  OnboardingControllerGetStateAction,
+  OnboardingControllerStateChangeEvent,
+} from '../../../controllers/onboarding';
+import {
   PreferencesControllerGetStateAction,
   PreferencesControllerStateChangeEvent,
 } from '../../../controllers/preferences-controller';
@@ -39,9 +43,13 @@ export function getTokenRatesControllerMessenger(
   return controllerMessenger;
 }
 
-type AllowedInitializationActions = PreferencesControllerGetStateAction;
+type AllowedInitializationActions =
+  | PreferencesControllerGetStateAction
+  | OnboardingControllerGetStateAction;
 
-type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
+type AllowedInitializationEvents =
+  | PreferencesControllerStateChangeEvent
+  | OnboardingControllerStateChangeEvent;
 
 export type TokenRatesControllerInitMessenger = ReturnType<
   typeof getTokenRatesControllerInitMessenger
@@ -72,8 +80,14 @@ export function getTokenRatesControllerInitMessenger(
   });
   messenger.delegate({
     messenger: controllerInitMessenger,
-    actions: ['PreferencesController:getState'],
-    events: ['PreferencesController:stateChange'],
+    actions: [
+      'PreferencesController:getState',
+      'OnboardingController:getState',
+    ],
+    events: [
+      'PreferencesController:stateChange',
+      'OnboardingController:stateChange',
+    ],
   });
   return controllerInitMessenger;
 }


### PR DESCRIPTION
## **Description**

Requests to `https://price.api.cx.metamask.io/v3/spot-prices` can fire during onboarding, before the user has confirmed (or after they have declined) the basic functionality preference.

**Root cause:** `TokenRatesControllerInit` constructs the controller with `disabled: !useCurrencyRateCheck` only. While enabled, `TokenRatesController` fetches token prices in response to every `TokensController:stateChange` event — and `#getTokenAddresses` always includes the native asset (`eip155:1/slip44:60`, exactly the request the flaky privacy e2e tests catch), so it fetches even with an empty token list. Since `useCurrencyRateCheck` defaults to `true`, any token-state churn during onboarding triggers price API requests.

Every other spot-prices path already gates on onboarding: the UI polling hooks (`useTokenRatesPolling`, `useCurrencyRatePolling`) require `completedOnboarding`, and `AssetsControllerInit`'s `isBasicFunctionality` getter returns `false` during onboarding. This background event-driven path was the only ungated trigger — which also explains the intermittent failures in `test/e2e/tests/privacy/basic-functionality.spec.ts` and `onboarding-token-price-call-privacy.spec.ts` referenced in the issue (the leak depends on racy token-state changes during onboarding).

**Fix (mirrors the `AssetsControllerInit` pattern):**
- Initialize `TokenRatesController` with `disabled: !useCurrencyRateCheck || !completedOnboarding`
- Subscribe to `OnboardingController:stateChange`: when onboarding completes, re-evaluate the enabled state from current preferences — so the controller starts if basic functionality is on, and stays disabled if the user turned it off during onboarding
- The existing `PreferencesController:stateChange` subscription now also respects onboarding state, so toggling `useCurrencyRateCheck` during onboarding can no longer enable the controller early
- The init messenger delegates the two additional `OnboardingController` actions/events

For users who have already onboarded, startup behavior is unchanged (`completedOnboarding` is `true`, so `disabled` still reduces to `!useCurrencyRateCheck`).

## **Related issues**

Fixes: #43998

## **Manual testing steps**

1. Install fresh and start onboarding with an SRP import
2. On the wallet-ready screen, open **Manage default settings → General** and turn **Basic functionality** OFF
3. Open the wallet and watch the network tab (or proxy) for `price.api.cx.metamask.io/v3/spot-prices`
4. No spot-prices requests fire at any point during or after onboarding; re-enabling basic functionality in Settings resumes price fetching

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (`token-rates-controller-init.test.ts`: constructor `disabled` gating for all onboarding/preference combinations + enable/disable subscription behavior, 9/9 pass; 4 of them fail without the fix)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CHANGELOG entry: Fixed price API requests being sent during onboarding while the basic functionality toggle is off

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches privacy-sensitive background price API behavior during onboarding; logic is localized to init with broad unit test coverage and no change for already-onboarded users.
> 
> **Overview**
> **TokenRatesController** no longer fetches spot prices during onboarding. Init now sets `disabled` when `useCurrencyRateCheck` is off **or** `completedOnboarding` is false, and a shared `updateEnabledState` path enables the controller only when both are true.
> 
> Preference and onboarding listeners were refactored so toggling **Basic functionality** during onboarding cannot turn the controller on early; completing onboarding re-evaluates the current preference (including the case where the user turned basic functionality off before finishing). The init messenger now delegates **OnboardingController** get-state and state-change alongside preferences.
> 
> Tests cover constructor `disabled` combinations and subscription behavior (onboarding completion, preference changes before/after onboarding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915e5858840bb3696b8ec723fa41d177c4604054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->