### PR TITLE
fix(ci): bind AMO package EXIT trap path before set -u can fail

### DIFF
--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -155,6 +155,8 @@ run_package() {
   work_root="$(mktemp -d)"
   # Expand the path when registering the trap. With set -u, a trap that refs a
   # function-local on EXIT runs after the local is unbound and fails the job.
+  # Shellcheck: Early expansion is intentional here
+  # shellcheck disable=SC2064
   trap "rm -rf \"${work_root}\"" EXIT
   script_ref="${FIREFOX_BUNDLE_SCRIPT_REF}"
   clone_dir="${work_root}/firefox-bundle-script"

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -152,8 +152,9 @@ run_package() {
   ensure_mtree
 
   local work_root script_ref clone_dir last_listed
+  # Temp dir only; runner discards it. No EXIT trap: with set -u a trap that
+  # refs a function-local fires after the local is unbound and fails the job.
   work_root="$(mktemp -d)"
-  trap 'rm -rf "${work_root}"' EXIT
   script_ref="${FIREFOX_BUNDLE_SCRIPT_REF}"
   clone_dir="${work_root}/firefox-bundle-script"
 

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -155,8 +155,7 @@ run_package() {
   work_root="$(mktemp -d)"
   # Expand the path when registering the trap. With set -u, a trap that refs a
   # function-local on EXIT runs after the local is unbound and fails the job.
-  # ponytail: quote-embed is enough; runner is ephemeral either way.
-  trap 'rm -rf "'"${work_root}"'"' EXIT
+  trap "rm -rf \"${work_root}\"" EXIT
   script_ref="${FIREFOX_BUNDLE_SCRIPT_REF}"
   clone_dir="${work_root}/firefox-bundle-script"
 

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -152,9 +152,11 @@ run_package() {
   ensure_mtree
 
   local work_root script_ref clone_dir last_listed
-  # Temp dir only; runner discards it. No EXIT trap: with set -u a trap that
-  # refs a function-local fires after the local is unbound and fails the job.
   work_root="$(mktemp -d)"
+  # Expand the path when registering the trap. With set -u, a trap that refs a
+  # function-local on EXIT runs after the local is unbound and fails the job.
+  # ponytail: quote-embed is enough; runner is ephemeral either way.
+  trap 'rm -rf "'"${work_root}"'"' EXIT
   script_ref="${FIREFOX_BUNDLE_SCRIPT_REF}"
   clone_dir="${work_root}/firefox-bundle-script"
 


### PR DESCRIPTION
## **Description**

Follow-up to [#45101](https://github.com/MetaMask/metamask-extension/pull/45101). The AMO reviewer `package` step finishes successfully (reproduced builds identical), then fails on EXIT: the cleanup trap expands function-local `work_root` after it is unbound under `set -u`, so upload never runs.

Fix by expanding the temp path when registering the trap, so cleanup still runs and `set -u` is satisfied. Quoting form per review: `trap "… \"${work_root}\"" EXIT`.

Smoke evidence on [#45168](https://github.com/MetaMask/metamask-extension/pull/45168) (`v13.42.0`, package-only, no S3):

- [main script (broken trap) — failed](https://github.com/MetaMask/metamask-extension/actions/runs/30884003518): builds identical, then `work_root: unbound variable`
- [trap removed — passed](https://github.com/MetaMask/metamask-extension/actions/runs/30884824038): packaging proven green
- [quote-embed fixed trap — passed](https://github.com/MetaMask/metamask-extension/actions/runs/30887618231)
- [review quoting form — passed](https://github.com/MetaMask/metamask-extension/actions/runs/30939206457): package + verify green (12m55s)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3674](https://consensyssoftware.atlassian.net/browse/INFRA-3674)

## **Manual testing steps**

1. Confirm `.github/scripts/publish-firefox-reviewer-artifacts.sh` registers an EXIT cleanup with the path expanded at trap registration time.
2. Review the smoke runs linked above.
3. On the next production release, confirm the Publish release job's AMO reviewer S3 step completes and objects appear under `s3://prd-va-mmc-extension-submission-amo-reviewer-source/reviewer-source/X.Y.Z/`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[INFRA-3674]: https://consensyssoftware.atlassian.net/browse/INFRA-3674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only shell cleanup change with no product runtime impact; reduces release job failure risk after successful packaging.
> 
> **Overview**
> Fixes a **post-success failure** in the Firefox AMO reviewer `package` step: packaging could finish, then the EXIT cleanup trap would error with `work_root: unbound variable` under `set -u`, blocking the upload step.
> 
> In `run_package` inside `publish-firefox-reviewer-artifacts.sh`, the trap now **embeds the temp directory path at registration** (`trap "rm -rf \"${work_root}\"" EXIT`) instead of referencing the function-local `work_root` when the trap fires. Cleanup still runs and strict unset-variable mode stays enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5014044c22ccd91ce116becbfc9413f4f7f1902b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->