### PR TITLE
fix: bound blockaid report url length to prevent 414 uri too long

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.test.ts
@@ -17,7 +17,13 @@ import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/co
 import { Severity } from '../../../../helpers/constants/design-system';
 import mockState from '../../../../../test/data/mock-state.json';
 import { SecurityAlertResponse } from '../../types/confirm';
-import useBlockaidAlert from './useBlockaidAlerts';
+import useBlockaidAlert, {
+  MAX_REPORT_URL_LENGTH,
+  REPORT_FIELD_TRUNCATION_MARKER,
+} from './useBlockaidAlerts';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const zlib = require('zlib');
 
 const mockSecurityAlertResponse: SecurityAlertResponse = {
   securityAlertId: 'test-id-mock',
@@ -51,6 +57,31 @@ const IGNORED_TYPES = [
   BlockaidResultType.NotApplicable,
   'NewUnexpectedTypeFromAPI',
 ];
+
+/**
+ * Generates a deterministic, poorly-compressible hex string so that gzip
+ * cannot shrink the payload below the URL length limit.
+ *
+ * @param length - The length of the generated string.
+ * @returns A pseudo-random hex string of the given length.
+ */
+function generateIncompressibleHexData(length: number): string {
+  let seed = 42;
+  let result = '';
+  while (result.length < length) {
+    // Linear congruential generator for deterministic pseudo-random output.
+    seed = (seed * 1103515245 + 12345) % 2147483648;
+    result += seed.toString(16);
+  }
+  return `0x${result.slice(0, length)}`;
+}
+
+function decodeReportUrlData(reportUrl: string): Record<string, string> {
+  const encodedData = new URL(reportUrl).searchParams.get('data') as string;
+  return JSON.parse(
+    zlib.gunzipSync(Buffer.from(encodedData, 'base64')).toString(),
+  );
+}
 
 describe('useBlockaidAlerts', () => {
   it('returns an empty array when there is no confirmation', () => {
@@ -101,6 +132,76 @@ describe('useBlockaidAlerts', () => {
     expect(result.current[0].reportUrl).toBeDefined();
     delete result.current[0].reportUrl;
     expect(result.current[0]).toStrictEqual(EXPECTED_ALERT);
+  });
+
+  it('includes the full request params in the report URL for normal payloads', () => {
+    const msgParams = {
+      from: '0x8eeee1781fd885ff5ddef7789486676961873d12',
+      data: '0x48656c6c6f',
+      origin: 'https://metamask.github.io',
+    };
+    const mockCurrentState = getMockPersonalSignConfirmStateForRequest(
+      { ...currentConfirmationMock, msgParams },
+      {
+        metamask: {
+          signatureSecurityAlertResponses: {
+            'test-id-mock': mockSecurityAlertResponse,
+          },
+        },
+      },
+    );
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useBlockaidAlert(),
+      mockCurrentState,
+    );
+
+    const reportUrl = result.current[0].reportUrl as string;
+    expect(reportUrl.length).toBeLessThanOrEqual(MAX_REPORT_URL_LENGTH);
+
+    const reportData = decodeReportUrlData(reportUrl);
+    expect(reportData.jsonRpcParams).toStrictEqual(JSON.stringify(msgParams));
+    expect(reportData.jsonRpcParams).not.toContain(
+      REPORT_FIELD_TRUNCATION_MARKER,
+    );
+  });
+
+  it('bounds the report URL length for oversized payloads while keeping key fields', () => {
+    const msgParams = {
+      from: '0x8eeee1781fd885ff5ddef7789486676961873d12',
+      data: generateIncompressibleHexData(200000),
+      origin: 'https://metamask.github.io',
+    };
+    const mockCurrentState = getMockPersonalSignConfirmStateForRequest(
+      { ...currentConfirmationMock, msgParams },
+      {
+        metamask: {
+          signatureSecurityAlertResponses: {
+            'test-id-mock': mockSecurityAlertResponse,
+          },
+        },
+      },
+    );
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useBlockaidAlert(),
+      mockCurrentState,
+    );
+
+    expect(result.current).toHaveLength(1);
+
+    const reportUrl = result.current[0].reportUrl as string;
+    expect(reportUrl.length).toBeLessThanOrEqual(MAX_REPORT_URL_LENGTH);
+
+    const reportData = decodeReportUrlData(reportUrl);
+    expect(reportData.blockaidVersion).toBeDefined();
+    expect(reportData.classification).toStrictEqual('test-reason');
+    expect(reportData.domain).toStrictEqual('https://metamask.github.io');
+    expect(reportData.jsonRpcMethod).toStrictEqual(
+      TransactionType.personalSign,
+    );
+    expect(reportData.resultType).toStrictEqual(BlockaidResultType.Malicious);
+    expect(reportData.jsonRpcParams).toContain(REPORT_FIELD_TRUNCATION_MARKER);
   });
 
   jestIt.each(IGNORED_TYPES)(

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
@@ -28,6 +28,79 @@ import { normalizeProviderAlert } from './utils';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const zlib = require('zlib');
 
+/**
+ * Maximum length of the generated report URL. Web servers commonly reject
+ * URLs in the 8k character range with "414 URI Too Long", so the report URL
+ * is kept comfortably below that.
+ */
+export const MAX_REPORT_URL_LENGTH = 4096;
+
+/** Marker appended to report fields that were truncated to bound the URL. */
+export const REPORT_FIELD_TRUNCATION_MARKER = '...[truncated]';
+
+/**
+ * Report fields that contain unbounded, free-form data and may be truncated
+ * to keep the report URL within {@link MAX_REPORT_URL_LENGTH}. Identifying
+ * metadata (chain, domain, classification, etc.) is never truncated.
+ */
+const SHRINKABLE_REPORT_FIELDS = ['jsonRpcParams', 'reproduce'] as const;
+
+const encodeReportUrl = (stringifiedReportData: string): string => {
+  const encodedData =
+    zlib?.gzipSync?.(stringifiedReportData) ?? stringifiedReportData;
+
+  return `${FALSE_POSITIVE_REPORT_BASE_URL}?data=${encodeURIComponent(
+    encodedData.toString('base64'),
+  )}&utm_source=${SECURITY_PROVIDER_UTM_SOURCE}`;
+};
+
+const truncateReportField = (value: string): string => {
+  const nextLength = Math.floor(value.length / 2);
+
+  if (nextLength <= REPORT_FIELD_TRUNCATION_MARKER.length) {
+    return REPORT_FIELD_TRUNCATION_MARKER;
+  }
+
+  return `${value.slice(0, nextLength)}${REPORT_FIELD_TRUNCATION_MARKER}`;
+};
+
+/**
+ * Builds the false positive report URL, truncating oversized free-form fields
+ * (e.g. the full transaction params of a Seaport order) as needed so that the
+ * URL stays within practical length limits and is not rejected by the report
+ * portal with "414 URI Too Long".
+ *
+ * @param stringifiedReportData - The stringified report data to encode.
+ * @returns The report URL, bounded to {@link MAX_REPORT_URL_LENGTH}.
+ */
+export const getReportUrl = (stringifiedReportData: string): string => {
+  let reportUrl = encodeReportUrl(stringifiedReportData);
+
+  if (reportUrl.length <= MAX_REPORT_URL_LENGTH) {
+    return reportUrl;
+  }
+
+  const reportData: Record<string, unknown> = JSON.parse(stringifiedReportData);
+
+  while (reportUrl.length > MAX_REPORT_URL_LENGTH) {
+    const field = SHRINKABLE_REPORT_FIELDS.find(
+      (key) =>
+        typeof reportData[key] === 'string' &&
+        (reportData[key] as string).length >
+          REPORT_FIELD_TRUNCATION_MARKER.length,
+    );
+
+    if (!field) {
+      break;
+    }
+
+    reportData[field] = truncateReportField(reportData[field] as string);
+    reportUrl = encodeReportUrl(JSON.stringify(reportData));
+  }
+
+  return reportUrl;
+};
+
 export const ALERT_RESULT_TYPES = [
   BlockaidResultType.Malicious,
   BlockaidResultType.Warning,
@@ -116,12 +189,7 @@ const useBlockaidAlerts = (): Alert[] => {
 
     let reportUrl: string = ZENDESK_URLS.SUPPORT_URL;
     if (stringifiedJSONData) {
-      const encodedData =
-        zlib?.gzipSync?.(stringifiedJSONData) ?? stringifiedJSONData;
-
-      reportUrl = `${FALSE_POSITIVE_REPORT_BASE_URL}?data=${encodeURIComponent(
-        encodedData.toString('base64'),
-      )}&utm_source=${SECURITY_PROVIDER_UTM_SOURCE}`;
+      reportUrl = getReportUrl(stringifiedJSONData);
     }
 
     return [normalizeProviderAlert(securityAlertResponse, t, reportUrl)];


### PR DESCRIPTION
## **Description**

Clicking "Report an issue" on the Blockaid banner for a Malicious Seaport request opened an error page: `Error: URI Too Long` (HTTP 414).

Root cause: `useBlockaidAlerts` serializes the whole report payload — including `jsonRpcParams` (the full transaction/signature params, which for a Seaport order is a very large typed-data blob) and `reproduce` (security provider features) — gzips it, base64-encodes it, and puts it into the `?data=` query param of the false positive portal URL. For large payloads the resulting URL exceeds the server's URL length limit and the portal rejects it with 414.

Fix: the report URL is now bounded to `MAX_REPORT_URL_LENGTH` (4096 characters, comfortably below the ~8k range where servers start rejecting URLs). When the encoded URL exceeds the limit, the unbounded free-form fields are progressively truncated — `jsonRpcParams` first, then `reproduce` — with an explicit `...[truncated]` marker so the portal/triage team can see the data was cut. The identifying metadata (`chain`, `domain`, `classification`, `jsonRpcMethod`, `resultType`, `blockaidVersion`, `blockNumber`) is never truncated. Normal-sized payloads are completely unaffected (the URL is returned unchanged when it is already within the limit).

Unit tests added:
- an oversized (incompressible) payload produces a report URL bounded to `MAX_REPORT_URL_LENGTH` whose decoded data still contains all key identifying fields and the truncation marker
- a normal payload keeps its full, untruncated `jsonRpcParams`

## **Related issues**

Fixes: #43392

## **Manual testing steps**

1. Connect to the [test dapp](https://metamask.github.io/test-dapp/)
2. Trigger MALICIOUS SEAPORT (PPOM section)
3. Click "See details" in the Blockaid banner on the confirmation
4. Click "Report an issue"
5. The false positive portal opens normally (no "URI Too Long" error page)
6. Also trigger a small malicious request (e.g. Malicious Personal Sign) and verify "Report an issue" still opens the portal with the full request params in the report data

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

CHANGELOG entry: Fixed the "Report an issue" link on the Blockaid banner opening a "URI Too Long" error page for large requests such as malicious Seaport orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to how report links are encoded; it does not alter Blockaid verdicts or confirmation approval logic.
> 
> **Overview**
> Fixes **Report an issue** on Blockaid alerts failing with HTTP 414 when the gzipped/base64 report payload in the query string grows too large (e.g. malicious Seaport typed data).
> 
> Report URL building now goes through **`getReportUrl`**, which caps URLs at **`MAX_REPORT_URL_LENGTH` (4096)**. If encoding still exceeds that limit, only **`jsonRpcParams`** and **`reproduce`** are halved iteratively with a **`...[truncated]`** marker; metadata like domain, classification, and result type is left intact. Small payloads are unchanged.
> 
> Tests cover full params for normal requests and bounded URLs plus preserved key fields when params are oversized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecf7735962af0cdbcbce2cb68b42d8d4a77fc13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->