### PR TITLE
fix(quality-gates): stop gating the live-network benchmark population against mocked ceilings

### DIFF
--- a/.github/scripts/benchmark-stats-commit.sh
+++ b/.github/scripts/benchmark-stats-commit.sh
@@ -132,11 +132,22 @@ assemble_performance_data() {
 
     echo "Collected ${file_count} preset(s)" >&2
 
+    # Record which network population produced these numbers. Consumers only
+    # ever build a baseline from entries matching their own population — a
+    # `live` run carries upstream latency that a `mocked` run does not, so
+    # blending them yields deltas that describe the internet rather than the
+    # commit. Mirrors resolveBenchmarkMockMode() in shared/constants/benchmarks.ts.
+    local mock_mode='mocked'
+    if [[ "${RAW_BRANCH}" == "main" || "${RAW_BRANCH}" == release/* ]]; then
+        mock_mode='live'
+    fi
+
     # presets_json can exceed ARG_MAX; pass it via stdin instead of as a jq argument
     # (a too-large argv makes the kernel fail to exec jq with "Argument list too long").
     printf '%s' "${presets_json}" | jq \
         --argjson timestamp "$(date +%s000)" \
-        '{ timestamp: $timestamp, presets: . }'
+        --arg mockMode "${mock_mode}" \
+        '{ timestamp: $timestamp, mockMode: $mockMode, presets: . }'
 }
 
 # Resolve stats file and assemble data

--- a/development/metamaskbot-build-announce/compare-benchmarks.test.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.test.ts
@@ -1,6 +1,9 @@
 import { promises as fs } from 'fs';
 import type { BenchmarkResults } from '../../shared/constants/benchmarks';
-import { THRESHOLD_SEVERITY } from '../../shared/constants/benchmarks';
+import {
+  BENCHMARK_MOCK_MODE,
+  THRESHOLD_SEVERITY,
+} from '../../shared/constants/benchmarks';
 import {
   runComparison,
   buildMetricLines,
@@ -106,6 +109,60 @@ describe('compare-benchmarks', () => {
       const result = runComparison(benchmarks, {});
       expect(result.anyFailed).toBe(true);
       expect(result.comparisons[0].absoluteFailed).toBe(true);
+    });
+
+    it('does not fail on a live-population run, but still records the breach', () => {
+      // Same gated breach as above. On `live` the timing carries upstream
+      // latency that is not a property of the commit, so it is reported
+      // rather than blocking.
+      const benchmarks = [
+        {
+          name: 'benchmark-chrome-webpack-startupStandardHome',
+          data: {
+            startupStandardHome: makeBenchmarkResults('uiStartup', {
+              p75: { uiStartup: 99999 },
+              p95: { uiStartup: 99999 },
+              mean: { uiStartup: 99999 },
+            }),
+          },
+        },
+      ];
+
+      const result = runComparison(benchmarks, {}, BENCHMARK_MOCK_MODE.LIVE);
+
+      expect(result.anyFailed).toBe(false);
+      expect(result.enforced).toBe(false);
+      expect(result.mockMode).toBe(BENCHMARK_MOCK_MODE.LIVE);
+      // The measurement is unchanged — only the consequence is.
+      expect(result.comparisons[0].absoluteFailed).toBe(true);
+    });
+
+    it('reports a live-population breach as a warning with an explanatory result line', () => {
+      const benchmarks = [
+        {
+          name: 'benchmark-chrome-webpack-startupStandardHome',
+          data: {
+            startupStandardHome: makeBenchmarkResults('uiStartup', {
+              p75: { uiStartup: 99999 },
+              p95: { uiStartup: 99999 },
+              mean: { uiStartup: 99999 },
+            }),
+          },
+        },
+      ];
+
+      const result = runComparison(benchmarks, {}, BENCHMARK_MOCK_MODE.LIVE);
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      try {
+        printReport(result);
+        const allCalls = consoleSpy.mock.calls.flat().join('\n');
+        expect(allCalls).toContain('WARN  startupStandardHome');
+        expect(allCalls).not.toMatch(/FAIL\s+startupStandardHome/u);
+        expect(allCalls).toContain('NOT enforced');
+        expect(allCalls).toContain('RESULT: PASS (ceilings not enforced)');
+      } finally {
+        consoleSpy.mockRestore();
+      }
     });
 
     it('does not fail when a non-allowlisted metric exceeds its fail threshold', () => {

--- a/development/metamaskbot-build-announce/compare-benchmarks.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.ts
@@ -10,8 +10,15 @@
  * node development/metamaskbot-build-announce/compare-benchmarks.ts \
  * --current <path-to-benchmark-json-directory>
  *
+ * Absolute ceilings are enforced only for `mocked` runs. A `live` run's
+ * timings include upstream latency that is not a property of the commit and
+ * drifts on its own — a fixed ceiling over such a series goes red and stays
+ * red regardless of what lands. Live breaches are still reported, as
+ * warnings, so the signal is kept without blocking on it.
+ *
  * Exit codes:
- * 0 — no allowlisted (GATED_METRICS) metric exceeded its fail threshold
+ * 0 — no allowlisted (GATED_METRICS) metric exceeded its fail threshold, or
+ * the run measured the `live` population and ceilings were not enforced
  * 1 — at least one allowlisted metric exceeded its fail threshold;
  * non-allowlisted breaches are degraded to warnings and do not block
  * 2 — usage error or fatal crash
@@ -21,8 +28,13 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { parseArgs } from 'util';
 
-import { THRESHOLD_SEVERITY } from '../../shared/constants/benchmarks';
+import {
+  BENCHMARK_MOCK_MODE,
+  resolveBenchmarkMockMode,
+  THRESHOLD_SEVERITY,
+} from '../../shared/constants/benchmarks';
 import type {
+  BenchmarkMockMode,
   ThresholdSeverity,
   ComparisonKey,
   BenchmarkResults,
@@ -69,10 +81,14 @@ export async function loadCurrentBenchmarks(
 }
 
 /**
- * Loads the historical baseline.
+ * Loads the historical baseline for a population.
+ *
+ * @param mockMode - Population the current run measured.
  */
-async function loadBaseline(): Promise<HistoricalBaselineReference> {
-  const result = await fetchHistoricalPerformanceDataFromMain();
+async function loadBaseline(
+  mockMode: BenchmarkMockMode,
+): Promise<HistoricalBaselineReference> {
+  const result = await fetchHistoricalPerformanceDataFromMain(mockMode);
   return result?.baseline ?? {};
 }
 
@@ -81,11 +97,20 @@ async function loadBaseline(): Promise<HistoricalBaselineReference> {
  *
  * @param benchmarks - Loaded benchmark files.
  * @param baseline - Historical baseline reference.
+ * @param mockMode - Population the run measured. Ceilings block only for
+ * `mocked`; `live` breaches are reported without failing the gate.
  */
 export function runComparison(
   benchmarks: LoadedBenchmark[],
   baseline: HistoricalBaselineReference,
-): { comparisons: BenchmarkEntryComparison[]; anyFailed: boolean } {
+  mockMode: BenchmarkMockMode = BENCHMARK_MOCK_MODE.MOCKED,
+): {
+  comparisons: BenchmarkEntryComparison[];
+  anyFailed: boolean;
+  mockMode: BenchmarkMockMode;
+  enforced: boolean;
+} {
+  const enforced = mockMode === BENCHMARK_MOCK_MODE.MOCKED;
   const comparisons: BenchmarkEntryComparison[] = [];
   let anyFailed = false;
 
@@ -137,13 +162,13 @@ export function runComparison(
 
       comparisons.push(comparison);
 
-      if (comparison.absoluteFailed) {
+      if (comparison.absoluteFailed && enforced) {
         anyFailed = true;
       }
     }
   }
 
-  return { comparisons, anyFailed };
+  return { comparisons, anyFailed, mockMode, enforced };
 }
 
 function violationIcon(severity: ThresholdSeverity): string {
@@ -314,10 +339,27 @@ function formatName(comparison: BenchmarkEntryComparison): string {
 export function printReport(result: {
   comparisons: BenchmarkEntryComparison[];
   anyFailed: boolean;
+  mockMode?: BenchmarkMockMode;
+  enforced?: boolean;
 }): void {
+  const enforced = result.enforced ?? true;
+
   console.log('\n═══════════════════════════════════════');
   console.log('  Performance Benchmark Quality Gate');
   console.log('═══════════════════════════════════════');
+
+  if (!enforced) {
+    console.log(
+      `\nNOTE  This run measured the "${result.mockMode ?? BENCHMARK_MOCK_MODE.LIVE}" population — upstream requests`,
+    );
+    console.log(
+      '      reached real servers, so timings carry latency that is not a property',
+    );
+    console.log(
+      '      of this commit. Absolute ceilings are reported below but NOT enforced;',
+    );
+    console.log('      they gate mocked runs (PRs) only.');
+  }
 
   // Pre-compute metric lines to avoid duplicate work
   const withLines = result.comparisons.map((c) => ({
@@ -325,10 +367,15 @@ export function printReport(result: {
     lines: buildMetricLines(c),
   }));
 
-  const failed = withLines.filter((w) => w.comparison.absoluteFailed);
+  // A ceiling breach only groups as FAIL when this run's population is
+  // actually gated; otherwise it is reported alongside the warnings.
+  const isBlocking = (w: { comparison: BenchmarkEntryComparison }): boolean =>
+    w.comparison.absoluteFailed && enforced;
+
+  const failed = withLines.filter(isBlocking);
   const warned = withLines.filter(
     (w) =>
-      !w.comparison.absoluteFailed &&
+      !isBlocking(w) &&
       (w.comparison.absoluteViolations.some(
         (v) => v.severity === THRESHOLD_SEVERITY.Warn,
       ) ||
@@ -336,7 +383,7 @@ export function printReport(result: {
   );
   const passed = withLines.filter(
     (w) =>
-      !w.comparison.absoluteFailed &&
+      !isBlocking(w) &&
       !w.comparison.absoluteViolations.some(
         (v) => v.severity === THRESHOLD_SEVERITY.Warn,
       ) &&
@@ -390,6 +437,13 @@ export function printReport(result: {
     console.log(
       '\nRESULT: FAIL — at least one benchmark exceeds constant fail limit',
     );
+  } else if (!enforced) {
+    const breaches = withLines.filter(
+      (w) => w.comparison.absoluteFailed,
+    ).length;
+    console.log(
+      `\nRESULT: PASS (ceilings not enforced) — ${breaches} benchmark(s) exceeded a constant fail limit, reported as warnings`,
+    );
   } else {
     console.log('\nRESULT: PASS — all benchmarks within constant limits');
   }
@@ -414,9 +468,12 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const baseline = await loadBaseline();
+  // Same branch-derived value the benchmark harness used to decide whether to
+  // mock, so the gate evaluates the population that was actually measured.
+  const mockMode = resolveBenchmarkMockMode(process.env.GITHUB_REF_NAME);
+  const baseline = await loadBaseline(mockMode);
 
-  const result = runComparison(benchmarks, baseline);
+  const result = runComparison(benchmarks, baseline, mockMode);
   printReport(result);
 
   process.exit(result.anyFailed ? 1 : 0);

--- a/development/metamaskbot-build-announce/compare-benchmarks.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.ts
@@ -335,6 +335,8 @@ function formatName(comparison: BenchmarkEntryComparison): string {
  * @param result - Comparison results.
  * @param result.comparisons
  * @param result.anyFailed
+ * @param result.mockMode
+ * @param result.enforced
  */
 export function printReport(result: {
   comparisons: BenchmarkEntryComparison[];
@@ -437,15 +439,15 @@ export function printReport(result: {
     console.log(
       '\nRESULT: FAIL — at least one benchmark exceeds constant fail limit',
     );
-  } else if (!enforced) {
+  } else if (enforced) {
+    console.log('\nRESULT: PASS — all benchmarks within constant limits');
+  } else {
     const breaches = withLines.filter(
       (w) => w.comparison.absoluteFailed,
     ).length;
     console.log(
       `\nRESULT: PASS (ceilings not enforced) — ${breaches} benchmark(s) exceeded a constant fail limit, reported as warnings`,
     );
-  } else {
-    console.log('\nRESULT: PASS — all benchmarks within constant limits');
   }
 }
 

--- a/development/metamaskbot-build-announce/historical-comparison.test.ts
+++ b/development/metamaskbot-build-announce/historical-comparison.test.ts
@@ -1,3 +1,4 @@
+import { BENCHMARK_MOCK_MODE } from '../../shared/constants/benchmarks';
 import {
   aggregateHistoricalData,
   aggregateHistoricalDataWithCommit,
@@ -65,7 +66,7 @@ describe('aggregateHistoricalData', () => {
   });
 
   it('averages across the 3 most recent commits', () => {
-    const result = aggregateHistoricalData(mockFile);
+    const result = aggregateHistoricalData(mockFile, BENCHMARK_MOCK_MODE.LIVE);
 
     expect(result['pageLoad/standardHome']?.uiStartup?.mean).toBe(1500);
     expect(result['pageLoad/standardHome']?.uiStartup?.p75).toBe(1650);
@@ -92,7 +93,7 @@ describe('aggregateHistoricalData', () => {
       },
     };
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     expect(result['pageLoad/standardHome']?.uiStartup?.mean).toBe(1000);
     expect(result['userActions/loadNewAccount']?.loadNewAccount?.mean).toBe(
@@ -101,7 +102,7 @@ describe('aggregateHistoricalData', () => {
   });
 
   it('returns empty object when data has no commits', () => {
-    const result = aggregateHistoricalData({});
+    const result = aggregateHistoricalData({}, BENCHMARK_MOCK_MODE.LIVE);
 
     expect(result).toStrictEqual({});
   });
@@ -113,7 +114,7 @@ describe('aggregateHistoricalData', () => {
       good: makeCommit(),
     });
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     expect(result['pageLoad/standardHome']?.uiStartup?.mean).toBe(1000);
   });
@@ -135,7 +136,7 @@ describe('aggregateHistoricalData', () => {
       },
     });
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     expect(result['pageLoad/badEntry']).toBeUndefined();
     expect(result['pageLoad/goodEntry']?.uiStartup?.mean).toBe(800);
@@ -159,7 +160,7 @@ describe('aggregateHistoricalData', () => {
       },
     });
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     expect(result['pageLoad/entry']?.good?.mean).toBe(500);
     expect(result['pageLoad/entry']?.good?.p75).toBe(550);
@@ -172,7 +173,7 @@ describe('aggregateHistoricalData', () => {
       c1: { timestamp: 1 },
     });
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     expect(result).toStrictEqual({});
   });
@@ -188,7 +189,7 @@ describe('aggregateHistoricalData', () => {
       },
     });
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     expect(result['pageLoad/standardHome']).toBeUndefined();
     expect(result['userActions/loadNewAccount']?.loadNewAccount?.mean).toBe(
@@ -226,7 +227,7 @@ describe('aggregateHistoricalData', () => {
       },
     });
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     // stdDev true-branch: result should include a stdDev field
     expect(result['pageLoad/entry']?.metric).toHaveProperty('stdDev');
@@ -264,7 +265,7 @@ describe('aggregateHistoricalData', () => {
       },
     });
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     // mean([Infinity, -Infinity]) = NaN → entry must be skipped
     expect(result['pageLoad/nanEntry']).toBeUndefined();
@@ -284,7 +285,7 @@ describe('aggregateHistoricalData', () => {
       },
     });
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     expect(result['pageLoad/entry']?.metric?.mean).toBe(500);
     expect(result['pageLoad/entry']?.metric?.p75).toBe(500);
@@ -306,7 +307,10 @@ describe('aggregateHistoricalDataWithCommit', () => {
       ghi789: makeCommit({ timestamp: 1_700_000_002 }),
     };
 
-    const result = aggregateHistoricalDataWithCommit(data);
+    const result = aggregateHistoricalDataWithCommit(
+      data,
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
 
     expect(result.latestCommit).toBe('ghi789');
     expect(result.latestTimestamp).toBe(1_700_000_002);
@@ -317,7 +321,10 @@ describe('aggregateHistoricalDataWithCommit', () => {
   it('returns empty string and 0 timestamp when data is empty', () => {
     const data: HistoricalPerformanceFile = {};
 
-    const result = aggregateHistoricalDataWithCommit(data);
+    const result = aggregateHistoricalDataWithCommit(
+      data,
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
 
     expect(result.latestCommit).toBe('');
     expect(result.latestTimestamp).toBe(0);
@@ -331,7 +338,10 @@ describe('aggregateHistoricalDataWithCommit', () => {
       middle: makeCommit({ timestamp: 1_700_000_001 }),
     };
 
-    const result = aggregateHistoricalDataWithCommit(data);
+    const result = aggregateHistoricalDataWithCommit(
+      data,
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
 
     expect(result.latestCommit).toBe('newest');
     expect(result.latestTimestamp).toBe(1_700_000_003);
@@ -344,7 +354,10 @@ describe('aggregateHistoricalDataWithCommit', () => {
       nullTimestamp: { timestamp: null, presets: {} },
     });
 
-    const result = aggregateHistoricalDataWithCommit(data);
+    const result = aggregateHistoricalDataWithCommit(
+      data,
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
 
     expect(result.latestCommit).toBe('valid');
     expect(result.latestTimestamp).toBe(1_700_000_001);
@@ -390,7 +403,10 @@ describe('aggregateHistoricalDataWithCommit', () => {
       }),
     };
 
-    const result = aggregateHistoricalDataWithCommit(data);
+    const result = aggregateHistoricalDataWithCommit(
+      data,
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
 
     expect(result.latestCommit).toBe('commit3');
     expect(result.latestTimestamp).toBe(1_700_000_002);
@@ -425,7 +441,9 @@ describe('fetchHistoricalPerformanceDataFromMain', () => {
   it('fetches from main and returns aggregated data with commit info', async () => {
     mockFetch.mockReturnValueOnce(makeOkResponse(mockFile));
 
-    const result = await fetchHistoricalPerformanceDataFromMain();
+    const result = await fetchHistoricalPerformanceDataFromMain(
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
 
     expect(result?.baseline['pageLoad/standardHome']?.uiStartup?.mean).toBe(
       1500,
@@ -440,7 +458,9 @@ describe('fetchHistoricalPerformanceDataFromMain', () => {
   it('returns null when main has no data', async () => {
     mockFetch.mockReturnValueOnce(makeNotFoundResponse());
 
-    const result = await fetchHistoricalPerformanceDataFromMain();
+    const result = await fetchHistoricalPerformanceDataFromMain(
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
 
     expect(result).toBeNull();
   });
@@ -448,7 +468,9 @@ describe('fetchHistoricalPerformanceDataFromMain', () => {
   it('returns null when main returns an empty object', async () => {
     mockFetch.mockReturnValueOnce(makeOkResponse({}));
 
-    const result = await fetchHistoricalPerformanceDataFromMain();
+    const result = await fetchHistoricalPerformanceDataFromMain(
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
 
     expect(result).toBeNull();
   });
@@ -469,7 +491,7 @@ describe('fetchHistoricalPerformanceDataFromMain', () => {
       },
     });
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     expect(result['pageLoad/standardHome']?.uiStartup?.p75).toBe(1000);
     expect(result['pageLoad/standardHome']?.uiStartup?.p95).toBe(1300);
@@ -492,7 +514,7 @@ describe('fetchHistoricalPerformanceDataFromMain', () => {
       },
     });
 
-    const result = aggregateHistoricalData(data);
+    const result = aggregateHistoricalData(data, BENCHMARK_MOCK_MODE.LIVE);
 
     // p95 should fall back to the mean value (1000)
     expect(result['pageLoad/standardHome']?.uiStartup?.p95).toBe(1000);
@@ -508,7 +530,9 @@ describe('fetchHistoricalPerformanceDataFromMain', () => {
     });
     mockFetch.mockReturnValueOnce(makeOkResponse(invalidData));
 
-    const result = await fetchHistoricalPerformanceDataFromMain();
+    const result = await fetchHistoricalPerformanceDataFromMain(
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
 
     expect(result).toBeNull();
   });
@@ -516,8 +540,111 @@ describe('fetchHistoricalPerformanceDataFromMain', () => {
   it('returns null when fetch throws', async () => {
     mockFetch.mockRejectedValue(new Error('network error'));
 
-    const result = await fetchHistoricalPerformanceDataFromMain();
+    const result = await fetchHistoricalPerformanceDataFromMain(
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
 
     expect(result).toBeNull();
+  });
+
+  it('returns null when the file holds no entries for the requested population', async () => {
+    // Every entry is `live`; a mocked consumer must get nothing rather than a
+    // cross-population baseline.
+    mockFetch.mockReturnValueOnce(makeOkResponse(mockFile));
+
+    const result = await fetchHistoricalPerformanceDataFromMain(
+      BENCHMARK_MOCK_MODE.MOCKED,
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('population separation', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const mixedFile: HistoricalPerformanceFile = {
+    liveCommit: makeCommit({
+      timestamp: 1_700_000_000,
+      mockMode: BENCHMARK_MOCK_MODE.LIVE,
+      presets: {
+        pageLoad: {
+          standardHome: {
+            mean: { uiStartup: 9000 },
+            p75: { uiStartup: 9000 },
+            p95: { uiStartup: 9000 },
+          },
+        },
+      },
+    }),
+    mockedCommit: makeCommit({
+      timestamp: 1_700_000_001,
+      mockMode: BENCHMARK_MOCK_MODE.MOCKED,
+      presets: {
+        pageLoad: {
+          standardHome: {
+            mean: { uiStartup: 1000 },
+            p75: { uiStartup: 1000 },
+            p95: { uiStartup: 1000 },
+          },
+        },
+      },
+    }),
+  };
+
+  it('builds the baseline only from entries matching the requested population', () => {
+    const live = aggregateHistoricalData(mixedFile, BENCHMARK_MOCK_MODE.LIVE);
+    const mocked = aggregateHistoricalData(
+      mixedFile,
+      BENCHMARK_MOCK_MODE.MOCKED,
+    );
+
+    // Never the 5000 that averaging the two populations together would give.
+    expect(live['pageLoad/standardHome']?.uiStartup?.mean).toBe(9000);
+    expect(mocked['pageLoad/standardHome']?.uiStartup?.mean).toBe(1000);
+  });
+
+  it('treats entries written before mode was recorded as live', () => {
+    // All existing history predates the field, and every one of those runs
+    // was a main/release push — which is live by construction.
+    const legacyOnly: HistoricalPerformanceFile = {
+      legacy: makeCommit({
+        presets: {
+          pageLoad: {
+            standardHome: {
+              mean: { uiStartup: 4242 },
+              p75: { uiStartup: 4242 },
+              p95: { uiStartup: 4242 },
+            },
+          },
+        },
+      }),
+    };
+
+    expect(
+      aggregateHistoricalData(legacyOnly, BENCHMARK_MOCK_MODE.LIVE)[
+        'pageLoad/standardHome'
+      ]?.uiStartup?.mean,
+    ).toBe(4242);
+    expect(
+      aggregateHistoricalData(legacyOnly, BENCHMARK_MOCK_MODE.MOCKED),
+    ).toStrictEqual({});
+  });
+
+  it('reports provenance from the selected population, not the newest entry overall', () => {
+    const result = aggregateHistoricalDataWithCommit(
+      mixedFile,
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
+
+    // `mockedCommit` is newer, but it is not what the baseline was built from.
+    expect(result.latestCommit).toBe('liveCommit');
+    expect(result.latestTimestamp).toBe(1_700_000_000);
   });
 });

--- a/development/metamaskbot-build-announce/historical-comparison.ts
+++ b/development/metamaskbot-build-announce/historical-comparison.ts
@@ -5,8 +5,12 @@
  * and aggregates it into a mean-of-means reference for PR comment comparisons.
  */
 import { calculateMean } from '../../test/e2e/benchmarks/utils/statistics';
-import { STAT_KEY } from '../../shared/constants/benchmarks';
+import {
+  BENCHMARK_MOCK_MODE,
+  STAT_KEY,
+} from '../../shared/constants/benchmarks';
 import type {
+  BenchmarkMockMode,
   BenchmarkResults,
   HistoricalBaselineMetrics,
 } from '../../shared/constants/benchmarks';
@@ -17,7 +21,22 @@ type NestedPresetEntry = Record<string, Partial<BenchmarkResults>>;
 type HistoricalCommitEntry = {
   timestamp: number;
   presets: Record<string, NestedPresetEntry>;
+  /**
+   * Network population the commit's run measured. Absent on every entry
+   * written before mode was recorded; those runs were all `main`/`release/*`
+   * pushes, which are `live` by construction — hence the default below.
+   */
+  mockMode?: BenchmarkMockMode;
 };
+
+/**
+ * Reads the population a historical entry was measured under.
+ *
+ * @param entry - A commit entry from the stats file.
+ */
+function entryMockMode(entry: HistoricalCommitEntry): BenchmarkMockMode {
+  return entry.mockMode ?? BENCHMARK_MOCK_MODE.LIVE;
+}
 
 export type HistoricalPerformanceFile = Record<string, HistoricalCommitEntry>;
 
@@ -36,9 +55,18 @@ export type HistoricalBaselineResult = {
  * Fetches historical performance data from the `main` branch of
  * extension_benchmark_stats.
  *
+ * Returns `null` when the file holds no entries for `mockMode` — the caller
+ * then reports no baseline rather than a cross-population delta. Today that
+ * is the expected outcome for `mocked` consumers, because only `main` and
+ * `release/*` publish stats and both run `live`; see the follow-up to
+ * publish a `mocked` series.
+ *
+ * @param mockMode - Population the consuming run measured.
  * @returns Reference map (benchmarkName -> metric -> baseline) with latest commit info, or null if unavailable.
  */
-export async function fetchHistoricalPerformanceDataFromMain(): Promise<HistoricalBaselineResult | null> {
+export async function fetchHistoricalPerformanceDataFromMain(
+  mockMode: BenchmarkMockMode,
+): Promise<HistoricalBaselineResult | null> {
   try {
     const response = await fetch(
       EXTENSION_BENCHMARK_STATS_MAIN_PERFORMANCE_DATA_URL,
@@ -51,7 +79,7 @@ export async function fetchHistoricalPerformanceDataFromMain(): Promise<Historic
       return null;
     }
     const { baseline, latestCommit, latestTimestamp } =
-      aggregateHistoricalDataWithCommit(data);
+      aggregateHistoricalDataWithCommit(data, mockMode);
     return Object.keys(baseline).length > 0
       ? { baseline, latestCommit, latestTimestamp }
       : null;
@@ -173,14 +201,22 @@ function buildMetricBaselines(
  * startup baseline, and to smooth out run-to-run variance.
  * Values from all commits are averaged together.
  *
+ * Only commits measured under `mockMode` contribute. A `mocked` run compared
+ * against a `live` baseline (or the reverse) produces deltas that are an
+ * artifact of upstream latency rather than of the commit, so the populations
+ * are kept apart rather than blended.
+ *
  * @param data - Full historical data file contents.
+ * @param mockMode - Population to build the baseline from.
  * @returns Aggregated reference map.
  */
 export function aggregateHistoricalData(
   data: HistoricalPerformanceFile,
+  mockMode: BenchmarkMockMode,
 ): HistoricalBaselineReference {
   const latestCommits = Object.keys(data)
     .filter((hash) => data[hash]?.timestamp)
+    .filter((hash) => entryMockMode(data[hash]) === mockMode)
     .sort((a, b) => data[b].timestamp - data[a].timestamp)
     .slice(0, 5);
 
@@ -204,11 +240,17 @@ export function aggregateHistoricalData(
 /**
  * Aggregates historical data and returns the baseline along with the latest commit info.
  *
+ * `latestCommit`/`latestTimestamp` describe the newest entry in the selected
+ * population, so the reported provenance matches the numbers the baseline was
+ * actually built from.
+ *
  * @param data - Full historical data file contents.
+ * @param mockMode - Population to build the baseline from.
  * @returns Aggregated reference map with latest commit hash and timestamp.
  */
 export function aggregateHistoricalDataWithCommit(
   data: HistoricalPerformanceFile,
+  mockMode: BenchmarkMockMode,
 ): {
   baseline: HistoricalBaselineReference;
   latestCommit: string;
@@ -216,11 +258,12 @@ export function aggregateHistoricalDataWithCommit(
 } {
   const sortedCommits = Object.keys(data)
     .filter((hash) => data[hash]?.timestamp)
+    .filter((hash) => entryMockMode(data[hash]) === mockMode)
     .sort((a, b) => data[b].timestamp - data[a].timestamp);
 
   const latestCommit = sortedCommits[0] || '';
   const latestTimestamp = data[latestCommit]?.timestamp || 0;
-  const baseline = aggregateHistoricalData(data);
+  const baseline = aggregateHistoricalData(data, mockMode);
 
   return { baseline, latestCommit, latestTimestamp };
 }

--- a/development/metamaskbot-build-announce/performance-benchmarks.ts
+++ b/development/metamaskbot-build-announce/performance-benchmarks.ts
@@ -7,6 +7,7 @@ import {
   BENCHMARK_PLATFORMS,
   BENCHMARK_TYPE,
   DEFAULT_RELATIVE_THRESHOLDS,
+  resolveBenchmarkMockMode,
   STAT_KEY,
   THRESHOLD_SEVERITY,
 } from '../../shared/constants/benchmarks';
@@ -1218,7 +1219,12 @@ export async function buildPerformanceBenchmarksSection(
       [BENCHMARK_PLATFORMS.CHROME],
       benchmarkBuildTypes,
     ),
-    fetchHistoricalPerformanceDataFromMain(),
+    // Population-matched: a mocked PR run is only ever compared against a
+    // mocked baseline, so the deltas reflect the commit rather than upstream
+    // latency. Yields no baseline until a matching series exists.
+    fetchHistoricalPerformanceDataFromMain(
+      resolveBenchmarkMockMode(process.env.GITHUB_REF_NAME),
+    ),
   ]);
 
   const resolvedBaseline = baselineResult?.baseline ?? undefined;

--- a/development/metamaskbot-build-announce/performance-benchmarks.ts
+++ b/development/metamaskbot-build-announce/performance-benchmarks.ts
@@ -672,6 +672,18 @@ export { BENCHMARK_ANNOUNCE_SECTIONS };
 /**
  * User journey benchmarks use the real API on `main` and `release/*` branches; other
  * branches use a mock API. Aligns with `BRANCH` / `GITHUB_HEAD_REF` in prerelease publish.
+ *
+ * KNOWN DISCREPANCY (pre-existing, deliberately not changed here): this labels the
+ * PR comment, and it resolves the branch differently from the harness that decides
+ * what actually ran. `shouldUseMockedRequests()` reads `GITHUB_REF_NAME`, which on a
+ * `pull_request` event is `<number>/merge`; `getCiBranchName()` prefers
+ * `BRANCH`/`GITHUB_HEAD_REF`, which is the head branch. So a PR *from* a `release/*`
+ * branch runs against mocks while this reports `real`. Whether the harness or this
+ * label is the wrong one is a product question — #39587 intended release branches to
+ * exercise real servers, which a release PR currently does not — so it is filed
+ * rather than silently resolved. Anything that must describe the population that was
+ * *measured* (baseline selection, gating) reads `GITHUB_REF_NAME` via
+ * `resolveBenchmarkMockMode`, never this function.
  */
 export function getUserJourneyBenchmarkApiModeFromBranch(): 'mock' | 'real' {
   const branch = getCiBranchName();
@@ -1222,6 +1234,17 @@ export async function buildPerformanceBenchmarksSection(
     // Population-matched: a mocked PR run is only ever compared against a
     // mocked baseline, so the deltas reflect the commit rather than upstream
     // latency. Yields no baseline until a matching series exists.
+    //
+    // Reads `GITHUB_REF_NAME` bare, NOT `getCiBranchName()`, because this must
+    // report the population the benchmark harness actually measured, and
+    // `shouldUseMockedRequests()` in mock-config.ts reads `GITHUB_REF_NAME`.
+    // The two sources disagree on `pull_request` events, where `GITHUB_REF_NAME`
+    // is `<number>/merge` while `GITHUB_HEAD_REF` is the head branch — so a PR
+    // from a `release/*` branch runs mocked but `getCiBranchName()` reports
+    // `release/…`. Selecting a baseline off the head branch there would compare
+    // a mocked run against the live series, which is the defect this whole
+    // change exists to remove. See the note on
+    // `getUserJourneyBenchmarkApiModeFromBranch`.
     fetchHistoricalPerformanceDataFromMain(
       resolveBenchmarkMockMode(process.env.GITHUB_REF_NAME),
     ),

--- a/development/metamaskbot-build-announce/performance-benchmarks.ts
+++ b/development/metamaskbot-build-announce/performance-benchmarks.ts
@@ -673,17 +673,17 @@ export { BENCHMARK_ANNOUNCE_SECTIONS };
  * User journey benchmarks use the real API on `main` and `release/*` branches; other
  * branches use a mock API. Aligns with `BRANCH` / `GITHUB_HEAD_REF` in prerelease publish.
  *
- * KNOWN DISCREPANCY (pre-existing, deliberately not changed here): this labels the
- * PR comment, and it resolves the branch differently from the harness that decides
- * what actually ran. `shouldUseMockedRequests()` reads `GITHUB_REF_NAME`, which on a
- * `pull_request` event is `<number>/merge`; `getCiBranchName()` prefers
- * `BRANCH`/`GITHUB_HEAD_REF`, which is the head branch. So a PR *from* a `release/*`
- * branch runs against mocks while this reports `real`. Whether the harness or this
- * label is the wrong one is a product question — #39587 intended release branches to
- * exercise real servers, which a release PR currently does not — so it is filed
- * rather than silently resolved. Anything that must describe the population that was
- * *measured* (baseline selection, gating) reads `GITHUB_REF_NAME` via
- * `resolveBenchmarkMockMode`, never this function.
+ * This resolves the branch differently from `shouldUseMockedRequests()`, which reads
+ * `GITHUB_REF_NAME` while this prefers `BRANCH`/`GITHUB_HEAD_REF`. The two cannot
+ * currently disagree: main.yml's `pull_request` trigger carries
+ * `branches-ignore: [stable]`, which filters on the base branch, so release PRs
+ * (base `stable`) never reach it and release branches are exercised through `push`,
+ * where both sources return `release/…`. Feature PRs return `mock` from either.
+ *
+ * The equivalence is a property of the trigger config rather than of these functions,
+ * so anything that must describe the population actually *measured* — baseline
+ * selection, gating — still reads `GITHUB_REF_NAME` via `resolveBenchmarkMockMode`,
+ * which is the source the harness itself uses.
  */
 export function getUserJourneyBenchmarkApiModeFromBranch(): 'mock' | 'real' {
   const branch = getCiBranchName();
@@ -1238,13 +1238,10 @@ export async function buildPerformanceBenchmarksSection(
     // Reads `GITHUB_REF_NAME` bare, NOT `getCiBranchName()`, because this must
     // report the population the benchmark harness actually measured, and
     // `shouldUseMockedRequests()` in mock-config.ts reads `GITHUB_REF_NAME`.
-    // The two sources disagree on `pull_request` events, where `GITHUB_REF_NAME`
-    // is `<number>/merge` while `GITHUB_HEAD_REF` is the head branch — so a PR
-    // from a `release/*` branch runs mocked but `getCiBranchName()` reports
-    // `release/…`. Selecting a baseline off the head branch there would compare
-    // a mocked run against the live series, which is the defect this whole
-    // change exists to remove. See the note on
-    // `getUserJourneyBenchmarkApiModeFromBranch`.
+    // The two agree today, but only because main.yml's `pull_request` trigger
+    // excludes base `stable`, so release branches arrive via `push`. Reading the
+    // same source the harness reads keeps that agreement a property of this call
+    // rather than of the trigger config.
     fetchHistoricalPerformanceDataFromMain(
       resolveBenchmarkMockMode(process.env.GITHUB_REF_NAME),
     ),

--- a/shared/constants/benchmarks.test.ts
+++ b/shared/constants/benchmarks.test.ts
@@ -1,0 +1,43 @@
+import { BENCHMARK_MOCK_MODE, resolveBenchmarkMockMode } from './benchmarks';
+
+describe('resolveBenchmarkMockMode', () => {
+  it('treats main as the live population', () => {
+    expect(resolveBenchmarkMockMode('main')).toBe(BENCHMARK_MOCK_MODE.LIVE);
+  });
+
+  it('treats release branches as the live population', () => {
+    expect(resolveBenchmarkMockMode('release/13.42.0')).toBe(
+      BENCHMARK_MOCK_MODE.LIVE,
+    );
+  });
+
+  it('treats pull request merge refs as the mocked population', () => {
+    // On `pull_request` events GITHUB_REF_NAME is `<number>/merge`, never the
+    // head branch name — the gate's enforcement hinges on this resolving to
+    // `mocked`.
+    expect(resolveBenchmarkMockMode('45147/merge')).toBe(
+      BENCHMARK_MOCK_MODE.MOCKED,
+    );
+  });
+
+  it('treats feature branches as the mocked population', () => {
+    expect(resolveBenchmarkMockMode('jongsun/ci/some-change')).toBe(
+      BENCHMARK_MOCK_MODE.MOCKED,
+    );
+  });
+
+  it('does not mistake a branch merely prefixed with main for main', () => {
+    expect(resolveBenchmarkMockMode('maintenance/cleanup')).toBe(
+      BENCHMARK_MOCK_MODE.MOCKED,
+    );
+  });
+
+  it('defaults to the mocked population when the branch is unset', () => {
+    // Local dev has no GITHUB_REF_NAME; mocked is both the safe default and
+    // what the harness already does there.
+    expect(resolveBenchmarkMockMode(undefined)).toBe(
+      BENCHMARK_MOCK_MODE.MOCKED,
+    );
+    expect(resolveBenchmarkMockMode('')).toBe(BENCHMARK_MOCK_MODE.MOCKED);
+  });
+});

--- a/shared/constants/benchmarks.ts
+++ b/shared/constants/benchmarks.ts
@@ -204,6 +204,47 @@ export const DEFAULT_RELATIVE_THRESHOLDS: RelativeThresholds = {
   warnPercent: 0.05,
 };
 
+/**
+ * Network population a benchmark run measured.
+ *
+ * `mocked` — upstream HTTP is served by the mock suite, so timings are a
+ * property of the commit under test. `live` — requests reach real servers,
+ * so timings also carry upstream latency, which is not attributable to the
+ * commit and drifts independently of it.
+ *
+ * The two are different statistical populations and must never be compared
+ * to each other, nor held to the same absolute ceiling.
+ */
+export const BENCHMARK_MOCK_MODE = {
+  MOCKED: 'mocked',
+  LIVE: 'live',
+} as const;
+
+export type BenchmarkMockMode =
+  (typeof BENCHMARK_MOCK_MODE)[keyof typeof BENCHMARK_MOCK_MODE];
+
+/**
+ * Resolves the network population for a run from its branch name.
+ *
+ * `main` and `release/*` exercise real servers (introduced by #39587 to keep
+ * a real-world signal on the trunk); every other ref — PRs, local dev — runs
+ * against the mock suite for determinism.
+ *
+ * Pure function of the branch name so both the benchmark harness and the
+ * quality gate can derive the same answer without sharing runtime state.
+ *
+ * @param branch - Branch name, e.g. `process.env.GITHUB_REF_NAME`.
+ */
+export function resolveBenchmarkMockMode(
+  branch: string | undefined,
+): BenchmarkMockMode {
+  const name = branch ?? '';
+  const isMainOrRelease = name === 'main' || name.startsWith('release/');
+  return isMainOrRelease
+    ? BENCHMARK_MOCK_MODE.LIVE
+    : BENCHMARK_MOCK_MODE.MOCKED;
+}
+
 export const BENCHMARK_PLATFORMS = {
   CHROME: 'chrome',
   FIREFOX: 'firefox',

--- a/test/e2e/benchmarks/utils/mock-config.ts
+++ b/test/e2e/benchmarks/utils/mock-config.ts
@@ -1,8 +1,26 @@
 import { Mockttp, MockedEndpoint } from 'mockttp';
 import {
+  BENCHMARK_MOCK_MODE,
+  resolveBenchmarkMockMode,
+  type BenchmarkMockMode,
+} from '../../../../shared/constants/benchmarks';
+import {
   mockBenchmarkEndpoints,
   userStorageHostMock,
 } from '../mocks/performance-mocks';
+
+/**
+ * Network population this run measures, derived from GITHUB_REF_NAME.
+ *
+ * Downstream consumers (the quality gate, the historical baseline) key off
+ * the same value so a `live` run's numbers are never gated against ceilings
+ * calibrated on `mocked` runs, nor used as their baseline.
+ *
+ * @returns The mock mode for the current branch.
+ */
+export function getBenchmarkMockMode(): BenchmarkMockMode {
+  return resolveBenchmarkMockMode(process.env.GITHUB_REF_NAME);
+}
 
 /**
  * Check if mocked requests should be used for performance benchmarks.
@@ -14,10 +32,7 @@ import {
  * @returns true if mocks should be used, false for real server requests
  */
 export function shouldUseMockedRequests(): boolean {
-  const branch = process.env.GITHUB_REF_NAME || '';
-  const isMainOrRelease = branch === 'main' || branch.startsWith('release/');
-  // Use real server (no mocks) only for main/release/* branches
-  return !isMainOrRelease;
+  return getBenchmarkMockMode() === BENCHMARK_MOCK_MODE.MOCKED;
 }
 
 /**


### PR DESCRIPTION
## **Changelog**

CHANGELOG entry: null

## **Description**

The benchmark harness measures **two different populations**. `main` and `release/*` run against real servers; every other ref runs against the mock suite — `shouldUseMockedRequests` in `test/e2e/benchmarks/utils/mock-config.ts`, introduced by #39587 to keep a real-world signal on the trunk. The quality gate applied one set of absolute ceilings to both, and the historical baseline blended them.

A live timing carries upstream latency that is not a property of the commit and drifts on its own, so a fixed ceiling over that series goes red and stays red. It did:

| metric (chrome) | ceiling | over ceiling on `main` |
|---|---:|---|
| `onboardingImportWallet.total` | 11050ms | **100%** of recorded runs since 2026-06-09 |
| `onboardingNewWallet.total` | 5460ms | **145 of 147** since 2026-07-17 |

Across the same window `onboardingImportWallet.doneButtonToHomeScreen` drifted 4.7s → 21.5s → 33.9s → 47.8s with no corresponding product change, and `openAccountMenuToAccountListLoaded` went 2.5s → 43.8s in a single day. Those are upstream latency, not regressions.

This also explains why #43961 did not move the numbers on `main`: its mocks live in `setupMocking`, and `main` takes the `setupMockingPassThrough` path, which sends every request to the live server. The fix was real but unreachable from the population it was expected to help.

**Two changes:**

- **Ceilings gate mocked runs only.** Live breaches are still measured and printed, as warnings, under a banner naming the population. The signal is kept; the blocking is not.
- **The baseline is never blended across populations.** Stats entries now record `mockMode`; `aggregateHistoricalData` selects only entries matching the consuming run. Entries predating the field default to `live` — which is what every one of them is, since only `main`/`release/*` publish stats.

`resolveBenchmarkMockMode` is a pure function of the branch name, so the harness and the gate cannot disagree, and `benchmark-stats-commit.sh` mirrors it.

### **Known tradeoff**

This leaves mocked runs **without historical deltas** until a mocked series is published, because the only publisher today is `main`, which is live. Reporting nothing is the correct state — the previous deltas compared a mocked measurement against a live baseline and so described upstream latency rather than the commit — but it is a visible loss in PR comments until the follow-up lands.

It also does **not** re-derive the ceilings. #42291 set the `total` values from Sentry 30-day production p75/p95, which is a third population again; that calibration needs redoing from CI data. Tracked in the follow-up issue.

## **Related issues**

Fixes: #45046

- #39587 — introduced the mocked/live split
- #42291 — set the current `total` ceilings from production Sentry data
- #43958 / #43961 — Solana discovery mocks (real fix, unreachable from `main`)

## **Manual testing steps**

1. `yarn jest shared/constants/benchmarks.test.ts development/metamaskbot-build-announce/`
2. Confirm the `run-benchmarks / quality-gate` job on this PR still **enforces** (mocked population) — a gated breach here should still fail.
3. After merge, confirm the next `main` push reports its breaches as warnings with `RESULT: PASS (ceilings not enforced)` rather than failing.

## **Screenshots/Recordings**

CI-only change with no user-visible surface; nothing to capture.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI quality-gate pass/fail behavior for main/release and how historical baselines are selected for PR comments. Well-covered by tests, but incorrect mode resolution would silently stop enforcing ceilings on PRs.
> 
> **Overview**
> Stops treating **live** (`main`/`release/*`) and **mocked** (PRs) benchmark timings as one population. Live runs include upstream latency that drifts independently of the commit, so fixed ceilings were failing permanently on trunk.
> 
> **Ceilings now gate mocked runs only.** `runComparison` takes a `mockMode`; live breaches are still measured and printed as warnings under an explanatory banner, but they no longer fail the gate.
> 
> **Baselines stay population-matched.** Stats commits record `mockMode`; aggregation filters to matching entries (legacy entries default to `live`). Shared `resolveBenchmarkMockMode` keeps the harness, gate, and stats publisher aligned on the same branch-derived answer.
> 
> Tradeoff: mocked PR runs lose historical deltas until a mocked series is published, since today only live trunk publishes stats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 338de4366f5d60005f25f6059330a662ad5744e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
