### PR TITLE
fix(musd): remove APY percentages from mUSD CTA copy

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -5331,10 +5331,6 @@
     "message": "Kein anfallender Bonus",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "Bonus von $1 %",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "Ihr Bonus",
     "description": "Section title on the mUSD asset details page"
@@ -5399,10 +5395,6 @@
     "message": "Tauschen Sie Ihre Stablecoins in mUSD um und erhalten Sie einen jährlichen Bonus von $1 %.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Erhalten Sie $1 % auf Ihre Stablecoins",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "mUSD kaufen"
   },
@@ -5458,14 +5450,6 @@
   "musdConvert": {
     "message": "Konvertieren"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Konvertieren und $1 % erhalten",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Verdienen Sie einen Bonus von $1 %",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Erste Schritte"
   },
@@ -5475,10 +5459,6 @@
   },
   "musdEducationNotNow": {
     "message": "Nicht jetzt"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Erhalten Sie {$1 % mUSD-Bonus",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "mUSD erhalten"

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -5331,10 +5331,6 @@
     "message": "Δεν έχετε συγκεντρώσει κάποιο μπόνους",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "$1% μπόνους",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "Το μπόνους σας",
     "description": "Section title on the mUSD asset details page"
@@ -5399,10 +5395,6 @@
     "message": "Μετατρέψτε τα stablecoins σας σε mUSD και λάβετε $1% μπόνους ετησίως.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Λάβετε $1% στα stablecoins σας",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "Αγοράστε mUSD"
   },
@@ -5458,14 +5450,6 @@
   "musdConvert": {
     "message": "Μετατροπή"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Μετατρέψτε και κερδίστε $1%",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Κερδίστε $1% σε μπόνους",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Ξεκινήστε"
   },
@@ -5475,10 +5459,6 @@
   },
   "musdEducationNotNow": {
     "message": "Όχι τώρα"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Κερδίστε $1% μπόνους σε mUSD",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "Αποκτήστε mUSD"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5417,8 +5417,8 @@
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
   "musdAssetBonusRate": {
-    "message": "$1% bonus",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
+    "message": "Bonus",
+    "description": "Tag next to Your bonus on the mUSD asset details page"
   },
   "musdAssetBonusTitle": {
     "message": "Your bonus",
@@ -5484,10 +5484,6 @@
     "message": "Convert your stablecoins to mUSD and get a $1% annualized bonus.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Get $1% on your stablecoins",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "Buy mUSD"
   },
@@ -5543,14 +5539,6 @@
   "musdConvert": {
     "message": "Convert"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Convert and get $1%",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Earn a $1% bonus",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Get started"
   },
@@ -5560,10 +5548,6 @@
   },
   "musdEducationNotNow": {
     "message": "Not now"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Get $1% mUSD bonus",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "Get mUSD"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5417,8 +5417,8 @@
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
   "musdAssetBonusRate": {
-    "message": "$1% bonus",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
+    "message": "Bonus",
+    "description": "Tag next to Your bonus on the mUSD asset details page"
   },
   "musdAssetBonusTitle": {
     "message": "Your bonus",
@@ -5484,10 +5484,6 @@
     "message": "Convert your stablecoins to mUSD and get a $1% annualized bonus.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Get $1% on your stablecoins",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "Buy mUSD"
   },
@@ -5543,14 +5539,6 @@
   "musdConvert": {
     "message": "Convert"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Convert and get $1%",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Earn a $1% bonus",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Get started"
   },
@@ -5560,10 +5548,6 @@
   },
   "musdEducationNotNow": {
     "message": "Not now"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Get $1% mUSD bonus",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "Get mUSD"

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -5335,10 +5335,6 @@
     "message": "No hay bono acumulado",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "Bono del $1 %",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "Tu bono",
     "description": "Section title on the mUSD asset details page"
@@ -5403,10 +5399,6 @@
     "message": "Convierte tus monedas estables a mUSD y obtén un $1 % de bono anualizado.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Obtén un $1 % en tus monedas estables",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "Comprar mUSD"
   },
