### PR TITLE
fix: keep back arrow inside wallet when asset page is opened via deep link

### DIFF
--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -22,7 +22,24 @@ import useMultiPolling from '../../../hooks/useMultiPolling';
 import { getAssetsBySelectedAccountGroup } from '../../../selectors/assets';
 import { MUSD_TOKEN_ADDRESS } from '../../../components/app/musd/constants';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import AssetPage from './asset-page';
+
+const mockNavigate = jest.fn();
+// When set, overrides the `key` of the location returned by `useLocation` so
+// tests can simulate in-app history (any key other than 'default').
+let mockLocationKeyOverride: string | null = null;
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useLocation: () => {
+    const location = jest.requireActual('react-router-dom').useLocation();
+    return mockLocationKeyOverride
+      ? { ...location, key: mockLocationKeyOverride }
+      : location;
+  },
+}));
 
 jest.mock('../../../hooks/useAnalytics', () => {
   const { createEventBuilder } = jest.requireActual(
@@ -441,6 +458,42 @@ describe('AssetPage', () => {
     expect(actions[0].payload).toStrictEqual({
       name: 'CONVERT_TOKEN_TO_NFT',
       tokenAddress: token.address,
+    });
+  });
+
+  describe('back button', () => {
+    beforeEach(() => {
+      mockNavigate.mockClear();
+      mockLocationKeyOverride = null;
+    });
+
+    it('navigates home when the page is the initial history entry (e.g. deep link entry)', () => {
+      // renderWithProvider mounts the page as the router's initial entry, so
+      // location.key is 'default' — the same as when a deep link redirects
+      // the tab straight to this page.
+      const { getByLabelText } = renderWithProvider(
+        <AssetPage asset={token} optionsButton={null} />,
+        store,
+      );
+
+      fireEvent.click(getByLabelText(messages.back.message));
+
+      expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
+        replace: true,
+      });
+    });
+
+    it('navigates back in history when there is in-app history', () => {
+      mockLocationKeyOverride = 'abc123';
+
+      const { getByLabelText } = renderWithProvider(
+        <AssetPage asset={token} optionsButton={null} />,
+        store,
+      );
+
+      fireEvent.click(getByLabelText(messages.back.message));
+
+      expect(mockNavigate).toHaveBeenCalledWith(-1);
     });
   });
 

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -39,7 +39,7 @@ import React, {
   useState,
 } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
@@ -59,6 +59,7 @@ import { AddressCopyButton } from '../../../components/multichain';
 // eslint-disable-next-line import-x/no-restricted-paths
 import { ActivityList } from '../../activity/activity-list';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
@@ -131,6 +132,7 @@ const AssetPage = ({
 }) => {
   const t = useI18nContext();
   const navigate = useNavigate();
+  const location = useLocation();
   const { decodedAsset } = processAssetParams(useParams());
   const currency = useSelector(getCurrentCurrency);
   const isEvm = isEvmChainId(asset.chainId);
@@ -414,6 +416,19 @@ const AssetPage = ({
     setIsMarketClosedModalOpen(true);
   }, []);
 
+  // When the UI was entered directly at this page (e.g. a deep link
+  // redirecting the tab into the extension), there is no in-app history to go
+  // back to — `navigate(-1)` would pop browser history and leave the wallet.
+  // Detect this via location.key being 'default' (initial entry) and navigate
+  // to the home page instead.
+  const handleBack = useCallback(() => {
+    if (location.key === 'default') {
+      navigate(DEFAULT_ROUTE, { replace: true });
+    } else {
+      transitionBack(() => navigate(-1));
+    }
+  }, [location.key, navigate]);
+
   return (
     <AssetPageSecurityTrustProvider
       assetId={caipAssetId as CaipAssetType}
@@ -434,7 +449,7 @@ const AssetPage = ({
               size={ButtonIconSize.Md}
               ariaLabel={t('back') as string}
               iconName={IconName.ArrowLeft}
-              onClick={() => transitionBack(() => navigate(-1))}
+              onClick={handleBack}
               className="asset-page__back-button"
             />
           </Box>


### PR DESCRIPTION
## **Description**

After opening an asset deep link (e.g. `https://link.metamask.io/asset?assetId=eip155:1/erc20:0x6B17...`), pressing the back arrow on the asset page takes the user out of MetaMask entirely, back to the website they were on.

**Root cause:** `DeepLinkRouter` redirects the current tab straight into the extension UI at the asset route (`browser.tabs.update(tabId, ...)` in `app/scripts/lib/deep-links/deep-link-router.ts`). The asset page is therefore the router's *first* history entry, while the page the user came from is still behind it in the tab's browser history. The asset page back arrow unconditionally called `navigate(-1)` (`ui/pages/asset/components/asset-page.tsx`), which pops browser history and leaves the wallet.

**Fix:** detect the direct-entry case via `location.key === 'default'` (react-router's initial history entry) and navigate to the home page (`DEFAULT_ROUTE`, replace) instead — matching the issue's expected behavior ("Land to Home?"). This is the same fresh-tab back-handling pattern already used in `ui/pages/multichain-accounts/account-list/account-list.tsx`, `choose-new-wallet-type-page.tsx`, and `connect-hardware/select-hardware.tsx`. Normal in-app back navigation (asset page reached from the token list, etc.) is unchanged.

Tests: two new cases in `asset-page.test.tsx` — initial-entry click navigates to `DEFAULT_ROUTE` (fails without the fix with `navigate(-1)`), and in-app-history click still calls `navigate(-1)`.

## **Related issues**

Fixes: #44590

## **Manual testing steps**

1. Open the browser and go to any page
2. Paste a deep link, e.g. `https://link.metamask.io/asset?assetId=eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F` (continue through the interstitial if shown)
3. On the asset page, click the back arrow
4. You land on the MetaMask home page instead of the previous website
5. Regression check: open MetaMask normally, click a token in the list, press the back arrow — you return to the token list as before

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (`asset-page.test.tsx` back-button suite: deep-link entry goes home, in-app history still goes back; 22/22 pass, no console-baseline violations)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CHANGELOG entry: Fixed the back arrow navigating outside of MetaMask after opening the wallet via a deep link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation change on the asset page, aligned with existing fresh-tab back handling elsewhere; no auth, data, or payment impact.
> 
> **Overview**
> Fixes the asset page **back** control so deep-linked opens no longer send users out of MetaMask.
> 
> The back arrow no longer always calls `navigate(-1)`. When the route is the router’s initial entry (`location.key === 'default'`, e.g. after a deep link loads the asset tab directly), back now goes to **`DEFAULT_ROUTE`** with `replace: true`. In-app navigation to the asset page still uses `transitionBack` and `navigate(-1)`.
> 
> **Tests** mock `useNavigate` / `useLocation` and cover both the deep-link (home) and in-app history (back) cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e94db3317a82cf91ef33abb9b369307733c058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->