### PR TITLE
feat(ramps): add mapRampsOrderSafely and ramp format helpers

### DIFF
--- a/ui/hooks/ramps/utils/formatPendingRampTokenLabel.test.ts
+++ b/ui/hooks/ramps/utils/formatPendingRampTokenLabel.test.ts
@@ -1,0 +1,12 @@
+import { formatPendingRampTokenLabel } from './formatPendingRampTokenLabel';
+
+describe('formatPendingRampTokenLabel', () => {
+  it('includes the symbol when present', () => {
+    expect(formatPendingRampTokenLabel('ETH')).toBe('... ETH');
+  });
+
+  it('returns ellipsis alone when symbol is missing', () => {
+    expect(formatPendingRampTokenLabel()).toBe('...');
+    expect(formatPendingRampTokenLabel('')).toBe('...');
+  });
+});

--- a/ui/hooks/ramps/utils/formatPendingRampTokenLabel.ts
+++ b/ui/hooks/ramps/utils/formatPendingRampTokenLabel.ts
@@ -1,0 +1,9 @@
+/**
+ * Pending Activity primary label when crypto amount is not yet known.
+ *
+ * @param symbol - Token symbol, if any.
+ * @returns Ellipsis label, optionally followed by the symbol.
+ */
+export function formatPendingRampTokenLabel(symbol?: string): string {
+  return `...${symbol ? ` ${symbol}` : ''}`;
+}

--- a/ui/hooks/ramps/utils/formatRampCurrencyAmount.test.ts
+++ b/ui/hooks/ramps/utils/formatRampCurrencyAmount.test.ts
@@ -1,0 +1,21 @@
+import { formatRampCurrencyAmount } from './formatRampCurrencyAmount';
+
+const format = (value: number, currency: string) => `${value}:${currency}`;
+
+describe('formatRampCurrencyAmount', () => {
+  it('formats a positive amount with currency', () => {
+    expect(formatRampCurrencyAmount(50, 'USD', format)).toBe('50:USD');
+  });
+
+  it('returns undefined when currency is missing', () => {
+    expect(formatRampCurrencyAmount(50, undefined, format)).toBeUndefined();
+  });
+
+  it('returns undefined for non-displayable amounts', () => {
+    expect(formatRampCurrencyAmount(null, 'USD', format)).toBeUndefined();
+    expect(formatRampCurrencyAmount(undefined, 'USD', format)).toBeUndefined();
+    expect(formatRampCurrencyAmount(0, 'USD', format)).toBeUndefined();
+    expect(formatRampCurrencyAmount(NaN, 'USD', format)).toBeUndefined();
+    expect(formatRampCurrencyAmount(Infinity, 'USD', format)).toBeUndefined();
+  });
+});

--- a/ui/hooks/ramps/utils/formatRampCurrencyAmount.ts
+++ b/ui/hooks/ramps/utils/formatRampCurrencyAmount.ts
@@ -1,0 +1,25 @@
+import { hasPositiveNumericAmount } from './hasPositiveNumericAmount';
+
+type FormatCurrencyWithMinThreshold = (
+  value: number,
+  currency: string,
+) => string;
+
+/**
+ * Formats a ramps fiat/fee amount when both amount and currency are usable.
+ *
+ * @param amount - Raw amount from the mapped activity item.
+ * @param currency - ISO currency or fee symbol.
+ * @param formatCurrencyWithMinThreshold - Formatter from `useFormatters`.
+ * @returns Formatted currency string, or undefined when not displayable.
+ */
+export function formatRampCurrencyAmount(
+  amount: unknown,
+  currency: string | undefined,
+  formatCurrencyWithMinThreshold: FormatCurrencyWithMinThreshold,
+): string | undefined {
+  if (!currency || !hasPositiveNumericAmount(amount)) {
+    return undefined;
+  }
+  return formatCurrencyWithMinThreshold(Number(amount), currency);
+}

