### PR TITLE
fix: patch transaction-controller to strip leading zero digits from value in eth_estimateGas

### DIFF
--- a/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch
+++ b/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/utils/gas.cjs b/dist/utils/gas.cjs
-index dd5270324ffc6d96845a3ea244bfa28e88454475..ec93e4799dd907e55c95d38f3da4dc7b23905236 100644
+index dd5270324ffc6d96845a3ea244bfa28e88454475..d6a54ff2dde2de4d8d0c3b231cedd3fe42b60a7a 100644
 --- a/dist/utils/gas.cjs
 +++ b/dist/utils/gas.cjs
 @@ -76,7 +76,7 @@ async function estimateGas({ ignoreDelegationSignatures, isSimulationEnabled, ge
@@ -11,7 +11,7 @@ index dd5270324ffc6d96845a3ea244bfa28e88454475..ec93e4799dd907e55c95d38f3da4dc7b
      request.authorizationList = normalizeAuthorizationList(request.authorizationList, chainId);
      delete request.gasPrice;
      delete request.maxFeePerGas;
-@@ -499,6 +499,24 @@ function normalizeAuthorizationList(authorizationList, chainId) {
+@@ -499,6 +499,22 @@ function normalizeAuthorizationList(authorizationList, chainId) {
          yParity: authorization.yParity ?? '0x1',
      }));
  }
