### PR TITLE
feat: updated ux styling in Search Page

### DIFF
--- a/ui/components/app/perps/market-row/market-row.tsx
+++ b/ui/components/app/perps/market-row/market-row.tsx
@@ -165,10 +165,10 @@ export const MarketRow = ({
       />
       {/* Left side: Symbol, leverage, and metric */}
       <Box
-        className="min-w-0 flex-1"
+        className="min-w-0 flex-1 overflow-hidden"
         flexDirection={BoxFlexDirection.Column}
         alignItems={BoxAlignItems.Start}
-        gap={1}
+        gap={0}
       >
         <Box
           className="min-w-0 max-w-full"
@@ -176,7 +176,10 @@ export const MarketRow = ({
           alignItems={BoxAlignItems.Center}
           gap={2}
         >
-          <Text fontWeight={FontWeight.Medium} className="min-w-0 truncate">
+          <Text
+            fontWeight={FontWeight.Medium}
+            className="block max-w-full truncate"
+          >
             {displaySymbol}
           </Text>
           {market.maxLeverage && (
@@ -201,6 +204,7 @@ export const MarketRow = ({
               <Text
                 variant={TextVariant.BodySm}
                 color={TextColor.TextAlternative}
+                className="block max-w-full truncate"
                 data-testid={`market-row-ticker-${market.symbol.replace(/:/gu, '-')}`}
               >
                 {displayTicker}
@@ -213,22 +217,34 @@ export const MarketRow = ({
               </Text>
             </>
           )}
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            className="block max-w-full truncate"
+          >
             {metricValue}
           </Text>
         </Box>
       </Box>
       {/* Right side: Price and 24h change */}
       <Box
-        className="shrink-0"
+        className="w-24 shrink-0 overflow-hidden"
         flexDirection={BoxFlexDirection.Column}
         alignItems={BoxAlignItems.End}
         gap={1}
       >
-        <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          className="block max-w-full truncate text-right"
+        >
           {market.price}
         </Text>
-        <Text variant={TextVariant.BodySm} color={changeColor}>
+        <Text
+          variant={TextVariant.BodySm}
+          color={changeColor}
+          className="block max-w-full truncate text-right"
+        >
           {formatSignedChangePercent(market.change24hPercent)}
         </Text>
       </Box>

--- a/ui/pages/discover-search/discover-asset-row.tsx
+++ b/ui/pages/discover-search/discover-asset-row.tsx
@@ -1,8 +1,11 @@
 import React, { useMemo } from 'react';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import {
+  AvatarNetwork,
+  AvatarNetworkSize,
   AvatarToken,
   AvatarTokenSize,
+  BadgeWrapper,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
@@ -11,7 +14,6 @@ import {
   Text,
   TextColor,
   TextVariant,
-  twMerge,
 } from '@metamask/design-system-react';
 import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
 
@@ -22,6 +24,7 @@ import {
   formatSignedChangePercent,
   getChangeColor,
 } from '../../components/app/perps/utils';
+import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../shared/constants/network';
 
 const ROW_STYLES =
   'justify-start rounded-none min-w-0 h-auto min-h-[72px] gap-3 text-left cursor-pointer bg-default px-4 py-3 hover:bg-hover active:bg-pressed';
@@ -46,6 +49,20 @@ const formatAssetPrice = (price: string | undefined) => {
   }).format(value);
 };
 
+const getNetworkImageMapKey = ({
+  namespace,
+  reference,
+}: {
+  namespace: string;
+  reference: string;
+}) => {
+  if (namespace === 'eip155') {
+    return `0x${BigInt(reference).toString(16)}`;
+  }
+
+  return `${namespace}:${reference}`;
+};
+
 /**
  * Discover row for crypto / stocks: icon, name, cap·vol, price, 24h %.
  * @param options0
@@ -65,6 +82,20 @@ export const DiscoverAssetRow = ({
       return undefined;
     }
     return getCaipAssetImageUrl(asset.assetId);
+  }, [asset.assetId]);
+
+  const network = useMemo(() => {
+    if (!isCaipAssetType(asset.assetId)) {
+      return undefined;
+    }
+
+    const parsedAssetId = parseCaipAssetType(asset.assetId);
+    const imageMapKey = getNetworkImageMapKey(parsedAssetId.chain);
+
+    return {
+      name: parsedAssetId.chainId,
+      imageUrl: CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[imageMapKey],
+    };
   }, [asset.assetId]);
 
   const secondaryText = useMemo(() => {
@@ -92,40 +123,69 @@ export const DiscoverAssetRow = ({
 
   return (
     <ButtonBase
-      className={twMerge(ROW_STYLES)}
+      className={ROW_STYLES}
       isFullWidth={true}
       data-testid={testId}
       onClick={handleClick}
     >
-      <AvatarToken
-        name={asset.symbol}
-        src={imageUrl}
-        size={AvatarTokenSize.Md}
+      <BadgeWrapper
         className="shrink-0"
-      />
+        badge={
+          network?.imageUrl ? (
+            <AvatarNetwork
+              name={network.name}
+              src={network.imageUrl}
+              size={AvatarNetworkSize.Xs}
+              className="h-4 w-4 min-w-4 rounded-md border-2 border-background-default bg-background-default"
+              data-testid={`${testId}-network`}
+            />
+          ) : null
+        }
+      >
+        <AvatarToken
+          name={asset.symbol}
+          src={imageUrl}
+          size={AvatarTokenSize.Lg}
+        />
+      </BadgeWrapper>
       <Box
-        className="min-w-0 flex-1"
+        className="min-w-0 flex-1 overflow-hidden"
         flexDirection={BoxFlexDirection.Column}
         alignItems={BoxAlignItems.Start}
-        gap={1}
+        gap={0}
       >
-        <Text fontWeight={FontWeight.Medium} className="min-w-0 truncate">
+        <Text
+          fontWeight={FontWeight.Medium}
+          className="block max-w-full truncate"
+        >
           {asset.name || asset.symbol}
         </Text>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+        <Text
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
+          className="block max-w-full truncate"
+        >
           {secondaryText}
         </Text>
       </Box>
       <Box
-        className="shrink-0"
+        className="w-24 shrink-0 overflow-hidden"
         flexDirection={BoxFlexDirection.Column}
         alignItems={BoxAlignItems.End}
         gap={1}
       >
-        <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          className="block max-w-full truncate text-right"
+        >
           {formatAssetPrice(asset.price)}
         </Text>
-        <Text variant={TextVariant.BodySm} color={changeColor}>
+        <Text
+          variant={TextVariant.BodySm}
+          color={changeColor}
+          className="block max-w-full truncate text-right"
+        >
           {changePct ? formatSignedChangePercent(changePct) : '—'}
         </Text>
       </Box>

--- a/ui/pages/discover-search/discover-search-section-header.tsx
+++ b/ui/pages/discover-search/discover-search-section-header.tsx
@@ -6,6 +6,10 @@ import {
   BoxJustifyContent,
   ButtonBase,
   FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
   Text,
   TextColor,
   TextVariant,
@@ -38,24 +42,33 @@ export const DiscoverSearchSectionHeader = ({
 
   return (
     <Box
-      className="px-4 py-2"
+      className="px-4 pb-3 pt-3"
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
       justifyContent={BoxJustifyContent.Between}
       data-testid={dataTestId}
     >
-      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+      <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
         {title}
       </Text>
       {showViewAll && onViewAll ? (
         <ButtonBase
-          className="h-auto rounded-none bg-transparent px-0 py-0 hover:bg-transparent active:bg-transparent"
+          className="h-auto gap-1 rounded-none bg-transparent px-0 py-0 hover:bg-transparent active:bg-transparent"
           onClick={onViewAll}
           data-testid={`${dataTestId ?? 'discover-section'}-view-all`}
         >
-          <Text variant={TextVariant.BodySm} color={TextColor.PrimaryDefault}>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
+          >
             {t('viewAll')}
           </Text>
+          <Icon
+            name={IconName.ArrowRight}
+            size={IconSize.Md}
+            color={IconColor.IconAlternative}
+          />
         </ButtonBase>
       ) : null}
     </Box>

--- a/ui/pages/discover-search/discover-search.test.tsx
+++ b/ui/pages/discover-search/discover-search.test.tsx
@@ -202,4 +202,28 @@ describe('DiscoverSearchPage', () => {
       '/asset/bip122:000000000019d6689c085ae165831e93/bip122%3A000000000019d6689c085ae165831e93%2Fslip44%3A0',
     );
   });
+
+  it('renders no-results search design on empty category tabs', () => {
+    const searchQuery = 'erwerwqer';
+
+    mockUseDiscoverSearch.mockReturnValue(getEmptyDiscoverSearchResult());
+    renderPage();
+
+    fireEvent.change(screen.getByTestId('discover-search-input'), {
+      target: { value: searchQuery },
+    });
+    fireEvent.click(screen.getByTestId('discover-tab-crypto'));
+
+    expect(
+      screen.getByTestId('discover-search-no-results'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        messages.discoverSearchNoResultsFor.message.replace('$1', searchQuery),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.discoverSearchPopularAssets.message),
+    ).toBeInTheDocument();
+  });
 });

--- a/ui/pages/discover-search/discover-search.tsx
+++ b/ui/pages/discover-search/discover-search.tsx
@@ -19,7 +19,7 @@ import {
   TextFieldSize,
   TextVariant,
 } from '@metamask/design-system-react';
-import { isCaipAssetType, type CaipAssetType } from '@metamask/utils';
+import { isCaipAssetType } from '@metamask/utils';
 
 import { MarketRow } from '../../components/app/perps/market-row';
 import { Tab, Tabs } from '../../components/ui/tabs';
@@ -57,23 +57,34 @@ const EmptyState = ({ message }: { message: string }) => (
   </Box>
 );
 
-type DiscoverAllEmptyStateProps = {
+type DiscoverSearchEmptyStateProps = {
   noResultsMessage: string;
-  onAssetPress: (assetId: CaipAssetType) => void;
   query: string;
 };
 
-const DiscoverAllEmptyState = ({
+const DiscoverSearchEmptyState = ({
   noResultsMessage,
-  onAssetPress,
   query,
-}: DiscoverAllEmptyStateProps) => {
+}: DiscoverSearchEmptyStateProps) => {
+  const navigate = useNavigate();
+
   if (query) {
-    return <DiscoverNoResultsState query={query} onAssetPress={onAssetPress} />;
+    return (
+      <DiscoverNoResultsState
+        query={query}
+        onAssetPress={(assetId) => navigate(buildAssetRoutePath(assetId))}
+      />
+    );
   }
 
   return <EmptyState message={noResultsMessage} />;
 };
+
+const DiscoverSearchSectionDivider = () => (
+  <Box className="px-4 py-2">
+    <Box className="border-t border-muted" />
+  </Box>
+);
 
 /**
  * Discover search page: search + All / Crypto / Perps / Stock tabs.
@@ -131,6 +142,7 @@ export const DiscoverSearchPage = () => {
   }, []);
 
   const trimmedSearchQuery = searchQuery.trim();
+  const noResultsMessage = t('discoverSearchNoResults');
 
   const previewCrypto = useMemo(
     () => cryptoSection.items.slice(0, DISCOVER_SEARCH_PREVIEW_COUNT),
@@ -157,6 +169,10 @@ export const DiscoverSearchPage = () => {
 
   const showAllLoading = allLoading && !hasAnyPreview;
   const showAllEmpty = !allLoading && !hasAnyPreview;
+  const showCryptoPreview = previewCrypto.length > 0 || cryptoSection.isLoading;
+  const showPerpsPreview =
+    isPerpsAvailable && (previewPerps.length > 0 || perps.isLoading);
+  const showStocksPreview = previewStocks.length > 0 || stocks.isLoading;
 
   const renderAllTabSkeleton = () => (
     <Box
@@ -172,6 +188,7 @@ export const DiscoverSearchPage = () => {
 
       {isPerpsAvailable ? (
         <>
+          <DiscoverSearchSectionDivider />
           <DiscoverSearchSectionHeader
             title={t('perps')}
             showViewAll={false}
@@ -181,6 +198,7 @@ export const DiscoverSearchPage = () => {
         </>
       ) : null}
 
+      <DiscoverSearchSectionDivider />
       <DiscoverSearchSectionHeader
         title={t('perpsFilterStocks')}
         showViewAll={false}
@@ -199,7 +217,12 @@ export const DiscoverSearchPage = () => {
       return <DiscoverSearchSectionSkeleton testIdPrefix={testIdPrefix} />;
     }
     if (items.length === 0) {
-      return <EmptyState message={t('discoverSearchNoResults')} />;
+      return (
+        <DiscoverSearchEmptyState
+          noResultsMessage={noResultsMessage}
+          query={trimmedSearchQuery}
+        />
+      );
     }
     return items.map((asset) => (
       <DiscoverAssetRow
@@ -216,7 +239,12 @@ export const DiscoverSearchPage = () => {
       return <DiscoverSearchSectionSkeleton testIdPrefix="discover-perps" />;
     }
     if (items.length === 0) {
-      return <EmptyState message={t('discoverSearchNoResults')} />;
+      return (
+        <DiscoverSearchEmptyState
+          noResultsMessage={noResultsMessage}
+          query={trimmedSearchQuery}
+        />
+      );
     }
     return items.map((market) => (
       <MarketRow
@@ -235,16 +263,15 @@ export const DiscoverSearchPage = () => {
     }
     if (showAllEmpty) {
       return (
-        <DiscoverAllEmptyState
-          noResultsMessage={t('discoverSearchNoResults')}
-          onAssetPress={(assetId) => navigate(buildAssetRoutePath(assetId))}
+        <DiscoverSearchEmptyState
+          noResultsMessage={noResultsMessage}
           query={trimmedSearchQuery}
         />
       );
     }
     return (
       <Box flexDirection={BoxFlexDirection.Column}>
-        {previewCrypto.length > 0 || cryptoSection.isLoading ? (
+        {showCryptoPreview ? (
           <>
             <DiscoverSearchSectionHeader
               title={t('perpsFilterCrypto')}
@@ -259,8 +286,9 @@ export const DiscoverSearchPage = () => {
           </>
         ) : null}
 
-        {isPerpsAvailable && (previewPerps.length > 0 || perps.isLoading) ? (
+        {showPerpsPreview ? (
           <>
+            {showCryptoPreview ? <DiscoverSearchSectionDivider /> : null}
             <DiscoverSearchSectionHeader
               title={t('perps')}
               onViewAll={() => handleViewAll('perps')}
@@ -270,8 +298,11 @@ export const DiscoverSearchPage = () => {
           </>
         ) : null}
 
-        {previewStocks.length > 0 || stocks.isLoading ? (
+        {showStocksPreview ? (
           <>
+            {showCryptoPreview || showPerpsPreview ? (
+              <DiscoverSearchSectionDivider />
+            ) : null}
             <DiscoverSearchSectionHeader
               title={t('perpsFilterStocks')}
               onViewAll={() => handleViewAll('stocks')}
@@ -296,7 +327,7 @@ export const DiscoverSearchPage = () => {
       data-testid="discover-search-page"
     >
       <Box
-        className="shrink-0 gap-2 px-4 py-3"
+        className="shrink-0 gap-2 px-4 py-4"
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
       >
@@ -334,7 +365,7 @@ export const DiscoverSearchPage = () => {
         activeTab={activeTab}
         onTabClick={(tab) => setActiveTab(tab as DiscoverSearchTab)}
         className="min-h-0 flex-1"
-        tabListProps={{ className: 'px-4 shrink-0' }}
+        tabListProps={{ className: 'px-4 pb-4 shrink-0' }}
         tabContentProps={{ className: 'min-h-0 overflow-y-auto' }}
       >
         <Tab name={t('all')} tabKey="all" data-testid="discover-tab-all">


### PR DESCRIPTION
This PR is to update paddings and font styling in Search Page

[Figma](https://www.figma.com/design/gb2U5v8Q7ZkFRNwtElGAkp/Discover-search-on-extension?node-id=37-1193&m=dev)
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build and run the extension.
2. Enable the extensionUXSearch feature flag.
3. Open the extension and click the Search entry point in the app header.
4. Verify the Discover Search page header has correct vertical spacing.
5. Verify the tabs have correct bottom spacing.
6. On the All tab, verify Crypto, Perps, and Stocks section headers match the Figma typography.
7. Verify “View all” uses muted text/icon styling and the arrow icon is the correct size.
8. Verify dividers appear between sections.
9. Verify crypto and stock rows show larger token avatars with network badges.
10. Verify long asset names, prices, and percentage changes truncate instead of overlapping.
11. Search for a query with no results and verify the no-results design appears.
12. Switch to Crypto, Perps, and Stocks tabs with the same no-result query and verify the same empty state appears.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only styling and empty-state routing; no auth, data, or payment logic changes.
> 
> **Overview**
> **Discover Search** gets spacing and typography aligned with design: more header/tab padding, **section headers** use bold heading style, and **View all** is muted text with a right arrow. **Dividers** separate Crypto, Perps, and Stocks on the All tab.
> 
> **Crypto/stock rows** use a larger token avatar with an optional **chain network badge** (from CAIP asset id). **Perps `MarketRow`** and discover asset rows share **truncation** fixes (`overflow-hidden`, fixed price column width, `truncate` on labels/prices) so long names and numbers don’t overlap.
> 
> When a search returns nothing, the **no-results** experience (message + popular assets) now shows on **category tabs** (Crypto/Perps/Stocks), not only on All, via a shared `DiscoverSearchEmptyState`. A test covers the Crypto tab empty-search case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bbc340894802587116b5a28d30631b972e97938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->