--- a/ui/hooks/ramps/utils/hasPositiveNumericAmount.test.ts
+++ b/ui/hooks/ramps/utils/hasPositiveNumericAmount.test.ts
@@ -1,0 +1,23 @@
+import { hasPositiveNumericAmount } from './hasPositiveNumericAmount';
+
+describe('hasPositiveNumericAmount', () => {
+  it('returns true for positive finite amounts', () => {
+    expect(hasPositiveNumericAmount(1)).toBe(true);
+    expect(hasPositiveNumericAmount(0.013745)).toBe(true);
+    expect(hasPositiveNumericAmount('1.5')).toBe(true);
+    expect(hasPositiveNumericAmount('0.01')).toBe(true);
+  });
+
+  it('returns false for non-positive or non-finite amounts', () => {
+    expect(hasPositiveNumericAmount(null)).toBe(false);
+    expect(hasPositiveNumericAmount(undefined)).toBe(false);
+    expect(hasPositiveNumericAmount('')).toBe(false);
+    expect(hasPositiveNumericAmount(0)).toBe(false);
+    expect(hasPositiveNumericAmount('0')).toBe(false);
+    expect(hasPositiveNumericAmount(-1)).toBe(false);
+    expect(hasPositiveNumericAmount('-0.5')).toBe(false);
+    expect(hasPositiveNumericAmount(NaN)).toBe(false);
+    expect(hasPositiveNumericAmount(Infinity)).toBe(false);
+    expect(hasPositiveNumericAmount(-Infinity)).toBe(false);
+  });
+});

--- a/ui/hooks/ramps/utils/hasPositiveNumericAmount.ts
+++ b/ui/hooks/ramps/utils/hasPositiveNumericAmount.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns true when `value` is a finite number greater than zero.
+ *
+ * Accepts string or number inputs (as returned by the ramps API / mapper).
+ *
+ * @param value - Candidate amount.
+ * @returns Whether the value is a displayable positive amount.
+ */
+export function hasPositiveNumericAmount(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0;
+}

