### PR TITLE
fix: patch smart-transactions-controller to add the tx-sentinel robinhood URL cp-13.43.0

### DIFF
--- a/.yarn/patches/@metamask-smart-transactions-controller-npm-25.0.0-3afc599382.patch
+++ b/.yarn/patches/@metamask-smart-transactions-controller-npm-25.0.0-3afc599382.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/constants.cjs b/dist/constants.cjs
+index 6e2f2c9b7653662de038e16bc4a9af4baf98f1f4..0adcf007d9473851821d2bed8522ada4745bfecd 100644
+--- a/dist/constants.cjs
++++ b/dist/constants.cjs
+@@ -7,6 +7,7 @@ exports.SENTINEL_API_BASE_URL_MAP = {
+     1: 'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io',
+     56: 'https://tx-sentinel-bsc-mainnet.api.cx.metamask.io',
+     137: 'https://tx-sentinel-polygon-mainnet.api.cx.metamask.io',
++    4663: 'https://tx-sentinel-robinhood-mainnet.api.cx.metamask.io',
+     8453: 'https://tx-sentinel-base-mainnet.api.cx.metamask.io',
+     42161: 'https://tx-sentinel-arbitrum-mainnet.api.cx.metamask.io',
+     59144: 'https://tx-sentinel-linea-mainnet.api.cx.metamask.io',
+diff --git a/dist/constants.mjs b/dist/constants.mjs
+index 3d615196ef851a2ed20e5637f19b36bb00b32423..eb7e5aa3ea6b93ad2503522a81d8cff41433db0d 100644
+--- a/dist/constants.mjs
++++ b/dist/constants.mjs
+@@ -4,6 +4,7 @@ export const SENTINEL_API_BASE_URL_MAP = {
+     1: 'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io',
+     56: 'https://tx-sentinel-bsc-mainnet.api.cx.metamask.io',
+     137: 'https://tx-sentinel-polygon-mainnet.api.cx.metamask.io',
++    4663: 'https://tx-sentinel-robinhood-mainnet.api.cx.metamask.io',
+     8453: 'https://tx-sentinel-base-mainnet.api.cx.metamask.io',
+     42161: 'https://tx-sentinel-arbitrum-mainnet.api.cx.metamask.io',
+     59144: 'https://tx-sentinel-linea-mainnet.api.cx.metamask.io',

--- a/package.json
+++ b/package.json
@@ -462,7 +462,7 @@
     "@metamask/sentinel-api-service": "^1.0.0",
     "@metamask/shield-controller": "^5.1.2",
     "@metamask/signature-controller": "^39.2.6",
-    "@metamask/smart-transactions-controller": "25.0.0",
+    "@metamask/smart-transactions-controller": "patch:@metamask/smart-transactions-controller@npm%3A25.0.0#~/.yarn/patches/@metamask-smart-transactions-controller-npm-25.0.0-3afc599382.patch",
     "@metamask/snap-account-service": "^2.1.1",
     "@metamask/snaps-controllers": "^21.0.0",
     "@metamask/snaps-execution-environments": "^11.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8048,6 +8048,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/smart-transactions-controller@patch:@metamask/smart-transactions-controller@npm%3A25.0.0#~/.yarn/patches/@metamask-smart-transactions-controller-npm-25.0.0-3afc599382.patch":
+  version: 25.0.0
+  resolution: "@metamask/smart-transactions-controller@patch:@metamask/smart-transactions-controller@npm%3A25.0.0#~/.yarn/patches/@metamask-smart-transactions-controller-npm-25.0.0-3afc599382.patch::version=25.0.0&hash=7f8f78"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.9"
+    "@ethersproject/bytes": "npm:^5.7.0"
+    "@ethersproject/keccak256": "npm:^5.8.0"
+    "@ethersproject/transactions": "npm:^5.7.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/network-controller": "npm:^34.0.0"
+    "@metamask/polling-controller": "npm:^16.0.8"
+    "@metamask/profile-sync-controller": "npm:^28.2.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/transaction-controller": "npm:^68.3.0"
+    "@metamask/utils": "npm:^11.11.0"
+    bignumber.js: "npm:^9.1.2"
+    lodash: "npm:^4.17.21"
+    reselect: "npm:^5.1.1"
+  checksum: 10/1e210a79c3bbfcf10cc2d7da4425635be5505080b93de2b8ae511bf4a4f96700044cf2da7373a8e5cbdc5cdf614fba82e35312948194560ffdf55a688252d82a
+  languageName: node
+  linkType: hard
+
 "@metamask/snap-account-abstraction-keyring-site@npm:^1.0.0":
   version: 1.0.0
   resolution: "@metamask/snap-account-abstraction-keyring-site@npm:1.0.0"
@@ -32905,7 +32932,7 @@ __metadata:
     "@metamask/shield-controller": "npm:^5.1.2"
     "@metamask/signature-controller": "npm:^39.2.6"
     "@metamask/skills": "npm:^0.1.0"
-    "@metamask/smart-transactions-controller": "npm:25.0.0"
+    "@metamask/smart-transactions-controller": "patch:@metamask/smart-transactions-controller@npm%3A25.0.0#~/.yarn/patches/@metamask-smart-transactions-controller-npm-25.0.0-3afc599382.patch"
     "@metamask/snap-account-abstraction-keyring-site": "npm:^1.0.0"
     "@metamask/snap-account-service": "npm:^2.1.1"
     "@metamask/snap-simple-keyring-site": "npm:^2.1.1"


### PR DESCRIPTION
The URL is missing in the package for STX to be enabled on 13.43.0. The package update is currently being released https://github.com/MetaMask/core/pull/9784 and the package will be bumped in the next client release

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single map entry in a vendored dependency patch; no app logic changes, same pattern as existing chain sentinel URLs.
> 
> **Overview**
> **Hotfixes Smart Transactions on Robinhood Chain (4663)** for 13.43.0 by patching `@metamask/smart-transactions-controller@25.0.0` instead of waiting on an upstream package release.
> 
> The Yarn patch extends `SENTINEL_API_BASE_URL_MAP` in the controller’s built `constants` (CJS and ESM) with `4663` → `https://tx-sentinel-robinhood-mainnet.api.cx.metamask.io`, matching how other chains map to MetaMask tx-sentinel hosts. **`package.json`** and **`yarn.lock`** now resolve the dependency through that patch path.
> 
> This is intended as a short-lived client-side workaround until the fix lands in `@metamask/core` and the extension bumps the unpinned package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c8d78bf176b6b14918d8589c7ce420923dee13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->