@@ -5462,14 +5454,6 @@
   "musdConvert": {
     "message": "Convertir"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Convierte y obtén un $1 %",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Gana un bono del $1 %",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Comenzar"
   },
@@ -5479,10 +5463,6 @@
   },
   "musdEducationNotNow": {
     "message": "Ahora no"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Obtén un bono del $1 % en mUSD",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "Obtener USDC"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -5331,10 +5331,6 @@
     "message": "Aucun bonus accumulé",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "Bonus de $1 %",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "Votre bonus",
     "description": "Section title on the mUSD asset details page"
@@ -5399,10 +5395,6 @@
     "message": "Convertissez vos stablecoins en mUSD et obtenez un bonus annualisé de $1 %.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Obtenez un bonus de $1 % sur vos stablecoins",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "Acheter des mUSD"
   },
@@ -5458,14 +5450,6 @@
   "musdConvert": {
     "message": "Convertir"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Convertissez et obtenez un bonus de $1 %",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Obtenez un bonus de $1 %",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Commencer"
   },
@@ -5475,10 +5459,6 @@
   },
   "musdEducationNotNow": {
     "message": "Pas maintenant"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Obtenez $1 % de bonus en mUSD",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "Obtenir des mUSD"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -5331,10 +5331,6 @@
     "message": "अगला कोई बोनस अर्जित नहीं किया जा रहा है",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "$1% बोनस",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "आपका बोनस",
     "description": "Section title on the mUSD asset details page"
@@ -5399,10 +5395,6 @@
     "message": "अपने स्टेबलकॉइन्स को mUSD में बदलें और $1% वार्षिक बोनस प्राप्त करें।",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "अपने स्टेबलकॉइन्स पर $1% पाएं",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "mUSD खरीदें"
   },
@@ -5458,14 +5450,6 @@
   "musdConvert": {
     "message": "कन्वर्ट करें"
   },
-  "musdConvertAndGetBonus": {
-    "message": "कन्वर्ट करें और $1% पाएं",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "$1% बोनस कमाएं",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "शुरू करें"
   },
@@ -5475,10 +5459,6 @@
   },
   "musdEducationNotNow": {
     "message": "अभी नहीं"
-  },
-  "musdGetBonusPercentage": {
-    "message": "$1% mUSD बोनस पाएं",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "mUSD प्राप्त करें"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -5335,10 +5335,6 @@
     "message": "Tidak ada bonus yang terakumulasi",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "Bonus $1%",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "Bonus Anda",
     "description": "Section title on the mUSD asset details page"
@@ -5403,10 +5399,6 @@
     "message": "Konversikan stablecoin Anda ke mUSD dan dapatkan bonus tahunan sebesar $1%.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Dapatkan $1% untuk stablecoin Anda",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "Beli mUSD"
   },
@@ -5462,14 +5454,6 @@
   "musdConvert": {
     "message": "Konversikan"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Konversikan dan dapatkan $1%",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Dapatkan bonus sebesar $1%",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Mulai"
   },
@@ -5479,10 +5463,6 @@
   },
   "musdEducationNotNow": {
     "message": "Tidak sekarang"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Dapatkan bonus $1% mUSD",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "Dapatkan mUSD"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -5335,10 +5335,6 @@
     "message": "獲得しているボーナスはありません",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "$1%のボーナス",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "ボーナス",
     "description": "Section title on the mUSD asset details page"
@@ -5403,10 +5399,6 @@
     "message": "お持ちのステーブルコインをmUSDに換えて、年換算$1%のボーナスを獲得しましょう。",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "ステーブルコインで$1%をゲット",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "mUSDを購入"
   },
@@ -5462,14 +5454,6 @@
   "musdConvert": {
     "message": "変換"
   },
