### PR TITLE
fix: add timeout and reject path to PPOM messenger subscriptions

### DIFF
--- a/app/scripts/lib/ppom/ppom-util.ts
+++ b/app/scripts/lib/ppom/ppom-util.ts
@@ -371,7 +371,7 @@ async function waitForTransactionMetadata(
   const transactionFilter = (meta: TransactionMeta) =>
     meta.securityAlertResponse?.securityAlertId === securityAlertId;
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const transactionMeta =
       transactionController.state.transactions.find(transactionFilter);
 
@@ -380,6 +380,18 @@ async function waitForTransactionMetadata(
       return;
     }
 
+    const timeoutId = setTimeout(() => {
+      messenger.unsubscribe(
+        'TransactionController:unapprovedTransactionAdded',
+        callback,
+      );
+      reject(
+        new Error(
+          `Timed out waiting for transaction metadata: ${securityAlertId}`,
+        ),
+      );
+    }, 60_000);
+
     const callback = (event: TransactionMeta) => {
       if (!transactionFilter(event)) {
         return;
@@ -387,6 +399,7 @@ async function waitForTransactionMetadata(
 
       log('Found transaction metadata', event);
 
+      clearTimeout(timeoutId);
       messenger.unsubscribe(
         'TransactionController:unapprovedTransactionAdded',
         callback,
@@ -415,13 +428,22 @@ async function waitForSignatureRequest(
         request.securityAlertResponse?.securityAlertId === securityAlertId,
     );
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const signatureRequest = signatureFilter(signatureController.state);
 
     if (signatureRequest) {
       resolve(signatureRequest);
       return;
     }
+
+    const timeoutId = setTimeout(() => {
+      messenger.unsubscribe('SignatureController:stateChange', callback);
+      reject(
+        new Error(
+          `Timed out waiting for signature request: ${securityAlertId}`,
+        ),
+      );
+    }, 60_000);
 
     const callback = (state: SignatureControllerState) => {
       const request = signatureFilter(state);
@@ -432,6 +454,7 @@ async function waitForSignatureRequest(
 
       log('Found signature request', request);
 
+      clearTimeout(timeoutId);
       messenger.unsubscribe('SignatureController:stateChange', callback);
 
       resolve(request);

--- a/app/scripts/lib/ppom/ppom-util.ts
+++ b/app/scripts/lib/ppom/ppom-util.ts
@@ -46,6 +46,19 @@ const log = createProjectLogger('ppom-util');
 
 const { sentry } = global;
 
+/**
+ * Thrown when waitForTransactionMetadata or waitForSignatureRequest times out
+ * waiting for a controller object that never arrives (e.g. tx rejected during
+ * PPOM network call). Caught in validateRequestWithPPOM to avoid re-subscribing
+ * and triggering a second unhandled timeout rejection.
+ */
+class PPOMWaitTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PPOMWaitTimeoutError';
+  }
+}
+
 const SECURITY_ALERT_RESPONSE_ERROR = {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -100,6 +113,14 @@ export async function validateRequestWithPPOM({
     await updateSecurityResponse(request.method, securityAlertId, ppomResponse);
   } catch (error: unknown) {
     log('Error', error);
+
+    // If the wait timed out it means the tx/sig was rejected before PPOM
+    // completed. There is no controller object to update, and calling
+    // updateSecurityResponse again would re-subscribe and produce a second
+    // unhandled timeout rejection after another 60 seconds.
+    if (error instanceof PPOMWaitTimeoutError) {
+      return;
+    }
 
     await updateSecurityResponse(
       request.method,
@@ -386,7 +407,7 @@ async function waitForTransactionMetadata(
         callback,
       );
       reject(
-        new Error(
+        new PPOMWaitTimeoutError(
           `Timed out waiting for transaction metadata: ${securityAlertId}`,
         ),
       );
@@ -439,7 +460,7 @@ async function waitForSignatureRequest(
     const timeoutId = setTimeout(() => {
       messenger.unsubscribe('SignatureController:stateChange', callback);
       reject(
-        new Error(
+        new PPOMWaitTimeoutError(
           `Timed out waiting for signature request: ${securityAlertId}`,
         ),
       );


### PR DESCRIPTION
## **Description**

Fixes permanent messenger subscription leaks when a user rejects a transaction or signature while PPOM validation is still running. `waitForTransactionMetadata` and `waitForSignatureRequest` previously only resolved and never timed out or unsubscribed if the matching controller entry never appeared.

Both wait helpers now use 60-second timeouts that reject with a dedicated `PPOMWaitTimeoutError`, unsubscribe the messenger listener on timeout, and clear the timeout on success.

In `validateRequestWithPPOM`, that timeout error is caught and ignored instead of calling `updateSecurityResponse` again which would re-subscribe and risk a second unhandled rejection.

## **Related issues**

Fixes #45129

## **Manual testing steps**

1. Trigger `eth_sendTransaction` from a dApp
2. While PPOM loading indicator is visible, reject the confirmation
3. Repeat multiple times
4. Verify no subscription accumulation occurs in messenger listeners

## **Screenshots/Recordings**

N/A internal async cleanup, no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/contributor-docs/blob/main/docs/extension/coding-standards.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (not required for external contributors)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I've verified the PR satisfies the requirements