--- a/ui/hooks/ramps/utils/mapRampsOrderSafely.test.ts
+++ b/ui/hooks/ramps/utils/mapRampsOrderSafely.test.ts
@@ -1,0 +1,146 @@
+import type { RampsOrder } from '@metamask/ramps-controller';
+import type { ActivityListItem } from '../../../../shared/lib/activity/types';
+import { mapRampsOrderSafely } from './mapRampsOrderSafely';
+
+type RampOrderItem = Extract<
+  ActivityListItem,
+  { type: 'rampBuy' | 'rampSell' }
+>;
+
+const baseOrder = {
+  provider: { id: 'mockprovider-staging', name: 'MockProvider (Staging)' },
+  cryptoAmount: 0.013745,
+  fiatAmount: 50,
+  cryptoCurrency: { assetId: 'eip155:1/slip44:60', symbol: 'ETH' },
+  fiatCurrency: { symbol: 'USD' },
+  providerOrderId: '33dfa019e795ddba9974ccfddbeba7f9',
+  providerOrderLink: 'https://example.com/status/123',
+  createdAt: 1699368322000,
+  totalFeesFiat: 0.98,
+  txHash: 'fake-hash-staging-server',
+  walletAddress: '0x005958702dbcf1c499ffd67dc60dbd4c6992201e',
+  status: 'COMPLETED',
+  orderType: 'BUY',
+  network: { name: 'Ethereum', chainId: 'eip155:1' },
+} as unknown as RampsOrder;
+
+describe('mapRampsOrderSafely', () => {
+  it('returns the shared ActivityItem without remapping data.id', () => {
+    const order = {
+      ...baseOrder,
+      id: '/providers/transak/orders/order-abc',
+      providerOrderId: 'order-abc',
+      txHash: '',
+      status: 'PENDING',
+    } as unknown as RampsOrder;
+
+    const mapped = mapRampsOrderSafely(order) as RampOrderItem | undefined;
+
+    expect(mapped?.hash).toBeUndefined();
+    expect(mapped?.data.id).toBe('/providers/transak/orders/order-abc');
+  });
+
+  it('returns undefined when the shared mapper filters the order out', () => {
+    const order = {
+      ...baseOrder,
+      status: 'PRECREATED',
+    } as unknown as RampsOrder;
+
+    expect(mapRampsOrderSafely(order)).toBeUndefined();
+  });
+
+  it('returns undefined when the order cannot resolve a chainId', () => {
+    const order = {
+      ...baseOrder,
+      network: undefined,
+      cryptoCurrency: undefined,
+    } as unknown as RampsOrder;
+
+    expect(mapRampsOrderSafely(order)).toBeUndefined();
+  });
+
+  it('keeps a provider-reported crypto amount while the order is pending', () => {
+    const order = {
+      ...baseOrder,
+      status: 'PENDING',
+    } as unknown as RampsOrder;
+
+    const mapped = mapRampsOrderSafely(order) as RampOrderItem | undefined;
+
+    expect(mapped?.data.token?.amount).toBe('0.013745');
+  });
+
+  it('maps a pending order without crypto currency metadata', () => {
+    const order = {
+      ...baseOrder,
+      providerOrderId: 'order-without-currency',
+      cryptoCurrency: undefined,
+      fiatCurrency: undefined,
+      status: 'PENDING',
+    } as unknown as RampsOrder;
+
+    const mapped = mapRampsOrderSafely(order) as RampOrderItem | undefined;
+
+    expect(mapped?.data.token).toBeUndefined();
+    expect(mapped?.data.fiat?.currency).toBeUndefined();
+  });
+
+  it('normalizes a missing txHash so the shared mapper does not throw', () => {
+    const order = {
+      ...baseOrder,
+      txHash: null,
+      status: 'PENDING',
+    } as unknown as RampsOrder;
+
+    expect(mapRampsOrderSafely(order)?.type).toBe('rampBuy');
+  });
+
+  it('strips zero crypto and fiat amounts from the mapped item', () => {
+    const order = {
+      ...baseOrder,
+      cryptoAmount: 0,
+      fiatAmount: 0,
+      status: 'PENDING',
+    } as unknown as RampsOrder;
+
+    const mapped = mapRampsOrderSafely(order) as RampOrderItem | undefined;
+
+    expect(mapped?.data.token?.amount).toBeUndefined();
+    expect(mapped?.data.fiat).toBeUndefined();
+  });
+
+  it('strips non-finite crypto and fiat amounts from the mapped item', () => {
+    const order = {
+      ...baseOrder,
+      cryptoAmount: NaN,
+      fiatAmount: Infinity,
+      status: 'PENDING',
+    } as unknown as RampsOrder;
+
+    const mapped = mapRampsOrderSafely(order) as RampOrderItem | undefined;
+
+    expect(mapped?.data.token?.amount).toBeUndefined();
+    expect(mapped?.data.fiat).toBeUndefined();
+  });
+
+  it('resolves chainId from cryptoCurrency.assetId when network is missing', () => {
+    const order = {
+      ...baseOrder,
+      network: undefined,
+      cryptoCurrency: { assetId: 'eip155:1/slip44:60', symbol: 'ETH' },
+      status: 'PENDING',
+    } as unknown as RampsOrder;
+
+    expect(mapRampsOrderSafely(order)?.chainId).toBe('eip155:1');
+  });
+
+  it('maps when network is already a non-empty CAIP chain string', () => {
+    const order = {
+      ...baseOrder,
+      network: 'eip155:1',
+      status: 'PENDING',
+    } as unknown as RampsOrder;
+
+    expect(mapRampsOrderSafely(order)?.chainId).toBe('eip155:1');
+  });
+});

