### PR TITLE
test: fix anti-patterns in TokensTab page object by removing references to NetworkManager

### DIFF
--- a/test/e2e/page-objects/flows/network.flow.ts
+++ b/test/e2e/page-objects/flows/network.flow.ts
@@ -11,6 +11,54 @@ import NetworkManager from '../pages/network-manager';
 const NON_EVM_SNAP_READY_DELAY_MS = 10_000;
 const NON_EVM_NETWORKS_NEEDING_DELAY = ['Tron', 'Bitcoin'];
 
+/**
+ * Opens the network filter from the asset list and enables every network in the
+ * given category, widening the asset list to all of them.
+ *
+ * @param driver - The webdriver instance.
+ * @param networkCategory - The tab to select all networks from.
+ */
+export const selectAllNetworksFromNetworkSelect = async (
+  driver: Driver,
+  networkCategory: string = 'Popular',
+) => {
+  console.log(`Selecting all networks in category: ${networkCategory}`);
+  const tokensTab = new TokensTab(driver);
+  const networkManager = new NetworkManager(driver);
+
+  await tokensTab.openNetworksFilter();
+  await networkManager.checkPageIsLoaded();
+  await networkManager.selectTab(networkCategory);
+  await networkManager.selectAllNetworks();
+};
+
+/**
+ * Opens the network filter from the asset list and enables only the given
+ * network, scoping the asset list to it. Prefer
+ * `switchToNetworkFromNetworkSelect` unless the caller has already waited for
+ * the network's Snap to be ready.
+ *
+ * @param driver - The webdriver instance.
+ * @param networkCategory - The tab the network is listed under.
+ * @param networkName - The display name of the network to select.
+ */
+export const selectOnlyNetworkFromNetworkSelect = async (
+  driver: Driver,
+  networkCategory: string,
+  networkName: string,
+) => {
+  console.log(
+    `Selecting only network: ${networkName} in category: ${networkCategory}`,
+  );
+  const tokensTab = new TokensTab(driver);
+  const networkManager = new NetworkManager(driver);
+
+  await tokensTab.openNetworksFilter();
+  await networkManager.checkPageIsLoaded();
+  await networkManager.selectTab(networkCategory);
+  await networkManager.selectNetworkByNameWithWait(networkName);
+};
+
 export const switchToNetworkFromNetworkSelect = async (
   driver: Driver,
   networkCategory: string,
@@ -19,16 +67,16 @@ export const switchToNetworkFromNetworkSelect = async (
   console.log(
     `Switching to network: ${networkName} in category: ${networkCategory}`,
   );
-  const tokensTab = new TokensTab(driver);
-  const networkManager = new NetworkManager(driver);
 
   if (NON_EVM_NETWORKS_NEEDING_DELAY.includes(networkName)) {
     await driver.delay(NON_EVM_SNAP_READY_DELAY_MS);
   }
 
-  await tokensTab.openNetworksFilter();
-  await networkManager.selectTab(networkCategory);
-  await networkManager.selectNetworkByNameWithWait(networkName);
+  await selectOnlyNetworkFromNetworkSelect(
+    driver,
+    networkCategory,
+    networkName,
+  );
 };
 
 export async function waitForNetworkManagerBackdropToClear(

--- a/test/e2e/page-objects/flows/network.flow.ts
+++ b/test/e2e/page-objects/flows/network.flow.ts
@@ -34,31 +34,12 @@ export const selectAllNetworksFromNetworkSelect = async (
 
 /**
  * Opens the network filter from the asset list and enables only the given
- * network, scoping the asset list to it. Prefer
- * `switchToNetworkFromNetworkSelect` unless the caller has already waited for
- * the network's Snap to be ready.
+ * network, scoping the asset list to it.
  *
  * @param driver - The webdriver instance.
  * @param networkCategory - The tab the network is listed under.
- * @param networkName - The display name of the network to select.
+ * @param networkName - The display name of the network to switch to.
  */
-export const selectOnlyNetworkFromNetworkSelect = async (
-  driver: Driver,
-  networkCategory: string,
-  networkName: string,
-) => {
-  console.log(
-    `Selecting only network: ${networkName} in category: ${networkCategory}`,
-  );
-  const tokensTab = new TokensTab(driver);
-  const networkManager = new NetworkManager(driver);
-
-  await tokensTab.openNetworksFilter();
-  await networkManager.checkPageIsLoaded();
-  await networkManager.selectTab(networkCategory);
-  await networkManager.selectNetworkByNameWithWait(networkName);
-};
-
 export const switchToNetworkFromNetworkSelect = async (
   driver: Driver,
   networkCategory: string,
@@ -67,16 +48,17 @@ export const switchToNetworkFromNetworkSelect = async (
   console.log(
     `Switching to network: ${networkName} in category: ${networkCategory}`,
   );
+  const tokensTab = new TokensTab(driver);
+  const networkManager = new NetworkManager(driver);
 
   if (NON_EVM_NETWORKS_NEEDING_DELAY.includes(networkName)) {
     await driver.delay(NON_EVM_SNAP_READY_DELAY_MS);
   }
 
-  await selectOnlyNetworkFromNetworkSelect(
-    driver,
-    networkCategory,
-    networkName,
-  );
+  await tokensTab.openNetworksFilter();
+  await networkManager.checkPageIsLoaded();
+  await networkManager.selectTab(networkCategory);
+  await networkManager.selectNetworkByNameWithWait(networkName);
 };
 
 export async function waitForNetworkManagerBackdropToClear(

--- a/test/e2e/page-objects/pages/home/tokens-tab.ts
+++ b/test/e2e/page-objects/pages/home/tokens-tab.ts
@@ -2,7 +2,6 @@ import { strict as assert } from 'assert';
 import { By, WebElement } from 'selenium-webdriver';
 import { NETWORK_TO_NAME_MAP } from '../../../../../shared/constants/network';
 import { largeDelayMs, veryLargeDelayMs } from '../../../helpers';
-import NetworkManager from '../network-manager';
 import HomePage from './homepage';
 
 /** Timeout for waiting on the import-confirm button to disappear after submit. */
@@ -103,9 +102,6 @@ class TokensTab extends HomePage {
   private readonly lowValueAssetsToggleExpanded = `${this.lowValueAssetsToggle}[aria-expanded="true"]`;
 
   private readonly manageTokensButton = '[data-testid="manageTokens__button"]';
-
-  private readonly modalCloseButton =
-    '[data-testid="modal-header-close-button"]';
 
   private readonly modalWarningBanner = '[data-testid="custom-token-warning"]';
 
@@ -1109,11 +1105,15 @@ class TokensTab extends HomePage {
     await this.driver.waitForSelector(this.tokenImportedSuccessMessage);
   }
 
+  /**
+   * Clicks the network filter in the asset list control bar, which opens the
+   * network manager modal. Await `NetworkManager.checkPageIsLoaded` to wait for
+   * that modal.
+   */
   async openNetworksFilter(): Promise<void> {
     console.log(`Opening the network filter`);
     await this.waitForNetworksToggleStable();
     await this.driver.clickElement(this.networksToggle);
-    await this.driver.waitForSelector(this.modalCloseButton);
   }
 
   /**
@@ -1144,52 +1144,6 @@ class TokensTab extends HomePage {
   private async returnFromTokenManagementToHome(): Promise<void> {
     await this.driver.clickElement(this.tokenManagementBackButton);
     await this.driver.waitForSelector(this.multichainTokenListButton);
-  }
-
-  async selectAllNetworksInFilter(tab: string = 'Popular'): Promise<void> {
-    console.log('Selecting all networks in the asset list network filter');
-    await this.openNetworksFilter();
-    const networkManager = new NetworkManager(this.driver);
-    await networkManager.selectTab(tab);
-    await networkManager.selectAllNetworks();
-  }
-
-  /**
-   * Opens the Network Manager modal and selects all popular networks.
-   */
-  async selectAllNetworksInNetworkFilter(): Promise<void> {
-    console.log(
-      'Selecting all popular networks in the asset list network filter',
-    );
-    await this.openNetworksFilter();
-    const networkManager = new NetworkManager(this.driver);
-    await networkManager.selectTab('Popular');
-    await networkManager.selectAllNetworks();
-  }
-
-  async selectOnlyNetworkInFilter(
-    networkName: string,
-    tab: string = 'Popular',
-  ): Promise<void> {
-    console.log(
-      `Selecting only ${networkName} in the asset list network filter`,
-    );
-    await this.openNetworksFilter();
-    const networkManager = new NetworkManager(this.driver);
-    await networkManager.selectTab(tab);
-    await networkManager.selectNetworkByNameWithWait(networkName);
-  }
-
-  /**
-   * Opens the Network Manager modal and selects only Tron, scoping the asset
-   * list to a single network.
-   */
-  async selectOnlyTronInNetworkFilter(): Promise<void> {
-    console.log('Selecting only Tron in the asset list network filter');
-    await this.openNetworksFilter();
-    const networkManager = new NetworkManager(this.driver);
-    await networkManager.selectTab('Popular');
-    await networkManager.selectNetworkByNameWithWait('Tron');
   }
 
   async sortTokenList(

--- a/test/e2e/page-objects/pages/network-manager.ts
+++ b/test/e2e/page-objects/pages/network-manager.ts
@@ -130,6 +130,11 @@ class NetworkManager {
     }
   }
 
+  async checkPageIsLoaded(): Promise<void> {
+    console.log('Checking the network manager is loaded');
+    await this.driver.waitForSelector(this.networkManagerCloseButton);
+  }
+
   async checkTabIsSelected(tabName: string): Promise<void> {
     console.log(`Checking if ${tabName} tab is selected`);
     // Find the active tab and verify it contains "Custom" text
@@ -194,7 +199,7 @@ class NetworkManager {
   async openNetworkManager(): Promise<void> {
     console.log(`Opening the network manager`);
     await this.driver.clickElement(this.networkManagerToggle);
-    await this.driver.waitForSelector(this.networkManagerCloseButton);
+    await this.checkPageIsLoaded();
   }
 
   async selectAllNetworks(): Promise<void> {

--- a/test/e2e/tests/btc/activity.spec.ts
+++ b/test/e2e/tests/btc/activity.spec.ts
@@ -5,9 +5,11 @@ import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import { broadcastBitcoinSend } from '../../page-objects/flows/bitcoin-send.flow';
 import { login } from '../../page-objects/flows/login.flow';
-import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
+import {
+  selectOnlyNetworkFromNetworkSelect,
+  switchToNetworkFromNetworkSelect,
+} from '../../page-objects/flows/network.flow';
 import ActivityTab from '../../page-objects/pages/home/activity-tab';
-import TokensTab from '../../page-objects/pages/home/tokens-tab';
 import HomePage from '../../page-objects/pages/home/homepage';
 import TransactionDetailsPage from '../../page-objects/pages/transaction-details-page';
 import {
@@ -125,8 +127,7 @@ describe('BTC Account - Activity', function (this: Suite) {
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
         await homePage.checkPageIsLoaded();
 
-        const assetList = new TokensTab(driver);
-        await assetList.selectOnlyNetworkInFilter('Bitcoin');
+        await selectOnlyNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
 
         await homePage.goToActivityList();
         const activity = new ActivityTab(driver);

--- a/test/e2e/tests/btc/activity.spec.ts
+++ b/test/e2e/tests/btc/activity.spec.ts
@@ -5,10 +5,7 @@ import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import { broadcastBitcoinSend } from '../../page-objects/flows/bitcoin-send.flow';
 import { login } from '../../page-objects/flows/login.flow';
-import {
-  selectOnlyNetworkFromNetworkSelect,
-  switchToNetworkFromNetworkSelect,
-} from '../../page-objects/flows/network.flow';
+import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
 import ActivityTab from '../../page-objects/pages/home/activity-tab';
 import HomePage from '../../page-objects/pages/home/homepage';
 import TransactionDetailsPage from '../../page-objects/pages/transaction-details-page';
@@ -126,8 +123,6 @@ describe('BTC Account - Activity', function (this: Suite) {
         const homePage = new HomePage(driver);
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
         await homePage.checkPageIsLoaded();
-
-        await selectOnlyNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
 
         await homePage.goToActivityList();
         const activity = new ActivityTab(driver);

--- a/test/e2e/tests/tron/assets.spec.ts
+++ b/test/e2e/tests/tron/assets.spec.ts
@@ -4,7 +4,6 @@ import { Driver } from '../../webdriver/driver';
 import { login } from '../../page-objects/flows/login.flow';
 import {
   selectAllNetworksFromNetworkSelect,
-  selectOnlyNetworkFromNetworkSelect,
   switchToNetworkFromNetworkSelect,
 } from '../../page-objects/flows/network.flow';
 import HomePage from '../../page-objects/pages/home/homepage';
@@ -217,7 +216,6 @@ describe('Tron - Assets', function (this: Suite) {
             await landOnTronHome(driver);
             const tokensTab = new TokensTab(driver);
             await waitForTronAssetList(tokensTab);
-            await selectOnlyNetworkFromNetworkSelect(driver, 'Popular', 'Tron');
             await tokensTab.checkOnlyAssetsArePresent([
               'Tron',
               'GasFreeTransferSolution',

--- a/test/e2e/tests/tron/assets.spec.ts
+++ b/test/e2e/tests/tron/assets.spec.ts
@@ -2,7 +2,11 @@ import { Suite } from 'mocha';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
 import { login } from '../../page-objects/flows/login.flow';
-import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
+import {
+  selectAllNetworksFromNetworkSelect,
+  selectOnlyNetworkFromNetworkSelect,
+  switchToNetworkFromNetworkSelect,
+} from '../../page-objects/flows/network.flow';
 import HomePage from '../../page-objects/pages/home/homepage';
 import TokensTab from '../../page-objects/pages/home/tokens-tab';
 import TronAssetDetailsPage from '../../page-objects/pages/asset/tron-asset-details';
@@ -195,7 +199,7 @@ describe('Tron - Assets', function (this: Suite) {
             await landOnTronHome(driver);
             const tokensTab = new TokensTab(driver);
             await waitForTronAssetList(tokensTab);
-            await tokensTab.selectAllNetworksInNetworkFilter();
+            await selectAllNetworksFromNetworkSelect(driver);
             await tokensTab.checkTokenExistsInList('Tron');
             await tokensTab.checkTokenExistsInList('Tether');
             await tokensTab.checkTokenExistsInList('Ethereum');
@@ -213,7 +217,7 @@ describe('Tron - Assets', function (this: Suite) {
             await landOnTronHome(driver);
             const tokensTab = new TokensTab(driver);
             await waitForTronAssetList(tokensTab);
-            await tokensTab.selectOnlyTronInNetworkFilter();
+            await selectOnlyNetworkFromNetworkSelect(driver, 'Popular', 'Tron');
             await tokensTab.checkOnlyAssetsArePresent([
               'Tron',
               'GasFreeTransferSolution',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There are anti-patterns in the TokensTab page object where it's referencing to NetworkManage page object, instead of using a flow,.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. ci should continue to pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test and page-object refactor only; no production wallet or extension runtime behavior changes.
> 
> **Overview**
> Refactors E2E page objects so **network manager interactions live in flows and `NetworkManager`**, not inside `TokensTab`.
> 
> **`network.flow.ts`** adds `selectAllNetworksFromNetworkSelect` and extends `switchToNetworkFromNetworkSelect` to wait for the modal via `NetworkManager.checkPageIsLoaded()` after opening the asset-list network filter.
> 
> **`TokensTab`** drops the `NetworkManager` import and removes helpers that opened the filter and selected all/one network (`selectAllNetworksInFilter`, `selectOnlyTronInNetworkFilter`, etc.). `openNetworksFilter()` only clicks the toggle; callers are expected to wait on `NetworkManager.checkPageIsLoaded()`.
> 
> **`NetworkManager`** centralizes modal-ready waiting in new `checkPageIsLoaded()` (used by `openNetworkManager()` as well).
> 
> **Specs** (BTC activity, Tron assets) call the network flow helpers instead of `TokensTab` filter methods; redundant duplicate Bitcoin network scoping after `switchToNetworkFromNetworkSelect` is removed in one BTC test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d5161b4ee3e4341218c220bb5749274bf2d242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->