### PR TITLE
test: fix flaky test `Tron account derivation discovers Tron accounts through Account 5 when each account has assets`

### DIFF
--- a/test/e2e/tests/tron/account-derivation.spec.ts
+++ b/test/e2e/tests/tron/account-derivation.spec.ts
@@ -203,6 +203,10 @@ describe('Tron account derivation', function (this: Suite) {
       async ({ driver }: { driver: Driver }) => {
         await completeImportSRPOnboardingFlow({ driver });
 
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+        await homePage.checkHasAccountSyncingSyncedAtLeastOnce();
+
         await assertTronAddressesForAccounts(driver, 5, {
           absentAccountLabel: 'Account 6',
         });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Sometimes the tests are flaky as we still see Sync in the add account button.

To prevent this we have the checkHasAccountSyncingSyncedAtLeastOnce already used in the identity tests, so we also use it here where we open the accounts menu right 

`Error: Found element {"tag":"p","text":"Syncing..."} that should not be present     at Driver.assertElementNotPresent (test/e2e/webdriver/driver.js:70...`


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. e2e should pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test-only change with no production code impact.
> 
> **Overview**
> Stabilizes the **asset-discovery** Tron E2E case (`discovers Tron accounts through Account 5 when each account has assets`) by waiting on the home page until account syncing has completed at least once, right after `completeImportSRPOnboardingFlow` and before address assertions.
> 
> The test now calls `HomePage.checkPageIsLoaded()` and `checkHasAccountSyncingSyncedAtLeastOnce()` so discovered accounts are present before opening the account menu and checking Tron addresses—addressing race-related flakiness on CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138ce69843fbd770af969e2f9395a9cb1ab2c9b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->