### PR TITLE
chore: migrate `addTransaction` & `addTransactionAndWaitForPublish` to LegacyBackgroundApiService

### DIFF
--- a/app/scripts/lib/account-supports-7702.ts
+++ b/app/scripts/lib/account-supports-7702.ts
@@ -1,33 +1,47 @@
+import { KeyringControllerGetKeyringForAccountAction } from '@metamask/keyring-controller';
 import { KEYRING_TYPES_SUPPORTING_7702 } from '../../../shared/constants/keyring';
+import { RootMessenger } from './messenger';
 
 /** Minimal shape; KeyringController.getKeyringForAccount is typed as Promise<unknown>. */
 type KeyringControllerLike = {
   getKeyringForAccount: (address: string) => Promise<unknown>;
 };
 
+/** Messenger able to resolve the keyring for an account. */
+type AccountSupports7702Messenger = RootMessenger<
+  KeyringControllerGetKeyringForAccountAction,
+  never
+>;
+
 /**
  * Returns whether the given account's keyring supports EIP-7702 gas fee tokens.
  * Used to avoid requesting 7702 from sentinel for hardware and other unsupported keyrings.
  *
  * @param address - Account address (e.g. request.from or transactionMeta.txParams?.from).
- * @param keyringControllerOrGetter - KeyringController instance or a function that returns it.
+ * @param keyringSource - A KeyringController instance, a function that returns
+ * it, or a messenger that can call `KeyringController:getKeyringForAccount`.
  * @returns True if the account supports 7702 (or address is missing / lookup fails; assume supported).
  */
 export async function accountSupports7702(
   address: string | undefined,
-  keyringControllerOrGetter:
+  keyringSource:
     | KeyringControllerLike
-    | (() => KeyringControllerLike),
+    | (() => KeyringControllerLike)
+    | AccountSupports7702Messenger,
 ): Promise<boolean> {
   if (!address) {
     return true;
   }
-  const keyringController =
-    typeof keyringControllerOrGetter === 'function'
-      ? keyringControllerOrGetter()
-      : keyringControllerOrGetter;
+  const resolved =
+    typeof keyringSource === 'function' ? keyringSource() : keyringSource;
   try {
-    const keyring = await keyringController.getKeyringForAccount(address);
+    const keyring =
+      'getKeyringForAccount' in resolved
+        ? await resolved.getKeyringForAccount(address)
+        : await resolved.call(
+            'KeyringController:getKeyringForAccount',
+            address,
+          );
     const keyringType =
       keyring &&
       typeof keyring === 'object' &&

--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -55,7 +55,7 @@ const createMiddleware = (
   const { chainId, error, securityAlertsEnabled, updateSecurityAlertResponse } =
     options;
 
-  const ppomController = {};
+  const messenger = {};
 
   const preferenceController = {
     state: {
@@ -88,7 +88,7 @@ const createMiddleware = (
   const middlewareFunction = createPPOMMiddleware(
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ppomController as any,
+    messenger as any,
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     preferenceController as any,

--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -1,5 +1,4 @@
 import { AccountsController } from '@metamask/accounts-controller';
-import { PPOMController } from '@metamask/ppom-validator';
 import {
   NetworkClientId,
   NetworkController,
@@ -23,6 +22,7 @@ import {
   generateSecurityAlertId,
   handlePPOMError,
   validateRequestWithPPOM,
+  type PPOMMessenger,
 } from './ppom-util';
 import {
   SecurityAlertResponse,
@@ -53,7 +53,7 @@ export type PPOMMiddlewareRequest<
  * after the user has confirmed or rejected the request,
  * the request will be forwarded to the next middleware, together with the PPOM response.
  *
- * @param ppomController - Instance of PPOMController.
+ * @param messenger - Messenger able to run the PPOM security validation flow.
  * @param preferencesController - Instance of PreferenceController.
  * @param networkController - Instance of NetworkController.
  * @param appStateController
@@ -66,7 +66,7 @@ export function createPPOMMiddleware<
   Params extends (string | { to: string })[],
   Result extends Json,
 >(
-  ppomController: PPOMController,
+  messenger: PPOMMessenger,
   preferencesController: PreferencesController,
   networkController: NetworkController,
   appStateController: AppStateController,
@@ -121,7 +121,7 @@ export function createPPOMMiddleware<
         { name: TraceName.PPOMValidation, parentContext: req.traceContext },
         () =>
           validateRequestWithPPOM({
-            ppomController,
+            messenger,
             request: req,
             securityAlertId,
             chainId: chainId as Hex,

--- a/app/scripts/lib/ppom/ppom-util.test.ts
+++ b/app/scripts/lib/ppom/ppom-util.test.ts
@@ -1,18 +1,14 @@
-import { PPOMController } from '@metamask/ppom-validator';
 import {
-  TransactionController,
-  TransactionControllerUnapprovedTransactionAddedEvent,
+  TransactionControllerState,
   TransactionEnvelopeType,
   TransactionMeta,
   TransactionParams,
   normalizeTransactionParams,
 } from '@metamask/transaction-controller';
 import {
-  SignatureController,
   SignatureControllerState,
   SignatureRequest,
   SignatureRequestType,
-  SignatureStateChange,
 } from '@metamask/signature-controller';
 import { Hex, JsonRpcRequest } from '@metamask/utils';
 import { PPOM } from '@blockaid/ppom_release';
@@ -21,6 +17,8 @@ import {
   MOCK_ANY_NAMESPACE,
   MockAnyNamespace,
   Messenger,
+  MessengerActions,
+  MessengerEvents,
 } from '@metamask/messenger';
 import {
   BlockaidReason,
@@ -28,14 +26,13 @@ import {
   LOADING_SECURITY_ALERT_RESPONSE,
   SecurityAlertSource,
 } from '../../../../shared/constants/security-provider';
-import { AppStateController } from '../../controllers/app-state-controller';
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import { isSnapPreinstalled } from '../../../../shared/lib/snaps/snaps';
-import { RootMessenger } from '../messenger';
 import {
   generateSecurityAlertId,
   updateSecurityAlertResponse,
   validateRequestWithPPOM,
+  type PPOMMessenger,
 } from './ppom-util';
 import { SecurityAlertResponse } from './types';
 import * as securityAlertAPI from './security-alerts-api';
@@ -96,20 +93,10 @@ const TRANSACTION_PARAMS_MOCK_2: TransactionParams = {
   to: '0x456',
 };
 
-const MESSENGER_MOCK = {
-  subscribe: jest.fn(),
-} as unknown as RootMessenger;
-
 function createPPOMMock() {
   return {
     validateJsonRpc: jest.fn(),
   } as unknown as jest.Mocked<PPOM>;
-}
-
-function createPPOMControllerMock() {
-  return {
-    usePPOM: jest.fn(),
-  } as unknown as jest.Mocked<PPOMController>;
 }
 
 function createErrorMock() {
@@ -119,45 +106,21 @@ function createErrorMock() {
   return error;
 }
 
-function createAppStateControllerMock() {
-  return {
-    addSignatureSecurityAlertResponse: jest.fn(),
-  } as unknown as jest.Mocked<AppStateController>;
-}
+type TestMessenger = Messenger<
+  MockAnyNamespace,
+  MessengerActions<PPOMMessenger>,
+  MessengerEvents<PPOMMessenger>
+>;
 
-function createSignatureControllerMock(
-  signatureRequests: SignatureControllerState['signatureRequests'],
-) {
-  return {
-    state: {
-      signatureRequests,
-    },
-  } as unknown as jest.Mocked<SignatureController>;
-}
-
-function createTransactionControllerMock(
-  state: TransactionController['state'],
-) {
-  return {
-    state,
-    updateSecurityAlertResponse: jest.fn(),
-  } as unknown as jest.Mocked<TransactionController>;
-}
-
-function createMessengerMock() {
-  return new Messenger<
-    MockAnyNamespace,
-    never,
-    SignatureStateChange | TransactionControllerUnapprovedTransactionAddedEvent
-  >({
-    namespace: MOCK_ANY_NAMESPACE,
-  });
+function createMessenger(): TestMessenger {
+  return new Messenger({ namespace: MOCK_ANY_NAMESPACE });
 }
 
 describe('PPOM Utils', () => {
   const updateSecurityAlertResponseMock = jest.fn();
   let isSecurityAlertsEnabledMock: jest.SpyInstance;
-  let ppomController: jest.Mocked<PPOMController>;
+  let messenger: TestMessenger;
+  let usePPOMMock: jest.Mock;
   let ppom: jest.Mocked<PPOM>;
 
   const normalizeTransactionParamsMock = jest.mocked(
@@ -181,11 +144,10 @@ describe('PPOM Utils', () => {
       .spyOn(securityAlertAPI, 'isSecurityAlertsAPIEnabled')
       .mockReturnValue(false);
 
-    ppomController = createPPOMControllerMock();
     ppom = createPPOMMock();
-
-    // @ts-expect-error PPOM from package does not match controller type
-    ppomController.usePPOM.mockImplementation((callback) => callback(ppom));
+    usePPOMMock = jest.fn((callback) => callback(ppom));
+    messenger = createMessenger();
+    messenger.registerActionHandler('PPOMController:usePPOM', usePPOMMock);
 
     normalizeTransactionParamsMock.mockImplementation(
       (params: TransactionParams) => params,
@@ -202,7 +164,7 @@ describe('PPOM Utils', () => {
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
-        ppomController,
+        messenger,
       });
       expect(updateSecurityAlertResponseMock).toHaveBeenCalledWith(
         REQUEST_MOCK.method,
@@ -220,7 +182,7 @@ describe('PPOM Utils', () => {
     it('updates securityAlertResponse with loading state', async () => {
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
-        ppomController,
+        messenger,
       });
 
       expect(updateSecurityAlertResponseMock).toHaveBeenCalledWith(
@@ -235,7 +197,7 @@ describe('PPOM Utils', () => {
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
-        ppomController,
+        messenger,
       });
 
       expect(updateSecurityAlertResponseMock).toHaveBeenCalledWith(
@@ -253,11 +215,11 @@ describe('PPOM Utils', () => {
     });
 
     it('updates error response if controller throws', async () => {
-      ppomController.usePPOM.mockRejectedValue(createErrorMock());
+      usePPOMMock.mockRejectedValue(createErrorMock());
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
-        ppomController,
+        messenger,
       });
 
       expect(updateSecurityAlertResponseMock).toHaveBeenCalledWith(
@@ -292,7 +254,7 @@ describe('PPOM Utils', () => {
 
         await validateRequestWithPPOM({
           ...validateRequestWithPPOMOptionsBase,
-          ppomController,
+          messenger,
           request,
         });
 
@@ -325,7 +287,7 @@ describe('PPOM Utils', () => {
 
         await validateRequestWithPPOM({
           ...validateRequestWithPPOMOptionsBase,
-          ppomController,
+          messenger,
           request,
         });
 
@@ -359,7 +321,7 @@ describe('PPOM Utils', () => {
 
         await validateRequestWithPPOM({
           ...validateRequestWithPPOMOptionsBase,
-          ppomController,
+          messenger,
           request,
         });
 
@@ -401,7 +363,7 @@ describe('PPOM Utils', () => {
 
         await validateRequestWithPPOM({
           ...validateRequestWithPPOMOptionsBase,
-          ppomController,
+          messenger,
           request,
         });
 
@@ -441,7 +403,7 @@ describe('PPOM Utils', () => {
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
-        ppomController,
+        messenger,
         request,
       });
 
@@ -466,7 +428,7 @@ describe('PPOM Utils', () => {
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
-        ppomController,
+        messenger,
         request,
       });
 
@@ -494,7 +456,7 @@ describe('PPOM Utils', () => {
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
-        ppomController,
+        messenger,
         request: request as never,
       });
 
@@ -557,7 +519,7 @@ describe('PPOM Utils', () => {
 
         await validateRequestWithPPOM({
           ...validateRequestWithPPOMOptionsBase,
-          ppomController,
+          messenger,
           request,
         });
 
@@ -630,7 +592,7 @@ describe('PPOM Utils', () => {
 
         await validateRequestWithPPOM({
           ...validateRequestWithPPOMOptionsBase,
-          ppomController,
+          messenger,
           request,
         });
 
@@ -700,7 +662,7 @@ describe('PPOM Utils', () => {
 
         await validateRequestWithPPOM({
           ...validateRequestWithPPOMOptionsBase,
-          ppomController,
+          messenger,
           request,
         });
 
@@ -751,7 +713,7 @@ describe('PPOM Utils', () => {
 
         await validateRequestWithPPOM({
           ...validateRequestWithPPOMOptionsBase,
-          ppomController,
+          messenger,
           request,
         });
 
@@ -814,7 +776,7 @@ describe('PPOM Utils', () => {
 
         await validateRequestWithPPOM({
           ...validateRequestWithPPOMOptionsBase,
-          ppomController,
+          messenger,
           request,
         });
 
@@ -844,49 +806,57 @@ describe('PPOM Utils', () => {
 
   describe('updateSecurityAlertResponse', () => {
     it('adds response to app state controller if signature request already exists', async () => {
-      const appStateController = createAppStateControllerMock();
-
-      const signatureController = createSignatureControllerMock({
-        '123': {
-          securityAlertResponse: {
-            ...SECURITY_ALERT_RESPONSE_MOCK,
-            securityAlertId: SECURITY_ALERT_ID_MOCK,
-          },
-        } as unknown as SignatureRequest,
-      });
+      const addSignatureSecurityAlertResponseMock = jest.fn();
+      messenger.registerActionHandler(
+        'AppStateController:addSignatureSecurityAlertResponse',
+        addSignatureSecurityAlertResponseMock,
+      );
+      messenger.registerActionHandler(
+        'SignatureController:getState',
+        () =>
+          ({
+            signatureRequests: {
+              '123': {
+                securityAlertResponse: {
+                  ...SECURITY_ALERT_RESPONSE_MOCK,
+                  securityAlertId: SECURITY_ALERT_ID_MOCK,
+                },
+              } as unknown as SignatureRequest,
+            },
+          }) as unknown as SignatureControllerState,
+      );
 
       await updateSecurityAlertResponse({
-        appStateController,
-        method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
-        messenger: MESSENGER_MOCK,
-        securityAlertId: SECURITY_ALERT_ID_MOCK,
-        securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
-        signatureController,
-        transactionController: {} as unknown as TransactionController,
-      });
-
-      expect(
-        appStateController.addSignatureSecurityAlertResponse,
-      ).toHaveBeenCalledTimes(1);
-
-      expect(
-        appStateController.addSignatureSecurityAlertResponse,
-      ).toHaveBeenCalledWith(SECURITY_ALERT_RESPONSE_MOCK);
-    });
-
-    it('adds response to app state controller after signature controller state change event', async () => {
-      const appStateController = createAppStateControllerMock();
-      const signatureController = createSignatureControllerMock({});
-      const messenger = createMessengerMock();
-
-      const updatePromise = updateSecurityAlertResponse({
-        appStateController,
         method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
         messenger,
         securityAlertId: SECURITY_ALERT_ID_MOCK,
         securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
-        signatureController,
-        transactionController: {} as unknown as TransactionController,
+      });
+
+      expect(addSignatureSecurityAlertResponseMock).toHaveBeenCalledTimes(1);
+
+      expect(addSignatureSecurityAlertResponseMock).toHaveBeenCalledWith(
+        SECURITY_ALERT_RESPONSE_MOCK,
+      );
+    });
+
+    it('adds response to app state controller after signature controller state change event', async () => {
+      const addSignatureSecurityAlertResponseMock = jest.fn();
+      messenger.registerActionHandler(
+        'AppStateController:addSignatureSecurityAlertResponse',
+        addSignatureSecurityAlertResponseMock,
+      );
+      messenger.registerActionHandler(
+        'SignatureController:getState',
+        () =>
+          ({ signatureRequests: {} }) as unknown as SignatureControllerState,
+      );
+
+      const updatePromise = updateSecurityAlertResponse({
+        method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
+        messenger,
+        securityAlertId: SECURITY_ALERT_ID_MOCK,
+        securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
       });
 
       messenger.publish(
@@ -903,69 +873,67 @@ describe('PPOM Utils', () => {
 
       await updatePromise;
 
-      expect(
-        appStateController.addSignatureSecurityAlertResponse,
-      ).toHaveBeenCalledTimes(1);
+      expect(addSignatureSecurityAlertResponseMock).toHaveBeenCalledTimes(1);
 
-      expect(
-        appStateController.addSignatureSecurityAlertResponse,
-      ).toHaveBeenCalledWith(SECURITY_ALERT_RESPONSE_MOCK);
+      expect(addSignatureSecurityAlertResponseMock).toHaveBeenCalledWith(
+        SECURITY_ALERT_RESPONSE_MOCK,
+      );
     });
 
     it('adds response to transaction controller if transaction already exists', async () => {
-      const transactionController = createTransactionControllerMock({
-        transactions: [
-          {
-            id: TRANSACTION_ID_MOCK,
-            securityAlertResponse: {
-              securityAlertId: SECURITY_ALERT_ID_MOCK,
-            },
-          },
-        ],
-      } as unknown as TransactionController['state']);
+      const updateTransactionSecurityAlertResponseMock = jest.fn();
+      messenger.registerActionHandler(
+        'TransactionController:updateSecurityAlertResponse',
+        updateTransactionSecurityAlertResponseMock,
+      );
+      messenger.registerActionHandler(
+        'TransactionController:getState',
+        () =>
+          ({
+            transactions: [
+              {
+                id: TRANSACTION_ID_MOCK,
+                securityAlertResponse: {
+                  securityAlertId: SECURITY_ALERT_ID_MOCK,
+                },
+              },
+            ],
+          }) as unknown as TransactionControllerState,
+      );
 
       await updateSecurityAlertResponse({
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        appStateController: {} as any,
-        method: 'eth_sendTransaction',
-        messenger: MESSENGER_MOCK,
-        securityAlertId: SECURITY_ALERT_ID_MOCK,
-        securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        signatureController: {} as any,
-        transactionController,
-      });
-
-      expect(
-        transactionController.updateSecurityAlertResponse,
-      ).toHaveBeenCalledTimes(1);
-
-      expect(
-        transactionController.updateSecurityAlertResponse,
-      ).toHaveBeenCalledWith(TRANSACTION_ID_MOCK, SECURITY_ALERT_RESPONSE_MOCK);
-    });
-
-    it('adds response to transaction controller after transaction added event', async () => {
-      const transactionController = createTransactionControllerMock({
-        transactions: [],
-      } as unknown as TransactionController['state']);
-
-      const messenger = createMessengerMock();
-
-      const updatePromise = updateSecurityAlertResponse({
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        appStateController: {} as any,
         method: 'eth_sendTransaction',
         messenger,
         securityAlertId: SECURITY_ALERT_ID_MOCK,
         securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        signatureController: {} as any,
-        transactionController,
+      });
+
+      expect(updateTransactionSecurityAlertResponseMock).toHaveBeenCalledTimes(
+        1,
+      );
+
+      expect(updateTransactionSecurityAlertResponseMock).toHaveBeenCalledWith(
+        TRANSACTION_ID_MOCK,
+        SECURITY_ALERT_RESPONSE_MOCK,
+      );
+    });
+
+    it('adds response to transaction controller after transaction added event', async () => {
+      const updateTransactionSecurityAlertResponseMock = jest.fn();
+      messenger.registerActionHandler(
+        'TransactionController:updateSecurityAlertResponse',
+        updateTransactionSecurityAlertResponseMock,
+      );
+      messenger.registerActionHandler(
+        'TransactionController:getState',
+        () => ({ transactions: [] }) as unknown as TransactionControllerState,
+      );
+
+      const updatePromise = updateSecurityAlertResponse({
+        method: 'eth_sendTransaction',
+        messenger,
+        securityAlertId: SECURITY_ALERT_ID_MOCK,
+        securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
       });
 
       messenger.publish('TransactionController:unapprovedTransactionAdded', {
@@ -976,13 +944,14 @@ describe('PPOM Utils', () => {
 
       await updatePromise;
 
-      expect(
-        transactionController.updateSecurityAlertResponse,
-      ).toHaveBeenCalledTimes(1);
+      expect(updateTransactionSecurityAlertResponseMock).toHaveBeenCalledTimes(
+        1,
+      );
 
-      expect(
-        transactionController.updateSecurityAlertResponse,
-      ).toHaveBeenCalledWith(TRANSACTION_ID_MOCK, SECURITY_ALERT_RESPONSE_MOCK);
+      expect(updateTransactionSecurityAlertResponseMock).toHaveBeenCalledWith(
+        TRANSACTION_ID_MOCK,
+        SECURITY_ALERT_RESPONSE_MOCK,
+      );
     });
   });
 
@@ -1008,12 +977,12 @@ describe('PPOM Utils', () => {
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
-        ppomController,
+        messenger,
         request,
         getSecurityAlertsConfig: getSecurityAlertsConfigMock,
       });
 
-      expect(ppomController.usePPOM).not.toHaveBeenCalled();
+      expect(usePPOMMock).not.toHaveBeenCalled();
       expect(ppom.validateJsonRpc).not.toHaveBeenCalled();
 
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledTimes(1);
@@ -1039,12 +1008,12 @@ describe('PPOM Utils', () => {
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
-        ppomController,
+        messenger,
         request,
         getSecurityAlertsConfig: getSecurityAlertsConfigMock,
       });
 
-      expect(ppomController.usePPOM).toHaveBeenCalledTimes(1);
+      expect(usePPOMMock).toHaveBeenCalledTimes(1);
 
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledTimes(1);
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledWith(

--- a/app/scripts/lib/ppom/ppom-util.ts
+++ b/app/scripts/lib/ppom/ppom-util.ts
@@ -1,7 +1,7 @@
-import { PPOMController } from '@metamask/ppom-validator';
 import {
-  TransactionController,
+  TransactionControllerGetStateAction,
   TransactionControllerUnapprovedTransactionAddedEvent,
+  TransactionControllerUpdateSecurityAlertResponseAction,
   TransactionMeta,
   TransactionParams,
   normalizeTransactionParams,
@@ -9,8 +9,9 @@ import {
 import { Hex, JsonRpcRequest, createProjectLogger } from '@metamask/utils';
 import { v4 as uuid } from 'uuid';
 import { PPOM } from '@blockaid/ppom_release';
+import { UsePPOM } from '@metamask/ppom-validator';
 import {
-  SignatureController,
+  GetSignatureState,
   SignatureControllerState,
   SignatureRequest,
   SignatureStateChange,
@@ -26,7 +27,7 @@ import {
 } from '../../../../shared/constants/security-provider';
 import { isSnapPreinstalled } from '../../../../shared/lib/snaps/snaps';
 import { SIGNING_METHODS } from '../../../../shared/constants/transaction';
-import { AppStateController } from '../../controllers/app-state-controller';
+import { AppStateControllerAddSignatureSecurityAlertResponseAction } from '../../controllers/app-state-controller-method-action-types';
 import { sanitizeMessageRecursively } from '../../../../shared/lib/typed-signature';
 import { parseTypedDataMessage } from '../../../../shared/lib/transaction.utils';
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
@@ -46,6 +47,31 @@ const log = createProjectLogger('ppom-util');
 
 const { sentry } = global;
 
+/**
+ * Messenger able to run the PPOM security validation flow: validate via the
+ * PPOM controller, and read/write the loading + final security alert response
+ * onto the pending transaction or signature request.
+ */
+export type PPOMMessenger = RootMessenger<
+  | UsePPOM
+  | TransactionControllerGetStateAction
+  | TransactionControllerUpdateSecurityAlertResponseAction
+  | GetSignatureState
+  | AppStateControllerAddSignatureSecurityAlertResponseAction,
+  TransactionControllerUnapprovedTransactionAddedEvent | SignatureStateChange
+>;
+
+/**
+ * The real runtime signature of the `PPOMController:usePPOM` action, which
+ * accepts an optional `chainId`. The published action type omits it, so we
+ * narrow `messenger.call` to this shape when forwarding the chain id.
+ */
+type UsePPOMCall = (
+  action: 'PPOMController:usePPOM',
+  callback: (ppom: PPOM) => Promise<unknown>,
+  chainId: string,
+) => Promise<unknown>;
+
 const SECURITY_ALERT_RESPONSE_ERROR = {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -59,14 +85,14 @@ type PPOMRequest = JsonRpcRequest & {
 };
 
 export async function validateRequestWithPPOM({
-  ppomController,
+  messenger,
   request,
   securityAlertId,
   chainId,
   updateSecurityAlertResponse: updateSecurityResponse,
   getSecurityAlertsConfig,
 }: {
-  ppomController: PPOMController;
+  messenger: PPOMMessenger;
   request: PPOMRequest;
   securityAlertId: string;
   chainId: Hex;
@@ -86,16 +112,12 @@ export async function validateRequestWithPPOM({
 
     const ppomResponse = isSecurityAlertsAPIEnabled()
       ? await validateWithAPI(
-          ppomController,
+          messenger,
           chainId,
           normalizedRequest,
           getSecurityAlertsConfig,
         )
-      : await validateWithController(
-          ppomController,
-          normalizedRequest,
-          chainId,
-        );
+      : await validateWithController(messenger, normalizedRequest, chainId);
 
     await updateSecurityResponse(request.method, securityAlertId, ppomResponse);
   } catch (error: unknown) {
@@ -114,32 +136,25 @@ export function generateSecurityAlertId(): string {
 }
 
 export async function updateSecurityAlertResponse({
-  appStateController,
   messenger,
   method,
   securityAlertId,
   securityAlertResponse,
-  signatureController,
-  transactionController,
 }: {
-  appStateController: AppStateController;
-  messenger: RootMessenger;
+  messenger: PPOMMessenger;
   method: string;
   securityAlertId: string;
   securityAlertResponse: SecurityAlertResponse;
-  signatureController: SignatureController;
-  transactionController: TransactionController;
 }): Promise<TransactionMeta | SignatureRequest> {
   const isSignatureRequest = SIGNING_METHODS.includes(method);
 
   if (isSignatureRequest) {
     const signatureRequest = await waitForSignatureRequest(
-      signatureController,
       securityAlertId,
       messenger,
     );
 
-    appStateController.addSignatureSecurityAlertResponse({
+    messenger.call('AppStateController:addSignatureSecurityAlertResponse', {
       ...securityAlertResponse,
       securityAlertId,
     });
@@ -148,15 +163,18 @@ export async function updateSecurityAlertResponse({
   }
 
   const transactionMeta = await waitForTransactionMetadata(
-    transactionController,
     securityAlertId,
     messenger,
   );
 
-  transactionController.updateSecurityAlertResponse(transactionMeta.id, {
-    ...securityAlertResponse,
-    securityAlertId,
-  } as SecurityAlertResponse);
+  messenger.call(
+    'TransactionController:updateSecurityAlertResponse',
+    transactionMeta.id,
+    {
+      ...securityAlertResponse,
+      securityAlertId,
+    } as SecurityAlertResponse,
+  );
 
   return transactionMeta;
 }
@@ -314,12 +332,17 @@ function getErrorData(error: unknown) {
 }
 
 async function validateWithController(
-  ppomController: PPOMController,
+  messenger: PPOMMessenger,
   request: SecurityAlertsAPIRequest | PPOMRequest,
   chainId: string,
 ): Promise<SecurityAlertResponse> {
   try {
-    const response = (await ppomController.usePPOM(
+    // The published `PPOMController:usePPOM` action type omits the optional
+    // `chainId` argument that the runtime handler accepts and that we must
+    // forward to validate against the confirmation's chain.
+    // ponytail: cast works around the upstream type omission; drop when fixed.
+    const response = (await (messenger.call as unknown as UsePPOMCall)(
+      'PPOMController:usePPOM',
       (ppom: PPOM) => ppom.validateJsonRpc(request),
       chainId,
     )) as SecurityAlertResponse;
@@ -338,7 +361,7 @@ async function validateWithController(
 }
 
 async function validateWithAPI(
-  ppomController: PPOMController,
+  messenger: PPOMMessenger,
   chainId: string,
   request: SecurityAlertsAPIRequest | PPOMRequest,
   getSecurityAlertsConfig?: GetSecurityAlertsConfig,
@@ -356,24 +379,21 @@ async function validateWithAPI(
     };
   } catch (error: unknown) {
     handlePPOMError(error, `Error validating request with security alerts API`);
-    return await validateWithController(ppomController, request, chainId);
+    return await validateWithController(messenger, request, chainId);
   }
 }
 
 async function waitForTransactionMetadata(
-  transactionController: TransactionController,
   securityAlertId: string,
-  messenger: RootMessenger<
-    never,
-    TransactionControllerUnapprovedTransactionAddedEvent
-  >,
+  messenger: PPOMMessenger,
 ): Promise<TransactionMeta> {
   const transactionFilter = (meta: TransactionMeta) =>
     meta.securityAlertResponse?.securityAlertId === securityAlertId;
 
   return new Promise((resolve) => {
-    const transactionMeta =
-      transactionController.state.transactions.find(transactionFilter);
+    const transactionMeta = messenger
+      .call('TransactionController:getState')
+      .transactions.find(transactionFilter);
 
     if (transactionMeta) {
       resolve(transactionMeta);
@@ -405,9 +425,8 @@ async function waitForTransactionMetadata(
 }
 
 async function waitForSignatureRequest(
-  signatureController: SignatureController,
   securityAlertId: string,
-  messenger: RootMessenger<never, SignatureStateChange>,
+  messenger: PPOMMessenger,
 ): Promise<SignatureRequest> {
   const signatureFilter = (state: SignatureControllerState) =>
     Object.values(state.signatureRequests).find(
@@ -416,7 +435,9 @@ async function waitForSignatureRequest(
     );
 
   return new Promise((resolve) => {
-    const signatureRequest = signatureFilter(signatureController.state);
+    const signatureRequest = signatureFilter(
+      messenger.call('SignatureController:getState'),
+    );
 
     if (signatureRequest) {
       resolve(signatureRequest);

--- a/app/scripts/lib/ppom/ppom-util.ts
+++ b/app/scripts/lib/ppom/ppom-util.ts
@@ -9,7 +9,6 @@ import {
 import { Hex, JsonRpcRequest, createProjectLogger } from '@metamask/utils';
 import { v4 as uuid } from 'uuid';
 import { PPOM } from '@blockaid/ppom_release';
-import { UsePPOM } from '@metamask/ppom-validator';
 import {
   GetSignatureState,
   SignatureControllerState,
@@ -53,7 +52,7 @@ const { sentry } = global;
  * onto the pending transaction or signature request.
  */
 export type PPOMMessenger = RootMessenger<
-  | UsePPOM
+  | UsePPOMAction
   | TransactionControllerGetStateAction
   | TransactionControllerUpdateSecurityAlertResponseAction
   | GetSignatureState
@@ -62,15 +61,17 @@ export type PPOMMessenger = RootMessenger<
 >;
 
 /**
- * The real runtime signature of the `PPOMController:usePPOM` action, which
- * accepts an optional `chainId`. The published action type omits it, so we
- * narrow `messenger.call` to this shape when forwarding the chain id.
+ * The `PPOMController:usePPOM` action. The published `UsePPOM` type omits the
+ * controller method's optional `chainId` argument, so it is redeclared here
+ * with the real runtime signature to forward the confirmation's chain id.
  */
-type UsePPOMCall = (
-  action: 'PPOMController:usePPOM',
-  callback: (ppom: PPOM) => Promise<unknown>,
-  chainId: string,
-) => Promise<unknown>;
+export type UsePPOMAction = {
+  type: 'PPOMController:usePPOM';
+  handler: (
+    callback: (ppom: PPOM) => Promise<unknown>,
+    chainId?: string,
+  ) => Promise<unknown>;
+};
 
 const SECURITY_ALERT_RESPONSE_ERROR = {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -337,11 +338,7 @@ async function validateWithController(
   chainId: string,
 ): Promise<SecurityAlertResponse> {
   try {
-    // The published `PPOMController:usePPOM` action type omits the optional
-    // `chainId` argument that the runtime handler accepts and that we must
-    // forward to validate against the confirmation's chain.
-    // ponytail: cast works around the upstream type omission; drop when fixed.
-    const response = (await (messenger.call as unknown as UsePPOMCall)(
+    const response = (await messenger.call(
       'PPOMController:usePPOM',
       (ppom: PPOM) => ppom.validateJsonRpc(request),
       chainId,

--- a/app/scripts/lib/transaction/util.test.ts
+++ b/app/scripts/lib/transaction/util.test.ts
@@ -1,11 +1,17 @@
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { MiddlewareContext } from '@metamask/json-rpc-engine/v2';
 import {
-  TransactionController,
+  TransactionControllerState,
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { UserOperationController } from '@metamask/user-operation-controller';
+import {
+  MOCK_ANY_NAMESPACE,
+  MockAnyNamespace,
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
 import { cloneDeep, omit } from 'lodash';
 import { Hex } from '@metamask/utils';
 import {
@@ -24,12 +30,11 @@ import { scanAddressAndAddToCache } from '../trust-signals/security-alerts-api';
 import {
   SupportedEVMChain,
   ResultType,
-  AddAddressSecurityAlertResponse,
-  GetAddressSecurityAlertResponse,
 } from '../../../../shared/lib/trust-signals';
 import { accountSupports7702 } from '../account-supports-7702';
 import {
   AddDappTransactionRequest,
+  AddTransactionMessenger,
   AddTransactionOptions,
   AddTransactionRequest,
   addDappTransaction,
@@ -162,29 +167,26 @@ const TRANSACTION_REQUEST_MOCK: AddTransactionRequest = {
   internalAccounts: [],
 } as unknown as AddTransactionRequest;
 
-function createTransactionControllerMock() {
-  return {
-    addTransaction: jest.fn(),
-    addTransactionBatch: jest.fn(),
-    state: { transactions: [] },
-  } as unknown as jest.Mocked<TransactionController>;
-}
+type TestMessenger = Messenger<
+  MockAnyNamespace,
+  MessengerActions<AddTransactionMessenger>,
+  MessengerEvents<AddTransactionMessenger>
+>;
 
-function createUserOperationControllerMock() {
-  return {
-    addUserOperationFromTransaction: jest.fn(),
-    startPollingByNetworkClientId: jest.fn(),
-  } as unknown as jest.Mocked<UserOperationController>;
+function createMessenger(): TestMessenger {
+  return new Messenger({ namespace: MOCK_ANY_NAMESPACE });
 }
 
 describe('Transaction Utils', () => {
   let request: AddTransactionRequest;
   let dappRequest: AddDappTransactionRequest;
   let tempoDappRequest: AddDappTransactionRequest;
-  let transactionController: jest.Mocked<TransactionController>;
-  let userOperationController: jest.Mocked<UserOperationController>;
-  let getAddressSecurityAlertResponseMock: jest.Mock;
-  let addAddressSecurityAlertResponseMock: jest.Mock;
+  let messenger: TestMessenger;
+  let transactions: TransactionMeta[];
+  let addTransactionMock: jest.Mock;
+  let addTransactionBatchMock: jest.Mock;
+  let addUserOperationFromTransactionMock: jest.Mock;
+  let startPollingByNetworkClientIdMock: jest.Mock;
   const validateRequestWithPPOMMock = jest.mocked(validateRequestWithPPOM);
   const generateSecurityAlertIdMock = jest.mocked(generateSecurityAlertId);
   const scanAddressAndAddToCacheMock = jest.mocked(scanAddressAndAddToCache);
@@ -198,10 +200,8 @@ describe('Transaction Utils', () => {
       realGetTempoTransactionBatchArgsImpl,
     );
     request = cloneDeep(TRANSACTION_REQUEST_MOCK);
-    transactionController = createTransactionControllerMock();
-    userOperationController = createUserOperationControllerMock();
-    getAddressSecurityAlertResponseMock = jest.fn();
-    addAddressSecurityAlertResponseMock = jest.fn();
+
+    transactions = [];
 
     scanAddressAndAddToCacheMock.mockResolvedValue({
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -209,39 +209,52 @@ describe('Transaction Utils', () => {
       label: 'Safe address',
     });
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    request.ppomController = {} as any;
-
-    transactionController.addTransaction.mockResolvedValue({
+    addTransactionMock = jest.fn().mockResolvedValue({
       result: Promise.resolve('testHash'),
       transactionMeta: TRANSACTION_META_MOCK,
     });
 
-    transactionController.addTransactionBatch.mockImplementation(async () => {
-      transactionController.state.transactions.push(
-        BATCH_TRANSACTION_META_MOCK,
-      );
+    addTransactionBatchMock = jest.fn().mockImplementation(async () => {
+      transactions.push(BATCH_TRANSACTION_META_MOCK);
       return {
         batchId: BATCHID_MOCK,
       };
     });
 
-    transactionController.state.transactions.push(TRANSACTION_META_MOCK);
+    transactions.push(TRANSACTION_META_MOCK);
 
-    userOperationController.addUserOperationFromTransaction.mockResolvedValue({
+    addUserOperationFromTransactionMock = jest.fn().mockResolvedValue({
       id: TRANSACTION_META_MOCK.id,
       hash: jest.fn().mockResolvedValue({}),
       transactionHash: jest.fn().mockResolvedValue(TRANSACTION_META_MOCK.hash),
     });
+    startPollingByNetworkClientIdMock = jest.fn();
+
+    messenger = createMessenger();
+    messenger.registerActionHandler(
+      'TransactionController:addTransaction',
+      addTransactionMock,
+    );
+    messenger.registerActionHandler(
+      'TransactionController:addTransactionBatch',
+      addTransactionBatchMock,
+    );
+    messenger.registerActionHandler(
+      'TransactionController:getState',
+      () => ({ transactions }) as unknown as TransactionControllerState,
+    );
+    messenger.registerActionHandler(
+      'UserOperationController:addUserOperationFromTransaction',
+      addUserOperationFromTransactionMock,
+    );
+    messenger.registerActionHandler(
+      'UserOperationController:startPollingByNetworkClientId',
+      startPollingByNetworkClientIdMock,
+    );
 
     generateSecurityAlertIdMock.mockReturnValue(SECURITY_ALERT_ID_MOCK);
 
-    request.transactionController = transactionController;
-    request.userOperationController = userOperationController;
-    request.updateSecurityAlertResponse = jest.fn();
-    request.getSecurityAlertResponse = getAddressSecurityAlertResponseMock;
-    request.addSecurityAlertResponse = addAddressSecurityAlertResponseMock;
+    request.messenger = messenger;
 
     dappRequest = {
       ...request,
@@ -267,14 +280,13 @@ describe('Transaction Utils', () => {
       it('adds transaction', async () => {
         await addTransaction(request);
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
-          ...TRANSACTION_OPTIONS_MOCK,
-        });
+        expect(addTransactionMock).toHaveBeenCalledTimes(1);
+        expect(addTransactionMock).toHaveBeenCalledWith(
+          TRANSACTION_PARAMS_MOCK,
+          {
+            ...TRANSACTION_OPTIONS_MOCK,
+          },
+        );
       });
 
       it('returns transaction meta', async () => {
@@ -283,7 +295,7 @@ describe('Transaction Utils', () => {
       });
 
       it('does not throw if result promise fails if waitForSubmit is false', async () => {
-        transactionController.addTransaction.mockResolvedValue({
+        addTransactionMock.mockResolvedValue({
           result: Promise.reject(new Error('Test Error')),
           transactionMeta: TRANSACTION_META_MOCK,
         });
@@ -294,7 +306,7 @@ describe('Transaction Utils', () => {
       it('throws if result promise fails if waitForSubmit is true', async () => {
         request.waitForSubmit = true;
 
-        transactionController.addTransaction.mockResolvedValue({
+        addTransactionMock.mockResolvedValue({
           result: Promise.reject(new Error('Test Error')),
           transactionMeta: TRANSACTION_META_MOCK,
         });
@@ -303,7 +315,7 @@ describe('Transaction Utils', () => {
       });
 
       it('does not wait for result if waitForSubmit is false', async () => {
-        transactionController.addTransaction.mockResolvedValue({
+        addTransactionMock.mockResolvedValue({
           result: new Promise(() => {
             /* Intentionally not resolved */
           }),
@@ -323,7 +335,7 @@ describe('Transaction Utils', () => {
           resultResolve = resolve;
         });
 
-        transactionController.addTransaction.mockResolvedValue({
+        addTransactionMock.mockResolvedValue({
           result: resultPromise,
           transactionMeta: TRANSACTION_META_MOCK,
         });
@@ -353,29 +365,26 @@ describe('Transaction Utils', () => {
       it('adds user operation', async () => {
         await addTransaction(request);
 
-        expect(
-          request.userOperationController.addUserOperationFromTransaction,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          request.userOperationController.addUserOperationFromTransaction,
-        ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
-          networkClientId: TRANSACTION_REQUEST_MOCK.networkClientId,
-          origin: TRANSACTION_OPTIONS_MOCK.origin,
-          requireApproval: TRANSACTION_OPTIONS_MOCK.requireApproval,
-          swaps: undefined,
-          type: TRANSACTION_OPTIONS_MOCK.type,
-        });
+        expect(addUserOperationFromTransactionMock).toHaveBeenCalledTimes(1);
+        expect(addUserOperationFromTransactionMock).toHaveBeenCalledWith(
+          TRANSACTION_PARAMS_MOCK,
+          {
+            networkClientId: TRANSACTION_REQUEST_MOCK.networkClientId,
+            origin: TRANSACTION_OPTIONS_MOCK.origin,
+            requireApproval: TRANSACTION_OPTIONS_MOCK.requireApproval,
+            swaps: undefined,
+            type: TRANSACTION_OPTIONS_MOCK.type,
+          },
+        );
       });
 
       it('starts polling', async () => {
         await addTransaction(request);
 
-        expect(
-          userOperationController.startPollingByNetworkClientId,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          userOperationController.startPollingByNetworkClientId,
-        ).toHaveBeenCalledWith(TRANSACTION_REQUEST_MOCK.networkClientId);
+        expect(startPollingByNetworkClientIdMock).toHaveBeenCalledTimes(1);
+        expect(startPollingByNetworkClientIdMock).toHaveBeenCalledWith(
+          TRANSACTION_REQUEST_MOCK.networkClientId,
+        );
       });
 
       it('returns transaction meta', async () => {
@@ -384,16 +393,14 @@ describe('Transaction Utils', () => {
       });
 
       it('does not wait for transaction hash promise if waitForSubmit is false', async () => {
-        userOperationController.addUserOperationFromTransaction.mockResolvedValue(
-          {
-            id: TRANSACTION_META_MOCK.id,
-            hash: undefined as never,
-            transactionHash: () =>
-              new Promise(() => {
-                /* Intentionally not resolved */
-              }),
-          },
-        );
+        addUserOperationFromTransactionMock.mockResolvedValue({
+          id: TRANSACTION_META_MOCK.id,
+          hash: undefined as never,
+          transactionHash: () =>
+            new Promise(() => {
+              /* Intentionally not resolved */
+            }),
+        });
 
         await expect(addTransaction(request)).resolves.toBeTruthy();
       });
@@ -408,13 +415,11 @@ describe('Transaction Utils', () => {
           transactionHashResolve = resolve;
         });
 
-        userOperationController.addUserOperationFromTransaction.mockResolvedValue(
-          {
-            id: TRANSACTION_META_MOCK.id,
-            hash: () => Promise.resolve(TRANSACTION_META_MOCK.hash),
-            transactionHash: () => transactionHashPromise,
-          },
-        );
+        addUserOperationFromTransactionMock.mockResolvedValue({
+          id: TRANSACTION_META_MOCK.id,
+          hash: () => Promise.resolve(TRANSACTION_META_MOCK.hash),
+          transactionHash: () => transactionHashPromise,
+        });
 
         addTransaction(request).then(() => {
           completed = true;
@@ -433,13 +438,11 @@ describe('Transaction Utils', () => {
       });
 
       it('does not throw if transaction hash promise fails and waitForSubmit is false', async () => {
-        userOperationController.addUserOperationFromTransaction.mockResolvedValue(
-          {
-            id: TRANSACTION_META_MOCK.id,
-            hash: jest.fn().mockRejectedValue(new Error('Test Error')),
-            transactionHash: jest.fn().mockResolvedValue({}),
-          },
-        );
+        addUserOperationFromTransactionMock.mockResolvedValue({
+          id: TRANSACTION_META_MOCK.id,
+          hash: jest.fn().mockRejectedValue(new Error('Test Error')),
+          transactionHash: jest.fn().mockResolvedValue({}),
+        });
 
         await expect(addTransaction(request)).resolves.toBeTruthy();
       });
@@ -447,15 +450,11 @@ describe('Transaction Utils', () => {
       it('throws if transaction hash promise fails and waitForSubmit is true', async () => {
         request.waitForSubmit = true;
 
-        userOperationController.addUserOperationFromTransaction.mockResolvedValue(
-          {
-            id: TRANSACTION_META_MOCK.id,
-            hash: undefined as never,
-            transactionHash: jest
-              .fn()
-              .mockRejectedValue(new Error('Test Error')),
-          },
-        );
+        addUserOperationFromTransactionMock.mockResolvedValue({
+          id: TRANSACTION_META_MOCK.id,
+          hash: undefined as never,
+          transactionHash: jest.fn().mockRejectedValue(new Error('Test Error')),
+        });
 
         await expect(addTransaction(request)).rejects.toThrow('Test Error');
       });
@@ -470,12 +469,8 @@ describe('Transaction Utils', () => {
 
         await addTransaction(request);
 
-        expect(
-          request.userOperationController.addUserOperationFromTransaction,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          request.userOperationController.addUserOperationFromTransaction,
-        ).toHaveBeenCalledWith(
+        expect(addUserOperationFromTransactionMock).toHaveBeenCalledTimes(1);
+        expect(addUserOperationFromTransactionMock).toHaveBeenCalledWith(
           TRANSACTION_PARAMS_MOCK,
           expect.objectContaining({
             swaps: {
@@ -491,12 +486,8 @@ describe('Transaction Utils', () => {
 
         await addTransaction(request);
 
-        expect(
-          request.userOperationController.addUserOperationFromTransaction,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          request.userOperationController.addUserOperationFromTransaction,
-        ).toHaveBeenCalledWith(
+        expect(addUserOperationFromTransactionMock).toHaveBeenCalledTimes(1);
+        expect(addUserOperationFromTransactionMock).toHaveBeenCalledWith(
           {
             ...TRANSACTION_PARAMS_MOCK,
             maxFeePerGas: '0xa',
@@ -515,22 +506,21 @@ describe('Transaction Utils', () => {
           chainId: '0x1',
         });
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledTimes(1);
+        expect(addTransactionMock).toHaveBeenCalledTimes(1);
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
-          ...TRANSACTION_OPTIONS_MOCK,
-          securityAlertResponse: {
-            reason: BlockaidReason.inProgress,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            result_type: BlockaidResultType.Loading,
-            securityAlertId: SECURITY_ALERT_ID_MOCK,
+        expect(addTransactionMock).toHaveBeenCalledWith(
+          TRANSACTION_PARAMS_MOCK,
+          {
+            ...TRANSACTION_OPTIONS_MOCK,
+            securityAlertResponse: {
+              reason: BlockaidReason.inProgress,
+              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              result_type: BlockaidResultType.Loading,
+              securityAlertId: SECURITY_ALERT_ID_MOCK,
+            },
           },
-        });
+        );
       });
 
       it('unless blockaid is disabled', async () => {
@@ -540,13 +530,9 @@ describe('Transaction Utils', () => {
           chainId: '0x1',
         });
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledTimes(1);
+        expect(addTransactionMock).toHaveBeenCalledTimes(1);
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledWith(
+        expect(addTransactionMock).toHaveBeenCalledWith(
           TRANSACTION_PARAMS_MOCK,
           TRANSACTION_OPTIONS_MOCK,
         );
@@ -569,13 +555,9 @@ describe('Transaction Utils', () => {
           internalAccounts: [INTERNAL_ACCOUNT],
         });
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledTimes(1);
+        expect(addTransactionMock).toHaveBeenCalledTimes(1);
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledWith(
+        expect(addTransactionMock).toHaveBeenCalledWith(
           sendRequest.transactionParams,
           TRANSACTION_OPTIONS_MOCK,
         );
@@ -593,16 +575,15 @@ describe('Transaction Utils', () => {
           chainId: '0x1',
         });
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledTimes(1);
+        expect(addTransactionMock).toHaveBeenCalledTimes(1);
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
-          ...TRANSACTION_OPTIONS_MOCK,
-          type: TransactionType.swap,
-        });
+        expect(addTransactionMock).toHaveBeenCalledWith(
+          TRANSACTION_PARAMS_MOCK,
+          {
+            ...TRANSACTION_OPTIONS_MOCK,
+            type: TransactionType.swap,
+          },
+        );
 
         expect(validateRequestWithPPOMMock).toHaveBeenCalledTimes(0);
       });
@@ -617,16 +598,15 @@ describe('Transaction Utils', () => {
           chainId: '0x1',
         });
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledTimes(1);
+        expect(addTransactionMock).toHaveBeenCalledTimes(1);
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
-          ...TRANSACTION_OPTIONS_MOCK,
-          type: TransactionType.swapApproval,
-        });
+        expect(addTransactionMock).toHaveBeenCalledWith(
+          TRANSACTION_PARAMS_MOCK,
+          {
+            ...TRANSACTION_OPTIONS_MOCK,
+            type: TransactionType.swapApproval,
+          },
+        );
 
         expect(validateRequestWithPPOMMock).toHaveBeenCalledTimes(0);
       });
@@ -658,9 +638,7 @@ describe('Transaction Utils', () => {
           chainId: '0x1',
         });
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledTimes(1);
+        expect(addTransactionMock).toHaveBeenCalledTimes(1);
 
         expect(validateRequestWithPPOMMock).toHaveBeenCalledTimes(0);
       });
@@ -671,10 +649,6 @@ describe('Transaction Utils', () => {
         request.transactionOptions.origin = ORIGIN_METAMASK;
         request.transactionParams.to =
           '0x1234567890123456789012345678901234567890';
-        request.addSecurityAlertResponse =
-          jest.fn() as AddAddressSecurityAlertResponse;
-        request.getSecurityAlertResponse =
-          jest.fn() as GetAddressSecurityAlertResponse;
       });
 
       it('calls scanAddressAndAddToCache', async () => {
@@ -746,20 +720,19 @@ describe('Transaction Utils', () => {
       it('adds transaction', async () => {
         await addDappTransaction(dappRequest);
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
-          ...TRANSACTION_OPTIONS_MOCK,
-          method: makeDappRequest().method,
-          requireApproval: true,
-          securityAlertResponse: makeRequestContext().assertGet(
-            'securityAlertResponse',
-          ),
-          type: undefined,
-        });
+        expect(addTransactionMock).toHaveBeenCalledTimes(1);
+        expect(addTransactionMock).toHaveBeenCalledWith(
+          TRANSACTION_PARAMS_MOCK,
+          {
+            ...TRANSACTION_OPTIONS_MOCK,
+            method: makeDappRequest().method,
+            requireApproval: true,
+            securityAlertResponse: makeRequestContext().assertGet(
+              'securityAlertResponse',
+            ),
+            type: undefined,
+          },
+        );
       });
 
       it('returns transaction hash', async () => {
@@ -768,7 +741,7 @@ describe('Transaction Utils', () => {
       });
 
       it('throws if result promise fails', async () => {
-        transactionController.addTransaction.mockResolvedValue({
+        addTransactionMock.mockResolvedValue({
           result: Promise.reject(new Error('Test Error')),
           transactionMeta: TRANSACTION_META_MOCK,
         });
@@ -787,29 +760,26 @@ describe('Transaction Utils', () => {
       it('adds user operation', async () => {
         await addDappTransaction(dappRequest);
 
-        expect(
-          request.userOperationController.addUserOperationFromTransaction,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          request.userOperationController.addUserOperationFromTransaction,
-        ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
-          networkClientId: TRANSACTION_REQUEST_MOCK.networkClientId,
-          origin: TRANSACTION_OPTIONS_MOCK.origin,
-          requireApproval: true,
-          swaps: undefined,
-          type: undefined,
-        });
+        expect(addUserOperationFromTransactionMock).toHaveBeenCalledTimes(1);
+        expect(addUserOperationFromTransactionMock).toHaveBeenCalledWith(
+          TRANSACTION_PARAMS_MOCK,
+          {
+            networkClientId: TRANSACTION_REQUEST_MOCK.networkClientId,
+            origin: TRANSACTION_OPTIONS_MOCK.origin,
+            requireApproval: true,
+            swaps: undefined,
+            type: undefined,
+          },
+        );
       });
 
       it('starts polling', async () => {
         await addDappTransaction(dappRequest);
 
-        expect(
-          userOperationController.startPollingByNetworkClientId,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          userOperationController.startPollingByNetworkClientId,
-        ).toHaveBeenCalledWith(TRANSACTION_REQUEST_MOCK.networkClientId);
+        expect(startPollingByNetworkClientIdMock).toHaveBeenCalledTimes(1);
+        expect(startPollingByNetworkClientIdMock).toHaveBeenCalledWith(
+          TRANSACTION_REQUEST_MOCK.networkClientId,
+        );
       });
 
       it('returns transaction hash', async () => {
@@ -818,15 +788,11 @@ describe('Transaction Utils', () => {
       });
 
       it('throws if transaction hash promise fails', async () => {
-        userOperationController.addUserOperationFromTransaction.mockResolvedValue(
-          {
-            id: TRANSACTION_META_MOCK.id,
-            hash: jest.fn().mockResolvedValue({}),
-            transactionHash: jest
-              .fn()
-              .mockRejectedValue(new Error('Test Error')),
-          },
-        );
+        addUserOperationFromTransactionMock.mockResolvedValue({
+          id: TRANSACTION_META_MOCK.id,
+          hash: jest.fn().mockResolvedValue({}),
+          transactionHash: jest.fn().mockRejectedValue(new Error('Test Error')),
+        });
 
         await expect(addDappTransaction(dappRequest)).rejects.toThrow(
           'Test Error',
@@ -841,22 +807,21 @@ describe('Transaction Utils', () => {
           chainId: '0x1079',
         });
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
-          ...TRANSACTION_OPTIONS_MOCK,
-          method: makeDappRequest().method,
-          requireApproval: true,
-          securityAlertResponse: makeRequestContext().assertGet(
-            'securityAlertResponse',
-          ),
-          type: undefined,
-          gasFeeToken: '0x20c0000000000000000000000000000000000000',
-          excludeNativeTokenForFee: true,
-        });
+        expect(addTransactionMock).toHaveBeenCalledTimes(1);
+        expect(addTransactionMock).toHaveBeenCalledWith(
+          TRANSACTION_PARAMS_MOCK,
+          {
+            ...TRANSACTION_OPTIONS_MOCK,
+            method: makeDappRequest().method,
+            requireApproval: true,
+            securityAlertResponse: makeRequestContext().assertGet(
+              'securityAlertResponse',
+            ),
+            type: undefined,
+            gasFeeToken: '0x20c0000000000000000000000000000000000000',
+            excludeNativeTokenForFee: true,
+          },
+        );
       });
 
       it('sends a classic tx if `to` is missing (contract deployment)', async () => {
@@ -870,20 +835,19 @@ describe('Transaction Utils', () => {
           chainId: '0x1079',
         });
 
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          request.transactionController.addTransaction,
-        ).toHaveBeenCalledWith(transactionParamsMockWithoutTo, {
-          ...TRANSACTION_OPTIONS_MOCK,
-          method: makeDappRequest().method,
-          requireApproval: true,
-          securityAlertResponse: makeRequestContext().assertGet(
-            'securityAlertResponse',
-          ),
-          type: undefined,
-        });
+        expect(addTransactionMock).toHaveBeenCalledTimes(1);
+        expect(addTransactionMock).toHaveBeenCalledWith(
+          transactionParamsMockWithoutTo,
+          {
+            ...TRANSACTION_OPTIONS_MOCK,
+            method: makeDappRequest().method,
+            requireApproval: true,
+            securityAlertResponse: makeRequestContext().assertGet(
+              'securityAlertResponse',
+            ),
+            type: undefined,
+          },
+        );
       });
     });
 
@@ -891,12 +855,8 @@ describe('Transaction Utils', () => {
       it('calls addTransactionBatch with converted Tempo-specific params', async () => {
         const result = await addDappTransaction(tempoDappRequest);
 
-        expect(
-          request.transactionController.addTransactionBatch,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          request.transactionController.addTransactionBatch,
-        ).toHaveBeenCalledWith(
+        expect(addTransactionBatchMock).toHaveBeenCalledTimes(1);
+        expect(addTransactionBatchMock).toHaveBeenCalledWith(
           expect.objectContaining({
             actionId: TRANSACTION_OPTIONS_MOCK.actionId,
             networkClientId: TRANSACTION_OPTIONS_MOCK.networkClientId,
@@ -924,9 +884,7 @@ describe('Transaction Utils', () => {
         await expect(addDappTransaction(tempoDappRequest)).rejects.toThrow(
           `Tempo Transaction: Mock error`,
         );
-        expect(
-          request.transactionController.addTransactionBatch,
-        ).not.toHaveBeenCalled();
+        expect(addTransactionBatchMock).not.toHaveBeenCalled();
       });
 
       it('does not call addTransactionBatch if accountSupports7702 resolves to false', async () => {
@@ -934,9 +892,7 @@ describe('Transaction Utils', () => {
         await expect(addDappTransaction(tempoDappRequest)).rejects.toThrow(
           `Wallet not supported for Tempo Transactions.`,
         );
-        expect(
-          request.transactionController.addTransactionBatch,
-        ).not.toHaveBeenCalled();
+        expect(addTransactionBatchMock).not.toHaveBeenCalled();
       });
     });
   });

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -3,44 +3,53 @@ import { EthAccountType } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   TransactionController,
+  TransactionControllerAddTransactionAction,
+  TransactionControllerAddTransactionBatchAction,
   TransactionMeta,
   TransactionParams,
   TransactionType,
 } from '@metamask/transaction-controller';
 import {
   AddUserOperationOptions,
-  UserOperationController,
+  UserOperationControllerAddUserOperationFromTransactionAction,
+  UserOperationControllerStartPollingByNetworkClientIdAction,
 } from '@metamask/user-operation-controller';
+import { KeyringControllerGetKeyringForAccountAction } from '@metamask/keyring-controller';
+import { MessengerActions, MessengerEvents } from '@metamask/messenger';
+import {
+  PRODUCT_TYPES,
+  SubscriptionControllerGetSubscriptionByProductAction,
+} from '@metamask/subscription-controller';
+import { AuthenticationControllerGetBearerTokenAction } from '@metamask/profile-sync-controller/auth';
 import type { Hex, JsonRpcRequest } from '@metamask/utils';
 import { addHexPrefix } from 'ethereumjs-util';
-import { PPOMController } from '@metamask/ppom-validator';
-
-import { KeyringController } from '@metamask/keyring-controller';
 import log from 'loglevel';
 import {
   generateSecurityAlertId,
   handlePPOMError,
+  updateSecurityAlertResponse,
   validateRequestWithPPOM,
+  type PPOMMessenger,
 } from '../ppom/ppom-util';
-import {
-  SecurityAlertResponse,
-  UpdateSecurityAlertResponse,
-  GetSecurityAlertsConfig,
-} from '../ppom/types';
+import { SecurityAlertResponse } from '../ppom/types';
 import {
   LOADING_SECURITY_ALERT_RESPONSE,
   SECURITY_PROVIDER_EXCLUDED_TRANSACTION_TYPES,
 } from '../../../../shared/constants/security-provider';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
 import { ORIGIN_METAMASK } from '../../../../shared/constants/app';
+import { getShieldGatewayConfig } from '../../../../shared/lib/shield/shield';
 import { scanAddressAndAddToCache } from '../trust-signals/security-alerts-api';
 import {
   mapChainIdToSupportedEVMChain,
-  AddAddressSecurityAlertResponse,
-  GetAddressSecurityAlertResponse,
   ScanAddressResponse,
 } from '../../../../shared/lib/trust-signals';
 import { getTransactionDataRecipient } from '../../../../shared/lib/transaction.utils';
+import {
+  AppStateControllerAddAddressSecurityAlertResponseAction,
+  AppStateControllerGetAddressSecurityAlertResponseAction,
+} from '../../controllers/app-state-controller-method-action-types';
+import { RootMessenger } from '../messenger';
 import { accountSupports7702 } from '../account-supports-7702';
 import {
   getTempoEvmTransactionArgs,
@@ -53,20 +62,34 @@ export type AddTransactionOptions = NonNullable<
   Parameters<TransactionController['addTransaction']>[1]
 >;
 
+/**
+ * The messenger used by the shared transaction-add pipeline. It extends the
+ * {@link PPOMMessenger} (security validation) with the actions needed to add a
+ * transaction or user operation, resolve an account's keyring, and read the
+ * security-alerts gateway configuration.
+ */
+export type AddTransactionMessenger = RootMessenger<
+  | MessengerActions<PPOMMessenger>
+  | TransactionControllerAddTransactionAction
+  | TransactionControllerAddTransactionBatchAction
+  | UserOperationControllerAddUserOperationFromTransactionAction
+  | UserOperationControllerStartPollingByNetworkClientIdAction
+  | KeyringControllerGetKeyringForAccountAction
+  | AppStateControllerGetAddressSecurityAlertResponseAction
+  | AppStateControllerAddAddressSecurityAlertResponseAction
+  | SubscriptionControllerGetSubscriptionByProductAction
+  | AuthenticationControllerGetBearerTokenAction,
+  MessengerEvents<PPOMMessenger>
+>;
+
 type BaseAddTransactionRequest = {
   chainId: Hex;
   networkClientId: string;
-  ppomController: PPOMController;
+  messenger: AddTransactionMessenger;
   securityAlertsEnabled: boolean;
   selectedAccount: InternalAccount;
   transactionParams: TransactionParams;
-  transactionController: TransactionController;
-  keyringController: KeyringController;
-  updateSecurityAlertResponse: UpdateSecurityAlertResponse;
-  userOperationController: UserOperationController;
   internalAccounts: InternalAccount[];
-  getSecurityAlertResponse: GetAddressSecurityAlertResponse;
-  addSecurityAlertResponse: AddAddressSecurityAlertResponse;
 };
 
 export type FinalAddTransactionRequest = BaseAddTransactionRequest & {
@@ -75,7 +98,6 @@ export type FinalAddTransactionRequest = BaseAddTransactionRequest & {
 
 export type AddTransactionRequest = FinalAddTransactionRequest & {
   waitForSubmit: boolean;
-  getSecurityAlertsConfig?: GetSecurityAlertsConfig;
 };
 
 export type AddDappTransactionRequest = BaseAddTransactionRequest & {
@@ -142,10 +164,10 @@ export async function addDappTransaction(
 async function addTransactionOnTempo(
   request: FinalAddTransactionRequest,
 ): AddTransactionResult {
-  const { chainId, keyringController } = request;
+  const { chainId, messenger } = request;
   const isEip7702SupportedByAccount = await accountSupports7702(
     request.transactionParams.from,
-    keyringController as Parameters<typeof accountSupports7702>[1],
+    messenger,
   );
 
   // Non-Tempo transaction (not type 0x76)
@@ -175,17 +197,13 @@ async function addTransactionOnTempo(
     throw new Error('Wallet not supported for Tempo Transactions.');
   }
   // Checks and infer Tempo Transaction format for supported fields.
-  const { transactionController } = request;
-
-  const result = await transactionController.addTransactionBatch(
+  const result = await messenger.call(
+    'TransactionController:addTransactionBatch',
     getTempoTransactionBatchArgs({ request, chainId }),
   );
   const { batchId } = result;
   // We've got a batchId but we want to return a tx hash to the dApp
-  const transactionMeta = getTransactionByBatchId(
-    batchId,
-    transactionController,
-  );
+  const transactionMeta = getTransactionByBatchId(batchId, messenger);
 
   if (!transactionMeta) {
     log.debug(`Batch ${batchId}: No matching transaction found.`);
@@ -225,7 +243,7 @@ export async function addTransaction(
 
   const finalTransactionMeta = getTransactionByHash(
     transactionHash as string,
-    request.transactionController,
+    request.messenger,
   );
 
   return finalTransactionMeta as TransactionMeta;
@@ -253,18 +271,17 @@ async function addTransactionOrUserOperation(
 async function addTransactionWithController(
   request: FinalAddTransactionRequest,
 ) {
-  const {
-    transactionController,
-    transactionOptions,
-    transactionParams,
-    networkClientId,
-  } = request;
+  const { messenger, transactionOptions, transactionParams, networkClientId } =
+    request;
 
-  const { result, transactionMeta } =
-    await transactionController.addTransaction(transactionParams, {
+  const { result, transactionMeta } = await messenger.call(
+    'TransactionController:addTransaction',
+    transactionParams,
+    {
       ...transactionOptions,
       networkClientId,
-    });
+    },
+  );
 
   return {
     transactionMeta,
@@ -275,13 +292,8 @@ async function addTransactionWithController(
 async function addUserOperationWithController(
   request: FinalAddTransactionRequest,
 ) {
-  const {
-    networkClientId,
-    transactionController,
-    transactionOptions,
-    transactionParams,
-    userOperationController,
-  } = request;
+  const { messenger, networkClientId, transactionOptions, transactionParams } =
+    request;
 
   const { maxFeePerGas, maxPriorityFeePerGas } = transactionParams;
 
@@ -309,19 +321,43 @@ async function addUserOperationWithController(
     type,
   };
 
-  const result = await userOperationController.addUserOperationFromTransaction(
+  const result = await messenger.call(
+    'UserOperationController:addUserOperationFromTransaction',
     normalisedTransaction,
     options,
   );
 
-  userOperationController.startPollingByNetworkClientId(networkClientId);
+  messenger.call(
+    'UserOperationController:startPollingByNetworkClientId',
+    networkClientId,
+  );
 
-  const transactionMeta = getTransactionById(result.id, transactionController);
+  const transactionMeta = findTransaction(
+    messenger,
+    (tx) => tx.id === result.id,
+  );
 
   return {
     transactionMeta,
     waitForHash: result.transactionHash,
   };
+}
+
+/**
+ * Finds a transaction in the TransactionController state that matches the given
+ * predicate, reading state via the messenger.
+ *
+ * @param messenger - The messenger used to read the TransactionController state.
+ * @param predicate - The predicate used to find the transaction.
+ * @returns The matching transaction, or `undefined` if none is found.
+ */
+function findTransaction(
+  messenger: AddTransactionMessenger,
+  predicate: (tx: TransactionMeta) => boolean,
+): TransactionMeta | undefined {
+  return messenger
+    .call('TransactionController:getState')
+    .transactions.find(predicate);
 }
 
 export function getTransactionById(
@@ -335,26 +371,43 @@ export function getTransactionById(
 
 function getTransactionByHash(
   transactionHash: string,
-  transactionController: TransactionController,
+  messenger: AddTransactionMessenger,
 ) {
-  return transactionController.state.transactions.find(
-    (tx) => tx.hash === transactionHash,
-  );
+  return findTransaction(messenger, (tx) => tx.hash === transactionHash);
 }
 
 function getTransactionByBatchId(
   batchId: string,
-  transactionController: TransactionController,
+  messenger: AddTransactionMessenger,
 ) {
-  return transactionController.state.transactions.find(
-    (tx) => tx.batchId === batchId,
-  );
+  return findTransaction(messenger, (tx) => tx.batchId === batchId);
+}
+
+/**
+ * Builds the security-alerts API configuration (gateway URL and authorization
+ * header) from the messenger, reading the shield subscription and bearer token.
+ *
+ * @param messenger - The messenger used to read the subscription and token.
+ * @param url - The URL of the Security Alerts API.
+ * @returns The security-alerts gateway configuration.
+ */
+async function getSecurityAlertsConfig(
+  messenger: AddTransactionMessenger,
+  url: string,
+): Promise<{ newUrl?: string; authorization?: string }> {
+  const getShieldSubscription = () =>
+    messenger.call(
+      'SubscriptionController:getSubscriptionByProduct',
+      PRODUCT_TYPES.SHIELD,
+    );
+  const getToken = () =>
+    messenger.call('AuthenticationController:getBearerToken');
+  return getShieldGatewayConfig(getToken, getShieldSubscription, url);
 }
 
 function scanAddressForTrustSignals(request: AddTransactionRequest) {
   const {
-    getSecurityAlertResponse,
-    addSecurityAlertResponse,
+    messenger,
     securityAlertsEnabled,
     transactionOptions,
     transactionParams,
@@ -375,14 +428,21 @@ function scanAddressForTrustSignals(request: AddTransactionRequest) {
   }
 
   const getAddressSecurityAlertResponseWithChain = (cacheKey: string) => {
-    return getSecurityAlertResponse(cacheKey);
+    return messenger.call(
+      'AppStateController:getAddressSecurityAlertResponse',
+      cacheKey,
+    );
   };
 
   const addAddressSecurityAlertResponseWithChain = (
     cacheKey: string,
     response: ScanAddressResponse,
   ) => {
-    return addSecurityAlertResponse(cacheKey, response);
+    return messenger.call(
+      'AppStateController:addAddressSecurityAlertResponse',
+      cacheKey,
+      response,
+    );
   };
 
   scanAddressAndAddToCache(
@@ -401,13 +461,11 @@ function scanAddressForTrustSignals(request: AddTransactionRequest) {
 async function validateSecurity(request: AddTransactionRequest) {
   const {
     chainId,
-    ppomController,
+    messenger,
     securityAlertsEnabled,
     transactionOptions,
     transactionParams,
-    updateSecurityAlertResponse,
     internalAccounts,
-    getSecurityAlertsConfig,
   } = request;
 
   scanAddressForTrustSignals(request);
@@ -459,12 +517,18 @@ async function validateSecurity(request: AddTransactionRequest) {
 
     // Intentionally not awaited to avoid blocking the confirmation process while the validation occurs.
     validateRequestWithPPOM({
-      ppomController,
+      messenger,
       request: ppomRequest,
       securityAlertId,
       chainId,
-      updateSecurityAlertResponse,
-      getSecurityAlertsConfig,
+      updateSecurityAlertResponse: (method, id, securityAlertResponse) =>
+        updateSecurityAlertResponse({
+          messenger,
+          method,
+          securityAlertId: id,
+          securityAlertResponse,
+        }),
+      getSecurityAlertsConfig: (url) => getSecurityAlertsConfig(messenger, url),
     });
 
     const securityAlertResponseLoading: SecurityAlertResponse = {

--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -153,6 +153,23 @@ export function getLegacyBackgroundApiServiceMessenger(
       'GasFeeController:disableNonRPCGasFeeApis',
       'ShieldController:start',
       'ShieldController:stop',
+      'TransactionController:addTransaction',
+      'TransactionController:addTransactionBatch',
+      'TransactionController:updateSecurityAlertResponse',
+      'UserOperationController:addUserOperationFromTransaction',
+      'UserOperationController:startPollingByNetworkClientId',
+      'PPOMController:usePPOM',
+      'KeyringController:getKeyringForAccount',
+      'SignatureController:getState',
+      'AppStateController:getAddressSecurityAlertResponse',
+      'AppStateController:addAddressSecurityAlertResponse',
+      'AppStateController:addSignatureSecurityAlertResponse',
+      'SubscriptionController:getSubscriptionByProduct',
+      'AuthenticationController:getBearerToken',
+    ],
+    events: [
+      'TransactionController:unapprovedTransactionAdded',
+      'SignatureController:stateChange',
     ],
   });
 

--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -29,6 +29,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'NetworkController:getState',
       'NetworkController:findNetworkClientIdByChainId',
       'NetworkController:getNetworkClientById',
+      'NetworkController:getNetworkConfigurationByNetworkClientId',
       'NetworkController:getSelectedNetworkClient',
       'NetworkController:lookupNetwork',
       'NetworkEnablementController:getState',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -242,7 +242,7 @@ import {
   getOriginsWithSessionProperty,
 } from './controllers/permissions';
 import createRPCMethodTrackingMiddleware from './lib/createRPCMethodTrackingMiddleware';
-import { addDappTransaction, addTransaction } from './lib/transaction/util';
+import { addDappTransaction } from './lib/transaction/util';
 import { addTypedMessage, addPersonalMessage } from './lib/signature/util';
 import {
   METAMASK_CAIP_MULTICHAIN_PROVIDER,
@@ -1096,7 +1096,7 @@ export default class MetamaskController extends EventEmitter {
               validateSecurity: (securityAlertId, request, chainId) =>
                 validateRequestWithPPOM({
                   chainId,
-                  ppomController: this.ppomController,
+                  messenger: this.controllerMessenger,
                   request,
                   securityAlertId,
                   updateSecurityAlertResponse:
@@ -1172,14 +1172,27 @@ export default class MetamaskController extends EventEmitter {
       // account mgmt
       getAccounts: (requestOrigin) => getAccounts({ origin: requestOrigin }),
       // tx signing
-      processTransaction: (transactionParams, dappRequest, requestContext) =>
-        addDappTransaction(
-          this.getAddTransactionRequest({
-            transactionParams,
-            dappRequest,
-            requestContext,
-          }),
-        ),
+      processTransaction: (transactionParams, dappRequest, requestContext) => {
+        const networkClientId = requestContext?.get('networkClientId');
+        const { chainId } =
+          this.networkController.getNetworkConfigurationByNetworkClientId(
+            networkClientId,
+          );
+        return addDappTransaction({
+          messenger: this.controllerMessenger,
+          internalAccounts: this.accountsController.listAccounts(),
+          selectedAccount: this.accountsController.getAccountByAddress(
+            transactionParams.from,
+          ),
+          networkClientId,
+          chainId,
+          transactionParams,
+          dappRequest,
+          requestContext,
+          securityAlertsEnabled:
+            this.preferencesController.state?.securityAlertsEnabled,
+        });
+      },
       // msg signing
       processTypedMessage: (...args) =>
         addTypedMessage({
@@ -3388,25 +3401,14 @@ export default class MetamaskController extends EventEmitter {
         this.controllerMessenger,
         'LegacyBackgroundApiService:getNextNonce',
       ),
-      addTransaction: (transactionParams, transactionOptions) =>
-        addTransaction(
-          this.getAddTransactionRequest({
-            transactionParams,
-            transactionOptions: { ...transactionOptions, isInternal: true },
-            waitForSubmit: false,
-          }),
-        ),
-      addTransactionAndWaitForPublish: (
-        transactionParams,
-        transactionOptions,
-      ) =>
-        addTransaction(
-          this.getAddTransactionRequest({
-            transactionParams,
-            transactionOptions: { ...transactionOptions, isInternal: true },
-            waitForSubmit: true,
-          }),
-        ),
+      addTransaction: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:addTransaction',
+      ),
+      addTransactionAndWaitForPublish: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:addTransactionAndWaitForPublish',
+      ),
       upsertTransactionUIMetricsFragment: this.controllerMessenger.call.bind(
         this.controllerMessenger,
         'LegacyBackgroundApiService:upsertTransactionUIMetricsFragment',
@@ -4496,51 +4498,6 @@ export default class MetamaskController extends EventEmitter {
   }
   // Identity Management (signature operations)
 
-  getAddTransactionRequest({
-    transactionParams,
-    transactionOptions,
-    dappRequest,
-    requestContext,
-    ...otherParams
-  }) {
-    const networkClientId =
-      requestContext?.get('networkClientId') ??
-      transactionOptions?.networkClientId;
-    const { chainId } =
-      this.networkController.getNetworkConfigurationByNetworkClientId(
-        networkClientId,
-      );
-    return {
-      internalAccounts: this.accountsController.listAccounts(),
-      dappRequest,
-      requestContext,
-      networkClientId,
-      selectedAccount: this.accountsController.getAccountByAddress(
-        transactionParams.from,
-      ),
-      transactionController: this.txController,
-      keyringController: this.keyringController,
-      transactionOptions,
-      transactionParams,
-      userOperationController: this.userOperationController,
-      chainId,
-      ppomController: this.ppomController,
-      securityAlertsEnabled:
-        this.preferencesController.state?.securityAlertsEnabled,
-      updateSecurityAlertResponse: this.updateSecurityAlertResponse.bind(this),
-      getSecurityAlertResponse:
-        this.appStateController.getAddressSecurityAlertResponse.bind(
-          this.appStateController,
-        ),
-      addSecurityAlertResponse:
-        this.appStateController.addAddressSecurityAlertResponse.bind(
-          this.appStateController,
-        ),
-      getSecurityAlertsConfig: this.getSecurityAlertsConfig.bind(this),
-      ...otherParams,
-    };
-  }
-
   //=============================================================================
   // END (VAULT / KEYRING RELATED METHODS)
   //=============================================================================
@@ -4733,13 +4690,10 @@ export default class MetamaskController extends EventEmitter {
     securityAlertResponse,
   ) {
     return await updateSecurityAlertResponse({
-      appStateController: this.appStateController,
       messenger: this.controllerMessenger,
       method,
       securityAlertId,
       securityAlertResponse,
-      signatureController: this.signatureController,
-      transactionController: this.txController,
     });
   }
 
@@ -5560,7 +5514,7 @@ export default class MetamaskController extends EventEmitter {
 
     engine.push(
       createPPOMMiddleware(
-        this.ppomController,
+        this.controllerMessenger,
         this.preferencesController,
         this.networkController,
         this.appStateController,
@@ -6080,7 +6034,7 @@ export default class MetamaskController extends EventEmitter {
 
     engine.push(
       createPPOMMiddleware(
-        this.ppomController,
+        this.controllerMessenger,
         this.preferencesController,
         this.networkController,
         this.appStateController,
@@ -7242,21 +7196,16 @@ export default class MetamaskController extends EventEmitter {
         upgradeContractAddress,
         networkClientId,
       },
-      async (transactionParams, options) => {
-        const transactionMeta = await addTransaction(
-          this.getAddTransactionRequest({
-            transactionParams,
-            transactionOptions: {
-              ...options,
-              isInternal: true,
-              origin: 'metamask',
-              requireApproval: true,
-            },
-            waitForSubmit: true,
-          }),
-        );
-        return transactionMeta;
-      },
+      async (transactionParams, options) =>
+        this.controllerMessenger.call(
+          'LegacyBackgroundApiService:addTransactionAndWaitForPublish',
+          transactionParams,
+          {
+            ...options,
+            origin: 'metamask',
+            requireApproval: true,
+          },
+        ),
     );
   }
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1015,61 +1015,6 @@ describe('MetaMaskController', () => {
       });
     });
 
-    describe('#getAddTransactionRequest', () => {
-      it('formats the transaction for submission', () => {
-        const transactionParams = { from: '0xa', to: '0xb' };
-        const transactionOptions = {
-          foo: true,
-          networkClientId: NETWORK_CONFIGURATION_ID_1,
-        };
-        const result = metamaskController.getAddTransactionRequest({
-          transactionParams,
-          transactionOptions,
-        });
-        expect(result).toStrictEqual({
-          internalAccounts:
-            metamaskController.accountsController.listAccounts(),
-          dappRequest: undefined,
-          requestContext: undefined,
-          networkClientId: NETWORK_CONFIGURATION_ID_1,
-          selectedAccount:
-            metamaskController.accountsController.getAccountByAddress(
-              transactionParams.from,
-            ),
-          transactionController: expect.any(Object),
-          keyringController: expect.any(Object),
-          transactionOptions,
-          transactionParams,
-          userOperationController: expect.any(Object),
-          chainId: '0x1',
-          ppomController: expect.any(Object),
-          securityAlertsEnabled: expect.any(Boolean),
-          updateSecurityAlertResponse: expect.any(Function),
-          getSecurityAlertResponse: expect.any(Function),
-          addSecurityAlertResponse: expect.any(Function),
-          getSecurityAlertsConfig: expect.any(Function),
-        });
-      });
-      it('passes through any additional params to the object', () => {
-        const transactionParams = { from: '0xa', to: '0xb' };
-        const transactionOptions = {
-          foo: true,
-          networkClientId: NETWORK_CONFIGURATION_ID_1,
-        };
-        const result = metamaskController.getAddTransactionRequest({
-          transactionParams,
-          transactionOptions,
-          test: '123',
-        });
-
-        expect(result).toMatchObject({
-          transactionParams,
-          transactionOptions,
-          test: '123',
-        });
-      });
-    });
-
     describe('getTransactionMetricsRequest', () => {
       it('getSmartTransactionsPreferenceEnabled returns selector result from metamask state', () => {
         metamaskController.preferencesController.update((state) => {

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -198,6 +198,34 @@ export type LegacyBackgroundApiServiceDecodeTransactionDataAction = {
 };
 
 /**
+ * Adds a transaction to the TransactionController (or a user operation for
+ * smart accounts) after running security validation, without waiting for the
+ * transaction to be published.
+ *
+ * @param transactionParams - The parameters of the transaction to add.
+ * @param transactionOptions - Options for adding the transaction.
+ * @returns The transaction metadata.
+ */
+export type LegacyBackgroundApiServiceAddTransactionAction = {
+  type: `LegacyBackgroundApiService:addTransaction`;
+  handler: LegacyBackgroundApiService['addTransaction'];
+};
+
+/**
+ * Adds a transaction to the TransactionController (or a user operation for
+ * smart accounts) after running security validation, waiting for the
+ * transaction to be published and returning the final transaction metadata.
+ *
+ * @param transactionParams - The parameters of the transaction to add.
+ * @param transactionOptions - Options for adding the transaction.
+ * @returns The final transaction metadata.
+ */
+export type LegacyBackgroundApiServiceAddTransactionAndWaitForPublishAction = {
+  type: `LegacyBackgroundApiService:addTransactionAndWaitForPublish`;
+  handler: LegacyBackgroundApiService['addTransactionAndWaitForPublish'];
+};
+
+/**
  * Verifies the validity of the current vault's seed phrase.
  *
  * Validity: seed phrase restores the accounts belonging to the current vault.
@@ -970,6 +998,8 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceCheckDelegationDisabledAction
   | LegacyBackgroundApiServiceEstimateGasAction
   | LegacyBackgroundApiServiceDecodeTransactionDataAction
+  | LegacyBackgroundApiServiceAddTransactionAction
+  | LegacyBackgroundApiServiceAddTransactionAndWaitForPublishAction
   | LegacyBackgroundApiServiceGetSeedPhraseAction
   | LegacyBackgroundApiServiceResetAccountAction
   | LegacyBackgroundApiServiceLookupSelectedNetworksAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -2076,6 +2076,155 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
+  describe('addTransaction', () => {
+    const TRANSACTION_PARAMS = {
+      from: '0xfromaddress',
+      to: '0xtoaddress',
+    } as unknown as Parameters<LegacyBackgroundApiService['addTransaction']>[0];
+    const NETWORK_CLIENT_ID = 'networkClientId';
+
+    /**
+     * Registers the handlers required by the transaction-add pipeline to add an
+     * EOA transaction with security alerts disabled.
+     *
+     * @param rootMessenger - The root messenger to register handlers on.
+     * @param transactions - The transactions to expose via
+     * `TransactionController:getState`.
+     */
+    function registerAddTransactionHandlers(
+      rootMessenger: RootMessenger,
+      transactions: TransactionMeta[] = [],
+    ): void {
+      rootMessenger.registerActionHandler(
+        'AccountsController:listAccounts',
+        jest.fn().mockReturnValue([]),
+      );
+      rootMessenger.registerActionHandler(
+        'AccountsController:getAccountByAddress',
+        jest
+          .fn()
+          .mockReturnValue(
+            createMockInternalAccount({ address: '0xfromaddress' }),
+          ),
+      );
+      rootMessenger.registerActionHandler(
+        'NetworkController:getState',
+        jest.fn().mockReturnValue({
+          networkConfigurationsByChainId: {
+            '0x1': {
+              chainId: '0x1',
+              rpcEndpoints: [{ networkClientId: NETWORK_CLIENT_ID }],
+            },
+          },
+        }),
+      );
+      rootMessenger.registerActionHandler(
+        'PreferencesController:getState',
+        jest.fn().mockReturnValue({ securityAlertsEnabled: false }),
+      );
+      rootMessenger.registerActionHandler(
+        'TransactionController:getState',
+        jest.fn().mockReturnValue({ transactions }),
+      );
+    }
+
+    it('adds the transaction via the TransactionController and returns its metadata without waiting for publish', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const transactionMeta = {
+          id: 'txId',
+          hash: '0xhash',
+        } as TransactionMeta;
+        registerAddTransactionHandlers(rootMessenger);
+        const addTransactionHandler = jest.fn().mockResolvedValue({
+          result: Promise.resolve('0xhash'),
+          transactionMeta,
+        });
+        rootMessenger.registerActionHandler(
+          'TransactionController:addTransaction',
+          addTransactionHandler,
+        );
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:addTransaction',
+          TRANSACTION_PARAMS,
+          { networkClientId: NETWORK_CLIENT_ID },
+        );
+
+        expect(addTransactionHandler).toHaveBeenCalledWith(TRANSACTION_PARAMS, {
+          networkClientId: NETWORK_CLIENT_ID,
+          isInternal: true,
+        });
+        expect(result).toStrictEqual(transactionMeta);
+      });
+    });
+  });
+
+  describe('addTransactionAndWaitForPublish', () => {
+    const TRANSACTION_PARAMS = {
+      from: '0xfromaddress',
+      to: '0xtoaddress',
+    } as unknown as Parameters<
+      LegacyBackgroundApiService['addTransactionAndWaitForPublish']
+    >[0];
+    const NETWORK_CLIENT_ID = 'networkClientId';
+
+    it('waits for the transaction to publish and returns the final metadata', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const finalTransactionMeta = {
+          id: 'txId',
+          hash: '0xhash',
+        } as TransactionMeta;
+
+        rootMessenger.registerActionHandler(
+          'AccountsController:listAccounts',
+          jest.fn().mockReturnValue([]),
+        );
+        rootMessenger.registerActionHandler(
+          'AccountsController:getAccountByAddress',
+          jest
+            .fn()
+            .mockReturnValue(
+              createMockInternalAccount({ address: '0xfromaddress' }),
+            ),
+        );
+        rootMessenger.registerActionHandler(
+          'NetworkController:getState',
+          jest.fn().mockReturnValue({
+            networkConfigurationsByChainId: {
+              '0x1': {
+                chainId: '0x1',
+                rpcEndpoints: [{ networkClientId: NETWORK_CLIENT_ID }],
+              },
+            },
+          }),
+        );
+        rootMessenger.registerActionHandler(
+          'PreferencesController:getState',
+          jest.fn().mockReturnValue({ securityAlertsEnabled: false }),
+        );
+        rootMessenger.registerActionHandler(
+          'TransactionController:getState',
+          jest.fn().mockReturnValue({ transactions: [finalTransactionMeta] }),
+        );
+        rootMessenger.registerActionHandler(
+          'TransactionController:addTransaction',
+          jest.fn().mockResolvedValue({
+            result: Promise.resolve('0xhash'),
+            transactionMeta: { id: 'txId' } as TransactionMeta,
+          }),
+        );
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:addTransactionAndWaitForPublish',
+          TRANSACTION_PARAMS,
+          { networkClientId: NETWORK_CLIENT_ID },
+        );
+
+        expect(result).toStrictEqual(finalTransactionMeta);
+      });
+    });
+  });
+
   describe('resetAccount', () => {
     it('resets the account and returns the selected address', async () => {
       const selectedAddress = '0x123';
@@ -6968,6 +7117,23 @@ function getMessenger(
       'GasFeeController:disableNonRPCGasFeeApis',
       'ShieldController:start',
       'ShieldController:stop',
+      'TransactionController:addTransaction',
+      'TransactionController:addTransactionBatch',
+      'TransactionController:updateSecurityAlertResponse',
+      'UserOperationController:addUserOperationFromTransaction',
+      'UserOperationController:startPollingByNetworkClientId',
+      'PPOMController:usePPOM',
+      'KeyringController:getKeyringForAccount',
+      'SignatureController:getState',
+      'AppStateController:getAddressSecurityAlertResponse',
+      'AppStateController:addAddressSecurityAlertResponse',
+      'AppStateController:addSignatureSecurityAlertResponse',
+      'SubscriptionController:getSubscriptionByProduct',
+      'AuthenticationController:getBearerToken',
+    ],
+    events: [
+      'TransactionController:unapprovedTransactionAdded',
+      'SignatureController:stateChange',
     ],
   });
 

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -2108,15 +2108,8 @@ describe('LegacyBackgroundApiService', () => {
           ),
       );
       rootMessenger.registerActionHandler(
-        'NetworkController:getState',
-        jest.fn().mockReturnValue({
-          networkConfigurationsByChainId: {
-            '0x1': {
-              chainId: '0x1',
-              rpcEndpoints: [{ networkClientId: NETWORK_CLIENT_ID }],
-            },
-          },
-        }),
+        'NetworkController:getNetworkConfigurationByNetworkClientId',
+        jest.fn().mockReturnValue({ chainId: '0x1' }),
       );
       rootMessenger.registerActionHandler(
         'PreferencesController:getState',
@@ -2188,15 +2181,8 @@ describe('LegacyBackgroundApiService', () => {
             ),
         );
         rootMessenger.registerActionHandler(
-          'NetworkController:getState',
-          jest.fn().mockReturnValue({
-            networkConfigurationsByChainId: {
-              '0x1': {
-                chainId: '0x1',
-                rpcEndpoints: [{ networkClientId: NETWORK_CLIENT_ID }],
-              },
-            },
-          }),
+          'NetworkController:getNetworkConfigurationByNetworkClientId',
+          jest.fn().mockReturnValue({ chainId: '0x1' }),
         );
         rootMessenger.registerActionHandler(
           'PreferencesController:getState',
@@ -6995,6 +6981,7 @@ function getMessenger(
       'NetworkController:getState',
       'NetworkController:findNetworkClientIdByChainId',
       'NetworkController:getNetworkClientById',
+      'NetworkController:getNetworkConfigurationByNetworkClientId',
       'NetworkController:getSelectedNetworkClient',
       'NetworkController:lookupNetwork',
       'NetworkEnablementController:getState',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -3,6 +3,7 @@ import { Messenger } from '@metamask/messenger';
 import {
   NetworkControllerFindNetworkClientIdByChainIdAction,
   NetworkControllerGetNetworkClientByIdAction,
+  NetworkControllerGetNetworkConfigurationByNetworkClientIdAction,
   NetworkControllerGetSelectedNetworkClientAction,
   NetworkControllerGetStateAction,
   NetworkControllerLookupNetworkAction,
@@ -100,7 +101,6 @@ import {
   UserOperationControllerAddUserOperationFromTransactionAction,
   UserOperationControllerStartPollingByNetworkClientIdAction,
 } from '@metamask/user-operation-controller';
-import { UsePPOM } from '@metamask/ppom-validator';
 import {
   GetSignatureState,
   SignatureStateChange,
@@ -274,6 +274,7 @@ import {
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
 import { restrictKeyringForDeviceRead } from '../lib/hardware-device-read-keyring';
+import type { UsePPOMAction } from '../lib/ppom/ppom-util';
 import { OnboardingControllerGetIsSocialLoginFlowAction } from '../controllers/onboarding-method-action-types';
 import { getAccountsBySnapId } from '../lib/snap-keyring';
 import {
@@ -593,6 +594,7 @@ type AllowedActions =
   | MultichainAccountServiceResyncAccountsAction
   | NetworkControllerFindNetworkClientIdByChainIdAction
   | NetworkControllerGetNetworkClientByIdAction
+  | NetworkControllerGetNetworkConfigurationByNetworkClientIdAction
   | NetworkControllerGetSelectedNetworkClientAction
   | NetworkControllerGetStateAction
   | NetworkControllerLookupNetworkAction
@@ -659,7 +661,7 @@ type AllowedActions =
   | TransactionControllerUpdateEditableParamsAction
   | TransactionControllerUpdateSecurityAlertResponseAction
   | TransactionControllerWipeTransactionsAction
-  | UsePPOM
+  | UsePPOMAction
   | UserOperationControllerAddUserOperationFromTransactionAction
   | UserOperationControllerStartPollingByNetworkClientIdAction;
 
@@ -1149,23 +1151,17 @@ export class LegacyBackgroundApiService {
   }
 
   /**
-   * Resolves the chain ID that owns the given network client ID from the
-   * NetworkController state, mirroring
+   * Resolves the chain ID that owns the given network client ID, mirroring the
+   * former `getAddTransactionRequest`'s
    * `NetworkController.getNetworkConfigurationByNetworkClientId(...).chainId`.
    *
    * @param networkClientId - The network client ID to resolve.
    * @returns The chain ID.
    */
   #getChainIdByNetworkClientId(networkClientId?: string): Hex {
-    const { networkConfigurationsByChainId } = this.#messenger.call(
-      'NetworkController:getState',
-    );
-
-    const chainId = Object.values(networkConfigurationsByChainId).find(
-      (networkConfiguration) =>
-        networkConfiguration.rpcEndpoints.some(
-          (rpcEndpoint) => rpcEndpoint.networkClientId === networkClientId,
-        ),
+    const chainId = this.#messenger.call(
+      'NetworkController:getNetworkConfigurationByNetworkClientId',
+      networkClientId as string,
     )?.chainId;
 
     if (!chainId) {

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -1,6 +1,7 @@
 import log from 'loglevel';
 import { Messenger } from '@metamask/messenger';
 import {
+  NetworkConfiguration,
   NetworkControllerFindNetworkClientIdByChainIdAction,
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetNetworkConfigurationByNetworkClientIdAction,
@@ -1131,6 +1132,10 @@ export class LegacyBackgroundApiService {
     waitForSubmit: boolean,
   ): AddTransactionRequest {
     const networkClientId = transactionOptions?.networkClientId;
+    const { chainId } = this.#messenger.call(
+      'NetworkController:getNetworkConfigurationByNetworkClientId',
+      networkClientId as string,
+    ) as NetworkConfiguration;
 
     return {
       messenger: this.#messenger,
@@ -1140,7 +1145,7 @@ export class LegacyBackgroundApiService {
         transactionParams.from,
       ) as InternalAccount,
       networkClientId: networkClientId as string,
-      chainId: this.#getChainIdByNetworkClientId(networkClientId),
+      chainId,
       transactionParams,
       transactionOptions: { ...transactionOptions, isInternal: true },
       securityAlertsEnabled: this.#messenger.call(
@@ -1148,29 +1153,6 @@ export class LegacyBackgroundApiService {
       ).securityAlertsEnabled,
       waitForSubmit,
     };
-  }
-
-  /**
-   * Resolves the chain ID that owns the given network client ID, mirroring the
-   * former `getAddTransactionRequest`'s
-   * `NetworkController.getNetworkConfigurationByNetworkClientId(...).chainId`.
-   *
-   * @param networkClientId - The network client ID to resolve.
-   * @returns The chain ID.
-   */
-  #getChainIdByNetworkClientId(networkClientId?: string): Hex {
-    const chainId = this.#messenger.call(
-      'NetworkController:getNetworkConfigurationByNetworkClientId',
-      networkClientId as string,
-    )?.chainId;
-
-    if (!chainId) {
-      throw new Error(
-        `No chain ID found for network client ID: ${networkClientId}`,
-      );
-    }
-
-    return chainId;
   }
 
   /**

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -40,6 +40,7 @@ import {
   KeyringControllerExportAccountAction,
   KeyringControllerExportEncryptionKeyAction,
   KeyringControllerExportSeedPhraseAction,
+  KeyringControllerGetKeyringForAccountAction,
   KeyringControllerGetKeyringsByTypeAction,
   KeyringControllerGetStateAction,
   KeyringControllerImportAccountWithStrategyAction,
@@ -81,14 +82,29 @@ import { KeyringType } from '@metamask/keyring-api/v2';
 import { normalize } from '@metamask/eth-sig-util';
 import {
   TransactionContainerType,
+  TransactionControllerAddTransactionAction,
+  TransactionControllerAddTransactionBatchAction,
   TransactionControllerClearUnapprovedTransactionsAction,
   TransactionControllerEstimateGasAction,
   TransactionControllerGetNonceLockAction,
   TransactionControllerGetStateAction,
   TransactionControllerIsAtomicBatchSupportedAction,
+  TransactionControllerUnapprovedTransactionAddedEvent,
   TransactionControllerUpdateEditableParamsAction,
+  TransactionControllerUpdateSecurityAlertResponseAction,
   TransactionControllerWipeTransactionsAction,
+  type TransactionMeta,
+  type TransactionParams,
 } from '@metamask/transaction-controller';
+import {
+  UserOperationControllerAddUserOperationFromTransactionAction,
+  UserOperationControllerStartPollingByNetworkClientIdAction,
+} from '@metamask/user-operation-controller';
+import { UsePPOM } from '@metamask/ppom-validator';
+import {
+  GetSignatureState,
+  SignatureStateChange,
+} from '@metamask/signature-controller';
 import {
   AssetsContractControllerGetTokenStandardAndDetailsAction,
   CurrencyRateControllerSetCurrentCurrencyAction,
@@ -199,11 +215,13 @@ import {
   rpcErrors,
 } from '@metamask/rpc-errors';
 import {
+  AuthenticationControllerGetBearerTokenAction,
   AuthenticationControllerGetStateAction,
   AuthenticationControllerPerformSignOutAction,
 } from '@metamask/profile-sync-controller/auth';
 import {
   SubscriptionControllerGetStateAction,
+  SubscriptionControllerGetSubscriptionByProductAction,
   SubscriptionControllerStopAllPollingAction,
 } from '@metamask/subscription-controller';
 import {
@@ -267,6 +285,11 @@ import { openUpdateTabAndReload } from '../lib/open-update-tab-and-reload';
 import { applyTransactionContainers } from '../lib/transaction/containers/util';
 import { isRelaySupported } from '../lib/transaction/transaction-relay';
 import { decodeTransactionData } from '../lib/transaction/decode/util';
+import {
+  addTransaction as addTransactionToPipeline,
+  type AddTransactionOptions,
+  type AddTransactionRequest,
+} from '../lib/transaction/util';
 import { TransactionControllerInitMessenger } from '../wallet-init/messengers/transaction-controller-messenger';
 import {
   PreferencesControllerAddReferralApprovedAccountAction,
@@ -312,6 +335,9 @@ import {
   trace,
 } from '../../../shared/lib/trace';
 import {
+  AppStateControllerAddAddressSecurityAlertResponseAction,
+  AppStateControllerAddSignatureSecurityAlertResponseAction,
+  AppStateControllerGetAddressSecurityAlertResponseAction,
   AppStateControllerGetIsWalletResetInProgressAction,
   AppStateControllerSetIsWalletResetInProgressAction,
   AppStateControllerSetPasskeyAutoUnlockSuppressedAction,
@@ -407,6 +433,8 @@ type TokenStandardAndDetails = {
  */
 const MESSENGER_EXPOSED_METHODS = [
   'acceptPermissionsRequest',
+  'addTransaction',
+  'addTransactionAndWaitForPublish',
   'applyTransactionContainersExisting',
   'attemptLedgerTransportCreation',
   'captureTestError',
@@ -513,6 +541,9 @@ type AllowedActions =
   | ApprovalControllerGetStateAction
   | ApprovalControllerHasRequestAction
   | ApprovalControllerRejectRequestAction
+  | AppStateControllerAddAddressSecurityAlertResponseAction
+  | AppStateControllerAddSignatureSecurityAlertResponseAction
+  | AppStateControllerGetAddressSecurityAlertResponseAction
   | AppStateControllerGetIsWalletResetInProgressAction
   | AppStateControllerGetStateAction
   | AppStateControllerSetIsWalletResetInProgressAction
@@ -522,6 +553,7 @@ type AllowedActions =
   | AssetsControllerGetAssetsAction
   | AssetsControllerGetStateAction
   | AssetsControllerSetSelectedCurrencyAction
+  | AuthenticationControllerGetBearerTokenAction
   | AuthenticationControllerGetStateAction
   | AuthenticationControllerPerformSignOutAction
   | BridgeStatusControllerWipeBridgeStatusAction
@@ -534,6 +566,7 @@ type AllowedActions =
   | KeyringControllerExportAccountAction
   | KeyringControllerExportEncryptionKeyAction
   | KeyringControllerExportSeedPhraseAction
+  | KeyringControllerGetKeyringForAccountAction
   | KeyringControllerGetKeyringsByTypeAction
   | KeyringControllerGetStateAction
   | KeyringControllerImportAccountWithStrategyAction
@@ -603,24 +636,42 @@ type AllowedActions =
   | SeedlessOnboardingControllerSubmitPasswordAction
   | SeedlessOnboardingControllerSyncLatestGlobalPasswordAction
   | SeedlessOnboardingControllerUpdateBackupMetadataStateAction
+  | GetSignatureState
   | ShieldControllerStartAction
   | ShieldControllerStopAction
   | SmartTransactionsControllerWipeSmartTransactionsAction
   | SnapControllerClearStateAction
   | SnapInterfaceControllerDeleteInterfaceAction
   | SubscriptionControllerGetStateAction
+  | SubscriptionControllerGetSubscriptionByProductAction
   | SubscriptionControllerStopAllPollingAction
   | GetTokenListState
   | TokenDetectionControllerDisableAction
   | TokenDetectionControllerEnableAction
   | TokensControllerGetStateAction
+  | TransactionControllerAddTransactionAction
+  | TransactionControllerAddTransactionBatchAction
   | TransactionControllerClearUnapprovedTransactionsAction
   | TransactionControllerEstimateGasAction
   | TransactionControllerGetNonceLockAction
   | TransactionControllerGetStateAction
   | TransactionControllerIsAtomicBatchSupportedAction
   | TransactionControllerUpdateEditableParamsAction
-  | TransactionControllerWipeTransactionsAction;
+  | TransactionControllerUpdateSecurityAlertResponseAction
+  | TransactionControllerWipeTransactionsAction
+  | UsePPOM
+  | UserOperationControllerAddUserOperationFromTransactionAction
+  | UserOperationControllerStartPollingByNetworkClientIdAction;
+
+/**
+ * The events that the {@link LegacyBackgroundApiService} can subscribe to.
+ *
+ * Consumed by the shared transaction-add pipeline to await the pending
+ * transaction or signature request while running PPOM security validation.
+ */
+type AllowedEvents =
+  | TransactionControllerUnapprovedTransactionAddedEvent
+  | SignatureStateChange;
 
 /**
  * The {@link LegacyBackgroundApiService} messenger.
@@ -628,7 +679,7 @@ type AllowedActions =
 export type LegacyBackgroundApiServiceMessenger = Messenger<
   typeof serviceName,
   LegacyBackgroundApiServiceActions | AllowedActions,
-  never
+  AllowedEvents
 >;
 
 /**
@@ -1017,6 +1068,113 @@ export class LegacyBackgroundApiService {
       ...request,
       provider,
     });
+  }
+
+  /**
+   * Adds a transaction to the TransactionController (or a user operation for
+   * smart accounts) after running security validation, without waiting for the
+   * transaction to be published.
+   *
+   * @param transactionParams - The parameters of the transaction to add.
+   * @param transactionOptions - Options for adding the transaction.
+   * @returns The transaction metadata.
+   */
+  async addTransaction(
+    transactionParams: TransactionParams,
+    transactionOptions?: Partial<AddTransactionOptions>,
+  ): Promise<TransactionMeta> {
+    return addTransactionToPipeline(
+      this.#buildAddTransactionRequest(
+        transactionParams,
+        transactionOptions,
+        false,
+      ),
+    );
+  }
+
+  /**
+   * Adds a transaction to the TransactionController (or a user operation for
+   * smart accounts) after running security validation, waiting for the
+   * transaction to be published and returning the final transaction metadata.
+   *
+   * @param transactionParams - The parameters of the transaction to add.
+   * @param transactionOptions - Options for adding the transaction.
+   * @returns The final transaction metadata.
+   */
+  async addTransactionAndWaitForPublish(
+    transactionParams: TransactionParams,
+    transactionOptions?: Partial<AddTransactionOptions>,
+  ): Promise<TransactionMeta> {
+    return addTransactionToPipeline(
+      this.#buildAddTransactionRequest(
+        transactionParams,
+        transactionOptions,
+        true,
+      ),
+    );
+  }
+
+  /**
+   * Builds the request consumed by the shared transaction-add pipeline from the
+   * messenger, mirroring the former `MetamaskController.getAddTransactionRequest`.
+   *
+   * @param transactionParams - The parameters of the transaction to add.
+   * @param transactionOptions - Options for adding the transaction.
+   * @param waitForSubmit - Whether to wait for the transaction to be published.
+   * @returns The transaction-add request.
+   */
+  #buildAddTransactionRequest(
+    transactionParams: TransactionParams,
+    transactionOptions: Partial<AddTransactionOptions> | undefined,
+    waitForSubmit: boolean,
+  ): AddTransactionRequest {
+    const networkClientId = transactionOptions?.networkClientId;
+
+    return {
+      messenger: this.#messenger,
+      internalAccounts: this.#messenger.call('AccountsController:listAccounts'),
+      selectedAccount: this.#messenger.call(
+        'AccountsController:getAccountByAddress',
+        transactionParams.from,
+      ) as InternalAccount,
+      networkClientId: networkClientId as string,
+      chainId: this.#getChainIdByNetworkClientId(networkClientId),
+      transactionParams,
+      transactionOptions: { ...transactionOptions, isInternal: true },
+      securityAlertsEnabled: this.#messenger.call(
+        'PreferencesController:getState',
+      ).securityAlertsEnabled,
+      waitForSubmit,
+    };
+  }
+
+  /**
+   * Resolves the chain ID that owns the given network client ID from the
+   * NetworkController state, mirroring
+   * `NetworkController.getNetworkConfigurationByNetworkClientId(...).chainId`.
+   *
+   * @param networkClientId - The network client ID to resolve.
+   * @returns The chain ID.
+   */
+  #getChainIdByNetworkClientId(networkClientId?: string): Hex {
+    const { networkConfigurationsByChainId } = this.#messenger.call(
+      'NetworkController:getState',
+    );
+
+    const chainId = Object.values(networkConfigurationsByChainId).find(
+      (networkConfiguration) =>
+        networkConfiguration.rpcEndpoints.some(
+          (rpcEndpoint) => rpcEndpoint.networkClientId === networkClientId,
+        ),
+    )?.chainId;
+
+    if (!chainId) {
+      throw new Error(
+        `No chain ID found for network client ID: ${networkClientId}`,
+      );
+    }
+
+    return chainId;
   }
 
   /**


### PR DESCRIPTION
## **Description**

Part of WPC-418. Migrates the `addTransaction` and `addTransactionAndWaitForPublish` `getApi()` methods from `MetamaskController` into `LegacyBackgroundApiService`, exposed via the controller messenger.

Both were inline `getApi()` wrappers around the lib `addTransaction` helper, sharing `MetamaskController.getAddTransactionRequest()` (which passed whole controller instances). To migrate them cleanly, `getAddTransactionRequest` is **deleted** and the shared transaction-add pipeline is refactored to be **messenger-based** rather than receiving controller instances:

- `lib/transaction/util.ts` — the add-transaction request now carries a restricted `AddTransactionMessenger` instead of the `transactionController` / `keyringController` / `userOperationController` / `ppomController` instances and the security-alert callbacks. The pipeline calls `TransactionController:addTransaction`/`:addTransactionBatch`/`:getState`/`:updateSecurityAlertResponse`, `UserOperationController:addUserOperationFromTransaction`/`:startPollingByNetworkClientId`, and rebuilds the `updateSecurityAlertResponse` / `getSecurityAlertsConfig` closures from the messenger (the latter reads the SHIELD subscription + bearer token exactly as before).
- `lib/ppom/ppom-util.ts` — `validateRequestWithPPOM` / `updateSecurityAlertResponse` use `PPOMController:usePPOM`, the `AppStateController` security-alert actions, `TransactionController:updateSecurityAlertResponse`, and `SignatureController:getState`/`:stateChange`.
- `lib/account-supports-7702.ts` — resolves the keyring via `KeyringController:getKeyringForAccount`.

The service builds the request from the messenger (accounts / network / preferences) and calls the shared pipeline; `getApi()` now binds both methods to `LegacyBackgroundApiService`. The `addDappTransaction` path and the internal caller build their requests inline against the messenger. **Behavior is unchanged** — this is a refactor.

## **Related issues**

Progresses: [WPC-1069](https://consensyssoftware.atlassian.net/browse/WPC-1069)

## **Manual testing steps**

1. Send a native/token transfer from the wallet UI and confirm it submits and appears in activity.
2. Send a transaction with Blockaid/security alerts enabled and confirm the security banner still appears.
3. Trigger a dapp transaction (`eth_sendTransaction`) and confirm it still works.
4. On a smart account, confirm a transaction is added as a user operation.

## **Screenshots/Recordings**

N/A — no UI changes.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability.
- [ ] I've included tests if applicable.
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[WPC-1069]: https://consensyssoftware.atlassian.net/browse/WPC-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction submission, dapp flows, and Blockaid/PPOM security wiring across many call sites; intended as a no-behavior-change refactor but regressions would affect confirmations and alerts.
> 
> **Overview**
> Moves **`addTransaction`** and **`addTransactionAndWaitForPublish`** off `MetamaskController.getApi()` into **`LegacyBackgroundApiService`**, with `getApi()` delegating through **`LegacyBackgroundApiService:*`** messenger actions. **`getAddTransactionRequest`** is removed; callers (internal UI, dapp `processTransaction`, EIP-7702 upgrade) build requests from **`controllerMessenger`** or the service’s **`#buildAddTransactionRequest`**.
> 
> The shared add-transaction path is refactored to take a typed **`AddTransactionMessenger`** instead of **`TransactionController`**, **`UserOperationController`**, **`PPOMController`**, and security callbacks. It now uses messenger actions for add/batch/getState, user operations, PPOM validation, keyring 7702 checks, trust-signal address cache, and Shield gateway config.
> 
> **PPOM** (`ppom-util`, middleware) follows the same pattern: **`PPOMMessenger`**, **`PPOMController:usePPOM`**, and controller actions for security alert read/write. **`accountSupports7702`** can resolve the keyring via **`KeyringController:getKeyringForAccount`**. Delegation on the legacy API service messenger adds the needed actions and transaction/signature events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f07e17b15e9e3a21d367940785cf57f6a8b1216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->