### PR TITLE
feat: updated token details routing via search page

### DIFF
--- a/ui/pages/asset/components/chart/asset-chart.tsx
+++ b/ui/pages/asset/components/chart/asset-chart.tsx
@@ -170,6 +170,14 @@ const AssetChart = ({
     timeRange: selectedTimeRange,
   });
 
+  // Unowned Discover/deep-link tokens often have no TokenRatesController price.
+  // Fall back to the latest historical point so the header price still renders.
+  const displayPrice =
+    currentPrice ??
+    (!isPlaceholderData && prices.length > 0
+      ? prices[prices.length - 1]?.y
+      : undefined);
+
   const prevIsPlaceholderData = usePrevious(isPlaceholderData);
   const wasPlaceholderData = prevIsPlaceholderData && !isPlaceholderData;
 
@@ -224,10 +232,10 @@ const AssetChart = ({
   // Init the price ref with the current price
   useEffect(() => {
     priceRef?.current?.setPrice({
-      price: currentPrice,
+      price: displayPrice,
       date: Date.now(),
     });
-  }, [currentPrice]);
+  }, [displayPrice]);
 
   return (
     <Box className="flex rounded-lg" flexDirection={BoxFlexDirection.Column}>
@@ -235,7 +243,7 @@ const AssetChart = ({
         ref={priceRef}
         loading={loading || isPlaceholderData}
         currency={currency}
-        price={currentPrice}
+        price={displayPrice}
         date={Date.now()}
         comparePrice={
           isPlaceholderData || shouldShowChartEmptyState
@@ -270,7 +278,7 @@ const AssetChart = ({
               className="flex"
               flexDirection={BoxFlexDirection.Column}
               justifyContent={
-                currentPrice ? BoxJustifyContent.End : BoxJustifyContent.Start
+                displayPrice ? BoxJustifyContent.End : BoxJustifyContent.Start
               }
             >
               <Line
@@ -307,7 +315,7 @@ const AssetChart = ({
                 // Revert to current price when not hovering
                 onMouseOut={() => {
                   priceRef?.current?.setPrice({
-                    price: currentPrice,
+                    price: displayPrice,
                     date: Date.now(),
                   });
                 }}

--- a/ui/pages/asset/components/token-asset.tsx
+++ b/ui/pages/asset/components/token-asset.tsx
@@ -32,7 +32,15 @@ const TokenAsset = ({
   token: TokenWithAssetId;
   chainId: Hex;
 }) => {
-  const { address: hexOrCaipAddress, assetId, symbol, isERC721, image } = token;
+  const {
+    address: hexOrCaipAddress,
+    assetId,
+    symbol,
+    name: tokenName,
+    isERC721,
+    image,
+    price,
+  } = token as TokenWithAssetId & { price?: number };
   const address = assetId || hexOrCaipAddress;
 
   const tokenList = useSelector(getTokenList);
@@ -69,7 +77,10 @@ const TokenAsset = ({
   const tokenDataFromChain =
     erc20TokensByChain?.[chainId]?.data?.[address.toLowerCase()];
 
-  const name = tokenData?.name || tokenDataFromChain?.name || symbol;
+  // Prefer remote token-list metadata, then the route/location-state name
+  // (Discover Search / deep links), then symbol.
+  const name =
+    tokenData?.name || tokenDataFromChain?.name || tokenName || symbol;
   const iconUrl =
     tokenData?.iconUrl || tokenDataFromChain?.iconUrl || image || '';
 
@@ -98,6 +109,7 @@ const TokenAsset = ({
         image: iconUrl,
         aggregators,
         isERC721,
+        price,
       }}
       optionsButton={
         <AssetOptions

--- a/ui/pages/asset/hooks/useCurrentPrice.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.ts
@@ -40,7 +40,7 @@ export const useCurrentPrice = (asset: Asset): { currentPrice?: number } => {
     const currentPrice =
       tokenExchangeRate !== undefined && tokenMarketPrice !== undefined
         ? tokenExchangeRate * tokenMarketPrice
-        : asset.price;
+        : undefined;
 
     return { currentPrice };
   }
@@ -61,7 +61,7 @@ export const useCurrentPrice = (asset: Asset): { currentPrice?: number } => {
 
   const currentPrice = currentPriceAsString
     ? parseFloat(currentPriceAsString)
-    : asset.price;
+    : undefined;
 
   return { currentPrice };
 };

--- a/ui/pages/asset/hooks/useCurrentPrice.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.ts
@@ -40,7 +40,7 @@ export const useCurrentPrice = (asset: Asset): { currentPrice?: number } => {
     const currentPrice =
       tokenExchangeRate !== undefined && tokenMarketPrice !== undefined
         ? tokenExchangeRate * tokenMarketPrice
-        : undefined;
+        : asset.price;
 
     return { currentPrice };
   }
@@ -61,7 +61,7 @@ export const useCurrentPrice = (asset: Asset): { currentPrice?: number } => {
 
   const currentPrice = currentPriceAsString
     ? parseFloat(currentPriceAsString)
-    : undefined;
+    : asset.price;
 
   return { currentPrice };
 };

--- a/ui/pages/asset/hooks/useHistoricalPrices.ts
+++ b/ui/pages/asset/hooks/useHistoricalPrices.ts
@@ -82,13 +82,26 @@ const deriveMetadata = (prices: Point[]): HistoricalPrices['metadata'] => {
     }
   }
 
+  // Near-stable assets (e.g. yield-bearing USD tokens) can have sub-cent
+  // ranges that autoscaling turns into a noisy zigzag. Pad the Y domain to
+  // at least ~2% of mid-price so the chart stays readable.
+  const midPrice = (minPricePoint.y + maxPricePoint.y) / 2;
+  const priceRange = maxPricePoint.y - minPricePoint.y;
+  const minReadableRange = Math.abs(midPrice) * 0.02;
+  const shouldPadYDomain =
+    Number.isFinite(midPrice) &&
+    midPrice !== 0 &&
+    minReadableRange > 0 &&
+    priceRange < minReadableRange;
+  const yPadding = shouldPadYDomain ? (minReadableRange - priceRange) / 2 : 0;
+
   return {
     minPricePoint,
     maxPricePoint,
     xMin,
     xMax,
-    yMin: minPricePoint.y,
-    yMax: maxPricePoint.y,
+    yMin: minPricePoint.y - yPadding,
+    yMax: maxPricePoint.y + yPadding,
   };
 };
 

--- a/ui/pages/asset/hooks/useRouteAssetToken.ts
+++ b/ui/pages/asset/hooks/useRouteAssetToken.ts
@@ -20,6 +20,8 @@ export type LocationStateToken = {
   image?: string;
   isNative?: boolean;
   decimals: number;
+  /** Spot price from Discover Search / deep-link state when wallet market data is missing */
+  price?: number;
 };
 
 type UseRouteAssetTokenParams = {

--- a/ui/pages/asset/types/asset.ts
+++ b/ui/pages/asset/types/asset.ts
@@ -27,6 +27,11 @@ export type Asset = (
   name?: string;
   /** A URL to the asset's image */
   image: string;
+  /**
+   * Optional spot price (e.g. from Discover Search location state) used when
+   * TokenRatesController has no market data for this asset.
+   */
+  price?: number;
   /** True if the asset implements ERC721 */
   isERC721?: boolean;
   /** RWA metadata used for stock token UI */

--- a/ui/pages/discover-search/build-discover-asset-navigation.test.ts
+++ b/ui/pages/discover-search/build-discover-asset-navigation.test.ts
@@ -1,0 +1,98 @@
+import type { CaipAssetType } from '@metamask/utils';
+
+import { buildDiscoverAssetNavigation } from './build-discover-asset-navigation';
+
+describe('buildDiscoverAssetNavigation', () => {
+  it('builds a CAIP route with location-state token for native EVM assets', () => {
+    const result = buildDiscoverAssetNavigation({
+      assetId: 'eip155:1/slip44:60' as CaipAssetType,
+      name: 'Ethereum',
+      symbol: 'ETH',
+      decimals: 18,
+      price: '2500',
+    });
+
+    expect(result).toStrictEqual({
+      path: '/asset/eip155:1/eip155%3A1%2Fslip44%3A60',
+      state: {
+        token: {
+          address: '',
+          symbol: 'ETH',
+          name: 'Ethereum',
+          chainId: '0x1',
+          image: expect.any(String),
+          isNative: true,
+          decimals: 18,
+          price: 2500,
+        },
+      },
+    });
+  });
+
+  it('builds a CAIP route with location-state token for ERC-20 assets', () => {
+    const assetId =
+      'eip155:8453/erc20:0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf' as CaipAssetType;
+
+    const result = buildDiscoverAssetNavigation({
+      assetId,
+      name: 'Coinbase Wrapped BTC',
+      symbol: 'CBBTC',
+      decimals: 8,
+      price: '65000.12',
+    });
+
+    expect(result).toStrictEqual({
+      path: '/asset/eip155:8453/eip155%3A8453%2Ferc20%3A0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf',
+      state: {
+        token: {
+          address: '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
+          symbol: 'CBBTC',
+          name: 'Coinbase Wrapped BTC',
+          chainId: '0x2105',
+          image: expect.any(String),
+          isNative: false,
+          decimals: 8,
+          price: 65000.12,
+        },
+      },
+    });
+  });
+
+  it('builds a CAIP route with CAIP chainId/address for Solana assets', () => {
+    const assetId =
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' as CaipAssetType;
+
+    const result = buildDiscoverAssetNavigation({
+      assetId,
+      name: 'USD Coin',
+      symbol: 'USDC',
+      decimals: 6,
+    });
+
+    expect(result).toStrictEqual({
+      path: `/asset/solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/${encodeURIComponent(assetId)}`,
+      state: {
+        token: {
+          address: assetId,
+          symbol: 'USDC',
+          name: 'USD Coin',
+          chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          image: expect.any(String),
+          isNative: false,
+          decimals: 6,
+        },
+      },
+    });
+  });
+
+  it('returns null for an invalid asset id', () => {
+    expect(
+      buildDiscoverAssetNavigation({
+        assetId: 'not-a-caip-asset-id' as CaipAssetType,
+        name: 'Bad',
+        symbol: 'BAD',
+        decimals: 18,
+      }),
+    ).toBeNull();
+  });
+});

--- a/ui/pages/discover-search/build-discover-asset-navigation.ts
+++ b/ui/pages/discover-search/build-discover-asset-navigation.ts
@@ -1,0 +1,126 @@
+import type { TrendingAsset } from '@metamask/assets-controllers';
+import {
+  formatAddressToCaipReference,
+  formatChainIdToHex,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
+import {
+  type CaipAssetType,
+  type Hex,
+  isCaipAssetType,
+  parseCaipAssetType,
+} from '@metamask/utils';
+
+import { buildAssetRoutePath } from '../../../shared/lib/asset-route';
+import { getCaipAssetImageUrl } from '../../../shared/lib/asset-utils';
+
+/**
+ * Token metadata passed through router location state so the asset page can
+ * render unowned Discover Search results without a wallet holding.
+ * Shape matches the asset page's location-state token contract.
+ */
+export type DiscoverAssetLocationStateToken = {
+  address: string;
+  symbol: string;
+  name: string;
+  chainId: string;
+  image?: string;
+  isNative?: boolean;
+  decimals: number;
+  price?: number;
+};
+
+export type DiscoverAssetNavigation = {
+  path: string;
+  state: {
+    token: DiscoverAssetLocationStateToken;
+  };
+};
+
+type DiscoverAssetNavigationInput = Pick<
+  TrendingAsset,
+  'assetId' | 'symbol' | 'name' | 'decimals' | 'price'
+> & {
+  iconUrl?: string;
+};
+
+const getDiscoverAssetAddress = ({
+  assetId,
+  isNative,
+  isNonEvm,
+  assetReference,
+}: {
+  assetId: CaipAssetType;
+  isNative: boolean;
+  isNonEvm: boolean;
+  assetReference: string;
+}): string => {
+  if (isNonEvm) {
+    return assetId;
+  }
+
+  if (isNative) {
+    return '';
+  }
+
+  return formatAddressToCaipReference(assetReference);
+};
+
+const getDiscoverAssetPrice = (
+  price: string | undefined,
+): number | undefined => {
+  if (price === undefined || price === '') {
+    return undefined;
+  }
+
+  const numericPrice = Number(price);
+  return Number.isFinite(numericPrice) ? numericPrice : undefined;
+};
+
+/**
+ * Builds Discover Search → Token Details navigation.
+ * Uses the CAIP-19 asset route and passes token metadata in location state so
+ * unowned search results still render without a wallet holding or metadata fetch.
+ *
+ * @param asset - Discover search result (or popular-asset stub).
+ * @returns Navigation path + state, or null when assetId is not a CAIP asset type.
+ */
+export const buildDiscoverAssetNavigation = (
+  asset: DiscoverAssetNavigationInput,
+): DiscoverAssetNavigation | null => {
+  if (!isCaipAssetType(asset.assetId)) {
+    return null;
+  }
+
+  const assetId = asset.assetId as CaipAssetType;
+  const parsed = parseCaipAssetType(assetId);
+  const isNonEvm = isNonEvmChainId(parsed.chainId);
+  const isNative = parsed.assetNamespace === 'slip44';
+
+  const chainId = isNonEvm
+    ? parsed.chainId
+    : (formatChainIdToHex(parsed.chainId) as Hex);
+
+  const price = getDiscoverAssetPrice(asset.price);
+
+  return {
+    path: buildAssetRoutePath(assetId),
+    state: {
+      token: {
+        address: getDiscoverAssetAddress({
+          assetId,
+          isNative,
+          isNonEvm,
+          assetReference: parsed.assetReference,
+        }),
+        symbol: asset.symbol,
+        name: asset.name || asset.symbol,
+        chainId,
+        image: asset.iconUrl ?? getCaipAssetImageUrl(assetId) ?? '',
+        isNative,
+        decimals: asset.decimals,
+        ...(price === undefined ? {} : { price }),
+      },
+    },
+  };
+};

--- a/ui/pages/discover-search/build-discover-asset-navigation.ts
+++ b/ui/pages/discover-search/build-discover-asset-navigation.ts
@@ -74,7 +74,9 @@ const getDiscoverAssetPrice = (
   }
 
   const numericPrice = Number(price);
-  return Number.isFinite(numericPrice) ? numericPrice : undefined;
+  return Number.isFinite(numericPrice) && numericPrice > 0
+    ? numericPrice
+    : undefined;
 };
 
 /**

--- a/ui/pages/discover-search/build-discover-asset-navigation.ts
+++ b/ui/pages/discover-search/build-discover-asset-navigation.ts
@@ -39,9 +39,10 @@ export type DiscoverAssetNavigation = {
 
 type DiscoverAssetNavigationInput = Pick<
   TrendingAsset,
-  'assetId' | 'symbol' | 'name' | 'decimals' | 'price'
+  'assetId' | 'symbol' | 'name' | 'decimals'
 > & {
   iconUrl?: string;
+  price?: TrendingAsset['price'];
 };
 
 const getDiscoverAssetAddress = ({

--- a/ui/pages/discover-search/build-discover-asset-navigation.ts
+++ b/ui/pages/discover-search/build-discover-asset-navigation.ts
@@ -11,7 +11,10 @@ import {
   parseCaipAssetType,
 } from '@metamask/utils';
 
-import { buildAssetRoutePath } from '../../../shared/lib/asset-route';
+import {
+  ASSET_ROUTE,
+  buildAssetRoutePath,
+} from '../../../shared/lib/asset-route';
 import { getCaipAssetImageUrl } from '../../../shared/lib/asset-utils';
 
 /**
@@ -80,9 +83,20 @@ const getDiscoverAssetPrice = (
     : undefined;
 };
 
+const buildDiscoverAssetRoutePath = (
+  assetId: CaipAssetType,
+  parsed: ReturnType<typeof parseCaipAssetType>,
+): string => {
+  if (parsed.chain.namespace === 'eip155' && parsed.assetNamespace === 'erc20') {
+    return `${ASSET_ROUTE}/${formatChainIdToHex(parsed.chainId)}/${parsed.assetReference}`;
+  }
+
+  return buildAssetRoutePath(assetId);
+};
+
 /**
  * Builds Discover Search → Token Details navigation.
- * Uses the CAIP-19 asset route and passes token metadata in location state so
+ * Uses the legacy EVM token route where needed and passes token metadata in location state so
  * unowned search results still render without a wallet holding or metadata fetch.
  *
  * @param asset - Discover search result (or popular-asset stub).
@@ -107,7 +121,7 @@ export const buildDiscoverAssetNavigation = (
   const price = getDiscoverAssetPrice(asset.price);
 
   return {
-    path: buildAssetRoutePath(assetId),
+    path: buildDiscoverAssetRoutePath(assetId, parsed),
     state: {
       token: {
         address: getDiscoverAssetAddress({

--- a/ui/pages/discover-search/discover-search.test.tsx
+++ b/ui/pages/discover-search/discover-search.test.tsx
@@ -265,7 +265,7 @@ describe('DiscoverSearchPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 
-  it('navigates to the CAIP asset route when an asset result is clicked', () => {
+  it('navigates to the CAIP asset route with token state when an asset result is clicked', () => {
     renderPage();
 
     fireEvent.click(
@@ -274,6 +274,71 @@ describe('DiscoverSearchPage', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(
       '/asset/eip155:1/eip155%3A1%2Fslip44%3A60',
+      {
+        state: {
+          token: {
+            address: '',
+            symbol: 'ETH',
+            name: 'Ethereum',
+            chainId: '0x1',
+            image: expect.any(String),
+            isNative: true,
+            decimals: 18,
+            price: 2500,
+          },
+        },
+      },
+    );
+  });
+
+  it('navigates to the CAIP ERC-20 route with token state for unowned search results', () => {
+    mockUseDiscoverSearch.mockReturnValue({
+      ...getDefaultDiscoverSearchResult(),
+      crypto: {
+        id: 'crypto' as const,
+        items: [
+          {
+            assetId:
+              'eip155:8453/erc20:0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf',
+            name: 'Coinbase Wrapped BTC',
+            symbol: 'CBBTC',
+            decimals: 8,
+            price: '65000',
+            marketCap: 1_000_000_000,
+            aggregatedUsdVolume: 50_000_000,
+            priceChangePct: { h24: '1.2' },
+          },
+        ],
+        isLoading: false,
+        error: null,
+        totalCount: 1,
+      },
+    });
+
+    renderPage();
+
+    fireEvent.click(
+      screen.getByTestId(
+        'discover-crypto-preview-eip155:8453/erc20:0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf',
+      ),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/asset/eip155:8453/eip155%3A8453%2Ferc20%3A0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf',
+      {
+        state: {
+          token: {
+            address: '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
+            symbol: 'CBBTC',
+            name: 'Coinbase Wrapped BTC',
+            chainId: '0x2105',
+            image: expect.any(String),
+            isNative: false,
+            decimals: 8,
+            price: 65000,
+          },
+        },
+      },
     );
   });
 

--- a/ui/pages/discover-search/discover-search.tsx
+++ b/ui/pages/discover-search/discover-search.tsx
@@ -18,8 +18,6 @@ import {
   TextFieldSearch,
   TextVariant,
 } from '@metamask/design-system-react';
-import { isCaipAssetType } from '@metamask/utils';
-
 import { MarketRow } from '../../components/app/perps/market-row';
 import { Tab, Tabs } from '../../components/ui/tabs';
 import {
@@ -37,6 +35,7 @@ import { useI18nContext } from '../../hooks/useI18nContext';
 import { getIsPerpsExperienceAvailable } from '../../selectors/perps/feature-flags';
 import { buildAssetRoutePath } from '../../../shared/lib/asset-route';
 import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
+import { buildDiscoverAssetNavigation } from './build-discover-asset-navigation';
 import { DiscoverAssetRow } from './discover-asset-row';
 import { DiscoverNoResultsState } from './discover-no-results-state';
 import { DiscoverSearchSectionHeader } from './discover-search-section-header';
@@ -212,9 +211,12 @@ export const DiscoverSearchPage = () => {
 
   const handleAssetPress = useCallback(
     (asset: TrendingAsset) => {
-      if (isCaipAssetType(asset.assetId)) {
-        navigate(buildAssetRoutePath(asset.assetId));
+      const navigation = buildDiscoverAssetNavigation(asset);
+      if (!navigation) {
+        return;
       }
+
+      navigate(navigation.path, { state: navigation.state });
     },
     [navigate],
   );


### PR DESCRIPTION
This PR fixes Discover Search navigation and display behavior

## **Description**

EVM ERC-20 search results now route to the same legacy token details URL used by the homepage, so clicking results like USDC opens the token details page correctly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated url for discover search navigation

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the extension and click the Search entry point in the app header.
2. Search for a crypto token such as USDC.
3. Verify results show token name, network badge, price, market cap, volume, and 24h change.
4. Verify verified tokens show the verified icon aligned with the token name.
5. Verify risky tokens show the “Risky” badge with the triangle icon.
6. Click an ERC-20 result such as USDC.
7. Verify the token details page opens correctly.
8. Click Back from token details.
9. Verify Discover Search restores the previous search text and selected tab.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**




https://github.com/user-attachments/assets/2632d8df-7f3a-4737-901d-bc6f08ea25e0


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and routing-only changes with tests; no auth or transaction paths, though incorrect route/state could affect deep-linked token detail display.
> 
> **Overview**
> **Discover Search** now navigates to token details via `buildDiscoverAssetNavigation`, which picks the **legacy EVM ERC-20 URL** (`/asset/{hexChain}/{address}`) where appropriate and passes **router location state** (name, symbol, decimals, image, optional spot **price**) so **unowned** results still render without wallet holdings or token-list metadata.
> 
> The **asset page** consumes that state: token **name** falls back to the deep-link name, and optional **`price`** flows into the asset model and chart header. **`AssetChart`** uses a **`displayPrice`** that prefers controller price but falls back to the **latest historical chart point** when market data is missing. **`useHistoricalPrices`** pads the Y-axis when the price range is very tight (~stablecoins) so the line chart is less noisy.
> 
> Tests cover navigation for native EVM, ERC-20, Solana, invalid IDs, and updated Discover Search click behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fab2078c9b9f2c48592cf3c5c9e1d41ba901dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->