### PR TITLE
perf(7476): apply useTransition for account and network switching

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -52,6 +52,7 @@ import {
 import ImportControl from '../import-control';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useAnalytics } from '../../../../../hooks/useAnalytics';
+import { useBoolean } from '../../../../../hooks/useBoolean';
 import { TEST_CHAINS } from '../../../../../../shared/constants/network';
 import {
   MetaMetricsEventCategory,
@@ -164,6 +165,8 @@ const AssetListControlBar = ({
   const tokenNetworkFilter = useSelector(getTokenNetworkFilter);
   const [isNetworkFilterModalOpen, setIsNetworkFilterModalOpen] =
     useState(false);
+  const { value: isNetworkSwitchPending, setValue: setIsNetworkSwitchPending } =
+    useBoolean();
   const [isTokenSortPopoverOpen, setIsTokenSortPopoverOpen] = useState(false);
   const [isImportTokensPopoverOpen, setIsImportTokensPopoverOpen] =
     useState(false);
@@ -395,6 +398,8 @@ const AssetListControlBar = ({
           size={ButtonBaseSize.Sm}
           startIconName={IconName.Filter}
           startIconProps={{ marginInlineEnd: 1, size: IconSize.Md }}
+          loading={isNetworkSwitchPending}
+          disabled={isNetworkSwitchPending}
           backgroundColor={
             isNetworkFilterModalOpen
               ? BackgroundColor.backgroundPressed
@@ -494,6 +499,7 @@ const AssetListControlBar = ({
         <HomeNetworkFilterModal
           isOpen={isNetworkFilterModalOpen}
           onClose={closePopover}
+          onPendingChange={setIsNetworkSwitchPending}
         />
       )}
 

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { EthScope, isEvmAccountType } from '@metamask/keyring-api';
@@ -77,6 +77,7 @@ import { useDispatch } from '../../../../../store/hooks';
 type HomeNetworkFilterModalProps = {
   isOpen: boolean;
   onClose: () => void;
+  onPendingChange?: (isPending: boolean) => void;
 };
 
 type NetworkRowProps = {
@@ -342,8 +343,10 @@ export const NetworkSelectionModal = ({
 
 const HomeNetworkFilterModalContent = ({
   onClose,
+  onPendingChange,
 }: {
   onClose: () => void;
+  onPendingChange?: (isPending: boolean) => void;
 }) => {
   const t = useI18nContext();
   const dispatch = useDispatch();
@@ -385,7 +388,15 @@ const HomeNetworkFilterModalContent = ({
       );
     },
   );
-  const { handleNetworkChange } = useNetworkChangeHandlers();
+  const { handleNetworkChange, isPending } = useNetworkChangeHandlers();
+
+  useEffect(() => {
+    onPendingChange?.(isPending);
+    return () => {
+      onPendingChange?.(false);
+    };
+  }, [isPending, onPendingChange]);
+
   const {
     nonTestNetworks: allDefaultNetworkMap,
     isNetworkInDefaultNetworkTab,
@@ -492,10 +503,13 @@ const HomeNetworkFilterModalContent = ({
 
   const handleSelectNetwork = useCallback(
     async (chainId: CaipChainId) => {
+      if (isPending) {
+        return;
+      }
       await handleNetworkChange(chainId);
       onClose();
     },
-    [handleNetworkChange, onClose],
+    [handleNetworkChange, isPending, onClose],
   );
 
   const handleAddNetwork = useCallback(
@@ -519,7 +533,7 @@ const HomeNetworkFilterModalContent = ({
         key: 'default-networks',
         title: hasOnlyDefaultNetworks ? undefined : t('defaultNetworks'),
         items: defaultNetworks.map((network) => ({
-          disabled: isNetworkDisabled(network),
+          disabled: isPending || isNetworkDisabled(network),
           key: network.chainId,
           name: network.name,
           iconSrc: getNetworkIcon(network),
@@ -537,7 +551,7 @@ const HomeNetworkFilterModalContent = ({
         key: 'custom-networks',
         title: t('customNetworks'),
         items: customNetworks.map((network) => ({
-          disabled: isNetworkDisabled(network),
+          disabled: isPending || isNetworkDisabled(network),
           key: network.chainId,
           name: network.name,
           iconSrc: getNetworkIcon(network),
@@ -555,7 +569,7 @@ const HomeNetworkFilterModalContent = ({
         key: 'test-networks',
         title: t('testnets'),
         items: testNetworks.map((network) => ({
-          disabled: isNetworkDisabled(network),
+          disabled: isPending || isNetworkDisabled(network),
           key: network.chainId,
           name: network.name,
           iconSrc: getNetworkIcon(network),
@@ -574,8 +588,9 @@ const HomeNetworkFilterModalContent = ({
         title: t('additionalNetworks'),
         items: additionalNetworks.map((network) => {
           const disabled =
-            !isEvmChainId(network.chainId as CaipChainId) &&
-            isEvmOnlySelectedAccountGroup;
+            isPending ||
+            (!isEvmChainId(network.chainId as CaipChainId) &&
+              isEvmOnlySelectedAccountGroup);
 
           return {
             key: network.chainId,
@@ -607,6 +622,7 @@ const HomeNetworkFilterModalContent = ({
     isEvmOnlySelectedAccountGroup,
     isNetworkDisabled,
     isNetworkSelected,
+    isPending,
     showTestnets,
     t,
     testNetworks,
@@ -641,6 +657,12 @@ const HomeNetworkFilterModalContent = ({
 export const HomeNetworkFilterModal = ({
   isOpen,
   onClose,
+  onPendingChange,
 }: HomeNetworkFilterModalProps) => {
-  return isOpen ? <HomeNetworkFilterModalContent onClose={onClose} /> : null;
+  return isOpen ? (
+    <HomeNetworkFilterModalContent
+      onClose={onClose}
+      onPendingChange={onPendingChange}
+    />
+  ) : null;
 };

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -509,14 +509,12 @@ const HomeNetworkFilterModalContent = ({
       if (isPending) {
         return;
       }
-      // Own parent pending here so the filter button stays loading for the full
-      // awaited switch, including after this modal content unmounts on close.
       onPendingChange?.(true);
+      onClose();
       try {
         await handleNetworkChange(chainId);
       } finally {
         onPendingChange?.(false);
-        onClose();
       }
     },
     [handleNetworkChange, isPending, onClose, onPendingChange],

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { EthScope, isEvmAccountType } from '@metamask/keyring-api';
@@ -390,12 +390,12 @@ const HomeNetworkFilterModalContent = ({
   );
   const { handleNetworkChange, isPending } = useNetworkChangeHandlers();
 
-  useEffect(() => {
-    onPendingChange?.(isPending);
-    return () => {
-      onPendingChange?.(false);
-    };
-  }, [isPending, onPendingChange]);
+  const handleClose = useCallback(() => {
+    if (isPending) {
+      return;
+    }
+    onClose();
+  }, [isPending, onClose]);
 
   const {
     nonTestNetworks: allDefaultNetworkMap,
@@ -497,27 +497,40 @@ const HomeNetworkFilterModalContent = ({
   }, [blacklistedChainIds, evmNetworks, useExternalServices]);
 
   const handleSelectAllDefaultNetworks = useCallback(() => {
+    if (isPending) {
+      return;
+    }
     dispatch(setEnabledAllPopularNetworks());
     onClose();
-  }, [dispatch, onClose]);
+  }, [dispatch, isPending, onClose]);
 
   const handleSelectNetwork = useCallback(
     async (chainId: CaipChainId) => {
       if (isPending) {
         return;
       }
-      await handleNetworkChange(chainId);
-      onClose();
+      // Own parent pending here so the filter button stays loading for the full
+      // awaited switch, including after this modal content unmounts on close.
+      onPendingChange?.(true);
+      try {
+        await handleNetworkChange(chainId);
+      } finally {
+        onPendingChange?.(false);
+        onClose();
+      }
     },
-    [handleNetworkChange, isPending, onClose],
+    [handleNetworkChange, isPending, onClose, onPendingChange],
   );
 
   const handleAddNetwork = useCallback(
     async (network: AddNetworkFields) => {
+      if (isPending) {
+        return;
+      }
       await dispatch(addNetwork(network));
       onClose();
     },
-    [dispatch, onClose],
+    [dispatch, isPending, onClose],
   );
 
   const handleManageNetworks = useCallback(() => {
@@ -631,7 +644,7 @@ const HomeNetworkFilterModalContent = ({
   return (
     <NetworkSelectionModal
       isOpen
-      onClose={onClose}
+      onClose={handleClose}
       title={t('bridgeSelectNetwork')}
       topItem={{
         key: 'all-default-networks',

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
@@ -66,6 +66,27 @@ describe('MultichainAccountCell', () => {
     expect(cellElement).toHaveClass('is-selected');
   });
 
+  it('ignores clicks and shows pending styling when pending is true', () => {
+    const handleClick = jest.fn();
+    renderWithProvider(
+      <MultichainAccountCell
+        {...defaultProps}
+        onClick={handleClick}
+        pending={true}
+      />,
+      store,
+    );
+
+    const cellElement = screen.getByTestId(
+      `multichain-account-cell-${defaultProps.accountId}`,
+    );
+
+    expect(cellElement).toHaveClass('is-pending');
+    expect(cellElement).toHaveAttribute('aria-busy', 'true');
+    fireEvent.click(cellElement);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
   it('handles click events and applies pointer cursor when onClick is provided', () => {
     const handleClick = jest.fn();
     renderWithProvider(

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
@@ -83,6 +83,7 @@ describe('MultichainAccountCell', () => {
 
     expect(cellElement).toHaveClass('is-pending');
     expect(cellElement).toHaveAttribute('aria-busy', 'true');
+    expect(cellElement.style.cursor).toBe('wait');
     fireEvent.click(cellElement);
     expect(handleClick).not.toHaveBeenCalled();
   });

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -72,6 +72,11 @@ export type MultichainAccountCellProps = {
     | typeof STATUS_CONNECTED_TO_ANOTHER_ACCOUNT;
   privacyMode?: boolean;
   showDefaultAddress?: boolean;
+  /**
+   * When true, the cell ignores clicks and shows reduced opacity so the user
+   * sees that an account switch is in progress (React useTransition pending).
+   */
+  pending?: boolean;
 };
 
 export const MultichainAccountCell = ({
@@ -88,8 +93,21 @@ export const MultichainAccountCell = ({
   connectionStatus,
   privacyMode = false,
   showDefaultAddress = false,
+  pending = false,
 }: MultichainAccountCellProps) => {
-  const handleClick = () => onClick?.(accountId);
+  const handleClick = () => {
+    if (pending) {
+      return;
+    }
+    onClick?.(accountId);
+  };
+
+  let cursor: React.CSSProperties['cursor'] = 'default';
+  if (pending) {
+    cursor = 'wait';
+  } else if (onClick) {
+    cursor = 'pointer';
+  }
 
   // Use accountNameString for aria-label, or fallback to accountName if it's a string
   const ariaLabelName =
@@ -105,15 +123,18 @@ export const MultichainAccountCell = ({
       alignItems={BoxAlignItems.Center}
       justifyContent={BoxJustifyContent.Between}
       style={{
-        cursor: onClick ? 'pointer' : 'default',
+        cursor,
         position: 'relative',
+        opacity: pending ? 0.6 : undefined,
+        pointerEvents: pending ? 'none' : undefined,
       }}
       padding={4}
       gap={4}
       onClick={handleClick}
-      className={`multichain-account-cell${disableHoverEffect ? ' multichain-account-cell--no-hover' : ''}${selected && !startAccessory ? ' is-selected' : ''}`}
+      className={`multichain-account-cell${disableHoverEffect ? ' multichain-account-cell--no-hover' : ''}${selected && !startAccessory ? ' is-selected' : ''}${pending ? ' is-pending' : ''}`}
       data-testid={`multichain-account-cell-${accountId}`}
       key={`multichain-account-cell-${accountId}`}
+      aria-busy={pending || undefined}
       backgroundColor={
         selected && !startAccessory
           ? BoxBackgroundColor.BackgroundMuted

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -126,7 +126,6 @@ export const MultichainAccountCell = ({
         cursor,
         position: 'relative',
         opacity: pending ? 0.6 : undefined,
-        pointerEvents: pending ? 'none' : undefined,
       }}
       padding={4}
       gap={4}

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -238,7 +238,7 @@ describe('MultichainAccountList', () => {
     expect(screen.getByText('Account 1 from wallet 2')).toBeInTheDocument();
   });
 
-  it('marks only the selected account with a check icon and dispatches action on click', () => {
+  it('marks only the selected account with a check icon and dispatches action on click', async () => {
     renderComponent();
 
     // With default props, checkboxes should not be shown (showAccountCheckbox defaults to false)
@@ -256,13 +256,34 @@ describe('MultichainAccountList', () => {
     const accountCell = screen.getByTestId(
       `multichain-account-cell-${walletTwoGroupId}`,
     );
-    accountCell.click();
+    // useTransition schedules pending-state updates that must flush inside act
+    await act(async () => {
+      fireEvent.click(accountCell);
+    });
 
     // Verify that the action was dispatched with the correct account group ID
     expect(mockSetSelectedMultichainAccount).toHaveBeenCalledWith(
       walletTwoGroupId,
     );
     expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+  });
+
+  it('does not wrap custom handleAccountClick in the default switch transition gate', async () => {
+    const customHandleAccountClick = jest.fn();
+    renderComponent({
+      handleAccountClick: customHandleAccountClick,
+    });
+
+    const accountCell = screen.getByTestId(
+      `multichain-account-cell-${walletTwoGroupId}`,
+    );
+    await act(async () => {
+      fireEvent.click(accountCell);
+    });
+
+    expect(customHandleAccountClick).toHaveBeenCalledWith(walletTwoGroupId);
+    expect(mockSetSelectedMultichainAccount).not.toHaveBeenCalled();
+    expect(mockUseNavigate).not.toHaveBeenCalled();
   });
 
   it('updates selected account when selectedAccountGroup changes', () => {

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -4,6 +4,7 @@ import React, {
   useEffect,
   useMemo,
   useState,
+  useTransition,
 } from 'react';
 
 import {
@@ -113,6 +114,7 @@ export const MultichainAccountList = ({
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const [isPending, startTransition] = useTransition();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const t = useI18nContext();
   const defaultHomeActiveTabName: AccountOverviewTabKey = useSelector(
@@ -258,8 +260,11 @@ export const MultichainAccountList = ({
         ],
       });
 
-      dispatch(setSelectedMultichainAccount(accountGroupId));
-      navigate(DEFAULT_ROUTE);
+      // Defer expensive Home/Routes re-renders so the account list shell stays responsive.
+      startTransition(() => {
+        dispatch(setSelectedMultichainAccount(accountGroupId));
+        navigate(DEFAULT_ROUTE);
+      });
     },
     [
       trackEvent,
@@ -268,16 +273,23 @@ export const MultichainAccountList = ({
       defaultHomeActiveTabName,
       dispatch,
       navigate,
+      startTransition,
     ],
   );
 
   const handleAccountClickToUse = useCallback(
     (accountGroupId: AccountGroupId) => {
+      // Only gate the default switch path; custom handlers own their own pending UX.
+      if (isPending && !handleAccountClick) {
+        return;
+      }
       const handlerToUse = handleAccountClick ?? defaultHandleAccountClick;
       handlerToUse?.(accountGroupId);
     },
-    [handleAccountClick, defaultHandleAccountClick],
+    [handleAccountClick, defaultHandleAccountClick, isPending],
   );
+
+  const isSwitchPending = isPending && !handleAccountClick;
 
   const renderAccountCell = useCallback(
     (
@@ -321,6 +333,7 @@ export const MultichainAccountList = ({
             balance={formatCurrencyWithMinThreshold(balance, currency)}
             selected={selectedAccountGroupsSet.has(groupId as AccountGroupId)}
             onClick={handleAccountClickToUse}
+            pending={isSwitchPending}
             connectionStatus={
               connectedStatus as
                 | typeof STATUS_CONNECTED
@@ -342,6 +355,7 @@ export const MultichainAccountList = ({
                     isSelected={selectedAccountGroupsSet.has(
                       groupId as AccountGroupId,
                     )}
+                    isDisabled={isSwitchPending}
                     onChange={() => {
                       handleAccountClickToUse(groupId as AccountGroupId);
                     }}
@@ -371,6 +385,7 @@ export const MultichainAccountList = ({
       showConnectionStatus,
       selectedAccountGroupsSet,
       handleAccountClickToUse,
+      isSwitchPending,
       privacyMode,
       showAccountCheckbox,
       wallets,

--- a/ui/components/multichain/network-manager/components/custom-networks/custom-networks.tsx
+++ b/ui/components/multichain/network-manager/components/custom-networks/custom-networks.tsx
@@ -55,7 +55,7 @@ export const CustomNetworks = React.memo(() => {
 
   const { getItemCallbacks, hasMultiRpcOptions, isNetworkEnabled } =
     useNetworkItemCallbacks();
-  const { handleNetworkChange } = useNetworkChangeHandlers();
+  const { handleNetworkChange, isPending } = useNetworkChangeHandlers();
 
   const isEvmNetworkSelected = useSelector(getMultichainIsEvm);
 
@@ -74,10 +74,13 @@ export const CustomNetworks = React.memo(() => {
   // Memoize the network click handler
   const handleNetworkClick = useCallback(
     async (chainId: MultichainNetworkConfiguration['chainId']) => {
+      if (isPending) {
+        return;
+      }
       await handleNetworkChange(chainId);
       await dispatch(hideModal());
     },
-    [dispatch, handleNetworkChange],
+    [dispatch, handleNetworkChange, isPending],
   );
 
   // Renders a network in the network list
@@ -119,7 +122,7 @@ export const CustomNetworks = React.memo(() => {
           onDiscoverClick={onDiscoverClick}
           selected={isEnabled}
           onRpcEndpointClick={onRpcSelect}
-          disabled={!isNetworkEnabled(network)}
+          disabled={isPending || !isNetworkEnabled(network)}
         />
       );
     },
@@ -130,6 +133,7 @@ export const CustomNetworks = React.memo(() => {
       evmNetworks,
       isNetworkEnabled,
       handleNetworkClick,
+      isPending,
     ],
   );
 

--- a/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
+++ b/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
@@ -137,7 +137,8 @@ const DefaultNetworks = memo(() => {
   const { getItemCallbacks, hasMultiRpcOptions } = useNetworkItemCallbacks();
 
   // Use the shared network change handlers hook
-  const { handleNetworkChange } = useNetworkChangeHandlers();
+  const { handleNetworkChange, isPending, startTransition } =
+    useNetworkChangeHandlers();
 
   const isEvmNetworkSelected = useSelector(getMultichainIsEvm);
 
@@ -264,11 +265,10 @@ const DefaultNetworks = memo(() => {
 
     dispatch(setEnabledAllPopularNetworks());
     dispatch(hideModal());
-    // deferring execution to keep select all unblocked
-    setTimeout(() => {
+    startTransition(() => {
       dispatch(setActiveNetwork(finalNetworkClientId));
-    }, 0);
-  }, [dispatch, evmNetworks, orderedNetworks]);
+    });
+  }, [dispatch, evmNetworks, orderedNetworks, startTransition]);
 
   // Memoize the network change handler to avoid recreation
   const handleNetworkChangeCallback = useCallback(
@@ -363,6 +363,9 @@ const DefaultNetworks = memo(() => {
           onDiscoverClick={onDiscoverClick}
           onRpcEndpointClick={onRpcSelect}
           selected={isSelected}
+          // Last-remaining stays clickable so the modal can still close; the
+          // switch itself is no-op'd in handleNetworkChangeCallback.
+          disabled={isPending}
         />
       );
     });
@@ -382,6 +385,7 @@ const DefaultNetworks = memo(() => {
     enabledChainIds,
     useExternalServices,
     selectedNonEvmChainId,
+    isPending,
   ]);
 
   // Memoize the additional network list items

--- a/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
+++ b/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
@@ -365,7 +365,7 @@ const DefaultNetworks = memo(() => {
           selected={isSelected}
           // Last-remaining stays clickable so the modal can still close; the
           // switch itself is no-op'd in handleNetworkChangeCallback.
-          disabled={isPending}
+          disabled={isPending && !isLastRemainingNetwork}
         />
       );
     });

--- a/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.test.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.test.ts
@@ -1,0 +1,150 @@
+import { renderHook, act } from '@testing-library/react';
+import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import {
+  setActiveNetwork,
+  setEnabledNetworks,
+} from '../../../../store/actions';
+import { useNetworkChangeHandlers } from './useNetworkChangeHandlers';
+
+const mockDispatch = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockCreateEventBuilder = jest.fn(() => ({
+  addCategory: jest.fn().mockReturnThis(),
+  addProperties: jest.fn().mockReturnThis(),
+  build: jest.fn().mockReturnValue({ event: 'NavNetworkSwitched' }),
+}));
+
+const mockMainnetCaip = toEvmCaipChainId(CHAIN_IDS.MAINNET);
+const mockLineaCaip = toEvmCaipChainId(CHAIN_IDS.LINEA_MAINNET);
+
+jest.mock('../../../../store/hooks', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+jest.mock('../../../../hooks/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+jest.mock('../../../../store/actions', () => ({
+  detectNfts: jest.fn(() => ({ type: 'DETECT_NFTS' })),
+  setActiveNetwork: jest.fn((id: string) => ({
+    type: 'SET_ACTIVE_NETWORK',
+    id,
+  })),
+  setEnabledNetworks: jest.fn((chainId: string) => ({
+    type: 'SET_ENABLED_NETWORKS',
+    chainId,
+  })),
+  setNextNonce: jest.fn(() => ({ type: 'SET_NEXT_NONCE' })),
+  updateCustomNonce: jest.fn(() => ({ type: 'UPDATE_CUSTOM_NONCE' })),
+}));
+
+jest.mock('../../../../selectors', () => {
+  const { CHAIN_IDS: mockChainIds } = jest.requireActual(
+    '../../../../../shared/constants/network',
+  );
+  const { toEvmCaipChainId: mockToEvmCaipChainId } = jest.requireActual(
+    '@metamask/multichain-network-controller',
+  );
+  const mainnetCaip = mockToEvmCaipChainId(mockChainIds.MAINNET);
+  const lineaCaip = mockToEvmCaipChainId(mockChainIds.LINEA_MAINNET);
+
+  return {
+    getAllChainsToPoll: () => [],
+    getEnabledNetworksByNamespace: () => ({}),
+    getSelectedMultichainNetworkChainId: () => mainnetCaip,
+    getMultichainNetworkConfigurationsByChainId: () => [
+      {
+        [mainnetCaip]: {
+          chainId: mainnetCaip,
+          name: 'Ethereum',
+          isEvm: true,
+        },
+        [lineaCaip]: {
+          chainId: lineaCaip,
+          name: 'Linea',
+          isEvm: true,
+        },
+      },
+      {
+        [mainnetCaip]: {
+          chainId: mockChainIds.MAINNET,
+          defaultRpcEndpointIndex: 0,
+          rpcEndpoints: [
+            {
+              networkClientId: 'mainnet',
+              url: 'https://mainnet.infura.io',
+            },
+          ],
+        },
+        [lineaCaip]: {
+          chainId: mockChainIds.LINEA_MAINNET,
+          defaultRpcEndpointIndex: 0,
+          rpcEndpoints: [
+            {
+              networkClientId: 'linea-mainnet',
+              url: 'https://linea.infura.io',
+            },
+          ],
+        },
+      },
+    ],
+  };
+});
+
+jest.mock('../../../../../shared/lib/network.utils', () => ({
+  ...jest.requireActual('../../../../../shared/lib/network.utils'),
+  getRpcDataByChainId: (
+    chainId: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    evmNetworks: Record<string, any>,
+  ) => ({
+    defaultRpcEndpoint: evmNetworks[chainId].rpcEndpoints[0],
+  }),
+}));
+
+describe('useNetworkChangeHandlers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('dispatches enabled + active network updates for EVM switches', async () => {
+    const { result } = renderHook(() => useNetworkChangeHandlers());
+
+    await act(async () => {
+      await result.current.handleNetworkChange(mockLineaCaip);
+    });
+
+    expect(setEnabledNetworks).toHaveBeenCalledWith(CHAIN_IDS.LINEA_MAINNET);
+    expect(setActiveNetwork).toHaveBeenCalledWith('linea-mainnet');
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setEnabledNetworks(CHAIN_IDS.LINEA_MAINNET),
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setActiveNetwork('linea-mainnet'),
+    );
+    expect(mockTrackEvent).toHaveBeenCalled();
+  });
+
+  it('exposes isPending and startTransition for callers', () => {
+    const { result } = renderHook(() => useNetworkChangeHandlers());
+
+    expect(result.current.isPending).toBe(false);
+    expect(typeof result.current.startTransition).toBe('function');
+  });
+});

--- a/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.test.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.test.ts
@@ -147,4 +147,34 @@ describe('useNetworkChangeHandlers', () => {
     expect(result.current.isPending).toBe(false);
     expect(typeof result.current.startTransition).toBe('function');
   });
+
+  it('keeps isPending true until network switch dispatches settle', async () => {
+    let resolveEnabled!: () => void;
+    const enabledPromise = new Promise<void>((resolve) => {
+      resolveEnabled = resolve;
+    });
+
+    mockDispatch.mockImplementation((action: { type?: string }) => {
+      if (action?.type === 'SET_ENABLED_NETWORKS') {
+        return enabledPromise;
+      }
+      return Promise.resolve();
+    });
+
+    const { result } = renderHook(() => useNetworkChangeHandlers());
+
+    let changePromise!: Promise<void>;
+    await act(async () => {
+      changePromise = result.current.handleNetworkChange(mockLineaCaip);
+    });
+
+    expect(result.current.isPending).toBe(true);
+
+    await act(async () => {
+      resolveEnabled();
+      await changePromise;
+    });
+
+    expect(result.current.isPending).toBe(false);
+  });
 });

--- a/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useTransition } from 'react';
 import { type CaipChainId } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import { useAnalytics } from '../../../../hooks/useAnalytics';
@@ -60,6 +60,7 @@ export enum ACTION_MODE {
 export const useNetworkChangeHandlers = () => {
   const dispatch = useDispatch();
   const { trackEvent, createEventBuilder } = useAnalytics();
+  const [isPending, startTransition] = useTransition();
 
   const [multichainNetworks] = useSelector(
     getMultichainNetworkConfigurationsByChainId,
@@ -99,22 +100,23 @@ export const useNetworkChangeHandlers = () => {
       const { defaultRpcEndpoint } = getRpcDataByChainId(chainId, evmNetworks);
       const finalNetworkClientId = defaultRpcEndpoint.networkClientId;
 
-      dispatch(setEnabledNetworks(hexChainId));
-
-      // deferring execution to keep select all unblocked
-      setTimeout(() => {
+      // Defer expensive Home/Routes re-renders so the network list stays responsive.
+      startTransition(() => {
+        dispatch(setEnabledNetworks(hexChainId));
         dispatch(setActiveNetwork(finalNetworkClientId));
-      }, 0);
+      });
     },
-    [dispatch, evmNetworks],
+    [dispatch, evmNetworks, startTransition],
   );
 
   const handleNonEvmNetworkChange = useCallback(
-    async (chainId: CaipChainId) => {
-      dispatch(setActiveNetwork(chainId));
-      dispatch(setEnabledNetworks(chainId));
+    (chainId: CaipChainId) => {
+      startTransition(() => {
+        dispatch(setActiveNetwork(chainId));
+        dispatch(setEnabledNetworks(chainId));
+      });
     },
-    [dispatch],
+    [dispatch, startTransition],
   );
 
   const getMultichainNetworkConfigurationOrThrow = useCallback(
@@ -132,14 +134,18 @@ export const useNetworkChangeHandlers = () => {
 
   const handleNetworkChange = useCallback(
     async (chainId: CaipChainId) => {
+      if (isPending) {
+        return;
+      }
+
       const currentChain =
         getMultichainNetworkConfigurationOrThrow(currentChainId);
       const chain = getMultichainNetworkConfigurationOrThrow(chainId);
 
       if (chain.isEvm) {
-        await handleEvmNetworkChange(chainId);
+        handleEvmNetworkChange(chainId);
       } else {
-        await handleNonEvmNetworkChange(chainId);
+        handleNonEvmNetworkChange(chainId);
       }
 
       const chainIdToTrack = chain.isEvm
@@ -199,6 +205,7 @@ export const useNetworkChangeHandlers = () => {
       handleNonEvmNetworkChange,
       trackEvent,
       createEventBuilder,
+      isPending,
     ],
   );
 
@@ -212,5 +219,7 @@ export const useNetworkChangeHandlers = () => {
     actionMode,
     setActionMode,
     ACTION_MODE,
+    isPending,
+    startTransition,
   };
 };

--- a/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts
@@ -60,7 +60,9 @@ export enum ACTION_MODE {
 export const useNetworkChangeHandlers = () => {
   const dispatch = useDispatch();
   const { trackEvent, createEventBuilder } = useAnalytics();
-  const [isPending, startTransition] = useTransition();
+  const [isTransitionPending, startTransition] = useTransition();
+  const [isNetworkChangePending, setIsNetworkChangePending] = useState(false);
+  const isPending = isTransitionPending || isNetworkChangePending;
 
   const [multichainNetworks] = useSelector(
     getMultichainNetworkConfigurationsByChainId,
@@ -94,27 +96,46 @@ export const useNetworkChangeHandlers = () => {
   }, [enabledNetworksByNamespace, dispatch, allChainIds]);
 
   const handleEvmNetworkChange = useCallback(
-    (chainId: CaipChainId) => {
+    async (chainId: CaipChainId) => {
       const hexChainId = convertCaipToHexChainId(chainId);
 
       const { defaultRpcEndpoint } = getRpcDataByChainId(chainId, evmNetworks);
       const finalNetworkClientId = defaultRpcEndpoint.networkClientId;
 
-      // Defer expensive Home/Routes re-renders so the network list stays responsive.
-      startTransition(() => {
-        dispatch(setEnabledNetworks(hexChainId));
-        dispatch(setActiveNetwork(finalNetworkClientId));
-      });
+      setIsNetworkChangePending(true);
+      try {
+        // Defer expensive Home/Routes re-renders so the network list stays responsive.
+        // Promise.resolve unwraps thunk promises so isPending covers the background switch.
+        await new Promise<void>((resolve, reject) => {
+          startTransition(() => {
+            Promise.all([
+              Promise.resolve(dispatch(setEnabledNetworks(hexChainId))),
+              Promise.resolve(dispatch(setActiveNetwork(finalNetworkClientId))),
+            ]).then(() => resolve(), reject);
+          });
+        });
+      } finally {
+        setIsNetworkChangePending(false);
+      }
     },
     [dispatch, evmNetworks, startTransition],
   );
 
   const handleNonEvmNetworkChange = useCallback(
-    (chainId: CaipChainId) => {
-      startTransition(() => {
-        dispatch(setActiveNetwork(chainId));
-        dispatch(setEnabledNetworks(chainId));
-      });
+    async (chainId: CaipChainId) => {
+      setIsNetworkChangePending(true);
+      try {
+        await new Promise<void>((resolve, reject) => {
+          startTransition(() => {
+            Promise.all([
+              Promise.resolve(dispatch(setActiveNetwork(chainId))),
+              Promise.resolve(dispatch(setEnabledNetworks(chainId))),
+            ]).then(() => resolve(), reject);
+          });
+        });
+      } finally {
+        setIsNetworkChangePending(false);
+      }
     },
     [dispatch, startTransition],
   );
@@ -143,9 +164,9 @@ export const useNetworkChangeHandlers = () => {
       const chain = getMultichainNetworkConfigurationOrThrow(chainId);
 
       if (chain.isEvm) {
-        handleEvmNetworkChange(chainId);
+        await handleEvmNetworkChange(chainId);
       } else {
-        handleNonEvmNetworkChange(chainId);
+        await handleNonEvmNetworkChange(chainId);
       }
 
       const chainIdToTrack = chain.isEvm

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -2255,17 +2255,13 @@ describe('Actions', () => {
 
       setBackgroundConnection(background.getApi());
 
-      const expectedActions = [
-        { type: 'SHOW_LOADING_INDICATION', payload: undefined },
-        { type: 'HIDE_LOADING_INDICATION' },
-      ];
-
       await store.dispatch(
         actions.setSelectedMultichainAccount(
           'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default',
         ),
       );
-      expect(store.getActions()).toStrictEqual(expectedActions);
+      // No fullscreen loading indication — pending UI is owned by useTransition
+      expect(store.getActions()).toStrictEqual([]);
     });
   });
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2592,7 +2592,8 @@ export function setSelectedMultichainAccount(
   return async (dispatch, _getState) => {
     log.debug(`background.setSelectedMultichainAccount`);
     try {
-      dispatch(showLoadingIndication());
+      // Pending feedback is handled by useTransition in MultichainAccountList
+      // so the UI shell stays interactive during the switch.
       await submitRequestToBackground('setSelectedMultichainAccount', [
         accountGroupId,
       ]);
@@ -2601,8 +2602,6 @@ export function setSelectedMultichainAccount(
       await forceUpdateMetamaskState(dispatch);
     } catch (error) {
       logErrorWithMessage(error);
-    } finally {
-      dispatch(hideLoadingIndication());
     }
   };
 }

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2592,8 +2592,8 @@ export function setSelectedMultichainAccount(
   return async (dispatch, _getState) => {
     log.debug(`background.setSelectedMultichainAccount`);
     try {
-      // Pending feedback is handled by useTransition in MultichainAccountList
-      // so the UI shell stays interactive during the switch.
+      // Fullscreen loading indication removed; callers are responsible for pending UX
+      // (e.g. component-local state, or `useTransition` where appropriate).
       await submitRequestToBackground('setSelectedMultichainAccount', [
         accountGroupId,
       ]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Currently, account and network switches trigger expensive re-renders. A fullscreen loading overlay on account switch also blocked the shell. Concurrent transitions keep the shell interactive and surface pending feedback so clicks don’t feel dead.

This PR wraps primary account and network switch dispatches in React 18 `useTransition` so the UI shell stays responsive while Home, Routes, and balance trees re-render.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7476

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches high-traffic account and network switching paths and pending-state gating, so regressions could block or double-fire switches. Logic of what gets selected is unchanged; risk is mainly UX/timing around concurrent transitions.
> 
> **Overview**
> Keeps the account and network picker shells responsive during switches by wrapping the expensive Home/Routes updates in React **`useTransition`**, and replaces the fullscreen loading overlay with local pending feedback.
> 
> **Account switching:** `MultichainAccountList` now starts the select+navigate work in a transition, and `MultichainAccountCell` ignores clicks while pending (wait cursor, reduced opacity). `setSelectedMultichainAccount` no longer shows/hides the global loading indication.
> 
> **Network switching:** `useNetworkChangeHandlers` tracks pending state across the transition and network dispatches, then network lists and the home filter modal disable further clicks and surface loading on the filter button until the switch settles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f84d1f37c917c7be03beac994954c588864d06f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->