--- a/ui/hooks/ramps/utils/mapRampsOrderSafely.ts
+++ b/ui/hooks/ramps/utils/mapRampsOrderSafely.ts
@@ -1,0 +1,91 @@
+import { mapRampsOrder, type RampsOrderLike } from '@metamask/client-utils';
+import type { RampsOrder } from '@metamask/ramps-controller';
+import { hasPositiveNumericAmount } from './hasPositiveNumericAmount';
+
+/**
+ * Seeds `network` when the order only has chain info on `cryptoCurrency`.
+ *
+ * The shared mapper requires `network` to be defined before reading
+ * `cryptoCurrency`. Orders that still cannot resolve a chainId are left as-is
+ * so `mapRampsOrder` returns null.
+ *
+ * @param order - The raw ramps order.
+ * @returns The order, optionally with `network` seeded from crypto metadata.
+ */
+function seedNetworkIfNeeded(order: RampsOrder): RampsOrder {
+  const { network } = order;
+  if (typeof network === 'string' && network) {
+    return order;
+  }
+  if (typeof network === 'object' && network?.chainId) {
+    return order;
+  }
+
+  if (!order.cryptoCurrency?.chainId && !order.cryptoCurrency?.assetId) {
+    return order;
+  }
+
+  if (network !== undefined && network !== null) {
+    return order;
+  }
+
+  return {
+    ...order,
+    network: {
+      name: '',
+      chainId: order.cryptoCurrency.chainId ?? '',
+    },
+  };
+}
+
+/**
+ * Coerces a missing `txHash` to `''` for the shared mapper.
+ *
+ * @param order - The raw ramps order.
+ * @returns The order with `txHash` guaranteed to be a string.
+ */
+function withNormalizedTxHash(order: RampsOrder): RampsOrder {
+  const txHash = order.txHash as string | null | undefined;
+  return typeof txHash === 'string' ? order : { ...order, txHash: '' };
+}
+
+/**
+ * Maps a ramps order to an activity item for the extension UI.
+ *
+ * Returns undefined when the shared mapper cannot resolve a required chainId
+ * or otherwise filters the order out.
+ *
+ * @param order - The raw ramps order to map.
+ * @returns The mapped activity item, or undefined when filtered / unmappable.
+ */
+export function mapRampsOrderSafely(
+  order: RampsOrder,
+): NonNullable<ReturnType<typeof mapRampsOrder>> | undefined {
+  try {
+    const prepared = seedNetworkIfNeeded(withNormalizedTxHash(order));
+    const item =
+      mapRampsOrder(prepared as unknown as RampsOrderLike) ?? undefined;
+    if (!item || (item.type !== 'rampBuy' && item.type !== 'rampSell')) {
+      return item;
+    }
+
+    const hasCryptoAmount = hasPositiveNumericAmount(order.cryptoAmount);
+    const hasFiatAmount = hasPositiveNumericAmount(order.fiatAmount);
+
+    return {
+      ...item,
+      data: {
+        ...item.data,
+        token: item.data.token
+          ? {
+              ...item.data.token,
+              amount: hasCryptoAmount ? item.data.token.amount : undefined,
+            }
+          : undefined,
+        fiat: hasFiatAmount ? item.data.fiat : undefined,
+      },
+    };
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## **Description**

Foundation utilities for ramp orders in Activity (TRAM-3718). No UX wiring yet.

Depends on merged [#45143](https://github.com/MetaMask/metamask-extension/pull/45143) (`@metamask/client-utils@^2.0.0` with required ramp `chainId`).

### Changes
- `mapRampsOrderSafely` wraps `@metamask/client-utils` `mapRampsOrder` with network seeding, txHash normalization, and zero/non-finite amount stripping
- Unresolved chain → mapper returns null / helper returns `undefined` (matches required ramp `chainId` in client-utils)
- Small helpers: `hasPositiveNumericAmount`, `formatRampCurrencyAmount`, `formatPendingRampTokenLabel`

### Stack
1. This PR (foundation)
2. [#45185](https://github.com/MetaMask/metamask-extension/pull/45185) Checkout + Activity + order details
3. [#45186](https://github.com/MetaMask/metamask-extension/pull/45186) Status toasts

Replaces the monolith [#45144](https://github.com/MetaMask/metamask-extension/pull/45144) split.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TRAM-3718 (partial)

## **Manual testing steps**

1. No UX in this PR — verify unit tests for the four utility modules pass (`yarn jest ui/hooks/ramps/utils/mapRampsOrderSafely.test.ts ui/hooks/ramps/utils/formatRampCurrencyAmount.test.ts ui/hooks/ramps/utils/formatPendingRampTokenLabel.test.ts ui/hooks/ramps/utils/hasPositiveNumericAmount.test.ts`).
2. Confirm no Activity / checkout / toast behavior changes (utilities are unused until follow-up PRs).

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.