### PR TITLE
fix(confirmations): preserve details when toggling simulations

### DIFF
--- a/test/e2e/tests/confirmations/transactions/enforced-simulations.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/enforced-simulations.spec.ts
@@ -11,6 +11,7 @@ import { withFixtures } from '../../../helpers';
 import { login } from '../../../page-objects/flows/login.flow';
 import { createDappTransaction } from '../../../page-objects/flows/transaction.flow';
 import TransactionConfirmation from '../../../page-objects/pages/confirmations/transaction-confirmation';
+import ConfirmAlertModal from '../../../page-objects/pages/dialog/confirm-alert';
 import ActivityTab from '../../../page-objects/pages/home/activity-tab';
 import TestDappIndividualRequest from '../../../page-objects/pages/test-dapp-individual-request';
 import { MockedEndpoint } from '../../../mock-e2e';
@@ -74,6 +75,7 @@ describe('Enforced Simulations', function (this: Suite) {
           confirmation,
           localNodes[0],
           'confirmed',
+          true,
         );
 
         assert.strictEqual(
@@ -193,6 +195,7 @@ describe('Enforced Simulations', function (this: Suite) {
           confirmation,
           localNodes[0],
           'confirmed',
+          true,
         );
 
         assert.strictEqual(
@@ -309,6 +312,7 @@ describe('Enforced Simulations', function (this: Suite) {
           confirmation,
           localNodes[0],
           'failed',
+          true,
         );
 
         assert.strictEqual(
@@ -367,8 +371,16 @@ async function confirmAndGetTransaction(
   confirmation: TransactionConfirmation,
   anvil: Anvil,
   expectedStatus: 'confirmed' | 'failed',
+  acknowledgeDangerAlert = false,
 ) {
   await confirmation.clickFooterConfirmButton();
+
+  if (acknowledgeDangerAlert) {
+    const alertModal = new ConfirmAlertModal(driver);
+    await alertModal.acknowledgeAlert();
+    await alertModal.confirmFromAlertModal();
+    await confirmation.clickFooterConfirmButton();
+  }
 
   await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
 

--- a/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.test.ts
@@ -50,6 +50,50 @@ describe('useTokenValues', () => {
     });
   });
 
+  it('uses original transaction params when the transaction is wrapped', () => {
+    (useAssetDetailsMock as jest.Mock).mockImplementation(() => ({
+      decimals: '4',
+    }));
+
+    useTokenExchangeRateMock.mockReturnValue(new Numeric(0.91, 10));
+
+    const transactionMeta = genUnapprovedTokenTransferConfirmation({
+      amountHex:
+        '0000000000000000000000000000000000000000000000000000000000011170',
+    }) as TransactionMeta;
+    const originalTxParams = { ...transactionMeta.txParams };
+    transactionMeta.txParamsOriginal = originalTxParams;
+    transactionMeta.txParams = {
+      ...transactionMeta.txParams,
+      data: '0x1234',
+      to: '0x1111111111111111111111111111111111111111',
+      value: '0x0',
+    };
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useTokenValues(transactionMeta),
+      getMockConfirmStateForTransaction(transactionMeta),
+    );
+
+    expect(result.current).toEqual({
+      decodedTransferValue: '7',
+      displayTransferValue: '7',
+      fiatDisplayValue: '$6.37',
+      fiatValue: 6.37,
+      pending: false,
+    });
+    expect(useTokenExchangeRateMock).toHaveBeenCalledWith(
+      originalTxParams.to,
+      transactionMeta.chainId,
+    );
+    expect(useAssetDetailsMock).toHaveBeenCalledWith(
+      originalTxParams.to,
+      originalTxParams.from,
+      originalTxParams.data,
+      transactionMeta.chainId,
+    );
+  });
+
   it('returns undefined fiat balance and pending=false if no token rate is returned', async () => {
     (useAssetDetailsMock as jest.Mock).mockImplementation(() => ({
       decimals: '4',

--- a/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.ts
@@ -13,16 +13,20 @@ import { useTokenTransactionData } from './useTokenTransactionData';
 export const useTokenValues = (transactionMeta: TransactionMeta) => {
   const locale = useSelector(getIntlLocale);
   const parsedTransactionData = useTokenTransactionData();
+  const { txParams, txParamsOriginal } = transactionMeta;
+  const tokenAddress = txParamsOriginal?.to ?? txParams.to;
+  const userAddress = txParamsOriginal?.from ?? txParams.from;
+  const transactionData = txParamsOriginal?.data ?? txParams.data;
   const exchangeRate = useTokenExchangeRate(
-    transactionMeta?.txParams?.to,
-    transactionMeta?.chainId as Hex,
+    tokenAddress,
+    transactionMeta.chainId as Hex,
   );
   const fiatFormatter = useFiatFormatter();
 
   const { decimals } = useAssetDetails(
-    transactionMeta.txParams.to,
-    transactionMeta.txParams.from,
-    transactionMeta.txParams.data,
+    tokenAddress,
+    userAddress,
+    transactionData,
     transactionMeta.chainId,
   );
 

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.test.ts
@@ -44,6 +44,47 @@ describe('useTokenDetails', () => {
     });
   });
 
+  it('uses the original token address when the transaction is wrapped', () => {
+    const transactionMeta = genUnapprovedTokenTransferConfirmation(
+      {},
+    ) as TransactionMeta;
+    const originalTxParams = { ...transactionMeta.txParams };
+    transactionMeta.txParamsOriginal = originalTxParams;
+    transactionMeta.txParams = {
+      ...transactionMeta.txParams,
+      to: '0x1111111111111111111111111111111111111111',
+    };
+
+    const stateWithToken = {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        allTokens: {
+          [transactionMeta.chainId]: {
+            [originalTxParams.from as string]: [
+              {
+                address: originalTxParams.to,
+                symbol: ICON_SYMBOL,
+                image: ICON_URL,
+                decimals: 9,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const { result } = renderHookWithProvider(
+      () => useTokenDetails(transactionMeta),
+      stateWithToken,
+    );
+
+    expect(result.current).toEqual({
+      tokenImage: ICON_URL,
+      tokenSymbol: ICON_SYMBOL,
+    });
+  });
+
   it('returns undefined for tokenImage and "Unknown" for tokenSymbol if token is not in allTokens', () => {
     const transactionMeta = genUnapprovedTokenTransferConfirmation(
       {},

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
@@ -12,8 +12,7 @@ export const useTokenDetails = (transactionMeta: TransactionMeta) => {
   const allTokens = useSelector(getAllTokens);
   const tokenListToken = allTokens?.[chainId]?.[userAddress as string]?.find(
     (token) =>
-      token.address?.toLowerCase() ===
-      (tokenAddress?.toLowerCase() as string),
+      token.address?.toLowerCase() === (tokenAddress?.toLowerCase() as string),
   );
 
   const tokenImage = tokenListToken?.image || undefined;

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
@@ -5,14 +5,15 @@ import { getAllTokens } from '../../../../../../selectors';
 
 export const useTokenDetails = (transactionMeta: TransactionMeta) => {
   const t = useI18nContext();
-  const {
-    chainId,
-    txParams: { to, from },
-  } = transactionMeta ?? { txParams: {} };
+  const { chainId, txParams, txParamsOriginal } = transactionMeta;
+  const tokenAddress = txParamsOriginal?.to ?? txParams.to;
+  const userAddress = txParamsOriginal?.from ?? txParams.from;
 
   const allTokens = useSelector(getAllTokens);
-  const tokenListToken = allTokens?.[chainId]?.[from as string]?.find(
-    (token) => token.address?.toLowerCase() === (to?.toLowerCase() as string),
+  const tokenListToken = allTokens?.[chainId]?.[userAddress as string]?.find(
+    (token) =>
+      token.address?.toLowerCase() ===
+      (tokenAddress?.toLowerCase() as string),
   );
 
   const tokenImage = tokenListToken?.image || undefined;

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenTransactionData.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenTransactionData.ts
@@ -4,7 +4,9 @@ import { parseStandardTokenTransactionData } from '../../../../../../../shared/l
 
 export function useTokenTransactionData() {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
-  const transactionData = currentConfirmation?.txParams?.data;
+  const transactionData =
+    currentConfirmation?.txParamsOriginal?.data ??
+    currentConfirmation?.txParams?.data;
 
   if (!transactionData) {
     return undefined;

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/token-details-section.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/token-details-section.test.tsx
@@ -1,6 +1,11 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { getMockTokenTransferConfirmState } from '../../../../../../../test/data/confirmations/helper';
+import {
+  getMockConfirmStateForTransaction,
+  getMockTokenTransferConfirmState,
+} from '../../../../../../../test/data/confirmations/helper';
+import { genUnapprovedTokenTransferConfirmation } from '../../../../../../../test/data/confirmations/token-transfer';
 import { renderWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
 import { enLocale as messages } from '../../../../../../../test/lib/i18n-helpers';
 import { TokenDetailsSection } from './token-details-section';
@@ -35,5 +40,26 @@ describe('TokenDetailsSection', () => {
     expect(getByText(messages.network.message)).toBeInTheDocument();
     expect(getByText(messages.networkNameGoerli.message)).toBeInTheDocument();
     expect(getByText(messages.interactingWith.message)).toBeInTheDocument();
+  });
+
+  it('renders the original interacting-with address when the transaction is wrapped', () => {
+    const transactionMeta =
+      genUnapprovedTokenTransferConfirmation() as TransactionMeta;
+    transactionMeta.txParamsOriginal = { ...transactionMeta.txParams };
+    transactionMeta.txParams = {
+      ...transactionMeta.txParams,
+      to: '0x1111111111111111111111111111111111111111',
+    };
+    const mockStore = configureMockStore([])(
+      getMockConfirmStateForTransaction(transactionMeta),
+    );
+
+    const { getByText, queryByText } = renderWithConfirmContextProvider(
+      <TokenDetailsSection />,
+      mockStore,
+    );
+
+    expect(getByText('0x07614...3ad68')).toBeInTheDocument();
+    expect(queryByText('0x11111...11111')).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/token-details-section.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/token-details-section.tsx
@@ -22,7 +22,8 @@ export const TokenDetailsSection = () => {
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
 
-  const { chainId } = transactionMeta;
+  const { chainId, txParams, txParamsOriginal } = transactionMeta;
+  const tokenAddress = txParamsOriginal?.to ?? txParams.to;
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
   );
@@ -39,7 +40,7 @@ export const TokenDetailsSection = () => {
       tooltip={t('interactingWithTransactionDescription')}
     >
       <ConfirmInfoRowAddress
-        address={transactionMeta.txParams.to as string}
+        address={tokenAddress as string}
         chainId={chainId}
       />
     </ConfirmInfoRow>

--- a/ui/pages/confirmations/components/confirm/title/hooks/useCurrentSpendingCap.ts
+++ b/ui/pages/confirmations/components/confirm/title/hooks/useCurrentSpendingCap.ts
@@ -51,5 +51,8 @@ export function useCurrentSpendingCap(currentConfirmation: Confirmation) {
     customSpendingCap = spendingCap;
   }
 
-  return { customSpendingCap, pending };
+  return {
+    customSpendingCap,
+    pending: isTxWithSpendingCap && pending,
+  };
 }

--- a/ui/pages/confirmations/components/confirm/title/title.test.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.test.tsx
@@ -1,6 +1,7 @@
 import { waitFor } from '@testing-library/react';
 import React from 'react';
 import { TransactionType } from '@metamask/transaction-controller';
+import { BigNumber } from 'bignumber.js';
 import configureMockStore from 'redux-mock-store';
 import {
   getMockApproveConfirmState,
@@ -26,14 +27,17 @@ import {
 } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import { Confirmation } from '../../../types/confirm';
+import { useApproveTokenSimulation } from '../info/approve/hooks/use-approve-token-simulation';
 import { useIsNFT } from '../info/approve/hooks/use-is-nft';
 import ConfirmTitle from './title';
 
 jest.mock('../info/approve/hooks/use-approve-token-simulation', () => ({
   useApproveTokenSimulation: jest.fn(() => ({
+    isUnlimitedSpendingCap: false,
     spendingCap: '1000',
     formattedSpendingCap: '1000',
     value: '1000',
+    pending: false,
   })),
 }));
 
@@ -176,6 +180,27 @@ describe('ConfirmTitle', () => {
     );
 
     expect(getByText(tEn('confirmTitleTransaction'))).toBeInTheDocument();
+  });
+
+  it('keeps the contract interaction title while spending-cap data is pending', () => {
+    jest.mocked(useApproveTokenSimulation).mockReturnValueOnce({
+      isUnlimitedSpendingCap: false,
+      spendingCap: '0',
+      formattedSpendingCap: '0',
+      value: new BigNumber(0),
+      pending: true,
+    });
+    const mockStore = configureMockStore([])(
+      getMockContractInteractionConfirmState(),
+    );
+
+    const { getByText, queryByTestId } = renderWithConfirmContextProvider(
+      <ConfirmTitle />,
+      mockStore,
+    );
+
+    expect(getByText(tEn('confirmTitleTransaction'))).toBeInTheDocument();
+    expect(queryByTestId('confirm-title-skeleton')).not.toBeInTheDocument();
   });
 
   it('should render the title and description for a approval transaction for NFTs', () => {

--- a/ui/pages/confirmations/hooks/alerts/useAddressTrustSignalAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useAddressTrustSignalAlerts.test.ts
@@ -117,6 +117,39 @@ describe('useTrustSignalAlerts', () => {
       );
     });
 
+    it('uses the original address when the transaction is wrapped', () => {
+      mockUseTrustSignal.mockReturnValue({
+        state: TrustSignalDisplayState.Malicious,
+      });
+
+      const contractInteraction = genUnapprovedContractInteractionConfirmation({
+        chainId: CHAIN_IDS.GOERLI,
+      }) as TransactionMeta;
+      const currentConfirmation = {
+        ...contractInteraction,
+        txParams: {
+          ...contractInteraction.txParams,
+          to: SAFE_ADDRESS,
+        },
+        txParamsOriginal: {
+          ...contractInteraction.txParams,
+          to: MALICIOUS_ADDRESS,
+        },
+      } as TransactionMeta;
+
+      const { result } = renderHookWithConfirmContextProvider(
+        () => useAddressTrustSignalAlerts(),
+        getMockConfirmStateForTransaction(currentConfirmation),
+      );
+
+      expect(result.current).toEqual([expectedMaliciousAlert]);
+      expect(mockUseTrustSignal).toHaveBeenCalledWith(
+        MALICIOUS_ADDRESS,
+        NameType.ETHEREUM_ADDRESS,
+        CHAIN_IDS.GOERLI,
+      );
+    });
+
     it('returns warning alert for transaction with warning to address', () => {
       mockUseTrustSignal.mockReturnValue({
         state: TrustSignalDisplayState.Warning,

--- a/ui/pages/confirmations/hooks/alerts/useAddressTrustSignalAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useAddressTrustSignalAlerts.ts
@@ -23,9 +23,13 @@ export function useAddressTrustSignalAlerts(): Alert[] {
       return null;
     }
 
-    // For transactions, check the 'to' address
-    if ((currentConfirmation as TransactionMeta)?.txParams?.to) {
-      return (currentConfirmation as TransactionMeta).txParams.to;
+    // For transactions, check the original 'to' address before container
+    // wrapping replaces it with the delegation manager address.
+    const transactionMeta = currentConfirmation as TransactionMeta;
+    const transactionAddress =
+      transactionMeta?.txParamsOriginal?.to ?? transactionMeta?.txParams?.to;
+    if (transactionAddress) {
+      return transactionAddress;
     }
 
     // For signatures, check the verifying contract if available


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Enforced simulations replace the executable transaction parameters with a delegation-manager call while retaining the user-intended parameters in `txParamsOriginal`. Some confirmation UI paths were reading the wrapped parameters, which caused token details and the interacting-with address to change when protection was toggled. The wrapped address also restarted unrelated asset lookups, making the title briefly show a skeleton and dropping the existing trust signal.

This change uses the original transaction parameters for user-facing token details, calldata decoding, interacting-with addresses, and trust-signal checks. It also limits spending-cap loading state to transaction types that actually use a spending cap, so ordinary contract-interaction titles remain stable.

## **Changelog**

CHANGELOG entry: Fixed confirmation details changing or reloading when enforced simulations were toggled

## **Related issues**

Fixes: [CONF-1684](https://consensyssoftware.atlassian.net/browse/CONF-1684)
Fixes: [CONF-1685](https://consensyssoftware.atlassian.net/browse/CONF-1685)

## **Manual testing steps**

1. Open a dapp contract-interaction confirmation that is eligible for enforced simulations and has a trust signal on the “Interacting with” row.
2. Disable and re-enable “Added protection,” and verify that the “Transaction request” title does not show a skeleton and the trust signal remains visible.
3. Open an eligible ERC-20 send confirmation and note the token amount, symbol, and “Interacting with” address.
4. Disable and re-enable “Added protection,” and verify that the token amount does not show a persistent skeleton and that the amount, symbol, and address remain unchanged.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[CONF-1684]: https://consensyssoftware.atlassian.net/browse/CONF-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmation security display (trust signals, token amounts, interacting-with) for wrapped transactions; behavior change is intentional but user-facing and regression-tested.
> 
> **Overview**
> When **enforced simulations** wrap the executable call, confirmation UI was driven by wrapped `txParams` (delegation manager) instead of **`txParamsOriginal`**, so token amount/symbol, **Interacting with**, and trust signals could change or reload when toggling “Added protection.”
> 
> This PR prefers **`txParamsOriginal`** (with fallback to `txParams`) for token calldata decoding, asset lookups, fiat amounts, the interacting-with row, and address trust-signal checks. **`useCurrentSpendingCap`** only surfaces a pending state for approve-style transactions, so generic contract-interaction titles no longer flash a skeleton while unrelated simulation hooks load.
> 
> E2E **enforced-simulations** flows that hit malicious trust signals now step through the **danger alert** modal before confirming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5564662b16992ad7bf95495a971171c90b3f0e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->