### PR TITLE
fix(toasts): remove duplicate success toast on submit

### DIFF
--- a/ui/hooks/hardware-wallets/useHwSwapNavigation.test.ts
+++ b/ui/hooks/hardware-wallets/useHwSwapNavigation.test.ts
@@ -4,17 +4,10 @@ import { createSignatureState } from '../../pages/hardware-wallets/swap/hardware
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
 import { useHwSwapNavigation } from './useHwSwapNavigation';
 
-jest.mock('../../components/app/toast-listener/shared', () => ({
-  showSuccessToast: jest.fn(),
-}));
-
 jest.mock('../bridge/useBridgeNavigation', () => ({
   useBridgeNavigation: jest.fn(),
 }));
 
-const mockShowSuccessToast = jest.requireMock(
-  '../../components/app/toast-listener/shared',
-).showSuccessToast;
 const mockUseBridgeNavigation = jest.requireMock(
   '../bridge/useBridgeNavigation',
 ).useBridgeNavigation;
@@ -49,7 +42,6 @@ describe('useHwSwapNavigation', () => {
       jest.advanceTimersByTime(1000);
     });
 
-    expect(mockShowSuccessToast).toHaveBeenCalledTimes(1);
     expect(mockNavigateToDefaultRoute).toHaveBeenCalledTimes(1);
   });
 
@@ -69,7 +61,6 @@ describe('useHwSwapNavigation', () => {
     });
 
     expect(mockNavigateToDefaultRoute).not.toHaveBeenCalled();
-    expect(mockShowSuccessToast).not.toHaveBeenCalled();
   });
 
   it('does not navigate twice when status remains Submitted', async () => {
@@ -124,7 +115,6 @@ describe('useHwSwapNavigation', () => {
       jest.advanceTimersByTime(1000);
     });
 
-    expect(mockShowSuccessToast).toHaveBeenCalledTimes(1);
     expect(mockNavigateToDefaultRoute).not.toHaveBeenCalled();
     expect(updatedNavigateToDefaultRoute).toHaveBeenCalledTimes(1);
   });
@@ -154,7 +144,6 @@ describe('useHwSwapNavigation', () => {
       jest.advanceTimersByTime(1000);
     });
 
-    expect(mockShowSuccessToast).toHaveBeenCalledTimes(1);
     expect(mockNavigateToDefaultRoute).toHaveBeenCalledTimes(1);
 
     rerender();
@@ -163,7 +152,6 @@ describe('useHwSwapNavigation', () => {
       jest.advanceTimersByTime(1000);
     });
 
-    expect(mockShowSuccessToast).toHaveBeenCalledTimes(1);
     expect(mockNavigateToDefaultRoute).toHaveBeenCalledTimes(1);
     expect(updatedNavigateToDefaultRoute).not.toHaveBeenCalled();
   });

--- a/ui/hooks/hardware-wallets/useHwSwapNavigation.ts
+++ b/ui/hooks/hardware-wallets/useHwSwapNavigation.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 
-import { showSuccessToast } from '../../components/app/toast-listener/shared';
 import { useBridgeNavigation } from '../bridge/useBridgeNavigation';
 import { HardwareWalletSignatureStatus } from '../../pages/hardware-wallets/swap/hardware-wallet-signatures-state-machine';
 import type { HardwareWalletSignaturesState } from '../../pages/hardware-wallets/swap/hardware-wallet-signatures-state-machine';
@@ -13,9 +12,10 @@ type UseHardwareWalletNavigationOptions = {
  * Handles post-submission navigation for hardware wallet swap/bridge flows.
  *
  * When the signature state machine transitions to `Submitted`, this hook
- * displays a success toast and navigates the user back to the default bridge
- * route after a 1-second delay. Navigation is triggered only once per
- * submission cycle.
+ * navigates the user back to the default bridge route after a 1-second delay.
+ * Navigation is triggered only once per submission cycle.
+ *
+ * Transaction toasts are handled by `useTransactionEventToasts`.
  *
  * @param options - Configuration for the navigation hook.
  * @param options.signatureState - The current hardware-wallet signature state-machine state.
@@ -35,10 +35,8 @@ export function useHwSwapNavigation({
       return;
     }
 
-    const toastId = `bridge-hw-submitted-${Date.now()}`;
     const timer = setTimeout(async () => {
       hasNavigatedAfterSubmission.current = true;
-      showSuccessToast(toastId);
       await navigateToDefaultRoute();
     }, 1000);
 

--- a/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.basic.test.tsx
+++ b/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.basic.test.tsx
@@ -20,9 +20,6 @@ import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import HardwareWalletSignatures from '.';
 
 jest.mock('../../../hooks/bridge/useSubmitBridgeTransaction');
-jest.mock('../../../components/app/toast-listener/shared', () => ({
-  showSuccessToast: jest.fn(),
-}));
 jest.mock('./generic-hardware-wallet-animation', () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,

--- a/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.retry.test.tsx
+++ b/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.retry.test.tsx
@@ -25,9 +25,6 @@ import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import HardwareWalletSignatures from '.';
 
 jest.mock('../../../hooks/bridge/useSubmitBridgeTransaction');
-jest.mock('../../../components/app/toast-listener/shared', () => ({
-  showSuccessToast: jest.fn(),
-}));
 jest.mock('./generic-hardware-wallet-animation', () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,


### PR DESCRIPTION
## **Description**

Hardware wallet signing showed a premature "Transaction confirmed" toast. Removed the toast from `useHwSwapNavigation` as this is already handled by the transaction toast listener.

## **Changelog**

CHANGELOG entry: fix: duplicate confirmed toast when confirming with a hardware wallet

## **Related issues**

Fixes: #45068

## **Manual testing steps**

1. Import a Ledger (or Trezor) account.
2. Switch to a fast chain (Linea, Base, or local Anvil).
3. Start a Send, confirm on the device.
4. Verify only one "Transaction confirmed" toast appears (pending → confirmed).
5. Confirm home/default navigation still happens after submit.

## **Screenshots/Recordings**

<!--
### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)