### PR TITLE
fix(perps): use a fresh Perps balance in MM Pay withdrawal confirmation

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1619,6 +1619,9 @@
   "alertReasonPendingTransactions": {
     "message": "Pending transaction"
   },
+  "alertReasonPerpsWithdrawBalanceUnavailable": {
+    "message": "Balance unavailable"
+  },
   "alertReasonSignIn": {
     "message": "Suspicious sign-in request"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1583,6 +1583,9 @@
   "alertPayHardwareAccountTitle": {
     "message": "Wallet not supported"
   },
+  "alertPerpsWithdrawBalanceUnavailable": {
+    "message": "Couldn't check your Perps balance. Try again."
+  },
   "alertReasonFirstTimeInteraction": {
     "message": "1st interaction"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1619,6 +1619,9 @@
   "alertReasonPendingTransactions": {
     "message": "Pending transaction"
   },
+  "alertReasonPerpsWithdrawBalanceUnavailable": {
+    "message": "Balance unavailable"
+  },
   "alertReasonSignIn": {
     "message": "Suspicious sign-in request"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1583,6 +1583,9 @@
   "alertPayHardwareAccountTitle": {
     "message": "Wallet not supported"
   },
+  "alertPerpsWithdrawBalanceUnavailable": {
+    "message": "Couldn't check your Perps balance. Try again."
+  },
   "alertReasonFirstTimeInteraction": {
     "message": "1st interaction"
   },

--- a/ui/hooks/perps/coalesceBackgroundRequest.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.ts
@@ -10,9 +10,10 @@
  *
  * Two layers of dedup are provided: concurrent callers for the same key share
  * one in-flight Promise, and follow-up callers inside the TTL window get the
- * cached value without issuing a new request. 10 s matches the staleness
- * tolerance of the passive "Recent activity" preview on the perps home — the
- * only path that actually reads the TTL cache today. Top-level consumers
+ * cached value without issuing a new request. The default 10 s matches the
+ * staleness tolerance of the passive "Recent activity" preview on the perps
+ * home; callers that need a tighter window pass their own TTL, as the Perps
+ * withdraw confirmation alert does at 5 s. Top-level consumers
  * (`PerpsActivityPage`) pass `forceFreshOnMount` and bypass the cache
  * entirely.
  *

--- a/ui/pages/confirmations/hooks/alerts/constants.ts
+++ b/ui/pages/confirmations/hooks/alerts/constants.ts
@@ -13,6 +13,7 @@ export enum AlertsName {
   NoGasPrice = 'noGasPrice',
   NoPayTokenQuotes = 'noPayTokenQuotes',
   PendingTransaction = 'pendingTransactions',
+  PerpsWithdrawBalanceUnavailable = 'perpsWithdrawBalanceUnavailable',
   PayHardwareAccount = 'payHardwareAccount',
   SigningOrSubmitting = 'signingOrSubmitting',
   Blockaid = 'blockaid',

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
@@ -85,12 +85,16 @@ const EXPECTED_ALERT = {
   severity: Severity.Danger,
 };
 
-/** Blocked because the balance could not be read — not because it is short. */
-const UNAVAILABLE_COPY = "Couldn't check your Perps balance. Try again.";
+/**
+ * Blocked because the balance could not be read — not because it is short, so
+ * it carries its own alert key (telemetry) and its own copy. `reason` is the
+ * confirm button label and stays short; `message` explains inline.
+ */
 const EXPECTED_UNAVAILABLE_ALERT = {
   ...EXPECTED_ALERT,
-  message: UNAVAILABLE_COPY,
-  reason: UNAVAILABLE_COPY,
+  key: AlertsName.PerpsWithdrawBalanceUnavailable,
+  message: "Couldn't check your Perps balance. Try again.",
+  reason: 'Balance unavailable',
 };
 
 function buildPerpsWithdrawState() {
@@ -364,6 +368,26 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
         error,
       );
       consoleError.mockRestore();
+    });
+
+    it('reports the unverifiable block under its own alert key and a short button label', async () => {
+      // The key is what alert telemetry counts, so a degraded read must not
+      // land in the insufficient-balance bucket. `reason` is the disabled
+      // confirm button's label, so it stays close to "Insufficient funds"
+      // in length rather than carrying the full explanation.
+      setFreshAccount(null);
+      setEnteredAmount('100');
+
+      const result = await runSettledHook(buildPerpsWithdrawState());
+
+      await waitFor(() => expect(result.current).toHaveLength(1));
+      const [alert] = result.current;
+      expect(alert.key).toBe(AlertsName.PerpsWithdrawBalanceUnavailable);
+      expect(alert.key).not.toBe(AlertsName.InsufficientPayTokenBalance);
+      expect(alert.reason).not.toBe(alert.message);
+      expect((alert.reason as string).length).toBeLessThanOrEqual(
+        'Insufficient funds'.length + 4,
+      );
     });
 
     it('blocks without inventing a balance when the fresh read returns no account', async () => {

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
@@ -370,26 +370,6 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
       consoleError.mockRestore();
     });
 
-    it('reports the unverifiable block under its own alert key and a short button label', async () => {
-      // The key is what alert telemetry counts, so a degraded read must not
-      // land in the insufficient-balance bucket. `reason` is the disabled
-      // confirm button's label, so it stays close to "Insufficient funds"
-      // in length rather than carrying the full explanation.
-      setFreshAccount(null);
-      setEnteredAmount('100');
-
-      const result = await runSettledHook(buildPerpsWithdrawState());
-
-      await waitFor(() => expect(result.current).toHaveLength(1));
-      const [alert] = result.current;
-      expect(alert.key).toBe(AlertsName.PerpsWithdrawBalanceUnavailable);
-      expect(alert.key).not.toBe(AlertsName.InsufficientPayTokenBalance);
-      expect(alert.reason).not.toBe(alert.message);
-      expect((alert.reason as string).length).toBeLessThanOrEqual(
-        'Insufficient funds'.length + 4,
-      );
-    });
-
     it('blocks without inventing a balance when the fresh read returns no account', async () => {
       // Treating a missing account as $0 would block with "Insufficient
       // funds", which claims a balance nothing confirmed.

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
@@ -3,13 +3,16 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { waitFor } from '@testing-library/react';
 import {
   getMockConfirmState,
   getMockConfirmStateForTransaction,
 } from '../../../../../../test/data/confirmations/helper';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { resetCoalesceCacheForTests } from '../../../../../hooks/perps/coalesceBackgroundRequest';
 import { getPerpsStreamManager } from '../../../../../providers/perps';
+import { submitRequestToBackground } from '../../../../../store/background-connection';
 import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
 import { AlertsName } from '../constants';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
@@ -20,17 +23,51 @@ jest.mock('../../../../../providers/perps', () => ({
   ...jest.requireActual('../../../../../providers/perps'),
   getPerpsStreamManager: jest.fn(),
 }));
+jest.mock('../../../../../store/background-connection', () => ({
+  ...jest.requireActual('../../../../../store/background-connection'),
+  submitRequestToBackground: jest.fn(),
+}));
 jest.mock('../../pay/useTransactionPayData');
 
 const mockGetPerpsStreamManager = jest.mocked(getPerpsStreamManager);
+const mockSubmitRequestToBackground = jest.mocked(submitRequestToBackground);
 const mockUsePrimaryRequiredToken = jest.mocked(
   useTransactionPayPrimaryRequiredToken,
 );
 
-function mockStreamManagerAccount(account: AccountState | null) {
+/**
+ * Balance the streamed WebSocket cache would have reported. The hook must
+ * never read it — every case here sets it to a value that would produce the
+ * opposite decision from the fresh account state.
+ * @param withdrawableBalance
+ */
+function setStreamedBalance(withdrawableBalance: string | null) {
   mockGetPerpsStreamManager.mockReturnValue({
-    account: { getCachedData: () => account },
+    account: {
+      getCachedData: () =>
+        withdrawableBalance === null
+          ? null
+          : ({ withdrawableBalance } as AccountState),
+    },
   } as ReturnType<typeof getPerpsStreamManager>);
+}
+
+function setFreshAccount(account: Partial<AccountState> | null) {
+  mockSubmitRequestToBackground.mockResolvedValue(account);
+}
+
+function setFreshAccountRejects(error: Error) {
+  mockSubmitRequestToBackground.mockRejectedValue(error);
+}
+
+function setFreshBalance(withdrawableBalance: string) {
+  setFreshAccount({ withdrawableBalance });
+}
+
+function setEnteredAmount(amountFiat: string) {
+  mockUsePrimaryRequiredToken.mockReturnValue({
+    amountFiat,
+  } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
 }
 
 const EXPECTED_ALERT = {
@@ -57,135 +94,210 @@ function runHook(state: ReturnType<typeof buildPerpsWithdrawState>) {
   );
 }
 
-function setAccountBalance(withdrawableBalance: string | undefined) {
-  mockStreamManagerAccount(
-    withdrawableBalance ? ({ withdrawableBalance } as AccountState) : null,
-  );
-}
-
-function setAccount(account: {
-  spendableBalance?: string;
-  withdrawableBalance?: string;
-}) {
-  mockStreamManagerAccount(account as AccountState);
-}
-
-function setEnteredAmount(amountFiat: string) {
-  mockUsePrimaryRequiredToken.mockReturnValue({
-    amountFiat,
-  } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+/**
+ * Renders and waits for the fresh account-state read to settle.
+ * @param state
+ */
+async function runSettledHook(
+  state: ReturnType<typeof buildPerpsWithdrawState>,
+) {
+  const { result } = runHook(state);
+  await waitFor(() => {
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'perpsGetAccountState',
+      [],
+    );
+  });
+  return result;
 }
 
 describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    setAccountBalance('100');
+    resetCoalesceCacheForTests();
+    setStreamedBalance(null);
+    setFreshBalance('100');
     setEnteredAmount('10');
   });
 
-  it('returns no alert when entered amount is below the available balance', () => {
-    const { result } = runHook(buildPerpsWithdrawState());
-    expect(result.current).toStrictEqual([]);
+  it('returns no alert when entered amount is below the available balance', async () => {
+    const result = await runSettledHook(buildPerpsWithdrawState());
+    await waitFor(() => expect(result.current).toStrictEqual([]));
   });
 
-  it('returns no alert when entered amount equals the available balance', () => {
+  it('returns no alert when entered amount equals the available balance', async () => {
     setEnteredAmount('100');
-    const { result } = runHook(buildPerpsWithdrawState());
-    expect(result.current).toStrictEqual([]);
+    const result = await runSettledHook(buildPerpsWithdrawState());
+    await waitFor(() => expect(result.current).toStrictEqual([]));
   });
 
-  it('returns a blocking alert when entered amount exceeds the available balance', () => {
+  it('returns a blocking alert when entered amount exceeds the available balance', async () => {
     setEnteredAmount('150');
-    const { result } = runHook(buildPerpsWithdrawState());
-    expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+    const result = await runSettledHook(buildPerpsWithdrawState());
+    await waitFor(() => expect(result.current).toStrictEqual([EXPECTED_ALERT]));
   });
 
-  it('returns no alert when entered amount is zero', () => {
+  it('returns no alert when entered amount is zero', async () => {
     setEnteredAmount('0');
-    const { result } = runHook(buildPerpsWithdrawState());
-    expect(result.current).toStrictEqual([]);
+    const result = await runSettledHook(buildPerpsWithdrawState());
+    await waitFor(() => expect(result.current).toStrictEqual([]));
   });
 
-  it('treats a missing perps account balance as zero (no entered amount → no alert)', () => {
-    setAccountBalance(undefined);
+  it('returns no alert when there is no entered amount and no account', async () => {
+    setFreshAccount(null);
     setEnteredAmount('0');
-    const { result } = runHook(buildPerpsWithdrawState());
-    expect(result.current).toStrictEqual([]);
+    const result = await runSettledHook(buildPerpsWithdrawState());
+    await waitFor(() => expect(result.current).toStrictEqual([]));
   });
 
-  it('alerts when a missing perps account balance is paired with a non-zero amount', () => {
-    setAccountBalance(undefined);
-    setEnteredAmount('1');
-    const { result } = runHook(buildPerpsWithdrawState());
-    expect(result.current).toStrictEqual([EXPECTED_ALERT]);
-  });
-
-  it('returns no alert for non-perpsWithdraw transactions even when the amount exceeds balance', () => {
-    setEnteredAmount('150');
-    const contractInteraction =
-      genUnapprovedContractInteractionConfirmation() as TransactionMeta;
-    const state = getMockConfirmStateForTransaction(contractInteraction);
-    const { result } = renderHookWithConfirmContextProvider(
-      () => usePerpsWithdrawInsufficientBalanceAlert(),
-      state,
-    );
-    expect(result.current).toStrictEqual([]);
-  });
-
-  it('returns no alert when there is no current confirmation', () => {
+  it('returns no alert when there is no current confirmation', async () => {
     setEnteredAmount('150');
     const { result } = renderHookWithConfirmContextProvider(
       () => usePerpsWithdrawInsufficientBalanceAlert(),
       getMockConfirmState(),
     );
-    expect(result.current).toStrictEqual([]);
+    await waitFor(() => expect(result.current).toStrictEqual([]));
   });
 
-  it('uses `withdrawableBalance` over `spendableBalance` for the threshold', () => {
+  it('uses `withdrawableBalance` over `spendableBalance` for the threshold', async () => {
     // Unified mode: `spendableBalance` is $0 (perps clearinghouse) but the
     // user actually has $50 of withdrawable balance.
     // Withdrawing $40 must NOT trigger the alert.
-    setAccount({ spendableBalance: '0', withdrawableBalance: '50' });
+    setFreshAccount({ spendableBalance: '0', withdrawableBalance: '50' });
     setEnteredAmount('40');
-    const { result } = runHook(buildPerpsWithdrawState());
-    expect(result.current).toStrictEqual([]);
+    const result = await runSettledHook(buildPerpsWithdrawState());
+    await waitFor(() => expect(result.current).toStrictEqual([]));
   });
 
-  it('alerts when entered amount exceeds `withdrawableBalance`', () => {
-    setAccount({ spendableBalance: '0', withdrawableBalance: '50' });
+  it('alerts when entered amount exceeds `withdrawableBalance`', async () => {
+    setFreshAccount({ spendableBalance: '0', withdrawableBalance: '50' });
     setEnteredAmount('51');
-    const { result } = runHook(buildPerpsWithdrawState());
-    expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+    const result = await runSettledHook(buildPerpsWithdrawState());
+    await waitFor(() => expect(result.current).toStrictEqual([EXPECTED_ALERT]));
   });
 
-  it('returns no alert when Max only exceeds the balance below Perps precision', () => {
-    setAccount({ spendableBalance: '0', withdrawableBalance: '7.863083' });
+  it('returns no alert when Max only exceeds the balance below Perps precision', async () => {
+    setFreshAccount({ spendableBalance: '0', withdrawableBalance: '7.863083' });
     setEnteredAmount('7.8630830000000005');
-    const { result } = runHook(buildPerpsWithdrawState());
-    expect(result.current).toStrictEqual([]);
+    const result = await runSettledHook(buildPerpsWithdrawState());
+    await waitFor(() => expect(result.current).toStrictEqual([]));
   });
 
-  it('alerts when entered amount exceeds the balance by one Perps precision unit', () => {
-    setAccount({ spendableBalance: '0', withdrawableBalance: '7.863083' });
+  it('alerts when entered amount exceeds the balance by one Perps precision unit', async () => {
+    setFreshAccount({ spendableBalance: '0', withdrawableBalance: '7.863083' });
     setEnteredAmount('7.863084');
-    const { result } = runHook(buildPerpsWithdrawState());
-    expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+    const result = await runSettledHook(buildPerpsWithdrawState());
+    await waitFor(() => expect(result.current).toStrictEqual([EXPECTED_ALERT]));
   });
 
-  it('uses `amountFiat` (typed USD) over `amountUsd` (token count × $1) for the threshold', () => {
+  it('uses `amountFiat` (typed USD) over `amountUsd` (token count × $1) for the threshold', async () => {
     // For USDC at market rate ≈ 0.9998, the user typing $39.83 produces a
     // required token with `amountFiat` ≈ 39.83 (their real USD intent) but
     // `amountUsd` ≈ 39.84 (token count priced at $1). The HL balance is
     // 39.833436. Only `amountFiat` keeps the strict `>` semantic so a user
     // can withdraw exactly their available balance without a false-positive.
-    setAccount({ spendableBalance: '0', withdrawableBalance: '39.833436' });
+    setFreshAccount({
+      spendableBalance: '0',
+      withdrawableBalance: '39.833436',
+    });
     mockUsePrimaryRequiredToken.mockReturnValue({
       amountFiat: '39.83000054846650769962',
       amountUsd: '39.838382',
     } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
 
-    const { result } = runHook(buildPerpsWithdrawState());
+    const result = await runSettledHook(buildPerpsWithdrawState());
 
-    expect(result.current).toStrictEqual([]);
+    await waitFor(() => expect(result.current).toStrictEqual([]));
+  });
+
+  describe('fresh balance source', () => {
+    it('fresh balance source: blocks a withdrawal the stale streamed cache would have allowed', async () => {
+      // Stale-high: the WebSocket cache still reports the pre-trade balance,
+      // while the account the provider validates against only holds $20.
+      setStreamedBalance('500');
+      setFreshBalance('20');
+      setEnteredAmount('100');
+
+      const result = await runSettledHook(buildPerpsWithdrawState());
+
+      await waitFor(() =>
+        expect(result.current).toStrictEqual([EXPECTED_ALERT]),
+      );
+    });
+
+    it('fresh balance source: allows a withdrawal the stale streamed cache would have blocked', async () => {
+      // Stale-low: the singleton cache was rebuilt empty after an MV3
+      // restart, but the account really does hold $763.276429.
+      setStreamedBalance(null);
+      setFreshBalance('763.276429');
+      setEnteredAmount('381');
+
+      const result = await runSettledHook(buildPerpsWithdrawState());
+
+      await waitFor(() => expect(result.current).toStrictEqual([]));
+    });
+
+    it('fresh balance source: allows a withdrawal equal to the fresh balance', async () => {
+      setStreamedBalance('10');
+      setFreshBalance('250.5');
+      setEnteredAmount('250.5');
+
+      const result = await runSettledHook(buildPerpsWithdrawState());
+
+      await waitFor(() => expect(result.current).toStrictEqual([]));
+    });
+
+    it('fresh balance source: returns no alert while the fresh read is still in flight', async () => {
+      // Never resolves: the hook must not block on an unknown balance, which
+      // is exactly what the empty streamed cache used to do.
+      setStreamedBalance(null);
+      mockSubmitRequestToBackground.mockReturnValue(
+        new Promise(() => undefined),
+      );
+      setEnteredAmount('100');
+
+      const { result } = runHook(buildPerpsWithdrawState());
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'perpsGetAccountState',
+          [],
+        );
+      });
+      expect(result.current).toStrictEqual([]);
+    });
+  });
+
+  describe('perps scope', () => {
+    it('perps scope: does not query the perps controller for non-perps confirmations', async () => {
+      setStreamedBalance('500');
+      setEnteredAmount('150');
+      const contractInteraction =
+        genUnapprovedContractInteractionConfirmation() as TransactionMeta;
+      const state = getMockConfirmStateForTransaction(contractInteraction);
+
+      const { result } = renderHookWithConfirmContextProvider(
+        () => usePerpsWithdrawInsufficientBalanceAlert(),
+        state,
+      );
+
+      await waitFor(() => expect(result.current).toStrictEqual([]));
+      expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
+      expect(mockGetPerpsStreamManager).not.toHaveBeenCalled();
+    });
+
+    it('perps scope: blocks without inventing a balance when the fresh read fails', async () => {
+      // Degraded read: the streamed cache still claims $500, but nothing
+      // confirms the account can cover the withdrawal, so it is blocked.
+      setStreamedBalance('500');
+      setFreshAccountRejects(new Error('perps provider unreachable'));
+      setEnteredAmount('100');
+
+      const result = await runSettledHook(buildPerpsWithdrawState());
+
+      await waitFor(() =>
+        expect(result.current).toStrictEqual([EXPECTED_ALERT]),
+      );
+    });
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
@@ -11,6 +11,7 @@ import {
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { resetCoalesceCacheForTests } from '../../../../../hooks/perps/coalesceBackgroundRequest';
+import { usePerpsCacheKey } from '../../../../../hooks/perps/usePerpsCacheKey';
 import { getPerpsStreamManager } from '../../../../../providers/perps';
 import { submitRequestToBackground } from '../../../../../store/background-connection';
 import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
@@ -27,18 +28,23 @@ jest.mock('../../../../../store/background-connection', () => ({
   ...jest.requireActual('../../../../../store/background-connection'),
   submitRequestToBackground: jest.fn(),
 }));
+jest.mock('../../../../../hooks/perps/usePerpsCacheKey');
 jest.mock('../../pay/useTransactionPayData');
+
+const PERPS_CACHE_KEY = 'hyperliquid:testnet:0x1';
+const OTHER_PERPS_CACHE_KEY = 'hyperliquid:testnet:0x2';
 
 const mockGetPerpsStreamManager = jest.mocked(getPerpsStreamManager);
 const mockSubmitRequestToBackground = jest.mocked(submitRequestToBackground);
+const mockUsePerpsCacheKey = jest.mocked(usePerpsCacheKey);
 const mockUsePrimaryRequiredToken = jest.mocked(
   useTransactionPayPrimaryRequiredToken,
 );
 
 /**
- * Balance the streamed WebSocket cache would have reported. The hook must
- * never read it — every case here sets it to a value that would produce the
- * opposite decision from the fresh account state.
+ * Balance the streamed WebSocket cache would have reported. The Perps cases
+ * seed it with a value that would produce the opposite decision and assert
+ * the singleton is never consulted, which is what the pre-fix hook did.
  * @param withdrawableBalance
  */
 function setStreamedBalance(withdrawableBalance: string | null) {
@@ -79,6 +85,14 @@ const EXPECTED_ALERT = {
   severity: Severity.Danger,
 };
 
+/** Blocked because the balance could not be read — not because it is short. */
+const UNAVAILABLE_COPY = "Couldn't check your Perps balance. Try again.";
+const EXPECTED_UNAVAILABLE_ALERT = {
+  ...EXPECTED_ALERT,
+  message: UNAVAILABLE_COPY,
+  reason: UNAVAILABLE_COPY,
+};
+
 function buildPerpsWithdrawState() {
   const transaction = {
     ...genUnapprovedContractInteractionConfirmation(),
@@ -115,6 +129,7 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     resetCoalesceCacheForTests();
+    mockUsePerpsCacheKey.mockReturnValue(PERPS_CACHE_KEY);
     setStreamedBalance(null);
     setFreshBalance('100');
     setEnteredAmount('10');
@@ -211,7 +226,7 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
   });
 
   describe('fresh balance source', () => {
-    it('fresh balance source: blocks a withdrawal the stale streamed cache would have allowed', async () => {
+    it('blocks a withdrawal the stale streamed cache would have allowed', async () => {
       // Stale-high: the WebSocket cache still reports the pre-trade balance,
       // while the account the provider validates against only holds $20.
       setStreamedBalance('500');
@@ -223,9 +238,12 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
       await waitFor(() =>
         expect(result.current).toStrictEqual([EXPECTED_ALERT]),
       );
+      // The pre-fix hook read this cache on exactly this confirmation type;
+      // the fresh read must not consult it at all.
+      expect(mockGetPerpsStreamManager).not.toHaveBeenCalled();
     });
 
-    it('fresh balance source: allows a withdrawal the stale streamed cache would have blocked', async () => {
+    it('allows a withdrawal the stale streamed cache would have blocked', async () => {
       // Stale-low: the singleton cache was rebuilt empty after an MV3
       // restart, but the account really does hold $763.276429.
       setStreamedBalance(null);
@@ -237,7 +255,7 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
       await waitFor(() => expect(result.current).toStrictEqual([]));
     });
 
-    it('fresh balance source: allows a withdrawal equal to the fresh balance', async () => {
+    it('allows a withdrawal equal to the fresh balance', async () => {
       setStreamedBalance('10');
       setFreshBalance('250.5');
       setEnteredAmount('250.5');
@@ -247,7 +265,7 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
       await waitFor(() => expect(result.current).toStrictEqual([]));
     });
 
-    it('fresh balance source: returns no alert while the fresh read is still in flight', async () => {
+    it('returns no alert while the fresh read is still in flight', async () => {
       // Never resolves: the hook must not block on an unknown balance, which
       // is exactly what the empty streamed cache used to do.
       setStreamedBalance(null);
@@ -269,7 +287,7 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
   });
 
   describe('perps scope', () => {
-    it('perps scope: does not query the perps controller for non-perps confirmations', async () => {
+    it('does not query the perps controller for non-perps confirmations', async () => {
       setStreamedBalance('500');
       setEnteredAmount('150');
       const contractInteraction =
@@ -283,21 +301,68 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
 
       await waitFor(() => expect(result.current).toStrictEqual([]));
       expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
-      expect(mockGetPerpsStreamManager).not.toHaveBeenCalled();
     });
 
-    it('perps scope: blocks without inventing a balance when the fresh read fails', async () => {
+    it('blocks without inventing a balance when the fresh read fails', async () => {
       // Degraded read: the streamed cache still claims $500, but nothing
-      // confirms the account can cover the withdrawal, so it is blocked.
+      // confirms the account can cover the withdrawal, so it is blocked —
+      // and the copy says the balance is unknown, not that funds are short.
+      const consoleError = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
       setStreamedBalance('500');
-      setFreshAccountRejects(new Error('perps provider unreachable'));
+      const error = new Error('perps provider unreachable');
+      setFreshAccountRejects(error);
       setEnteredAmount('100');
 
       const result = await runSettledHook(buildPerpsWithdrawState());
 
       await waitFor(() =>
+        expect(result.current).toStrictEqual([EXPECTED_UNAVAILABLE_ALERT]),
+      );
+      // A blocked withdrawal has to be diagnosable.
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to fetch account'),
+        error,
+      );
+      consoleError.mockRestore();
+    });
+
+    it('blocks without inventing a balance when the fresh read returns no account', async () => {
+      // Treating a missing account as $0 would block with "Insufficient
+      // funds", which claims a balance nothing confirmed.
+      setStreamedBalance('500');
+      setFreshAccount(null);
+      setEnteredAmount('100');
+
+      const result = await runSettledHook(buildPerpsWithdrawState());
+
+      await waitFor(() =>
+        expect(result.current).toStrictEqual([EXPECTED_UNAVAILABLE_ALERT]),
+      );
+    });
+
+    it('falls back to loading rather than the previous scope balance when the account scope changes', async () => {
+      // First scope holds $50, so $100 is blocked there.
+      setStreamedBalance('500');
+      setFreshAccount({ withdrawableBalance: '50' });
+      setEnteredAmount('100');
+
+      const { result, rerender } = runHook(buildPerpsWithdrawState());
+      await waitFor(() =>
         expect(result.current).toStrictEqual([EXPECTED_ALERT]),
       );
+
+      // Switching account/network/provider changes the scope key. Until the
+      // new read settles the previous scope's balance says nothing about this
+      // one, so the hook must go back to loading instead of reusing it.
+      mockSubmitRequestToBackground.mockReturnValue(
+        new Promise(() => undefined),
+      );
+      mockUsePerpsCacheKey.mockReturnValue(OTHER_PERPS_CACHE_KEY);
+      rerender();
+
+      await waitFor(() => expect(result.current).toStrictEqual([]));
     });
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
@@ -303,6 +303,44 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
       expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
     });
 
+    it('falls back to loading rather than the previous scope balance when the account scope changes', async () => {
+      // First scope holds $50, so $100 is blocked there.
+      setStreamedBalance('500');
+      setFreshAccount({ withdrawableBalance: '50' });
+      setEnteredAmount('100');
+
+      const { result, rerender } = runHook(buildPerpsWithdrawState());
+      await waitFor(() =>
+        expect(result.current).toStrictEqual([EXPECTED_ALERT]),
+      );
+
+      // Switching account/network/provider changes the scope key. Until the
+      // new read settles the previous scope's balance says nothing about this
+      // one, so the hook must go back to loading instead of reusing it.
+      mockSubmitRequestToBackground.mockReturnValue(
+        new Promise(() => undefined),
+      );
+      mockUsePerpsCacheKey.mockReturnValue(OTHER_PERPS_CACHE_KEY);
+      rerender();
+
+      await waitFor(() => expect(result.current).toStrictEqual([]));
+    });
+
+    it('reuses one background request when the confirmation remounts inside the coalescing window', async () => {
+      // FRESH_BALANCE_TTL_MS exists so a re-mount does not add Hyperliquid
+      // request weight; without the coalescing wrapper this is two calls.
+      setEnteredAmount('10');
+
+      await runSettledHook(buildPerpsWithdrawState());
+      runHook(buildPerpsWithdrawState());
+
+      await waitFor(() =>
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1),
+      );
+    });
+  });
+
+  describe('degraded read', () => {
     it('blocks without inventing a balance when the fresh read fails', async () => {
       // Degraded read: the streamed cache still claims $500, but nothing
       // confirms the account can cover the withdrawal, so it is blocked —
@@ -340,29 +378,6 @@ describe('usePerpsWithdrawInsufficientBalanceAlert', () => {
       await waitFor(() =>
         expect(result.current).toStrictEqual([EXPECTED_UNAVAILABLE_ALERT]),
       );
-    });
-
-    it('falls back to loading rather than the previous scope balance when the account scope changes', async () => {
-      // First scope holds $50, so $100 is blocked there.
-      setStreamedBalance('500');
-      setFreshAccount({ withdrawableBalance: '50' });
-      setEnteredAmount('100');
-
-      const { result, rerender } = runHook(buildPerpsWithdrawState());
-      await waitFor(() =>
-        expect(result.current).toStrictEqual([EXPECTED_ALERT]),
-      );
-
-      // Switching account/network/provider changes the scope key. Until the
-      // new read settles the previous scope's balance says nothing about this
-      // one, so the hook must go back to loading instead of reusing it.
-      mockSubmitRequestToBackground.mockReturnValue(
-        new Promise(() => undefined),
-      );
-      mockUsePerpsCacheKey.mockReturnValue(OTHER_PERPS_CACHE_KEY);
-      rerender();
-
-      await waitFor(() => expect(result.current).toStrictEqual([]));
     });
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.ts
@@ -18,9 +18,11 @@ import { AlertsName } from '../constants';
 const PERPS_WITHDRAW_AMOUNT_DECIMALS = 6;
 
 // Coalescing window for the fresh read. Long enough that re-mounting the
-// confirmation (or a sibling Perps surface asking for the same account state)
-// reuses one HL request instead of adding weight against the per-IP budget,
-// short enough that the balance the user is blocked on is still current.
+// confirmation reuses one HL request instead of adding weight against the
+// per-IP budget, short enough that the balance the user is blocked on is
+// still current. Only this hook shares the key today: `PerpsStreamManager`
+// issues its own uncoalesced `perpsGetAccountState`, so it would have to route
+// through `coalesceBackgroundRequest` for the two to share a request.
 const FRESH_BALANCE_TTL_MS = 5000;
 
 type SettledBalance =

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.ts
@@ -176,19 +176,29 @@ export function usePerpsWithdrawInsufficientBalanceAlert(): Alert[] {
       return [];
     }
 
-    const message =
+    // `reason` becomes the disabled confirm button's label
+    // (`single-action-footer.tsx`), so it stays short; when it differs from
+    // `message`, `useTransactionCustomAmountAlerts` surfaces `message` inline.
+    // The key is what alert telemetry reports, so the two cases stay distinct.
+    const alert =
       blockReason === 'exceedsBalance'
-        ? t('alertInsufficientPayTokenBalance')
-        : t('alertPerpsWithdrawBalanceUnavailable');
+        ? {
+            key: AlertsName.InsufficientPayTokenBalance,
+            message: t('alertInsufficientPayTokenBalance'),
+            reason: t('alertInsufficientPayTokenBalance'),
+          }
+        : {
+            key: AlertsName.PerpsWithdrawBalanceUnavailable,
+            message: t('alertPerpsWithdrawBalanceUnavailable'),
+            reason: t('alertReasonPerpsWithdrawBalanceUnavailable'),
+          };
 
     return [
       {
         field: RowAlertKey.EstimatedFee,
         isBlocking: true,
-        key: AlertsName.InsufficientPayTokenBalance,
-        message,
-        reason: message,
         severity: Severity.Danger,
+        ...alert,
       },
     ];
   }, [blockReason, t]);

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.ts
@@ -1,31 +1,114 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { BigNumber } from 'bignumber.js';
+import type { AccountState } from '@metamask/perps-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
+import { coalesceBackgroundRequest } from '../../../../../hooks/perps/coalesceBackgroundRequest';
 import { getTradeableBalance } from '../../../../../hooks/perps/getTradeableBalance';
-import { getPerpsStreamManager } from '../../../../../providers/perps';
+import { usePerpsCacheKey } from '../../../../../hooks/perps/usePerpsCacheKey';
+import { submitRequestToBackground } from '../../../../../store/background-connection';
 import { useConfirmContext } from '../../../context/confirm';
 import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
 import { AlertsName } from '../constants';
 
 const PERPS_WITHDRAW_AMOUNT_DECIMALS = 6;
 
+// Coalescing window for the fresh read. Long enough that re-mounting the
+// confirmation (or a sibling Perps surface asking for the same account state)
+// reuses one HL request instead of adding weight against the per-IP budget,
+// short enough that the balance the user is blocked on is still current.
+const FRESH_BALANCE_TTL_MS = 5000;
+
+type SettledBalance =
+  | { status: 'loaded'; balance: string }
+  /** The read failed or returned no account. We do not invent a balance. */
+  | { status: 'unavailable' };
+
+type FreshBalance =
+  /** Not a Perps withdraw, so Perps was never queried. */
+  | { status: 'idle' }
+  /** Fresh read in flight; the balance is not known yet. */
+  | { status: 'loading' }
+  | SettledBalance;
+
+/**
+ * Reads the Perps account state the provider itself validates withdrawals
+ * against, instead of the streamed WebSocket cache.
+ *
+ * The `PerpsStreamManager` cache is a page-realm singleton that only holds
+ * data while something subscribes to it, so after an MV3 UI/service-worker
+ * restart it reads empty — and it can hold a stale balance while the provider
+ * sees a newer one. Basing a blocking decision on it lets the confirmation and
+ * the provider disagree in both directions.
+ *
+ * @param enabled - Only true for `perpsWithdraw` confirmations. While false,
+ * nothing is requested, so unrelated confirmations never initialize or query
+ * the Perps controller.
+ */
+function useFreshPerpsWithdrawableBalance(enabled: boolean): FreshBalance {
+  const perpsCacheKey = usePerpsCacheKey();
+  // Keyed by the Perps scope the read was issued for, so a result from the
+  // previous account, network or provider is never shown for the current one.
+  const [settled, setSettled] = useState<{
+    perpsCacheKey: string;
+    balance: SettledBalance;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    const resolve = (balance: SettledBalance) => {
+      if (!cancelled) {
+        setSettled({ perpsCacheKey, balance });
+      }
+    };
+
+    coalesceBackgroundRequest<AccountState | null>(
+      `perpsGetAccountState|${perpsCacheKey}`,
+      () =>
+        submitRequestToBackground<AccountState | null>(
+          'perpsGetAccountState',
+          [],
+        ),
+      FRESH_BALANCE_TTL_MS,
+    )
+      .then((account) =>
+        resolve(
+          account
+            ? { status: 'loaded', balance: getTradeableBalance(account) }
+            : { status: 'unavailable' },
+        ),
+      )
+      .catch(() => resolve({ status: 'unavailable' }));
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, perpsCacheKey]);
+
+  if (!enabled) {
+    return { status: 'idle' };
+  }
+
+  return settled?.perpsCacheKey === perpsCacheKey
+    ? settled.balance
+    : { status: 'loading' };
+}
+
 /**
  * Blocking alert when the entered amount exceeds the HL withdrawable balance.
  *
  * This hook is wired into `useTransactionAlerts`, which runs for every
- * confirmation type. To avoid `usePerpsLiveAccount` triggering a `perpsInit`
- * RPC (and an `api.hyperliquid.xyz` request) on every non-perps confirmation
- * — sends, contract interactions, swaps, etc. — we read the account directly
- * from the `PerpsStreamManager` singleton's cache, and only when the
- * confirmation actually is a `perpsWithdraw`. The Perps Withdraw confirmation
- * itself renders `PerpsWithdrawBalance`, which subscribes via
- * `usePerpsLiveAccount` and keeps the singleton's cache fresh, so our render-
- * time read sees up-to-date data by the time the user can enter an amount.
+ * confirmation type, so the fresh account-state read is gated on the
+ * confirmation actually being a `perpsWithdraw`: sends, swaps and contract
+ * interactions never touch Perps.
  */
 export function usePerpsWithdrawInsufficientBalanceAlert(): Alert[] {
   const t = useI18nContext();
@@ -36,18 +119,36 @@ export function usePerpsWithdrawInsufficientBalanceAlert(): Alert[] {
   const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
 
   const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
+  const freshBalance = useFreshPerpsWithdrawableBalance(isPerpsWithdraw);
+  const enteredAmountFiat = primaryRequiredToken?.amountFiat ?? '0';
 
-  // Side-effect-free read from the singleton — does NOT trigger init.
-  const account = isPerpsWithdraw
-    ? getPerpsStreamManager().account.getCachedData()
-    : null;
+  const exceedsBalance = useMemo(() => {
+    if (!isPerpsWithdraw) {
+      return false;
+    }
 
-  const availableBalance = new BigNumber(getTradeableBalance(account));
-  const enteredAmount = new BigNumber(primaryRequiredToken?.amountFiat ?? '0');
+    const enteredAmount = new BigNumber(enteredAmountFiat);
+    if (!enteredAmount.gt(0)) {
+      return false;
+    }
 
-  const exceedsBalance =
-    isPerpsWithdraw &&
-    exceedsPerpsWithdrawBalance(enteredAmount, availableBalance);
+    if (freshBalance.status === 'loaded') {
+      return exceedsPerpsWithdrawBalance(
+        enteredAmount,
+        new BigNumber(freshBalance.balance),
+      );
+    }
+
+    // Degraded read: block rather than approve an amount we could not verify.
+    // The provider would reject it anyway.
+    if (freshBalance.status === 'unavailable') {
+      return true;
+    }
+
+    // Idle or still in flight: nothing to compare against yet, and blocking
+    // here would flag a valid withdrawal for as long as the read runs.
+    return false;
+  }, [enteredAmountFiat, freshBalance, isPerpsWithdraw]);
 
   return useMemo(() => {
     if (!exceedsBalance) {

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.ts
@@ -35,6 +35,9 @@ type FreshBalance =
   | { status: 'loading' }
   | SettledBalance;
 
+/** Why the withdrawal is blocked, or `null` when it is not. */
+type BlockReason = 'exceedsBalance' | 'balanceUnavailable' | null;
+
 /**
  * Reads the Perps account state the provider itself validates withdrawals
  * against, instead of the streamed WebSocket cache.
@@ -44,6 +47,11 @@ type FreshBalance =
  * restart it reads empty — and it can hold a stale balance while the provider
  * sees a newer one. Basing a blocking decision on it lets the confirmation and
  * the provider disagree in both directions.
+ *
+ * "Fresh" means fresh as of mount, not live: the read runs once per
+ * `[enabled, perpsCacheKey]` and is never refreshed, which is enough for a
+ * short-lived confirmation and keeps the confirmation off the HL request
+ * budget. The provider re-validates the amount at submit time.
  *
  * @param enabled - Only true for `perpsWithdraw` confirmations. While false,
  * nothing is requested, so unrelated confirmations never initialize or query
@@ -86,7 +94,15 @@ function useFreshPerpsWithdrawableBalance(enabled: boolean): FreshBalance {
             : { status: 'unavailable' },
         ),
       )
-      .catch(() => resolve({ status: 'unavailable' }));
+      // Surfaced to the user as a blocking alert, but log it too: otherwise a
+      // withdrawal blocked by an unreachable provider leaves no trace.
+      .catch((error) => {
+        console.error(
+          '[usePerpsWithdrawInsufficientBalanceAlert] Failed to fetch account',
+          error,
+        );
+        resolve({ status: 'unavailable' });
+      });
 
     return () => {
       cancelled = true;
@@ -122,50 +138,58 @@ export function usePerpsWithdrawInsufficientBalanceAlert(): Alert[] {
   const freshBalance = useFreshPerpsWithdrawableBalance(isPerpsWithdraw);
   const enteredAmountFiat = primaryRequiredToken?.amountFiat ?? '0';
 
-  const exceedsBalance = useMemo(() => {
+  const blockReason = useMemo((): BlockReason => {
     if (!isPerpsWithdraw) {
-      return false;
+      return null;
     }
 
     const enteredAmount = new BigNumber(enteredAmountFiat);
     if (!enteredAmount.gt(0)) {
-      return false;
+      return null;
     }
 
     if (freshBalance.status === 'loaded') {
       return exceedsPerpsWithdrawBalance(
         enteredAmount,
         new BigNumber(freshBalance.balance),
-      );
+      )
+        ? 'exceedsBalance'
+        : null;
     }
 
     // Degraded read: block rather than approve an amount we could not verify.
-    // The provider would reject it anyway.
+    // The provider would reject it anyway. The copy has to say that, though —
+    // we do not know the balance, so we cannot claim the funds are insufficient.
     if (freshBalance.status === 'unavailable') {
-      return true;
+      return 'balanceUnavailable';
     }
 
     // Idle or still in flight: nothing to compare against yet, and blocking
     // here would flag a valid withdrawal for as long as the read runs.
-    return false;
+    return null;
   }, [enteredAmountFiat, freshBalance, isPerpsWithdraw]);
 
   return useMemo(() => {
-    if (!exceedsBalance) {
+    if (!blockReason) {
       return [];
     }
+
+    const message =
+      blockReason === 'exceedsBalance'
+        ? t('alertInsufficientPayTokenBalance')
+        : t('alertPerpsWithdrawBalanceUnavailable');
 
     return [
       {
         field: RowAlertKey.EstimatedFee,
         isBlocking: true,
         key: AlertsName.InsufficientPayTokenBalance,
-        message: t('alertInsufficientPayTokenBalance'),
-        reason: t('alertInsufficientPayTokenBalance'),
+        message,
+        reason: message,
         severity: Severity.Danger,
       },
     ];
-  }, [exceedsBalance, t]);
+  }, [blockReason, t]);
 }
 
 function exceedsPerpsWithdrawBalance(

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.test.ts
@@ -166,6 +166,33 @@ describe('useTransactionCustomAmountAlerts', () => {
     });
   });
 
+  it('sets hideResults to true when PerpsWithdrawBalanceUnavailable alert exists', () => {
+    useAlertsMock.mockReturnValue(
+      createMockUseAlertsReturnValue({
+        alerts: [
+          createMockAlert({
+            key: AlertsName.PerpsWithdrawBalanceUnavailable,
+            message: "Couldn't check your Perps balance. Try again.",
+            reason: 'Balance unavailable',
+            isBlocking: true,
+            severity: Severity.Danger,
+          }),
+        ],
+        hasDangerAlerts: true,
+        hasAlerts: true,
+        hasUnconfirmedDangerAlerts: true,
+      }),
+    );
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual({
+      alertMessage: "Couldn't check your Perps balance. Try again.",
+      disableUpdate: false,
+      hideResults: true,
+    });
+  });
+
   it('sets hideResults to true when SigningOrSubmitting alert exists', () => {
     useAlertsMock.mockReturnValue(
       createMockUseAlertsReturnValue({

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.ts
@@ -9,6 +9,7 @@ const ALERTS_HIDE_RESULTS: string[] = [
   AlertsName.DepositLimit,
   AlertsName.InsufficientPayTokenBalance,
   AlertsName.PayHardwareAccount,
+  AlertsName.PerpsWithdrawBalanceUnavailable,
   AlertsName.SigningOrSubmitting,
 ];
 

--- a/ui/pages/confirmations/hooks/useConfirmationAlertMetrics.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertMetrics.test.ts
@@ -86,6 +86,15 @@ beforeEach(() => {
 });
 
 describe('useConfirmationAlertMetrics', () => {
+  it('reports an unreadable Perps balance under its own metrics name', () => {
+    // The key was split from InsufficientPayTokenBalance so alert_triggered /
+    // alert_resolved stop conflating the two; without the mapping the property
+    // would silently become undefined.
+    expect(
+      ALERTS_NAME_METRICS[AlertsName.PerpsWithdrawBalanceUnavailable],
+    ).toBe('perps_withdraw_balance_unavailable');
+  });
+
   it('initializes metrics properties correctly', () => {
     const { result } = renderHookWithConfirmContextProvider(
       () => useConfirmationAlertMetrics(),

--- a/ui/pages/confirmations/hooks/useConfirmationAlertMetrics.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertMetrics.test.ts
@@ -88,8 +88,10 @@ beforeEach(() => {
 describe('useConfirmationAlertMetrics', () => {
   it('reports an unreadable Perps balance under its own metrics name', () => {
     // The key was split from InsufficientPayTokenBalance so alert_triggered /
-    // alert_resolved stop conflating the two; without the mapping the property
-    // would silently become undefined.
+    // alert_resolved stop conflating the two. `getAlertName` falls back to the
+    // raw key, so dropping or renaming the entry does not fail anything — it
+    // just silently changes the metric's shape mid-flight, emitting the
+    // camelCase `perpsWithdrawBalanceUnavailable` among snake_case names.
     expect(
       ALERTS_NAME_METRICS[AlertsName.PerpsWithdrawBalanceUnavailable],
     ).toBe('perps_withdraw_balance_unavailable');

--- a/ui/pages/confirmations/hooks/useConfirmationAlertMetrics.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertMetrics.ts
@@ -28,6 +28,8 @@ export const ALERTS_NAME_METRICS: Record<AlertsName | string, string> = {
   [AlertsName.NetworkBusy]: 'network_busy',
   [AlertsName.NoGasPrice]: 'no_gas_price',
   [AlertsName.PendingTransaction]: 'pending_transaction',
+  [AlertsName.PerpsWithdrawBalanceUnavailable]:
+    'perps_withdraw_balance_unavailable',
   [AlertsName.SigningOrSubmitting]: 'signing_or_submitting',
   [AlertsName.Blockaid]: 'blockaid',
 };


### PR DESCRIPTION
## **Description**

The MM Pay Perps withdrawal alert decided whether to block a withdrawal by reading the streamed `PerpsStreamManager` account cache synchronously. That cache is a page-realm singleton that only holds data while something subscribes to it, so after an MV3 UI/service-worker restart it reads empty — while the provider validates the same withdrawal against a fresh account-state read. The confirmation and the provider could therefore disagree in both directions: a stale-high cache let an over-balance withdrawal through, a stale-low or empty cache blocked a valid one.

The alert now bases its decision on a fresh `perpsGetAccountState` read, gated on the confirmation actually being a `perpsWithdraw` so sends, swaps and contract interactions still never initialize or query Perps, and coalesced under the Perps scope key so re-mounts add no extra Hyperliquid request weight. Loading no longer blocks a valid withdrawal, and a read that fails or returns no account blocks under its own alert key with its own copy ("Balance unavailable" on the button, "Couldn't check your Perps balance. Try again." inline) instead of claiming the funds are insufficient — so alert telemetry does not fold an unreadable balance into the insufficient-balance bucket.

Known gap, tracked separately: the "Available balance" readout and the Max/percentage presets on this confirmation still read the streamed account subscription, so they can briefly disagree with the alert. Reworking the confirmation's balance plumbing is out of scope here and is filed as [TAT-3661](https://consensyssoftware.atlassian.net/browse/TAT-3661).

## **Changelog**

CHANGELOG entry: Fixed a bug where the Perps withdrawal confirmation could allow or block a withdrawal based on an out-of-date balance

## **Related issues**

Fixes: [TAT-3632](https://consensyssoftware.atlassian.net/browse/TAT-3632)

## **Manual testing steps**

1. Open Perps with a funded account and note the withdrawable balance.
2. Restart the extension UI (reload the extension page) so the streamed account cache is empty, then open Perps > Withdraw.
3. Enter an amount below the real balance — no insufficient-funds alert appears and the withdrawal can be confirmed.
4. Enter an amount above the real balance — the blocking "Insufficient funds" alert appears.
5. Open an unrelated confirmation (send or contract interaction) and confirm no Perps account-state request is issued.
6. With the Perps provider unreachable, enter an amount — the withdrawal is blocked, the button reads "Balance unavailable" and the inline message explains the balance could not be checked, rather than claiming "Insufficient funds".

## **Screenshots/Recordings**

PR-complete re-validation of TAT-3632 after rebasing onto origin/main. No code changed, so there is no new before-state to capture; the proof is the live divergence probe plus the hook suite, and the one screenshot shows the real Perps balance the fresh read resolves to on the merged tree.

<table>
<tr><td align="center" valign="top" width="50%"><strong>Live Perps balance the fresh account-state read resolves to on the rebased build ($761.21 total = $756.36 withdrawable + $10.10 open BTC position)</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/45191/recipe-run/screenshots/evidence-ac3-live-fresh-perps-balance.png?sha=6ccba09c0dd618df" alt="Live Perps balance the fresh account-state read resolves to on the rebased build ($761.21 total = $756.36 withdrawable + $10.10 open BTC position)" width="320" /><br/><sub>Orientation for the live probe: with the streamed cache empty after a UI restart, the alert decides against this balance instead of $0. The divergence itself is in the ac3-probe-live-balance-divergence node output (streamedBalance 0 vs freshBalance 756.36175, decisionsDisagree true); the blocking decision is asserted by ac3-verify-blocking-under-divergence. Captured by capture-helper (artifact-manifest.json: provider capture-helper, mode snapshot, no fallback).</sub></td><td></td></tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "TAT-3632 — MM Pay Perps withdrawal blocks on a fresh balance",
  "description": "Proves the MM Pay Perps withdrawal alert decides from a fresh account-state read instead of the streamed WebSocket cache: reproduces the live streamed-vs-fresh divergence in the running extension, then asserts the hook's blocking decision, its non-Perps scoping, and its degraded-read behaviour. Preconditions: Extension runtime reachable over CDP on the slot port, wallet fixture unlocked. Perps provider reachable with a non-zero fresh withdrawable balance on the selected account (testnet Hyperliquid, Account 1). Probe runs from a non-Perps screen so nothing re-subscribes the streamed account channel.",
  "workflow": {
    "entry": "setup-status",
    "nodes": {
      "setup-status": {
        "action": "app.status",
        "next": "setup-cdp",
        "intent": "Resolve the Extension checkout and adapter status before the proof"
      },
      "setup-cdp": {
        "action": "cdp.target",
        "required": true,
        "timeout_ms": 15000,
        "next": "setup-unlock",
        "intent": "Confirm the Extension CDP runtime is reachable"
      },
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "timeout_ms": 45000,
        "next": "setup-warm-streamed-cache",
        "intent": "Ensure the fixture-backed wallet is unlocked"
      },
      "setup-warm-streamed-cache": {
        "action": "ui.navigate",
        "page": "perps",
        "next": "setup-leave-perps",
        "intent": "Open Perps so the streamed account channel populates its cache, matching a user who has already browsed Perps"
      },
      "setup-leave-perps": {
        "action": "ui.navigate",
        "page": "home",
        "next": "ac3-probe-live-balance-divergence",
        "intent": "Return to a non-Perps screen, where nothing re-subscribes the streamed account channel"
      },
      "ac3-probe-live-balance-divergence": {
        "action": "command",

        "timeout_ms": 180000,
        "next": "ac3-assert-streamed-cache-empty",
        "intent": "AC3: restart the UI realm (MV3-restart equivalent) and read the streamed cache and the fresh account state side by side, read-only"
      },
      "ac3-assert-streamed-cache-empty": {
        "action": "assert_json",

        "assert": {
          "path": "$.streamedAccountPresent",
          "operator": "eq",
          "value": false
        },
        "next": "ac3-assert-balances-diverge",
        "intent": "AC3: the streamed account cache the old hook read is empty after the UI restart"
      },
      "ac3-assert-balances-diverge": {
        "action": "assert_json",

        "assert": {
          "path": "$.diverges",
          "operator": "eq",
          "value": true
        },
        "next": "ac3-assert-decisions-disagree",
        "intent": "AC3: the streamed balance and the fresh account-state balance disagree in the live runtime"
      },
      "ac3-assert-decisions-disagree": {
        "action": "assert_json",

        "assert": {
          "path": "$.decisionsDisagree",
          "operator": "eq",
          "value": true
        },
        "next": "ac3-verify-blocking-under-divergence",
        "intent": "AC3: that divergence flips the withdrawal decision, so the source the hook reads changes the outcome"
      },
      "ac3-verify-blocking-under-divergence": {
        "action": "command",

        "timeout_ms": 300000,
        "next": "ac3-assert-blocking-no-failures",
        "intent": "AC3: exercise the confirmation alert with a stale-high streamed balance and a lower fresh balance"
      },
      "ac3-assert-blocking-no-failures": {
        "action": "assert_json",

        "assert": {
          "path": "$.numFailedTests",
          "operator": "eq",
          "value": 0
        },
        "next": "ac3-assert-blocking-test-ran",
        "intent": "AC3: the invalid withdrawal is blocked when the streamed cache would have allowed it"
      },
      "ac3-assert-blocking-test-ran": {
        "action": "assert_json",

        "assert": {
          "path": "$.numPassedTests",
          "operator": "eq",
          "value": 1
        },
        "next": "ac3-open-perps-balance",
        "intent": "AC3: exactly the stale-high blocking case ran, so the pass is not an empty filter"
      },
      "ac3-open-perps-balance": {
        "action": "ui.navigate",
        "page": "perps",
        "next": "ac3-wait-for-fresh-balance",
        "intent": "AC3: return to Perps to show the live balance the fresh read resolved to"
      },
      "ac3-wait-for-fresh-balance": {
        "action": "ui.wait_for",
        "test_id": "perps-balance-dropdown-balance",
        "visible": true,
        "timeout_ms": 30000,
        "next": "ac3-screenshot-live-fresh-balance",
        "intent": "AC3: wait for the live Perps balance readout before capturing it"
      },
      "ac3-screenshot-live-fresh-balance": {
        "action": "ui.screenshot",

        "label": "AC3: live Perps balance matching the fresh account-state read",
        "next": "ac1-run-fresh-balance-tests",
        "intent": "AC3: orientation capture of the real account balance the probe read as the fresh source"
      },
      "ac1-run-fresh-balance-tests": {
        "action": "command",

        "timeout_ms": 300000,
        "next": "ac1-assert-no-failures",
        "intent": "AC1: run the stale-high, stale-low, fresh-equal and loading cases for the fresh account-state decision"
      },
      "ac1-assert-no-failures": {
        "action": "assert_json",

        "assert": {
          "path": "$.numFailedTests",
          "operator": "eq",
          "value": 0
        },
        "next": "ac1-assert-cases-ran",
        "intent": "AC1: the blocking decision follows the fresh account-state result in every case"
      },
      "ac1-assert-cases-ran": {
        "action": "assert_json",

        "assert": {
          "path": "$.numPassedTests",
          "operator": "eq",
          "value": 4
        },
        "next": "ac2-run-perps-scope-tests",
        "intent": "AC1: all four fresh-balance cases ran, so the pass is not an empty filter"
      },
      "ac2-run-perps-scope-tests": {
        "action": "command",

        "timeout_ms": 300000,
        "next": "ac2-assert-no-failures",
        "intent": "AC2: run the non-Perps isolation, scope-change and request-coalescing cases plus both degraded-read cases"
      },
      "ac2-assert-no-failures": {
        "action": "assert_json",

        "assert": {
          "path": "$.numFailedTests",
          "operator": "eq",
          "value": 0
        },
        "next": "ac2-assert-cases-ran",
        "intent": "AC2: non-Perps confirmations never query Perps, and a degraded read fails safe without inventing a balance"
      },
      "ac2-assert-cases-ran": {
        "action": "assert_json",

        "assert": {
          "path": "$.numPassedTests",
          "operator": "eq",
          "value": 5
        },
        "next": "teardown-done",
        "intent": "AC2: all five scoping and degraded-read cases ran, so the pass is not an empty filter"
      },
      "teardown-done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
    setup_status["setup-status<br/>app.status"]
    setup_cdp["setup-cdp<br/>cdp.target"]
    setup_unlock["setup-unlock<br/>metamask.wallet.ensure_unlocked"]
    setup_warm_streamed_cache["setup-warm-streamed-cache<br/>ui.navigate"]
    setup_leave_perps["setup-leave-perps<br/>ui.navigate"]
    ac3_probe_live_balance_divergence["ac3-probe-live-balance-divergence<br/>command"]
    ac3_assert_streamed_cache_empty["ac3-assert-streamed-cache-empty<br/>assert_json"]
    ac3_assert_balances_diverge["ac3-assert-balances-diverge<br/>assert_json"]
    ac3_assert_decisions_disagree["ac3-assert-decisions-disagree<br/>assert_json"]
    ac3_verify_blocking_under_divergence["ac3-verify-blocking-under-divergence<br/>command"]
    ac3_assert_blocking_no_failures["ac3-assert-blocking-no-failures<br/>assert_json"]
    ac3_assert_blocking_test_ran["ac3-assert-blocking-test-ran<br/>assert_json"]
    ac3_open_perps_balance["ac3-open-perps-balance<br/>ui.navigate"]
    ac3_wait_for_fresh_balance["ac3-wait-for-fresh-balance<br/>ui.wait_for"]
    ac3_screenshot_live_fresh_balance["ac3-screenshot-live-fresh-balance<br/>ui.screenshot"]
    ac1_run_fresh_balance_tests["ac1-run-fresh-balance-tests<br/>command"]
    ac1_assert_no_failures["ac1-assert-no-failures<br/>assert_json"]
    ac1_assert_cases_ran["ac1-assert-cases-ran<br/>assert_json"]
    ac2_run_perps_scope_tests["ac2-run-perps-scope-tests<br/>command"]
    ac2_assert_no_failures["ac2-assert-no-failures<br/>assert_json"]
    ac2_assert_cases_ran["ac2-assert-cases-ran<br/>assert_json"]
    teardown_done(["teardown-done<br/>end"])
    setup_status --> setup_cdp
    setup_cdp --> setup_unlock
    setup_unlock --> setup_warm_streamed_cache
    setup_warm_streamed_cache --> setup_leave_perps
    setup_leave_perps --> ac3_probe_live_balance_divergence
    ac3_probe_live_balance_divergence --> ac3_assert_streamed_cache_empty
    ac3_assert_streamed_cache_empty --> ac3_assert_balances_diverge
    ac3_assert_balances_diverge --> ac3_assert_decisions_disagree
    ac3_assert_decisions_disagree --> ac3_verify_blocking_under_divergence
    ac3_verify_blocking_under_divergence --> ac3_assert_blocking_no_failures
    ac3_assert_blocking_no_failures --> ac3_assert_blocking_test_ran
    ac3_assert_blocking_test_ran --> ac3_open_perps_balance
    ac3_open_perps_balance --> ac3_wait_for_fresh_balance
    ac3_wait_for_fresh_balance --> ac3_screenshot_live_fresh_balance
    ac3_screenshot_live_fresh_balance --> ac1_run_fresh_balance_tests
    ac1_run_fresh_balance_tests --> ac1_assert_no_failures
    ac1_assert_no_failures --> ac1_assert_cases_ran
    ac1_assert_cases_ran --> ac2_run_perps_scope_tests
    ac2_run_perps_scope_tests --> ac2_assert_no_failures
    ac2_assert_no_failures --> ac2_assert_cases_ran
    ac2_assert_cases_ran --> teardown_done
```

</details>

[TAT-3661]: https://consensyssoftware.atlassian.net/browse/TAT-3661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes withdrawal blocking logic and user-facing confirm behavior for Perps pay flows; mitigated by fail-safe blocking on unreadable balance and scoped RPC only for perpsWithdraw.
> 
> **Overview**
> The Perps withdrawal confirmation **no longer blocks or allows withdrawals using the streamed `PerpsStreamManager` cache**. It now loads **withdrawable balance via a one-shot, coalesced `perpsGetAccountState` background call** (5s TTL) scoped to `perpsWithdraw` confirmations only.
> 
> **While the fresh read is in flight**, the hook does not block confirm. **If the read fails or returns no account**, it blocks with a new **`PerpsWithdrawBalanceUnavailable`** alert and copy (“Balance unavailable” / “Couldn't check your Perps balance…”) instead of “Insufficient funds,” with separate telemetry. That alert is included in **`ALERTS_HIDE_RESULTS`** like other blocking pay alerts.
> 
> Tests were expanded for stale-high/low streamed cache, loading, scope changes, request coalescing, and degraded reads; locale strings and metrics mapping were added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaa84b92d4aff142b9214d24da9084dd170896b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

