### PR TITLE
test: fix flaky Notification Preferences Sections persists section in-app notification preferences to authenticated user storage

### DIFF
--- a/test/e2e/tests/notifications/notification-preferences-sections.spec.ts
+++ b/test/e2e/tests/notifications/notification-preferences-sections.spec.ts
@@ -8,6 +8,7 @@ import { withFixtures } from '../../helpers';
 import { getProductionRemoteFlagApiResponse } from '../../feature-flags';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { goToNotificationsSettingsPage } from '../../page-objects/flows/notifications.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 import NotificationsSettingsPage from '../../page-objects/pages/settings/notifications-settings-page';
 import { MockttpNotificationTriggerServer } from '../../helpers/notifications/mock-notification-trigger-server';
 import { mockNotificationServices } from './mocks';
@@ -91,7 +92,12 @@ describe('Notification Preferences Sections', function () {
         // Re-open Settings > Notifications from a fresh (locked then unlocked)
         // session so the preferences are re-fetched from authenticated user
         // storage rather than read from in-memory state.
-        await driver.navigate();
+        //
+        // Leave Settings through the UI instead of reloading the page: a reload
+        // restarts authentication, user storage and notification fetches, and
+        // `setLocked` then queues behind that work in the background for longer
+        // than the unlock page wait allows.
+        await closeSettings(driver);
         await lockAndWaitForLoginPage(driver);
         await login(driver);
         await goToNotificationsSettingsPage(driver);

--- a/test/e2e/tests/notifications/notification-preferences-sections.spec.ts
+++ b/test/e2e/tests/notifications/notification-preferences-sections.spec.ts
@@ -89,14 +89,13 @@ describe('Notification Preferences Sections', function () {
           expectedState === 'enabled',
         );
 
-        // Re-open Settings > Notifications from a fresh (locked then unlocked)
-        // session so the preferences are re-fetched from authenticated user
-        // storage rather than read from in-memory state.
+        // Lock and unlock so the notifications controller re-authenticates and
+        // re-fetches preferences from user storage on unlock, ensuring the final
+        // assertion reads persisted state rather than the in-memory toggle value.
         //
-        // Leave Settings through the UI instead of reloading the page: a reload
-        // restarts authentication, user storage and notification fetches, and
-        // `setLocked` then queues behind that work in the background for longer
-        // than the unlock page wait allows.
+        // Exit Settings via the UI rather than a page reload: a reload triggers
+        // the same fetches, keeping the background busy when setLocked fires and
+        // causing the unlock-page wait to time out.
         await closeSettings(driver);
         await lockAndWaitForLoginPage(driver);
         await login(driver);


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The test is flaky and fails in CI with error `TimeoutError: Waiting for element to be located By(css selector, [data-testid="unlock-forgot-password-button"]`

CI logs [here](https://github.com/MetaMask/metamask-extension/actions/runs/30958161638/job/92157008631)

`driver.navigate()` before the lock step reloads the extension page, triggering a full background re-init (auth, user-storage, subscriptions). `setLocked` then queues behind all that work and never resolves within the 10-second timeout.

Replaced `driver.navigate() `with `closeSettings(driver)`, which exits Settings via the UI back button: no reload, background stays idle, lock transition is instant.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check CI

## **Screenshots/Recordings**

<img width="780" height="493" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/61d1b32c-f27b-4a54-954d-fc9bc44007c6" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code impact.
> 
> **Overview**
> Fixes CI flakiness in the notification preferences persistence e2e test where **`lockAndWaitForLoginPage`** timed out waiting for the unlock screen.
> 
> The lock/unlock step still validates that toggled preferences survive a fresh authenticated session, but the test now calls **`closeSettings(driver)`** instead of **`driver.navigate()`** before locking. A full page reload was kicking off heavy background work (auth, user-storage, subscriptions) so **`setLocked`** could not finish within the 10s wait; exiting Settings through the UI avoids that reload and keeps the background idle for a reliable lock transition.
> 
> Comments in the spec were updated to document this rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 535f0675eceaa6c9443f330ba07560c04832a4d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->