### PR TITLE
Fix/alias bridge native helpers

### DIFF
--- a/shared/constants/bridge.ts
+++ b/shared/constants/bridge.ts
@@ -5,7 +5,7 @@ import {
   BRIDGE_UAT_API_BASE_URL,
   ChainId,
   formatChainIdToCaip,
-  getNativeAssetForChainId,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
 } from '@metamask/bridge-controller';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import type { CaipChainId, CaipAssetType } from '@metamask/utils';
@@ -324,7 +324,9 @@ export const BRIDGE_CHAINID_COMMON_TOKEN_PAIR: BridgeChainTokenMap = {
     name: 'USD Coin',
     assetId: `${MultichainNetworks.SOLANA}/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`,
   },
-  [MultichainNetworks.BITCOIN]: getNativeAssetForChainId(CHAIN_IDS.MAINNET),
+  [MultichainNetworks.BITCOIN]: getBridgeNativeAssetForChainId(
+    CHAIN_IDS.MAINNET,
+  ),
   [MultichainNetworks.TRON]: {
     // TRX -> USDT on Tron
     address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',

--- a/shared/lib/activity/adapters/helpers.ts
+++ b/shared/lib/activity/adapters/helpers.ts
@@ -1,6 +1,6 @@
 import type { V1TransactionByHashResponse } from '@metamask/core-backend';
 import type { CaipChainId } from '@metamask/utils';
-import { getNativeAssetForChainId } from '@metamask/bridge-controller';
+import { getNativeAssetForChainId as getBridgeNativeAssetForChainId } from '@metamask/bridge-controller';
 import type { Hex } from 'viem';
 import {
   BRIDGE_CHAINID_COMMON_TOKEN_PAIR,
@@ -23,7 +23,7 @@ function isNftStandard(value?: string) {
 
 function getNativeAssetSafe(chainId: string | number) {
   try {
-    return getNativeAssetForChainId(chainId);
+    return getBridgeNativeAssetForChainId(chainId);
   } catch {
     return undefined;
   }

--- a/shared/lib/activity/adapters/helpers.ts
+++ b/shared/lib/activity/adapters/helpers.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../constants/bridge';
 import { CHAIN_IDS } from '../../../constants/network';
 import { STATIC_MAINNET_TOKEN_LIST } from '../../../constants/tokens';
-import { toAssetId } from '../../asset-utils';
+import { toActivityAssetId } from '../../asset-utils';
 import { isEqualCaseInsensitive as equalsIgnoreCase } from '../../string-utils';
 import type { TransactionGroup } from '../../multichain/types';
 import type { ActivityFee, TokenAmount } from '../types';
@@ -86,7 +86,7 @@ function getKnownTokenMetadata(
     return undefined;
   }
 
-  const assetId = toAssetId(contractAddress, chainId);
+  const assetId = toActivityAssetId(contractAddress, chainId);
   const tokenMetadata =
     (chainId === CHAIN_IDS.MAINNET || assetId?.startsWith('eip155:1/')
       ? STATIC_MAINNET_TOKEN_LIST[contractAddress.toLowerCase()]

--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -17,6 +17,7 @@ import {
   getAssetImageUrl,
   fetchAssetMetadata,
   toAssetId,
+  toActivityAssetId,
   fetchAssetMetadataForAssetIds,
   getNativeAssetId,
   isEvmChainId,
@@ -197,6 +198,73 @@ describe('asset-utils', () => {
       );
       expect(toAssetId(`sep41:${contractId}`, chainId)).toBe(
         `${chainId}/sep41:${contractId}`,
+      );
+    });
+  });
+
+  describe('toActivityAssetId', () => {
+    it('trusts an already-CAIP-formatted slip44 asset id directly', () => {
+      // Injective: not in @metamask/bridge-controller's swap-support table,
+      // so toAssetId alone would misrepresent this as an erc20 contract.
+      const caipAssetId = 'eip155:1776/slip44:22000119' as CaipAssetType;
+      expect(toActivityAssetId(caipAssetId, '0x6f0' as Hex)).toBe(caipAssetId);
+    });
+
+    it('falls back to toAssetId for a CAIP asset id in a non-slip44 namespace', () => {
+      const caipAssetId = CaipAssetTypeStruct.create('eip155:1/erc20:0x123');
+      expect(toActivityAssetId(caipAssetId, 'eip155:1')).toBe(caipAssetId);
+    });
+
+    it('resolves a raw native address to its slip44 id via the Price API table (Injective)', () => {
+      expect(
+        toActivityAssetId(
+          '0x0000000000000000000000000000000000000000',
+          '0x6f0' as Hex,
+        ),
+      ).toBe('eip155:1776/slip44:22000119');
+    });
+
+    it('resolves a raw native address to its erc20 id via the Price API table (Chiliz)', () => {
+      expect(
+        toActivityAssetId(
+          '0x0000000000000000000000000000000000000000',
+          '0x15b38' as Hex,
+        ),
+      ).toBe('eip155:88888/erc20:0x0000000000000000000000000000000000000000');
+    });
+
+    it('resolves a non-zero-address native (Mantle) that a plain zero-address check would miss', () => {
+      expect(
+        toActivityAssetId(
+          '0x0000000000000000000000000000000000000000',
+          '0x1388' as Hex,
+        ),
+      ).toBe('eip155:5000/erc20:0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000');
+    });
+
+    it('resolves a regular erc20 token address via the Price API table', () => {
+      expect(
+        toActivityAssetId(
+          '0xdeadbeef00000000000000000000000000dead',
+          '0x1' as Hex,
+        ),
+      ).toBe('eip155:1/erc20:0xdeadbeef00000000000000000000000000dead');
+    });
+
+    it('falls back to toAssetId for a native address on a chain unknown to the Price API table', () => {
+      const chainId = '0xfffff1' as Hex;
+      expect(
+        toActivityAssetId(
+          '0x0000000000000000000000000000000000000000',
+          chainId,
+        ),
+      ).toBe(toAssetId('0x0000000000000000000000000000000000000000', chainId));
+    });
+
+    it('falls back to toAssetId for a non-EVM chain id', () => {
+      const ref = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      expect(toActivityAssetId(ref, MultichainNetworks.SOLANA)).toBe(
+        toAssetId(ref, MultichainNetworks.SOLANA),
       );
     });
   });

--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -105,6 +105,19 @@ describe('asset-utils', () => {
       );
     });
 
+    it('preserves a slip44 native asset ID even for chains missing from the bridge-controller native asset map', () => {
+      // Injective (eip155:1776) is not in @metamask/bridge-controller's
+      // hardcoded native-asset table, so isBridgeNativeAddress/
+      // getBridgeNativeAssetForChainId can't recognize it as native.
+      const caipAssetId = CaipAssetTypeStruct.create(
+        'eip155:1776/slip44:220000119',
+      );
+      const chainId = 'eip155:1776' as CaipChainId;
+
+      const result = toAssetId(caipAssetId, chainId);
+      expect(result).toBe(caipAssetId);
+    });
+
     it('should create Solana token asset ID correctly', () => {
       const address = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
       const chainId = MultichainNetwork.Solana as CaipChainId;

--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -105,19 +105,6 @@ describe('asset-utils', () => {
       );
     });
 
-    it('preserves a slip44 native asset ID even for chains missing from the bridge-controller native asset map', () => {
-      // Injective (eip155:1776) is not in @metamask/bridge-controller's
-      // hardcoded native-asset table, so isBridgeNativeAddress/
-      // getBridgeNativeAssetForChainId can't recognize it as native.
-      const caipAssetId = CaipAssetTypeStruct.create(
-        'eip155:1776/slip44:220000119',
-      );
-      const chainId = 'eip155:1776' as CaipChainId;
-
-      const result = toAssetId(caipAssetId, chainId);
-      expect(result).toBe(caipAssetId);
-    });
-
     it('should create Solana token asset ID correctly', () => {
       const address = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
       const chainId = MultichainNetwork.Solana as CaipChainId;

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -19,9 +19,14 @@ import {
   isNativeAddress as isBridgeNativeAddress,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
+import {
+  getAssetId as getPriceApiAssetId,
+  getNativeTokenAddress as getPriceApiNativeTokenAddress,
+} from '@metamask/assets-controllers';
 
 import { MultichainNetworks } from '../constants/multichain/networks';
 import {
+  SLIP44_ASSET_NAMESPACE,
   TRON_SPECIAL_ASSET_CAIP_TYPES_SET,
   type TronSpecialAssetCaipType,
 } from '../constants/multichain/assets';
@@ -90,6 +95,62 @@ export const toAssetId = (
     );
   }
   return undefined;
+};
+
+/**
+ * Activity-specific asset id resolution, used only by the Activity feed's
+ * native-asset lookup (shared/lib/activity/adapters/helpers.ts) — kept
+ * separate from {@link toAssetId} so this doesn't change behavior for its
+ * ~25 other (mostly bridge/swap) call sites.
+ *
+ * @metamask/bridge-controller's isNativeAddress/getNativeAssetForChainId
+ * (aliased above) only resolve native assets for chains in its swap-support
+ * table. On any other chain, {@link toAssetId} falls through to its generic
+ * erc20 branch, which is harmless when that chain's native asset is
+ * address-based (e.g. the zero address) but wrong when it's slip44-based
+ * (e.g. Injective) — the erc20 branch then misrepresents the slip44
+ * reference as a contract address, breaking the Activity Tab token icon.
+ *
+ * This resolves native assets two ways instead: an already-CAIP-formatted
+ * slip44 input is trusted directly (per CAIP-19 the slip44 namespace is
+ * reserved for a chain's native asset), and raw address input is resolved
+ * via the Price API's per-chain native asset table
+ * (`getAssetId`/`getNativeTokenAddress`), which is chain-agnostic (no throw
+ * on unsupported chains) and already encodes both conventions correctly
+ * (e.g. Injective's slip44, Mantle/Polygon's non-zero native addresses).
+ * `isBridgeNativeAddress` is still used to decide whether a raw address is
+ * native at all, since it also catches the empty-string/falsy cases that
+ * the Price API table's own zero-address check would miss.
+ *
+ * @param address - The raw or CAIP-formatted asset address.
+ * @param chainId - The chain id in caip or hex format.
+ * @returns The CAIP-19 asset id, or `undefined` when it can't be resolved.
+ */
+export const toActivityAssetId = (
+  address: Hex | CaipAssetType | string,
+  chainId?: CaipChainId | Hex,
+): CaipAssetType | undefined => {
+  if (isCaipAssetType(address)) {
+    const { assetNamespace } = parseCaipAssetType(address);
+    if (assetNamespace === SLIP44_ASSET_NAMESPACE) {
+      return address;
+    }
+    return toAssetId(address, chainId);
+  }
+
+  if (isStrictHexString(chainId)) {
+    const priceApiAssetId = getPriceApiAssetId({
+      chainId,
+      tokenAddress: isBridgeNativeAddress(address)
+        ? getPriceApiNativeTokenAddress(chainId)
+        : address,
+    });
+    if (priceApiAssetId) {
+      return priceApiAssetId;
+    }
+  }
+
+  return toAssetId(address, chainId);
 };
 
 /**

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -22,6 +22,7 @@ import {
 
 import { MultichainNetworks } from '../constants/multichain/networks';
 import {
+  SLIP44_ASSET_NAMESPACE,
   TRON_SPECIAL_ASSET_CAIP_TYPES_SET,
   type TronSpecialAssetCaipType,
 } from '../constants/multichain/assets';
@@ -42,14 +43,31 @@ export const toAssetId = (
     : chainId;
 
   // Use chainId and address from caip assetId if provided
+  let assetNamespaceFromCaipAssetId: string | undefined;
   if (isCaipAssetType(address)) {
-    const { assetReference, chainId: chainIdFromCaipAssetId } =
-      parseCaipAssetType(address);
+    const {
+      assetReference,
+      assetNamespace,
+      chainId: chainIdFromCaipAssetId,
+    } = parseCaipAssetType(address);
     addressToUse = assetReference;
     chainIdToUse = chainIdFromCaipAssetId;
+    assetNamespaceFromCaipAssetId = assetNamespace;
   }
   if (!chainIdToUse) {
     return undefined;
+  }
+
+  // The slip44 namespace is reserved for a chain's native asset (CAIP-19), so
+  // an already-CAIP-formatted asset id tells us definitively when it's
+  // native. Trust that over isBridgeNativeAddress/getBridgeNativeAssetForChainId,
+  // which rely on a hardcoded symbol table that's missing chains like
+  // Injective and would otherwise fall through to the generic erc20 branch
+  // below, misrepresenting the slip44 reference as a contract address.
+  if (assetNamespaceFromCaipAssetId === SLIP44_ASSET_NAMESPACE) {
+    return CaipAssetTypeStruct.create(
+      `${chainIdToUse}/${SLIP44_ASSET_NAMESPACE}:${addressToUse}`,
+    );
   }
 
   if (isBridgeNativeAddress(addressToUse)) {

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -15,8 +15,8 @@ import log from 'loglevel';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import {
-  getNativeAssetForChainId,
-  isNativeAddress,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
+  isNativeAddress as isBridgeNativeAddress,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 
@@ -52,9 +52,9 @@ export const toAssetId = (
     return undefined;
   }
 
-  if (isNativeAddress(addressToUse)) {
+  if (isBridgeNativeAddress(addressToUse)) {
     try {
-      return getNativeAssetForChainId(chainIdToUse)?.assetId;
+      return getBridgeNativeAssetForChainId(chainIdToUse)?.assetId;
     } catch {
       // Skip error for unsupported chains (e.g., custom networks) so we obtain the assetId in another way
       // This allows the send flow to work for custom networks even if they're not in the swaps map
@@ -94,7 +94,7 @@ export const toAssetId = (
 
 /**
  * Resolve a chain's native asset as a CAIP-19 asset id, or `undefined` for
- * chains unknown to the bridge asset map (`getNativeAssetForChainId` throws on
+ * chains unknown to the bridge asset map (`getBridgeNativeAssetForChainId` throws on
  * custom/unsupported networks).
  *
  * @param chainId - The chain id in caip or hex format.
@@ -107,7 +107,7 @@ export const getNativeAssetId = (
     return undefined;
   }
   try {
-    return getNativeAssetForChainId(chainId).assetId;
+    return getBridgeNativeAssetForChainId(chainId).assetId;
   } catch {
     return undefined;
   }

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -22,7 +22,6 @@ import {
 
 import { MultichainNetworks } from '../constants/multichain/networks';
 import {
-  SLIP44_ASSET_NAMESPACE,
   TRON_SPECIAL_ASSET_CAIP_TYPES_SET,
   type TronSpecialAssetCaipType,
 } from '../constants/multichain/assets';
@@ -43,31 +42,14 @@ export const toAssetId = (
     : chainId;
 
   // Use chainId and address from caip assetId if provided
-  let assetNamespaceFromCaipAssetId: string | undefined;
   if (isCaipAssetType(address)) {
-    const {
-      assetReference,
-      assetNamespace,
-      chainId: chainIdFromCaipAssetId,
-    } = parseCaipAssetType(address);
+    const { assetReference, chainId: chainIdFromCaipAssetId } =
+      parseCaipAssetType(address);
     addressToUse = assetReference;
     chainIdToUse = chainIdFromCaipAssetId;
-    assetNamespaceFromCaipAssetId = assetNamespace;
   }
   if (!chainIdToUse) {
     return undefined;
-  }
-
-  // The slip44 namespace is reserved for a chain's native asset (CAIP-19), so
-  // an already-CAIP-formatted asset id tells us definitively when it's
-  // native. Trust that over isBridgeNativeAddress/getBridgeNativeAssetForChainId,
-  // which rely on a hardcoded symbol table that's missing chains like
-  // Injective and would otherwise fall through to the generic erc20 branch
-  // below, misrepresenting the slip44 reference as a contract address.
-  if (assetNamespaceFromCaipAssetId === SLIP44_ASSET_NAMESPACE) {
-    return CaipAssetTypeStruct.create(
-      `${chainIdToUse}/${SLIP44_ASSET_NAMESPACE}:${addressToUse}`,
-    );
   }
 
   if (isBridgeNativeAddress(addressToUse)) {

--- a/shared/lib/dapp-swap-comparison/dapp-swap-comparison-utils.ts
+++ b/shared/lib/dapp-swap-comparison/dapp-swap-comparison-utils.ts
@@ -2,7 +2,7 @@ import { BigNumber } from 'bignumber.js';
 import { Hex } from '@metamask/utils';
 import { Interface, TransactionDescription } from '@ethersproject/abi';
 import {
-  isNativeAddress,
+  isNativeAddress as isBridgeNativeAddress,
   QuoteResponseV1,
   TxData,
 } from '@metamask/bridge-controller';
@@ -152,7 +152,7 @@ export function getBalanceChangeFromSimulationData(
 
   const { nativeBalanceChange, tokenBalanceChanges } = simulationData;
   let balanceDifference = '0x0';
-  if (isNativeAddress(tokenAddress)) {
+  if (isBridgeNativeAddress(tokenAddress)) {
     balanceDifference = nativeBalanceChange?.difference ?? '0x0';
   } else {
     balanceDifference =

--- a/shared/lib/token-search/convert-search-result.ts
+++ b/shared/lib/token-search/convert-search-result.ts
@@ -4,7 +4,7 @@ import {
   type CaipChainId,
   type Hex,
 } from '@metamask/utils';
-import { isNativeAddress } from '@metamask/bridge-controller';
+import { isNativeAddress as isBridgeNativeAddress } from '@metamask/bridge-controller';
 
 import { type TokenSearchResult } from './token-search-api';
 
@@ -56,7 +56,8 @@ export const convertSearchResultToImportPayload = (
   }
 
   const isNative =
-    assetNamespace === 'slip44' || (isEvm && isNativeAddress(assetReference));
+    assetNamespace === 'slip44' ||
+    (isEvm && isBridgeNativeAddress(assetReference));
 
   return {
     assetId: result.assetId as CaipAssetType,

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -11,7 +11,7 @@ import {
 } from '@metamask/utils';
 import {
   BridgeAsset,
-  getNativeAssetForChainId,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
 } from '@metamask/bridge-controller';
 
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -90,7 +90,7 @@ import { useHandleSendNonEvm } from './hooks/useHandleSendNonEvm';
 
 /**
  * Allows to manually set the default Swap token when clicking on the Swap CTA from
- * native token page. If unset, `getNativeAssetForChainId` of bridge-controller is used.
+ * native token page. If unset, `getBridgeNativeAssetForChainId` of bridge-controller is used.
  */
 const NATIVE_SWAP_TOKEN_OVERRIDE_PER_CHAIN: { [key: string]: BridgeAsset } = {
   // On Arc, we want to Bridge/Swap the ERC20 flavor of USDC, not the native one.
@@ -99,7 +99,7 @@ const NATIVE_SWAP_TOKEN_OVERRIDE_PER_CHAIN: { [key: string]: BridgeAsset } = {
 
 function getSwapNativeTokenWithOverridesForChain(chainId: string): BridgeAsset {
   const override = NATIVE_SWAP_TOKEN_OVERRIDE_PER_CHAIN[chainId];
-  return override ?? getNativeAssetForChainId(chainId);
+  return override ?? getBridgeNativeAssetForChainId(chainId);
 }
 
 type MoreButtonsGroupProps<TagElem extends React.ElementType = 'div'> = {

--- a/ui/ducks/batch-sell/selectors.ts
+++ b/ui/ducks/batch-sell/selectors.ts
@@ -8,7 +8,7 @@ import {
 import {
   formatChainIdToCaip,
   formatChainIdToHex,
-  getNativeAssetForChainId,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
   selectBatchSellQuotes,
   selectBatchSellTrades,
   selectMinimumBalanceForRentExemptionInSOL,
@@ -164,7 +164,7 @@ const resolveTokenFiatPriceAndChange = (
   if (isEvmChainId(chainId as Hex | CaipChainId)) {
     const hexChainId = formatChainIdToHex(chainId);
     const isNative =
-      getNativeAssetForChainId(chainId)?.assetId.toLowerCase() ===
+      getBridgeNativeAssetForChainId(chainId)?.assetId.toLowerCase() ===
       asset.assetId.toLowerCase();
     // EVM native price lives under the zero-address key.
     const evmTokenAddress = (
@@ -240,7 +240,7 @@ export const getNativeAssetForChain = createSelector(
     if (!chainId) {
       return undefined;
     }
-    const nativeAssetId = getNativeAssetForChainId(chainId)?.assetId;
+    const nativeAssetId = getBridgeNativeAssetForChainId(chainId)?.assetId;
     if (!nativeAssetId) {
       return undefined;
     }

--- a/ui/ducks/bridge/asset-selectors.ts
+++ b/ui/ducks/bridge/asset-selectors.ts
@@ -1,7 +1,7 @@
 import {
   formatChainIdToCaip,
   formatChainIdToHex,
-  getNativeAssetForChainId,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
 } from '@metamask/bridge-controller';
 import { type AccountGroupId } from '@metamask/account-api';
 import { createSelector as untypedCreateSelector } from 'reselect';
@@ -189,7 +189,7 @@ const getNativeAssetsWithBalance = createSelector(
           return;
         }
 
-        const token = getNativeAssetForChainId(chainId);
+        const token = getBridgeNativeAssetForChainId(chainId);
         const account =
           accounts[normalizedAddress] ?? accounts[lowercasedAddress];
 
@@ -253,7 +253,8 @@ const getEvmExchangeRates = createSelector(
       if (!isStrictHexString(address)) {
         return;
       }
-      const { assetId: nativeAssetId } = getNativeAssetForChainId(chainId);
+      const { assetId: nativeAssetId } =
+        getBridgeNativeAssetForChainId(chainId);
 
       const nativeToCurrencyRate = exchangeRatesByAssetId[nativeAssetId] ?? 0;
       const hexChainId = formatChainIdToHex(chainId);

--- a/ui/ducks/bridge/bridge.ts
+++ b/ui/ducks/bridge/bridge.ts
@@ -5,7 +5,7 @@ import {
   isNonEvmChainId,
   formatChainIdToHex,
   type QuoteResponseV1,
-  isNativeAddress,
+  isNativeAddress as isBridgeNativeAddress,
   RequestStatus,
   type QuoteMetadata,
 } from '@metamask/bridge-controller';
@@ -70,7 +70,7 @@ const getBalanceAmount = async ({
   if (isNonEvmChainId(chainId) || !selectedAddress) {
     return null;
   }
-  const isNative = isNativeAddress(tokenAddress);
+  const isNative = isBridgeNativeAddress(tokenAddress);
 
   return await trace(
     {

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -4,10 +4,10 @@ import {
   isSolanaChainId,
   isBitcoinChainId,
   isTronChainId,
-  isNativeAddress,
+  isNativeAddress as isBridgeNativeAddress,
   formatChainIdToCaip,
   BRIDGE_QUOTE_MAX_RETURN_DIFFERENCE_PERCENTAGE,
-  getNativeAssetForChainId,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
   type BridgeAppState as BridgeAppStateFromController,
   selectBridgeQuotes,
   selectIsQuoteExpired,
@@ -217,7 +217,7 @@ const MINIMUM_NATIVE_RESERVE_BALANCE_PER_CHAIN: { [key: CaipChainId]: string } =
 const getMinimumReserveBalanceForCaipAssetId = (
   caipAssetId?: CaipAssetType,
 ): string => {
-  if (!caipAssetId || !isNativeAddress(caipAssetId)) {
+  if (!caipAssetId || !isBridgeNativeAddress(caipAssetId)) {
     return '0';
   }
   const { chainId } = parseCaipAssetType(caipAssetId);
@@ -251,7 +251,7 @@ const buildInsufficientNativeReserveError = ({
     nativeBalance &&
     validatedSrcAmount &&
     fromToken &&
-    isNativeAddress(fromToken.assetId) &&
+    isBridgeNativeAddress(fromToken.assetId) &&
     normalizedMaxSwappableNativeBalance.lt(validatedSrcAmount)
     ? {
         minimumNativeBalanceToBeKeptInAccount,
@@ -399,7 +399,7 @@ export const getFromToken = createSelector(
     // If the user has not selected a token, return the native token for the selected network as default
     // If selected network is not supported by swap/bridge, return ETH (edge case)
     if (!fromChain?.chainId) {
-      return toBridgeToken(getNativeAssetForChainId(FALLBACK_CHAIN_ID));
+      return toBridgeToken(getBridgeNativeAssetForChainId(FALLBACK_CHAIN_ID));
     }
     return getDefaultFromToken(fromChain.chainId);
   },
@@ -558,7 +558,7 @@ export const getFromNativeBalance = createSelector(
     }
 
     const { chainId } = fromChain;
-    const { decimals, assetId } = getNativeAssetForChainId(chainId);
+    const { decimals, assetId } = getBridgeNativeAssetForChainId(chainId);
 
     // Use the balance provided by the multichain balances controller for non-EVM chains
     if (isNonEvmChain(chainId)) {
@@ -651,7 +651,7 @@ export const getFromTokenConversionRate = createSelector(
       return nullResult;
     }
     const { chainId, assetId } = fromToken;
-    const nativeAsset = getNativeAssetForChainId(chainId);
+    const nativeAsset = getBridgeNativeAssetForChainId(chainId);
     if (!nativeAsset) {
       return nullResult;
     }
@@ -974,10 +974,10 @@ export const getQuoteRequestInsufficientBal = createSelector(
   (fromTokenBalance, validatedSrcAmount, insufficientNativeReserveError) =>
     Boolean(
       insufficientNativeReserveError ||
-      (validatedSrcAmount &&
-        fromTokenBalance &&
-        !Number.isNaN(Number(fromTokenBalance)) &&
-        new BigNumber(fromTokenBalance).lt(validatedSrcAmount)),
+        (validatedSrcAmount &&
+          fromTokenBalance &&
+          !Number.isNaN(Number(fromTokenBalance)) &&
+          new BigNumber(fromTokenBalance).lt(validatedSrcAmount)),
     ),
 );
 
@@ -999,7 +999,7 @@ export const isNativeBalanceInsufficientForQuote = (
   if (!quote.sentAmount?.amount || !quote.totalNetworkFee?.amount) {
     return false;
   }
-  return isNativeAddress(fromToken.assetId)
+  return isBridgeNativeAddress(fromToken.assetId)
     ? new BigNumber(nativeBalance)
         .sub(quote.totalNetworkFee.amount)
         .sub(quote.sentAmount.amount)
@@ -1070,11 +1070,11 @@ export const computeQuoteValidationErrors = (
   const isInsufficientNativeReserve = Boolean(insufficientNativeReserveError);
   const isNetworkFeeUnavailable = Boolean(
     quote &&
-    srcChainId &&
-    (isBitcoinChainId(srcChainId) || isTronChainId(srcChainId)) &&
-    !isGasless &&
-    (quote.totalNetworkFee?.amount === undefined ||
-      new BigNumber(quote.totalNetworkFee?.amount ?? '0').lte(0)),
+      srcChainId &&
+      (isBitcoinChainId(srcChainId) || isTronChainId(srcChainId)) &&
+      !isGasless &&
+      (quote.totalNetworkFee?.amount === undefined ||
+        new BigNumber(quote.totalNetworkFee?.amount ?? '0').lte(0)),
   );
 
   const parsedPriceImpactNumber = Number(quote?.quote?.priceData?.priceImpact);
@@ -1086,32 +1086,32 @@ export const computeQuoteValidationErrors = (
     // Shown prior to fetching quotes (native reserve error takes precedence)
     isInsufficientGasBalance: Boolean(
       nativeBalance &&
-      !quote &&
-      validatedSrcAmount &&
-      fromToken &&
-      !isGasless &&
-      (isNativeAddress(fromToken.assetId)
-        ? new BigNumber(nativeBalance)
-            .sub(minimumBalanceToKeep)
-            .lte(validatedSrcAmount)
-        : new BigNumber(nativeBalance).lte(0)),
+        !quote &&
+        validatedSrcAmount &&
+        fromToken &&
+        !isGasless &&
+        (isBridgeNativeAddress(fromToken.assetId)
+          ? new BigNumber(nativeBalance)
+              .sub(minimumBalanceToKeep)
+              .lte(validatedSrcAmount)
+          : new BigNumber(nativeBalance).lte(0)),
     ),
     isInsufficientNativeReserve,
     isNetworkFeeUnavailable,
     // Shown after fetching quotes
     isInsufficientGasForQuote: Boolean(
       !isNetworkFeeUnavailable &&
-      nativeBalance &&
-      quote &&
-      fromToken &&
-      fromTokenInputValue &&
-      !isGasless &&
-      isNativeBalanceInsufficientForQuote(
-        quote,
-        nativeBalance,
-        fromToken,
-        minimumBalanceToKeep,
-      ),
+        nativeBalance &&
+        quote &&
+        fromToken &&
+        fromTokenInputValue &&
+        !isGasless &&
+        isNativeBalanceInsufficientForQuote(
+          quote,
+          nativeBalance,
+          fromToken,
+          minimumBalanceToKeep,
+        ),
     ),
     isInsufficientBalance:
       validatedSrcAmount &&
@@ -1131,8 +1131,8 @@ export const computeQuoteValidationErrors = (
         : false,
     isPriceImpactWarning: Boolean(
       priceImpactNumber &&
-      priceImpactNumber > warning &&
-      priceImpactNumber <= error,
+        priceImpactNumber > warning &&
+        priceImpactNumber <= error,
     ),
     isPriceImpactError: Boolean(priceImpactNumber && priceImpactNumber > error),
   };
@@ -1193,10 +1193,10 @@ const _getBaseValidationErrors = createDeepEqualSelector(
         quoteStreamCompleteData?.hasQuotes === false ||
         Boolean(
           !activeQuote &&
-          isValidQuoteRequest(quoteRequest) &&
-          quotesLastFetchedMs &&
-          !isLoading &&
-          quotesRefreshCount > 0,
+            isValidQuoteRequest(quoteRequest) &&
+            quotesLastFetchedMs &&
+            !isLoading &&
+            quotesRefreshCount > 0,
         ),
     };
   },

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -8,7 +8,7 @@ import { BigNumber } from 'bignumber.js';
 import type { ContractMarketData } from '@metamask/assets-controllers';
 import {
   BridgeClientId,
-  getNativeAssetForChainId,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
   isNonEvmChainId,
   formatChainIdToHex,
   formatAddressToCaipReference,
@@ -38,8 +38,8 @@ export const assetIdsMatch = (
   left === right ||
   Boolean(
     left?.startsWith('eip155:') &&
-    right?.startsWith('eip155:') &&
-    left.toLowerCase() === right.toLowerCase(),
+      right?.startsWith('eip155:') &&
+      left.toLowerCase() === right.toLowerCase(),
   );
 
 /**
@@ -66,7 +66,7 @@ export const getNativeAssetForChainIdSafe = (
   chainId: string | number | Hex | CaipChainId,
 ) => {
   try {
-    return getNativeAssetForChainId(chainId);
+    return getBridgeNativeAssetForChainId(chainId);
   } catch {
     // Return undefined for unsupported chains (e.g., custom networks, test chains)
     return undefined;
@@ -82,7 +82,7 @@ export const getNativeAssetForChainIdSafe = (
  */
 export const getNativeTokenName = (chainId: string): string | undefined => {
   try {
-    return getNativeAssetForChainId(chainId)?.name;
+    return getBridgeNativeAssetForChainId(chainId)?.name;
   } catch {
     // Return undefined for unsupported chains (e.g., test chains)
     return undefined;
@@ -232,7 +232,7 @@ export const getDefaultFromToken = (fromChainId: CaipChainId) => {
   }
 
   // Last resort: native token
-  return toBridgeToken(getNativeAssetForChainId(fromChainId));
+  return toBridgeToken(getBridgeNativeAssetForChainId(fromChainId));
 };
 
 export const getDefaultToToken = (
@@ -266,7 +266,7 @@ export const getDefaultToToken = (
  * - CAIP strings     ("eip155:1", "solana:…", …) from ALLOWED_BRIDGE_CHAIN_IDS_IN_CAIP
  * - numeric ChainId  (1, 1151111081099710, …)     from Object.values(ChainId)
  *
- * getNativeAssetForChainId returns tokens whose chainId is a numeric ChainId enum value
+ * getBridgeNativeAssetForChainId returns tokens whose chainId is a numeric ChainId enum value
  * (e.g. ChainId.SOLANA = 1151111081099710), so we must check direct inclusion first
  * before attempting any hex conversion — otherwise the numeric value gets converted to an
  * obscure hex string that is absent from the list and the check incorrectly returns false.

--- a/ui/hooks/bridge/useBridgeNavigation.ts
+++ b/ui/hooks/bridge/useBridgeNavigation.ts
@@ -16,7 +16,7 @@ import {
   FeatureId,
   formatAddressToCaipReference,
   formatChainIdToHex,
-  isNativeAddress,
+  isNativeAddress as isBridgeNativeAddress,
   isNonEvmChainId,
   UnifiedSwapBridgeEventName,
 } from '@metamask/bridge-controller';
@@ -246,7 +246,7 @@ export const useBridgeNavigation = () => {
       const tokenAddress = isNonEvm
         ? asset.assetId
         : formatAddressToCaipReference(assetReference);
-      const isNative = isNativeAddress(
+      const isNative = isBridgeNativeAddress(
         isNonEvm ? assetReference : tokenAddress,
       );
 

--- a/ui/hooks/bridge/useBridging.ts
+++ b/ui/hooks/bridge/useBridging.ts
@@ -4,7 +4,7 @@ import {
   FeatureId,
   formatChainIdToCaip,
   GenericQuoteRequest,
-  getNativeAssetForChainId,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
   UnifiedSwapBridgeEventName,
 } from '@metamask/bridge-controller';
 import { parseCaipChainId } from '@metamask/utils';
@@ -142,7 +142,8 @@ const useBridging = () => {
         )[0];
         // Otherwise, use the native assetId
         const defaultAssetId =
-          bip44AssetId ?? getNativeAssetForChainId(fallbackChainId)?.assetId;
+          bip44AssetId ??
+          getBridgeNativeAssetForChainId(fallbackChainId)?.assetId;
         search.set(BridgeQueryParams.From, defaultAssetId);
       }
 

--- a/ui/hooks/bridge/useHasSufficientGasForQuoteForMetrics.ts
+++ b/ui/hooks/bridge/useHasSufficientGasForQuoteForMetrics.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import {
-  isNativeAddress,
+  isNativeAddress as isBridgeNativeAddress,
   selectMinimumBalanceForRentExemptionInSOL,
   type QuoteMetadata,
   type QuoteResponseV1,
@@ -45,7 +45,7 @@ export const computeHasSufficientGasForQuoteForMetrics = ({
   !nativeBalance ||
   !quote ||
   !fromToken ||
-  (isNativeAddress(fromToken.assetId) &&
+  (isBridgeNativeAddress(fromToken.assetId) &&
     new BigNumber(nativeBalance).sub(quote.sentAmount?.amount ?? 0).lte(0))
     ? null
     : !isNativeBalanceInsufficientForQuote(

--- a/ui/hooks/bridge/useTokensWithFiltering.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.ts
@@ -11,11 +11,11 @@ import {
   isBitcoinChainId,
   formatChainIdToCaip,
   formatChainIdToHex,
-  isNativeAddress,
+  isNativeAddress as isBridgeNativeAddress,
   fetchBridgeTokens,
   BridgeClientId,
   type BridgeAsset,
-  getNativeAssetForChainId,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import type {
@@ -69,7 +69,7 @@ const buildTokenData = (
       'assetId' in token ? token.assetId : toAssetId(token.address, chainId),
   };
 
-  if (isNativeAddress(token.address)) {
+  if (isBridgeNativeAddress(token.address)) {
     // Use MULTICHAIN_TOKEN_IMAGE_MAP for non-EVM chains
     const image = isNonEvmChainId(chainId)
       ? MULTICHAIN_TOKEN_IMAGE_MAP[
@@ -148,7 +148,7 @@ export const useTokensWithFiltering = (
     // For Bitcoin chains, we only support native asset
     if (isBitcoinChainId(chainId)) {
       // Return native asset for Bitcoin chains
-      const nativeAsset = getNativeAssetForChainId(chainId);
+      const nativeAsset = getBridgeNativeAssetForChainId(chainId);
       if (nativeAsset) {
         const key = nativeAsset.address ?? '';
         return {
@@ -238,7 +238,7 @@ export const useTokensWithFiltering = (
            * @returns Empty string for native addresses, original address otherwise
            */
           const normalizeAddress = (addr?: string) => {
-            return addr && isNativeAddress(addr) ? '' : addr;
+            return addr && isBridgeNativeAddress(addr) ? '' : addr;
           };
 
           return (
@@ -274,7 +274,7 @@ export const useTokensWithFiltering = (
             continue;
           }
           if (shouldAddToken(token.symbol, token.address, token.chainId)) {
-            if (isNativeAddress(token.address) || token.isNative) {
+            if (isBridgeNativeAddress(token.address) || token.isNative) {
               const nativeAsset = getNativeAssetForChainIdSafe(token.chainId);
               let assetImageUrl: string | undefined;
               try {

--- a/ui/pages/asset/build-token-from-caip-asset-id.ts
+++ b/ui/pages/asset/build-token-from-caip-asset-id.ts
@@ -1,4 +1,4 @@
-import { getNativeAssetForChainId } from '@metamask/bridge-controller';
+import { getNativeAssetForChainId as getBridgeNativeAssetForChainId } from '@metamask/bridge-controller';
 import {
   type CaipAssetType,
   type CaipChainId,
@@ -33,7 +33,7 @@ export const buildTokenFromCaipAssetId = async (
 
     if (assetNamespace === 'slip44') {
       try {
-        const native = getNativeAssetForChainId(caipChainId);
+        const native = getBridgeNativeAssetForChainId(caipChainId);
         const hexChainId = decimalToPrefixedHex(parsed.chain.reference) as Hex;
 
         return {

--- a/ui/pages/batch-sell/pages/review/hooks/useBatchSellAggregateValidation.ts
+++ b/ui/pages/batch-sell/pages/review/hooks/useBatchSellAggregateValidation.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
 import { CaipChainId } from '@metamask/utils';
-import { getNativeAssetForChainId } from '@metamask/bridge-controller';
+import { getNativeAssetForChainId as getBridgeNativeAssetForChainId } from '@metamask/bridge-controller';
 import { getNativeAssetForChain } from '../../../../../ducks/batch-sell/selectors';
 import { type BridgeAppState } from '../../../../../ducks/bridge/selectors';
 import {

--- a/ui/pages/bridge/hooks/useGasIncludedSupport.ts
+++ b/ui/pages/bridge/hooks/useGasIncludedSupport.ts
@@ -1,6 +1,6 @@
 import {
   isCrossChain,
-  isNativeAddress,
+  isNativeAddress as isBridgeNativeAddress,
   isSolanaChainId,
 } from '@metamask/bridge-controller';
 import { useEffect, useMemo, useState } from 'react';
@@ -71,7 +71,7 @@ export const useGasIncludedSupport = () => {
   // If native EVM and simulationIncludeFees are supported, gasless request params pretty much get ignored
   // This means the backend can always return a gasIncluded quote
   const nativeGasIncluded = useMemo(() => {
-    return fromToken?.assetId && isNativeAddress(fromToken.assetId)
+    return fromToken?.assetId && isBridgeNativeAddress(fromToken.assetId)
       ? networkFlags?.simulationIncludeFees
       : undefined;
   }, [networkFlags?.simulationIncludeFees, fromToken?.assetId]);

--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import {
   formatChainIdToCaip,
   formatChainIdToHex,
-  isNativeAddress,
+  isNativeAddress as isBridgeNativeAddress,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { getAccountLink } from '@metamask/etherscan-link';
@@ -351,7 +351,7 @@ export const BridgeInputGroup = ({
         {isAmountReadOnly &&
           token &&
           selectedChainId &&
-          !isNativeAddress(assetReference) && (
+          !isBridgeNativeAddress(assetReference) && (
             <Text
               display={Display.Flex}
               gap={1}

--- a/ui/pages/bridge/prepare/prepare-bridge-page.stories.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import {
-  getNativeAssetForChainId,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
   QuoteResponseV1,
   RequestStatus,
 } from '@metamask/bridge-controller';
@@ -65,8 +65,10 @@ const mockFeatureFlags = {
   },
 };
 const mockBridgeSlice = {
-  fromToken: toBridgeToken(getNativeAssetForChainId(CHAIN_IDS.MAINNET)),
-  toToken: toBridgeToken(getNativeAssetForChainId(CHAIN_IDS.LINEA_MAINNET)),
+  fromToken: toBridgeToken(getBridgeNativeAssetForChainId(CHAIN_IDS.MAINNET)),
+  toToken: toBridgeToken(
+    getBridgeNativeAssetForChainId(CHAIN_IDS.LINEA_MAINNET),
+  ),
   fromTokenInputValue: '1',
 };
 export const DefaultStory = () => {

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -6,7 +6,7 @@ import {
   FeatureId,
   formatChainIdToCaip,
   isValidQuoteRequest,
-  isNativeAddress,
+  isNativeAddress as isBridgeNativeAddress,
   isSolanaChainId,
   UnifiedSwapBridgeEventName,
   type BridgeController,
@@ -148,7 +148,8 @@ const PrepareBridgePage = ({
   const shouldShowMaxButton =
     fromToken &&
     // Always show for non-native tokens. Arc ERC20 USDC considered as native.
-    (isNativeAddress(fromToken.assetId) || isArcTokenUSDC(fromToken.assetId))
+    (isBridgeNativeAddress(fromToken.assetId) ||
+      isArcTokenUSDC(fromToken.assetId))
       ? !isSolanaChainId(fromToken.chainId) &&
         (gasIncluded || gasIncluded7702 || nativeGasIncluded)
       : true;

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -4,7 +4,7 @@ import { BigNumber } from 'bignumber.js';
 import {
   BRIDGE_MM_FEE_RATE,
   UnifiedSwapBridgeEventName,
-  getNativeAssetForChainId,
+  getNativeAssetForChainId as getBridgeNativeAssetForChainId,
 } from '@metamask/bridge-controller';
 import { Skeleton } from '@metamask/design-system-react';
 import {
@@ -116,8 +116,8 @@ export const MultichainBridgeQuoteCard = ({
   const gasSponsored = activeQuote?.quote?.gasSponsored ?? false;
   const isCrossChainBridge = Boolean(
     fromToken?.chainId &&
-    toToken?.chainId &&
-    fromToken.chainId !== toToken.chainId,
+      toToken?.chainId &&
+      fromToken.chainId !== toToken.chainId,
   );
 
   const isCurrentNetworkGasSponsored = useMemo(() => {
@@ -166,7 +166,7 @@ export const MultichainBridgeQuoteCard = ({
   ]);
 
   const nativeTokenSymbol = fromChain
-    ? getNativeAssetForChainId(fromChain.chainId).symbol
+    ? getBridgeNativeAssetForChainId(fromChain.chainId).symbol
     : '';
 
   const secondsUntilNextRefresh = useCountdownTimer();
@@ -256,7 +256,8 @@ export const MultichainBridgeQuoteCard = ({
                         // eslint-disable-next-line @typescript-eslint/naming-convention
                         token_symbol_source:
                           fromToken?.symbol ??
-                          getNativeAssetForChainId(fromChain.chainId).symbol,
+                          getBridgeNativeAssetForChainId(fromChain.chainId)
+                            .symbol,
                         // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
                         // eslint-disable-next-line @typescript-eslint/naming-convention
                         token_symbol_destination: toToken?.symbol ?? null,

--- a/ui/pages/confirmations/components/transactions/quote-swap-simulation-details/quote-swap-simulation-details.tsx
+++ b/ui/pages/confirmations/components/transactions/quote-swap-simulation-details/quote-swap-simulation-details.tsx
@@ -10,7 +10,7 @@ import {
 } from '@metamask/design-system-react';
 import { Hex } from '@metamask/utils';
 import {
-  isBridgeNativeAddress,
+  isNativeAddress as isBridgeNativeAddress,
   QuoteResponseV1,
 } from '@metamask/bridge-controller';
 import { TransactionMeta } from '@metamask/transaction-controller';

--- a/ui/pages/confirmations/components/transactions/quote-swap-simulation-details/quote-swap-simulation-details.tsx
+++ b/ui/pages/confirmations/components/transactions/quote-swap-simulation-details/quote-swap-simulation-details.tsx
@@ -9,7 +9,10 @@ import {
   TextVariant,
 } from '@metamask/design-system-react';
 import { Hex } from '@metamask/utils';
-import { isNativeAddress, QuoteResponseV1 } from '@metamask/bridge-controller';
+import {
+  isBridgeNativeAddress,
+  QuoteResponseV1,
+} from '@metamask/bridge-controller';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { toHex } from '@metamask/controller-utils';
 
@@ -36,7 +39,7 @@ const getSrcAssetBalanceChange = (
     chainId: toHex(srcAsset.chainId),
     address: srcAsset.address as Hex,
   } as AssetIdentifier;
-  if (isNativeAddress(srcAsset.address)) {
+  if (isBridgeNativeAddress(srcAsset.address)) {
     asset = {
       chainId: toHex(srcAsset.chainId),
       standard: TokenStandard.none,
@@ -72,7 +75,7 @@ const getDestAssetBalanceChange = (
     chainId: toHex(destAsset.chainId),
     address: destAsset.address as Hex,
   } as AssetIdentifier;
-  if (isNativeAddress(destAsset.address)) {
+  if (isBridgeNativeAddress(destAsset.address)) {
     asset = {
       chainId: toHex(destAsset.chainId),
       standard: TokenStandard.none,

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import { isNativeAddress } from '@metamask/bridge-controller';
+import { isNativeAddress as isBridgeNativeAddress } from '@metamask/bridge-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import {
@@ -57,7 +57,7 @@ export function usePostQuoteWithdrawTokenFilter(): WithdrawTokenFilterResult {
 
     return Object.entries(allowlist).flatMap(([chainId, addresses]) =>
       addresses
-        .filter((address) => !isNativeAddress(address.toLowerCase()))
+        .filter((address) => !isBridgeNativeAddress(address.toLowerCase()))
         .map((address) => ({
           chainId: chainId as Hex,
           address,
@@ -113,7 +113,7 @@ function buildAllowlistLookup(
       const lowerAddress = address.toLowerCase();
       addressSet.add(lowerAddress);
 
-      if (isNativeAddress(lowerAddress)) {
+      if (isBridgeNativeAddress(lowerAddress)) {
         const nativeAddress = getNativeTokenAddress(lowerChainId as Hex);
         addressSet.add(nativeAddress.toLowerCase());
       }

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapUSDValues.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapUSDValues.ts
@@ -1,14 +1,14 @@
 import { BigNumber } from 'bignumber.js';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { Hex } from '@metamask/utils';
-import { getNativeAssetForChainId } from '@metamask/bridge-controller';
+import { getNativeAssetForChainId as getBridgeNativeAssetForChainId } from '@metamask/bridge-controller';
 import { CHAIN_IDS, TransactionMeta } from '@metamask/transaction-controller';
 import { useCallback } from 'react';
 
 import { TokenStandAndDetails } from '../../../../../store/actions';
 import { fetchTokenExchangeRates } from '../../../../../helpers/utils/util';
 import { useAsyncResult } from '../../../../../hooks/useAsync';
-import { isNativeAddress } from '../../../../../helpers/utils/token-insights';
+import { isBridgeNativeAddress } from '../../../../../helpers/utils/token-insights';
 import {
   fetchAllTokenDetails,
   getTokenValueFromRecord,
@@ -33,7 +33,7 @@ export function useDappSwapUSDValues({
     Record<Hex, number | undefined>
   >(async () => {
     const addresses = tokenAddresses.filter(
-      (tokenAddress) => !isNativeAddress(tokenAddress),
+      (tokenAddress) => !isBridgeNativeAddress(tokenAddress),
     );
     const exchangeRates = await fetchTokenExchangeRates(
       'usd',
@@ -42,7 +42,7 @@ export function useDappSwapUSDValues({
     );
 
     if (chainId === CHAIN_IDS.POLYGON) {
-      const nativeAddress = getNativeAssetForChainId(chainId).address;
+      const nativeAddress = getBridgeNativeAssetForChainId(chainId).address;
       exchangeRates[nativeAddress] =
         exchangeRates[POLYGON_NATIVE_TOKEN_ADDRESS];
     }
@@ -55,10 +55,10 @@ export function useDappSwapUSDValues({
   >(async () => {
     let result = await fetchAllTokenDetails(tokenAddresses as Hex[], chainId);
     tokenAddresses.forEach((tokenAddress) => {
-      if (isNativeAddress(tokenAddress)) {
+      if (isBridgeNativeAddress(tokenAddress)) {
         result = {
           ...result,
-          [tokenAddress as Hex]: getNativeAssetForChainId(chainId),
+          [tokenAddress as Hex]: getBridgeNativeAssetForChainId(chainId),
         };
       }
     });

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapUSDValues.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapUSDValues.ts
@@ -8,7 +8,7 @@ import { useCallback } from 'react';
 import { TokenStandAndDetails } from '../../../../../store/actions';
 import { fetchTokenExchangeRates } from '../../../../../helpers/utils/util';
 import { useAsyncResult } from '../../../../../hooks/useAsync';
-import { isBridgeNativeAddress } from '../../../../../helpers/utils/token-insights';
+import { isNativeAddress as isBridgeNativeAddress } from '../../../../../helpers/utils/token-insights';
 import {
   fetchAllTokenDetails,
   getTokenValueFromRecord,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

DO NOT MERGE (experiments)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is scoped to Activity asset-ID resolution plus import renames; bridge/swap paths still use the aliased bridge helpers. Risk is mainly regression on Activity token display for edge-chain natives, mitigated by new unit tests.
> 
> **Overview**
> Adds **`toActivityAssetId`** for Activity feed token metadata only, leaving **`toAssetId`** unchanged for bridge/swap call sites. On chains outside the bridge swap table, native assets (especially **slip44** IDs like Injective) were misclassified as **erc20**, which broke Activity tab icons; the new helper trusts slip44 CAIP inputs and uses **`@metamask/assets-controllers`** Price API lookups for raw native/ERC-20 addresses before falling back to **`toAssetId`**.
> 
> **`shared/lib/activity/adapters/helpers.ts`** now uses **`toActivityAssetId`** in known-token metadata resolution.
> 
> Renames bridge-controller imports to **`getBridgeNativeAssetForChainId`** and **`isBridgeNativeAddress`** across bridge, batch-sell, confirmations, and related UI so it’s clear those helpers are swap-bridge scoped, not general asset resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6381bef1ced290b47c9b1ec8f4e3e4685119e8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->