### PR TITLE
fix: add Robinhood QuickNode failover to network controller map

### DIFF
--- a/app/scripts/wallet-init/initialization.test.ts
+++ b/app/scripts/wallet-init/initialization.test.ts
@@ -88,6 +88,7 @@ describe('initializeWallet', () => {
           failoverUrls: {
             '0x1': [],
             '0x10e6': [],
+            '0x1237': [],
             '0x13b2': [],
             '0x144': [],
             '0x2105': [],

--- a/app/scripts/wallet-init/instance-options/network-controller.ts
+++ b/app/scripts/wallet-init/instance-options/network-controller.ts
@@ -36,6 +36,8 @@ export function getNetworkControllerInstanceOptions(
       [CHAIN_IDS.MONAD]: getFailoverUrlsForInfuraNetwork('monad-mainnet'),
       [CHAIN_IDS.HYPE]: getFailoverUrlsForInfuraNetwork('hyperevm-mainnet'),
       [CHAIN_IDS.ARC]: getFailoverUrlsForInfuraNetwork('arc-mainnet'),
+      [CHAIN_IDS.ROBINHOOD_CHAIN]:
+        getFailoverUrlsForInfuraNetwork('robinhood-mainnet'),
     },
   };
 }


### PR DESCRIPTION
## **Description**

Robinhood ships a QuickNode failover url (`QUICKNODE_ROBINHOOD_URL`) and is a featured network, but it was missing from the NetworkController instance-options failover map in `getNetworkControllerInstanceOptions`. Every other featured chain with a QuickNode failover is in that map, so Robinhood was the odd one out: it only picked up failover from its persisted endpoint config (via FEATURED_RPCS) rather than the runtime map that covers all users.

This adds Robinhood alongside the other chains so the runtime failover map covers it consistently.

No new secret is needed. `QUICKNODE_ROBINHOOD_URL` already exists and is already consumed by `QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME` and FEATURED_RPCS.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build with `QUICKNODE_ROBINHOOD_URL` set.
2. Add the Robinhood network and open its RPC settings.
3. Confirm the QuickNode failover is applied for the Robinhood endpoint (same as the other featured chains).

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive RPC failover wiring for one chain; no auth or data-model changes.
> 
> **Overview**
> Adds **Robinhood** (`CHAIN_IDS.ROBINHOOD_CHAIN` / `0x1237`) to the `NetworkController` **runtime failover map** in `getNetworkControllerInstanceOptions`, using `getFailoverUrlsForInfuraNetwork('robinhood-mainnet')` like the other featured chains.
> 
> This aligns Robinhood with peers that already get QuickNode failover from the wallet-init map (not only from persisted `FEATURED_RPCS` config). The wallet init test expectation for `failoverUrls` is updated to include `0x1237`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e1aa85e1fecd71f39fb8a77bec1fea0b626df7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->