-  "musdConvertAndGetBonus": {
-    "message": "換金して$1%獲得",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "$1%のボーナスを獲得",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "利用を開始する"
   },
@@ -5479,10 +5463,6 @@
   },
   "musdEducationNotNow": {
     "message": "後で"
-  },
-  "musdGetBonusPercentage": {
-    "message": "$1%のmUSDボーナスを獲得",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "mUSDを入手"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -5335,10 +5335,6 @@
     "message": "적립 중인 보너스 없음",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "$1% 보너스",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "보너스",
     "description": "Section title on the mUSD asset details page"
@@ -5403,10 +5399,6 @@
     "message": "스테이블코인을 mUSD로 환전하고 $1%의 연 환산 보너스를 받으세요.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "스테이블코인의 $1% 받기",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "mUSD 구매"
   },
@@ -5462,14 +5454,6 @@
   "musdConvert": {
     "message": "전환"
   },
-  "musdConvertAndGetBonus": {
-    "message": "전환하고 $1% 받기",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "$1% 보너스 받기",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "시작하기"
   },
@@ -5479,10 +5463,6 @@
   },
   "musdEducationNotNow": {
     "message": "나중에"
-  },
-  "musdGetBonusPercentage": {
-    "message": "$1% mUSD 보너스 받기",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "mUSD 받기"

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -5331,10 +5331,6 @@
     "message": "Sem bônus acumulado",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "$1% de bônus",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "Seu bônus",
     "description": "Section title on the mUSD asset details page"
@@ -5399,10 +5395,6 @@
     "message": "Converta suas stablecoins em mUSD e ganhe um bônus anualizado de $1%.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Obtenha $1% sobre suas stablecoins",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "Comprar mUSD"
   },
@@ -5458,14 +5450,6 @@
   "musdConvert": {
     "message": "Converter"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Converta e ganhe $1%",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Ganhe um bônus de $1%",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Comece já"
   },
@@ -5475,10 +5459,6 @@
   },
   "musdEducationNotNow": {
     "message": "Agora não"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Receba $1% de bônus em mUSD",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "Obter mUSD"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -5331,10 +5331,6 @@
     "message": "Нет начисляемых бонусов",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "$1% бонуса",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "Ваш бонус",
     "description": "Section title on the mUSD asset details page"
@@ -5399,10 +5395,6 @@
     "message": "Конвертируйте свои стейблкоины в mUSD и получите годовой бонус $1%.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Получите $1% на свои стейблкоины",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "Купить mUSD"
   },
@@ -5458,14 +5450,6 @@
   "musdConvert": {
     "message": "Конвертировать"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Конвертируйте и получите $1%",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Заработайте бонус $1%",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "С чего начать"
   },
@@ -5475,10 +5459,6 @@
   },
   "musdEducationNotNow": {
     "message": "Не сейчас"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Получите бонус в размере $1% mUSD",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "Получить mUSD"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -5331,10 +5331,6 @@
     "message": "Walang naipon na bonus",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "$1% bonus",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "Iyong bonus",
     "description": "Section title on the mUSD asset details page"
@@ -5399,10 +5395,6 @@
     "message": "I-convert ang mga stablecoin mo sa mUSD at makakuha ng $1% taunang bonus.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Makakuha ng $1% sa mga stablecoin mo",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "Bumili ng mUSD"
   },
@@ -5458,14 +5450,6 @@
   "musdConvert": {
     "message": "I-convert"
   },
-  "musdConvertAndGetBonus": {
-    "message": "I-convert at makakuha ng $1%",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Kumita ng $1% bonus",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Magsimula"
   },