@@ -24,20 +24,18 @@ index dd5270324ffc6d96845a3ea244bfa28e88454475..ec93e4799dd907e55c95d38f3da4dc7b
 + * @returns The normalized transaction value.
 + */
 +function normalizeValue(value) {
-+    if (value === undefined) {
-+        return '0x0';
++    const valueOrDefault = value ?? '0x0';
++    if (!(0, utils_1.isStrictHexString)(valueOrDefault)) {
++        return valueOrDefault;
 +    }
-+    if (!(0, utils_1.isStrictHexString)(value)) {
-+        return value;
-+    }
-+    const stripped = (0, utils_1.remove0x)(value).replace(/^0+/u, '');
++    const stripped = (0, utils_1.remove0x)(valueOrDefault).replace(/^0+/u, '');
 +    return stripped.length === 0 ? '0x0' : (0, utils_1.add0x)(stripped);
 +}
  /**
   * Estimate the gas for a transaction using the `eth_estimateGas` method.
   *
 diff --git a/dist/utils/gas.mjs b/dist/utils/gas.mjs
-index e0d2c6982ec3b6d40ff1269400ff510bf368dfc8..b9ad7b1f2fc5ee39f7acb5746f1c42818bc6e51f 100644
+index e0d2c6982ec3b6d40ff1269400ff510bf368dfc8..5554eb112fd4f09257cff8aca90f2215606766d8 100644
 --- a/dist/utils/gas.mjs
 +++ b/dist/utils/gas.mjs
 @@ -1,5 +1,5 @@
@@ -56,7 +54,7 @@ index e0d2c6982ec3b6d40ff1269400ff510bf368dfc8..b9ad7b1f2fc5ee39f7acb5746f1c4281
      request.authorizationList = normalizeAuthorizationList(request.authorizationList, chainId);
      delete request.gasPrice;
      delete request.maxFeePerGas;
-@@ -490,6 +490,24 @@ function normalizeAuthorizationList(authorizationList, chainId) {
+@@ -490,6 +490,22 @@ function normalizeAuthorizationList(authorizationList, chainId) {
          yParity: authorization.yParity ?? '0x1',
      }));
  }
@@ -69,13 +67,11 @@ index e0d2c6982ec3b6d40ff1269400ff510bf368dfc8..b9ad7b1f2fc5ee39f7acb5746f1c4281
 + * @returns The normalized transaction value.
 + */
 +function normalizeValue(value) {
-+    if (value === undefined) {
-+        return '0x0';
++    const valueOrDefault = value ?? '0x0';
++    if (!isStrictHexString(valueOrDefault)) {
++        return valueOrDefault;
 +    }
-+    if (!isStrictHexString(value)) {
-+        return value;
-+    }
-+    const stripped = remove0x(value).replace(/^0+/u, '');
++    const stripped = remove0x(valueOrDefault).replace(/^0+/u, '');
 +    return stripped.length === 0 ? '0x0' : add0x(stripped);
 +}
  /**

--- a/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch
+++ b/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch
@@ -1,0 +1,83 @@
+diff --git a/dist/utils/gas.cjs b/dist/utils/gas.cjs
+index dd5270324ffc6d96845a3ea244bfa28e88454475..ec93e4799dd907e55c95d38f3da4dc7b23905236 100644
+--- a/dist/utils/gas.cjs
++++ b/dist/utils/gas.cjs
+@@ -76,7 +76,7 @@ async function estimateGas({ ignoreDelegationSignatures, isSimulationEnabled, ge
+         : uncappedFallback;
+     (0, exports.log)('Estimation fallback values', fallback);
+     request.data = data ? (0, utils_1.add0x)(data) : data;
+-    request.value = value ?? '0x0';
++    request.value = normalizeValue(value);
+     request.authorizationList = normalizeAuthorizationList(request.authorizationList, chainId);
+     delete request.gasPrice;
+     delete request.maxFeePerGas;
+@@ -499,6 +499,24 @@ function normalizeAuthorizationList(authorizationList, chainId) {
+         yParity: authorization.yParity ?? '0x1',
+     }));
+ }
++/**
++ * Normalize the value to a canonical hex quantity with no leading zero digits.
++ * Some RPC nodes (e.g. Go's `hexutil`) reject quantities such as `0x00` or
++ * `0x0de0b6b3a7640000`, failing gas estimation entirely.
++ *
++ * @param value - The transaction value to normalize.
++ * @returns The normalized transaction value.
++ */
++function normalizeValue(value) {
++    if (value === undefined) {
++        return '0x0';
++    }
++    if (!(0, utils_1.isStrictHexString)(value)) {
++        return value;
++    }
++    const stripped = (0, utils_1.remove0x)(value).replace(/^0+/u, '');
++    return stripped.length === 0 ? '0x0' : (0, utils_1.add0x)(stripped);
++}
+ /**
+  * Estimate the gas for a transaction using the `eth_estimateGas` method.
+  *
+diff --git a/dist/utils/gas.mjs b/dist/utils/gas.mjs
+index e0d2c6982ec3b6d40ff1269400ff510bf368dfc8..b9ad7b1f2fc5ee39f7acb5746f1c42818bc6e51f 100644
+--- a/dist/utils/gas.mjs
++++ b/dist/utils/gas.mjs
+@@ -1,5 +1,5 @@
+ import { BNToHex, fractionBN, hexToBN, toHex } from "@metamask/controller-utils";
+-import { add0x, createModuleLogger, remove0x } from "@metamask/utils";
++import { add0x, createModuleLogger, isStrictHexString, remove0x } from "@metamask/utils";
+ import { BigNumber } from "bignumber.js";
+ import { simulateTransactions } from "../api/simulation-api.mjs";
+ import { projectLogger } from "../logger.mjs";
+@@ -72,7 +72,7 @@ export async function estimateGas({ ignoreDelegationSignatures, isSimulationEnab
+         : uncappedFallback;
+     log('Estimation fallback values', fallback);
+     request.data = data ? add0x(data) : data;
+-    request.value = value ?? '0x0';
++    request.value = normalizeValue(value);
+     request.authorizationList = normalizeAuthorizationList(request.authorizationList, chainId);
+     delete request.gasPrice;
+     delete request.maxFeePerGas;
+@@ -490,6 +490,24 @@ function normalizeAuthorizationList(authorizationList, chainId) {
+         yParity: authorization.yParity ?? '0x1',
+     }));
+ }
++/**
++ * Normalize the value to a canonical hex quantity with no leading zero digits.
++ * Some RPC nodes (e.g. Go's `hexutil`) reject quantities such as `0x00` or
++ * `0x0de0b6b3a7640000`, failing gas estimation entirely.
++ *
++ * @param value - The transaction value to normalize.
++ * @returns The normalized transaction value.
++ */
++function normalizeValue(value) {
++    if (value === undefined) {
++        return '0x0';
++    }
++    if (!isStrictHexString(value)) {
++        return value;
++    }
++    const stripped = remove0x(value).replace(/^0+/u, '');
++    return stripped.length === 0 ? '0x0' : add0x(stripped);
++}
+ /**
+  * Estimate the gas for a transaction using the `eth_estimateGas` method.
+  *

--- a/package.json
+++ b/package.json
@@ -330,7 +330,12 @@
     "@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.11": "patch:@pmmmwh/react-refresh-webpack-plugin@npm%3A0.5.13#~/.yarn/patches/@pmmmwh-react-refresh-webpack-plugin-npm-0.5.13-25d13d4186.patch",
     "@metamask/messenger": "^2.0.0",
     "postcss@npm:7.0.36": "patch:postcss@npm%3A7.0.39#~/.yarn/patches/postcss-npm-7.0.39-0f8737296e.patch",
-    "postcss@npm:^7.0.16": "patch:postcss@npm%3A7.0.39#~/.yarn/patches/postcss-npm-7.0.39-0f8737296e.patch"
+    "postcss@npm:^7.0.16": "patch:postcss@npm%3A7.0.39#~/.yarn/patches/postcss-npm-7.0.39-0f8737296e.patch",
+    "@metamask/transaction-controller@npm:^69.5.0": "patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch",
+    "@metamask/transaction-controller@npm:^69.4.0": "patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch",
+    "@metamask/transaction-controller@npm:^69.0.0": "patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch",
+    "@metamask/transaction-controller@npm:^69.2.1": "patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch",
+    "@metamask/transaction-controller@npm:^69.3.0": "patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",
@@ -476,7 +481,7 @@
     "@metamask/solana-wallet-standard": "^1.0.0",
     "@metamask/storage-service": "^1.0.0",
     "@metamask/subscription-controller": "^6.2.0",
-    "@metamask/transaction-controller": "^69.1.0",
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch",
     "@metamask/transaction-pay-controller": "^26.0.0",
     "@metamask/tron-wallet-snap": "^1.33.1",
     "@metamask/user-operation-controller": "^41.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8557,6 +8557,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/transaction-controller@npm:69.5.0":
+  version: 69.5.0
+  resolution: "@metamask/transaction-controller@npm:69.5.0"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/rlp": "npm:^5.0.2"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^39.0.6"
+    "@metamask/approval-controller": "npm:^9.0.2"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/core-backend": "npm:^8.1.1"
+    "@metamask/gas-fee-controller": "npm:^26.3.1"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^35.0.1"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^5.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.11.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    ethereum-cryptography: "npm:^2.1.2"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+  checksum: 10/9999aed6cbd0563bf8543310c779b60898d0fd846a2a8cdad02b38c945c7f2f580af32ca7fe175f6b08253976b0253bc3a861aa19bc6cd3905ff8d5234da8b25
+  languageName: node
+  linkType: hard
+
 "@metamask/transaction-controller@npm:^64.0.0":
   version: 64.4.0
   resolution: "@metamask/transaction-controller@npm:64.4.0"
@@ -8671,9 +8710,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^69.0.0, @metamask/transaction-controller@npm:^69.1.0, @metamask/transaction-controller@npm:^69.2.1, @metamask/transaction-controller@npm:^69.3.0, @metamask/transaction-controller@npm:^69.4.0, @metamask/transaction-controller@npm:^69.5.0":
+"@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch":
   version: 69.5.0
-  resolution: "@metamask/transaction-controller@npm:69.5.0"
+  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch::version=69.5.0&hash=862a2e"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/rlp": "npm:^5.0.2"
@@ -8706,7 +8745,7 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/9999aed6cbd0563bf8543310c779b60898d0fd846a2a8cdad02b38c945c7f2f580af32ca7fe175f6b08253976b0253bc3a861aa19bc6cd3905ff8d5234da8b25
+  checksum: 10/1a21ce3176ea45974e44505981e1f89d7f95a330e562dfff17c6b525a50b37f611bf60d56d90171f9cc27bf845fbe18310daa806e3b3aa00e3d1e2c2efb055ce
   languageName: node
   linkType: hard
 
@@ -33053,7 +33092,7 @@ __metadata:
     "@metamask/test-dapp-solana": "npm:^0.3.1"
     "@metamask/test-dapp-tron": "npm:^0.3.1"
     "@metamask/test-snaps": "npm:^3.5.2"
-    "@metamask/transaction-controller": "npm:^69.1.0"
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch"
     "@metamask/transaction-pay-controller": "npm:^26.0.0"
     "@metamask/tron-wallet-snap": "npm:^1.33.1"
     "@metamask/user-operation-controller": "npm:^41.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8712,7 +8712,7 @@ __metadata:
 
 "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch":
   version: 69.5.0
-  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch::version=69.5.0&hash=862a2e"
+  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A69.5.0#~/.yarn/patches/@metamask-transaction-controller-npm-69.5.0-3c404e1bd2.patch::version=69.5.0&hash=de5782"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/rlp": "npm:^5.0.2"
@@ -8745,7 +8745,7 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/1a21ce3176ea45974e44505981e1f89d7f95a330e562dfff17c6b525a50b37f611bf60d56d90171f9cc27bf845fbe18310daa806e3b3aa00e3d1e2c2efb055ce
+  checksum: 10/361f218d89ee582943d005d0c382b1bbdfcef80365cbdad858a4a9b5625827e60252416afbe6ceb9933b066e3af1b8b6e7bf0283292c412a3deb93856effd95c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Gas estimation fails on networks whose RPC strictly parses hex quantities (Go's `hexutil`) when the transaction `value` contains leading zero digits (e.g. `0x00`, `0x0de0b6b3a7640000`):

```
json: cannot unmarshal hex number with leading zero digits into Go struct field TransactionArgs.value of type *hexutil.Big
```

Dapp libraries commonly pad hex values to an even byte length (ethers v6 `toBeHex(0)` returns `0x00`), so dapp transactions can hit this on strict chains (e.g. Robinhood Chain). The failed estimate silently falls back to a percentage of the block gas limit, which exceeds such chains' per-transaction gas cap, so affected transactions always fail.

This PR adds a Yarn patch for `@metamask/transaction-controller@69.5.0` that normalizes `value` in the `eth_estimateGas` request (`dist/utils/gas.cjs` + `dist/utils/gas.mjs`): leading zero digits are stripped from strict hex strings, nullish values keep defaulting to `0x0`, and non-hex input is left untouched so it still fails into the fallback path as before.

Notes:

- Root fix in core: MetaMask/core#9797 (includes unit tests). This patch is a stopgap so the fix can ship ahead of the next `transaction-controller` release, and should be dropped with the next controller bump.
- The patch resolutions are scoped to the `^69.x` descriptors that already resolved to `69.5.0`; the transitive `64.x` / `65.x` / `68.x` copies are untouched.
- No LavaMoat policy changes: the patch adds no new import edges (verified with `yarn lavamoat:auto`).

## **Changelog**

CHANGELOG entry: Fixed gas estimation on networks whose RPC rejects hex transaction values with leading zero digits

## **Related issues**

Fixes: CONF-1740

## **Manual testing steps**

1. Add a network whose RPC uses strict Go hex parsing (e.g. Robinhood Chain) and fund the account.
2. From a dapp, submit a transaction whose `value` has a leading zero digit (e.g. `0x00` for an approval, or an even-length padded amount like `0x0de0b6b3a7640000`).
3. Verify the confirmation shows a normal estimated gas limit (no "we couldn't estimate gas" fallback and no huge gas limit), and the transaction can be submitted successfully.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.