### PR TITLE
fix: resolve ip-address to >=10.3.1 for yarn audit cp-13.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "@grpc/grpc-js": "^1.9.16",
     "@metamask/network-controller": "34.0.0",
     "follow-redirects": "^1.16.0",
+    "ip-address": "^10.3.1",
     "@unrs/resolver-binding-wasm32-wasi": "npm:npm-empty-package@1.0.0",
     "jest-clean-console-reporter/chalk": "^4.1.2",
     "napi-postinstall": "npm:npm-empty-package@1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29174,10 +29174,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10/12fec399e1af5753ac322e47a6d81a50d3a528b3abb17c09525b2a2edcaedcca628c40520706f7037bc4d8e951b0296c47e7b86d0a8e6e2335c8f0ba4afcfac1
+"ip-address@npm:^10.3.1":
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 10/8a286dd112a88c372b10c706caca14dcf5ed029a11c3911062ad8937ca0f951aa513ecacf82e15ffcf6343749ae6c079dd9741282fc94033a06ff1b7bd6ce69a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->


Adds resolution for `ip-address@^10.3.1` to fix 3 yarn audit advisories: 
                                                                           
  - GHSA-mwp4-54f8-5fhr (HIGH)                                             
  - GHSA-4xrf-jv44-h6hh (MODERATE)                                         
  - GHSA-22jq-vg5j-6vgg (MODERATE)        

Failure: https://github.com/MetaMask/metamask-extension/actions/runs/30963484287/job/92172879892
[Slack thread ](https://consensys.slack.com/archives/C0BLWRC2TRB/p1785924452227219?thread_ts=1785892716.329899&cid=C0BLWRC2TRB)                                
                                                                           
  Dependency chain: `socks` → `ip-address@10.2.0` (vulnerable)             
                                                                           
  Cherry-pick to `release/13.43.0` required.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: #45163

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->
N/A
### **Before**

<!-- [screenshots/recordings] -->
N/A
### **After**

<!-- [screenshots/recordings] -->
N/A
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only security bump with no runtime code changes; risk is limited to behavior differences in the patched `ip-address` library used by SOCKS-related tooling.
> 
> **Overview**
> Adds a Yarn **`resolutions`** entry for **`ip-address@^10.3.1`**, forcing the lockfile from **10.2.0** to **10.4.0** so **`yarn audit`** clears three advisories on the transitive copy pulled in via **`socks`**.
> 
> No application or extension source changes—only **`package.json`** and **`yarn.lock`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ecc011a4ae6175f5fea906401a9284d7d5b881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->