@@ -5475,10 +5459,6 @@
   },
   "musdEducationNotNow": {
     "message": "Hindi sa ngayon"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Makakuha ng $1% mUSD bonus",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "Kumuha ng mUSD"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -5335,10 +5335,6 @@
     "message": "Biriken bonus yok",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "%$1 bonus",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "Bonusunuz",
     "description": "Section title on the mUSD asset details page"
@@ -5403,10 +5399,6 @@
     "message": "Stabil kripto paralarınızı mUSD'ye dönüştürün ve %$1 yıllıklandırılmış bonus alın.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Stabil kripto paralarınızda %$1 alın",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "mUSD al"
   },
@@ -5462,14 +5454,6 @@
   "musdConvert": {
     "message": "Dönüştür"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Dönüştür ve %$1 al",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "%$1 bonus kazan",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Başla"
   },
@@ -5479,10 +5463,6 @@
   },
   "musdEducationNotNow": {
     "message": "Şimdi değil"
-  },
-  "musdGetBonusPercentage": {
-    "message": "%$1 mUSD bonus al",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "mUSD kazan"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -5335,10 +5335,6 @@
     "message": "Không có thưởng tích lũy",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "Thưởng $1%",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "Thưởng của bạn",
     "description": "Section title on the mUSD asset details page"
@@ -5403,10 +5399,6 @@
     "message": "Chuyển đổi đồng ổn định của bạn sang mUSD và nhận thưởng quy đổi theo năm $1%.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "Nhận $1% trên số lượng đồng ổn định của bạn",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "Mua mUSD"
   },
@@ -5462,14 +5454,6 @@
   "musdConvert": {
     "message": "Chuyển đổi"
   },
-  "musdConvertAndGetBonus": {
-    "message": "Chuyển đổi và nhận $1%",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "Nhận thưởng $1%",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "Bắt đầu"
   },
@@ -5479,10 +5463,6 @@
   },
   "musdEducationNotNow": {
     "message": "Không phải bây giờ"
-  },
-  "musdGetBonusPercentage": {
-    "message": "Nhận thưởng $1% mUSD",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "Nhận mUSD"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -5331,10 +5331,6 @@
     "message": "无累积中的奖励",
     "description": "Disabled claim button label shown when user holds no mUSD and has no bonus to claim"
   },
