### PR TITLE
fix(confirmations): enable enforced simulations for wallet transactions

### DIFF
--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -139,12 +139,11 @@ describe('enforced-simulations', () => {
       ).toBe(true);
     });
 
-    describe.each([
+    for (const { description, origin } of [
       { description: 'no origin', origin: undefined },
       { description: 'the MetaMask origin', origin: ORIGIN_METAMASK },
-    ])(
-      'with a wallet-initiated transaction using $description',
-      ({ origin }) => {
+    ]) {
+      describe(`with a wallet-initiated transaction using ${description}`, () => {
         it('returns true when all conditions are met', () => {
           expect(
             isEnforcedSimulationsEligible(
@@ -188,8 +187,8 @@ describe('enforced-simulations', () => {
             ),
           ).toBe(false);
         });
-      },
-    );
+      });
+    }
 
     it('returns false when chain is not in eip7702 supported chains', () => {
       expect(

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -139,23 +139,57 @@ describe('enforced-simulations', () => {
       ).toBe(true);
     });
 
-    it('returns false when origin is undefined', () => {
-      expect(
-        isEnforcedSimulationsEligible(
-          { ...BASE_TRANSACTION_META, origin: undefined },
-          buildState(ResultType.Benign),
-        ),
-      ).toBe(false);
-    });
+    describe.each([
+      { description: 'no origin', origin: undefined },
+      { description: 'the MetaMask origin', origin: ORIGIN_METAMASK },
+    ])(
+      'with a wallet-initiated transaction using $description',
+      ({ origin }) => {
+        it('returns true when all conditions are met', () => {
+          expect(
+            isEnforcedSimulationsEligible(
+              { ...BASE_TRANSACTION_META, origin },
+              buildState(ResultType.Benign),
+            ),
+          ).toBe(true);
+        });
 
-    it('returns false when origin is MetaMask internal', () => {
-      expect(
-        isEnforcedSimulationsEligible(
-          { ...BASE_TRANSACTION_META, origin: ORIGIN_METAMASK },
-          buildState(ResultType.Benign),
-        ),
-      ).toBe(false);
-    });
+        it('returns false when the chain is unsupported', () => {
+          expect(
+            isEnforcedSimulationsEligible(
+              {
+                ...BASE_TRANSACTION_META,
+                origin,
+                chainId: UNSUPPORTED_CHAIN_ID,
+              },
+              buildState(ResultType.Benign),
+            ),
+          ).toBe(false);
+        });
+
+        it('returns false when there are no balance changes', () => {
+          expect(
+            isEnforcedSimulationsEligible(
+              {
+                ...BASE_TRANSACTION_META,
+                origin,
+                simulationData: { tokenBalanceChanges: [] },
+              },
+              buildState(ResultType.Benign),
+            ),
+          ).toBe(false);
+        });
+
+        it('returns false when the recipient is trusted', () => {
+          expect(
+            isEnforcedSimulationsEligible(
+              { ...BASE_TRANSACTION_META, origin },
+              buildState(ResultType.Trusted),
+            ),
+          ).toBe(false);
+        });
+      },
+    );
 
     it('returns false when chain is not in eip7702 supported chains', () => {
       expect(
@@ -462,13 +496,13 @@ describe('enforced-simulations', () => {
         ).toBe(false);
       });
 
-      it('still returns false when origin is MetaMask internal', () => {
+      it('returns true when origin is MetaMask internal', () => {
         expect(
           isEnforcedSimulationsEligible(
             { ...BASE_TRANSACTION_META, origin: ORIGIN_METAMASK },
             buildState(ResultType.Trusted),
           ),
-        ).toBe(false);
+        ).toBe(true);
       });
 
       it('is ignored when value is not the string "true"', () => {

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -2,7 +2,6 @@ import {
   SimulationData,
   TransactionMeta,
 } from '@metamask/transaction-controller';
-import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import { Hex } from '@metamask/utils';
 import {
@@ -123,11 +122,7 @@ export function isEnforcedSimulationsEligible(
   transactionMeta: TransactionMeta,
   state: EnforcedSimulationsState,
 ): boolean {
-  const { chainId, origin, simulationData } = transactionMeta;
-
-  if (!origin || origin === ORIGIN_METAMASK) {
-    return false;
-  }
+  const { chainId, simulationData } = transactionMeta;
 
   if (
     !state.eip7702SupportedChains?.some(


### PR DESCRIPTION
## **Description**

Wallet-initiated transactions have the internal MetaMask origin. The enforced simulations eligibility check rejected that case before evaluating the normal chain, balance-change, and trust-signal gates, preventing enforced simulations from protecting these transactions.

This change removes the origin gate so wallet-initiated transactions use the same eligibility checks as dapp-initiated transactions. The tests cover both wallet origin variants and verify that unsupported chains, transactions without balance changes, and trusted recipients remain ineligible.

## **Changelog**

CHANGELOG entry: Fixed enforced simulations not running for wallet-initiated transactions

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Start MetaMask with the `confirmations_enforced_simulations` remote feature enabled, using an EIP-7702-supported account and network.
2. Initiate a Send transaction from inside MetaMask to an untrusted recipient, with a transfer that produces a simulated balance change.
3. Continue to the confirmation and verify that enforced simulations are applied to the wallet-initiated transaction.
4. Repeat with a trusted recipient and verify that enforced simulations are not applied.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation-time eligibility for enforced simulations on wallet sends; behavior is intentionally broader but still gated by EIP-7702 chain support, simulations, and trust signals.
> 
> **Overview**
> **Wallet-initiated sends** (no dapp `origin` or internal MetaMask origin) were blocked from enforced simulations by an early origin check, even when chain, simulation balance changes, and recipient trust would have allowed them.
> 
> This PR **removes that origin gate** from `isEnforcedSimulationsEligible`, so wallet and dapp transactions share the same eligibility rules. Tests now cover wallet-origin variants and confirm unsupported chains, missing balance changes, and trusted recipients still block eligibility; under `FORCE_ENFORCED_SIMULATIONS`, MetaMask-internal origin is expected to be eligible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb867241ffa02b97ff835d9ae70fe2275b97fba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->