### PR TITLE
fix(useAsyncCallback): update component mount state handling to prevent ref issues in StrictMode

### DIFF
--- a/ui/hooks/useAsync.ts
+++ b/ui/hooks/useAsync.ts
@@ -95,8 +95,9 @@ export function useAsyncCallback<T>(
   // Track component mount state
   const isMounted = useRef(true);
 
-  // Update ref when component unmounts
+  // Re-arm on mount so a StrictMode remount doesn't leave the ref stuck false
   useEffect(() => {
+    isMounted.current = true;
     return () => {
       isMounted.current = false;
     };


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This `useAsyncCallback` in dev StrictMode loses its data on refire (via unmount/remount). Caused issues with token details page opening

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix(useAsyncCallback): update component mount state handling to prevent ref issues in StrictMode

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to search
2. Select Token you don't own
3. Expected Token Details Page Opens

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line hook lifecycle change; fixes dev StrictMode behavior without altering production mount/unmount semantics.
> 
> **Overview**
> **`useAsyncCallback`** now sets **`isMounted.current = true`** when its mount effect runs, not only on cleanup to `false`. In **React StrictMode** (dev), the simulated unmount left the ref **false** after remount, so **`execute`** could bail out immediately and async results never updated—e.g. **token details** after search.
> 
> **`useAsyncResult`** inherits the fix because it builds on **`useAsyncCallback`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b70295b34d10370dae9b25b0832b2cf92cb5bf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->