-  "musdAssetBonusRate": {
-    "message": "$1% 奖励",
-    "description": "Tag next to Your bonus on the mUSD asset details page, where $1 is the bonus APY percentage (e.g., 3)"
-  },
   "musdAssetBonusTitle": {
     "message": "您的奖励",
     "description": "Section title on the mUSD asset details page"
@@ -5399,10 +5395,6 @@
     "message": "将您的稳定币兑换为 mUSD，即可获得 $1% 的年化奖励。",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
-  "musdBoostTitle": {
-    "message": "获得稳定币的 $1% 奖励",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
   "musdBuyMusd": {
     "message": "购买 mUSD"
   },
@@ -5458,14 +5450,6 @@
   "musdConvert": {
     "message": "兑换"
   },
-  "musdConvertAndGetBonus": {
-    "message": "兑换并获得 $1%",
-    "description": "$1 is the bonus percentage (e.g., 3)"
-  },
-  "musdEarnBonusPercentage": {
-    "message": "获得 $1% 的奖励",
-    "description": "$1 is the bonus percentage (e.g., 3). Subtitle on the home token list mUSD Buy/Get CTA."
-  },
   "musdEducationGetStarted": {
     "message": "开始使用"
   },
@@ -5475,10 +5459,6 @@
   },
   "musdEducationNotNow": {
     "message": "暂时不"
-  },
-  "musdGetBonusPercentage": {
-    "message": "获取 $1% mUSD 奖励",
-    "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdGetMusd": {
     "message": "获取 mUSD"

--- a/ui/components/app/musd/musd-asset-cta.test.tsx
+++ b/ui/components/app/musd/musd-asset-cta.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import configureStore from '../../../store/store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { MusdAssetCta } from './musd-asset-cta';
 
 // Mock useI18nContext
@@ -104,7 +105,9 @@ describe('MusdAssetCta', () => {
         store,
       );
 
-      expect(screen.getByText('Get mUSD')).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.musdGetMusd.message),
+      ).toBeInTheDocument();
       expect(
         screen.getByText(
           'Convert your stablecoins to mUSD and get a 3% annualized bonus.',
@@ -269,7 +272,9 @@ describe('MusdAssetCta', () => {
         store,
       );
 
-      expect(screen.getByText('Get mUSD')).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.musdGetMusd.message),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui/components/app/musd/musd-asset-cta.test.tsx
+++ b/ui/components/app/musd/musd-asset-cta.test.tsx
@@ -11,7 +11,7 @@ import { MusdAssetCta } from './musd-asset-cta';
 jest.mock('../../../hooks/useI18nContext', () => ({
   useI18nContext: () => (key: string, values?: string[]) => {
     const translations: Record<string, string> = {
-      musdBoostTitle: `Get ${values?.[0] || '3'}% on your stablecoins`,
+      musdGetMusd: 'Get mUSD',
       musdBoostDescription: `Convert your stablecoins to mUSD and get a ${values?.[0] || '3'}% annualized bonus.`,
       musdConvert: 'Convert',
       dismiss: 'Dismiss',
@@ -104,9 +104,7 @@ describe('MusdAssetCta', () => {
         store,
       );
 
-      expect(
-        screen.getByText('Get 3% on your stablecoins'),
-      ).toBeInTheDocument();
+      expect(screen.getByText('Get mUSD')).toBeInTheDocument();
       expect(
         screen.getByText(
           'Convert your stablecoins to mUSD and get a 3% annualized bonus.',
@@ -271,9 +269,7 @@ describe('MusdAssetCta', () => {
         store,
       );
 
-      expect(
-        screen.getByText('Get 3% on your stablecoins'),
-      ).toBeInTheDocument();
+      expect(screen.getByText('Get mUSD')).toBeInTheDocument();
     });
   });
 

--- a/ui/components/app/musd/musd-asset-cta.tsx
+++ b/ui/components/app/musd/musd-asset-cta.tsx
@@ -115,7 +115,7 @@ export const MusdAssetCta = ({
    * Handle convert button click
    */
   const handleConvert = useCallback(async () => {
-    const ctaDisplayText = t('musdBoostTitle', [String(MUSD_CONVERSION_APY)]);
+    const ctaDisplayText = t('musdGetMusd');
     const redirectsTo = resolveMusdConversionCtaRedirectsTo({
       intent: 'conversion',
       educationSeen,
@@ -184,7 +184,7 @@ export const MusdAssetCta = ({
           fontWeight={FontWeight.Medium}
           color={TextColor.PrimaryDefault}
         >
-          {t('musdBoostTitle', [String(MUSD_CONVERSION_APY)])}
+          {t('musdGetMusd')}
         </Text>
       </Box>
     );
@@ -228,7 +228,7 @@ export const MusdAssetCta = ({
           variant={TextVariant.BodyMd}
           fontWeight={FontWeight.Medium}
         >
-          {t('musdBoostTitle', [String(MUSD_CONVERSION_APY)])}
+          {t('musdGetMusd')}
         </Text>
         <Text
           variant={TextVariant.BodySm}

--- a/ui/components/app/musd/musd-buy-get-cta.test.tsx
+++ b/ui/components/app/musd/musd-buy-get-cta.test.tsx
@@ -6,8 +6,7 @@ import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../store/store';
 import { BuyGetMusdCtaVariant } from '../../../hooks/musd/useMusdCtaVisibility';
-import { enLocale as messages, tEn } from '../../../../test/lib/i18n-helpers';
-import { MUSD_CONVERSION_APY } from './constants';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { MusdBuyGetCta } from './musd-buy-get-cta';
 
 // Mock useI18nContext
@@ -17,7 +16,7 @@ jest.mock('../../../hooks/useI18nContext', () => ({
       musdBuyMusd: 'Buy mUSD',
       musdGetMusd: 'Get mUSD',
       musdMetaMaskUsd: 'MetaMask USD',
-      musdEarnBonusPercentage: `Earn a ${values?.[0] || '3'}% bonus`,
+      musdAssetConvertTitle: 'Convert your stablecoins',
     };
     return translations[key] || key;
   },
@@ -379,9 +378,7 @@ describe('MusdBuyGetCta', () => {
         screen.getByText(messages.musdMetaMaskUsd.message),
       ).toBeInTheDocument();
       expect(
-        screen.getByText(
-          tEn('musdEarnBonusPercentage', [String(MUSD_CONVERSION_APY)]),
-        ),
+        screen.getByText(messages.musdAssetConvertTitle.message),
       ).toBeInTheDocument();
     });
   });

--- a/ui/components/app/musd/musd-buy-get-cta.tsx
+++ b/ui/components/app/musd/musd-buy-get-cta.tsx
@@ -48,7 +48,6 @@ import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRamps
 import { ASSET_CELL_HEIGHT } from '../assets/constants';
 import {
   getMusdAssetIdForChain,
-  MUSD_CONVERSION_APY,
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
   MUSD_TOKEN_ADDRESS,
 } from './constants';
@@ -249,7 +248,7 @@ export const MusdBuyGetCta = ({
           {ctaText}
         </Text>
         <Text variant={TextVariant.BodySm} color={TextColor.PrimaryDefault}>
-          {t('musdEarnBonusPercentage', [String(MUSD_CONVERSION_APY)])}
+          {t('musdAssetConvertTitle')}
         </Text>
       </Box>
 

--- a/ui/components/app/musd/musd-convert-link.test.tsx
+++ b/ui/components/app/musd/musd-convert-link.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { act, fireEvent, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../store/store';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { MusdConvertLink } from './musd-convert-link';
 
 // Mock useI18nContext
@@ -84,7 +85,7 @@ describe('MusdConvertLink', () => {
       mockStore,
     );
 
-    expect(screen.getByText('Get mUSD')).toBeInTheDocument();
+    expect(screen.getByText(messages.musdGetMusd.message)).toBeInTheDocument();
   });
 
   it('calls startConversionFlow on click', async () => {

--- a/ui/components/app/musd/musd-convert-link.test.tsx
+++ b/ui/components/app/musd/musd-convert-link.test.tsx
@@ -9,9 +9,9 @@ import { MusdConvertLink } from './musd-convert-link';
 
 // Mock useI18nContext
 jest.mock('../../../hooks/useI18nContext', () => ({
-  useI18nContext: () => (key: string, values?: string[]) => {
-    if (key === 'musdGetBonusPercentage') {
-      return `Get ${values?.[0] || '3'}% bonus`;
+  useI18nContext: () => (key: string) => {
+    if (key === 'musdGetMusd') {
+      return 'Get mUSD';
     }
     return key;
   },
@@ -84,7 +84,7 @@ describe('MusdConvertLink', () => {
       mockStore,
     );
 
-    expect(screen.getByText('Get 3% bonus')).toBeInTheDocument();
+    expect(screen.getByText('Get mUSD')).toBeInTheDocument();
   });
 
   it('calls startConversionFlow on click', async () => {

--- a/ui/components/app/musd/musd-convert-link.tsx
+++ b/ui/components/app/musd/musd-convert-link.tsx
@@ -2,7 +2,7 @@
  * MusdConvertLink Component
  *
  * A CTA link that appears in the token list footer-right slot.
- * Shows "Get X% bonus" text and navigates to the mUSD conversion flow.
+ * Shows "Get mUSD" text and navigates to the mUSD conversion flow.
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -22,7 +22,6 @@ import { useAnalytics } from '../../../hooks/useAnalytics';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useMusdConversion } from '../../../hooks/musd';
 import { getMultichainNetworkConfigurationsByChainId } from '../../../selectors/multichain';
-import { MUSD_CONVERSION_APY } from './constants';
 import {
   createMusdCtaClickedEventProperties,
   musdConversionFlowEntryPointToCtaEventLocation,
@@ -87,8 +86,7 @@ export const MusdConvertLink = ({
     };
   }, []);
 
-  const displayText =
-    ctaText ?? t('musdGetBonusPercentage', [String(MUSD_CONVERSION_APY)]);
+  const displayText = ctaText ?? t('musdGetMusd');
 
   const handleClick = useCallback(
     async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/ui/pages/asset/components/musd-bonus-section.tsx
+++ b/ui/pages/asset/components/musd-bonus-section.tsx
@@ -357,7 +357,7 @@ export function MusdBonusSection({
           </InfoPopover>
         </Box>
         <Tag
-          label={t('musdAssetBonusRate', [String(MUSD_CONVERSION_APY)])}
+          label={t('musdAssetBonusRate')}
           backgroundColor={BackgroundColor.successMuted}
           labelProps={{ color: LegacyTextColor.successDefault }}
         />

--- a/ui/pages/confirmations/components/confirm/header/simple-confirmation-header.test.tsx
+++ b/ui/pages/confirmations/components/confirm/header/simple-confirmation-header.test.tsx
@@ -65,11 +65,11 @@ describe('<SimpleConfirmationHeader />', () => {
   });
 
   describe('musdConversion type', () => {
-    it('renders the "Convert and get 3%" title', () => {
+    it('renders the "Get mUSD" title', () => {
       const { getByTestId } = render(TransactionType.musdConversion);
 
       expect(getByTestId('simple-confirmation-header-title')).toHaveTextContent(
-        'Convert and get 3%',
+        'Get mUSD',
       );
     });
 

--- a/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-header-content.tsx
+++ b/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-header-content.tsx
@@ -31,7 +31,7 @@ export function useMusdConversionHeaderContent(): HeaderContent {
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   return {
-    title: t('musdConvertAndGetBonus', [String(MUSD_CONVERSION_APY)]),
+    title: t('musdGetMusd'),
     endAccessory: (
       <InfoPopoverTooltip
         data-testid="musd-conversion-header-tooltip"

--- a/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
+++ b/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
@@ -63,7 +63,7 @@ const MusdBottomContent = () => {
  * Displays the amount input interface for conversion with custom override content
  * that shows the expected mUSD output amount.
  *
- * The heading with "Convert and get 3%" and info tooltip is rendered
+ * The heading with "Get mUSD" and info tooltip is rendered
  * by the MusdConversionHeader in the confirmation header area.
  *
  * Token filtering is handled by the PayWithModal component which detects


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Removes hardcoded APY percentage values from mUSD conversion CTA copy across the wallet UI.

1. What is the reason for the change?
   CTA and confirmation strings previously embedded a specific bonus APY (e.g. "Get 3% on your stablecoins", "Convert and get 3%"), which is brittle and not the desired messaging.
2. What is the improvement/solution?
   Replace those strings with generic copy such as "Get mUSD", "Convert your stablecoins", and "Bonus", and remove unused locale keys. Tests are updated to match.

## **Changelog**

CHANGELOG entry: Updated mUSD conversion CTAs to use generic Get mUSD and Bonus copy instead of showing a specific APY percentage

## **Related issues**

Fixes: MUSD-1222

## **Manual testing steps**

1. Run the extension and enable mUSD-related features as needed.
2. On the home token list, open the mUSD Buy/Get CTA and verify the subtitle reads "Convert your stablecoins" (no APY percentage).
3. On a supported stablecoin or mUSD asset page, verify convert CTAs show "Get mUSD" rather than an APY-based title.
4. Open the mUSD asset details bonus section and verify the tag label is "Bonus" (not "X% bonus").
5. Start an mUSD conversion confirmation and verify the header title is "Get mUSD".

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)