### PR TITLE
fix(ci): restrict AMO flask/production to release/*; block flask dispatch

### DIFF
--- a/.github/workflows/upload-extension-to-amo.yml
+++ b/.github/workflows/upload-extension-to-amo.yml
@@ -30,15 +30,15 @@ name: Upload extension to Firefox AMO
 #   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/main|release/*
 #   actor / actor_id = runway-github[bot] / 73448015 only (no human AssumeRole)
 # PRD production (amo-production):
-#   ref              = refs/heads/main | refs/heads/release/*
-#   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/main|release/*
+#   ref              = refs/heads/release/* only
+#   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/release/*
 #   no actor pin — human workflow_dispatch after amo-production env approval (INFRA-3769)
 #
-# GitHub Environment deployment branches: amo-production and amo-flask → main + release/*.
+# GitHub Environment deployment branches: amo-flask → main + release/*; amo-production → release/* only.
 # amo-production keeps @MetaMask/release-team required reviewers. amo-flask has none (Runway + IAM).
 #
 # INFRA-3649 — sender verification (defense-in-depth; primary gate is IAM trust).
-# INFRA-3769 — release-team may workflow_dispatch production (main or release/*).
+# INFRA-3769 — release-team may workflow_dispatch production from release/* only.
 # Flask is orchestrator workflow_call only — workflow_dispatch + target=flask is rejected.
 #
 # Lambda invoke must use alias qualifier (dev | flask | production); unqualified invoke is denied.
@@ -128,9 +128,14 @@ jobs:
               echo "::error::Dev (amo-dev) uploads must run from refs/heads/main (current: ${GITHUB_REF})"
               exit 1
             fi
-          elif [[ "${TARGET}" == "production" || "${TARGET}" == "flask" ]]; then
+          elif [[ "${TARGET}" == "production" ]]; then
+            if [[ ! "${GITHUB_REF}" =~ ^refs/heads/release/ ]]; then
+              echo "::error::Production uploads must run from refs/heads/release/* (current: ${GITHUB_REF})"
+              exit 1
+            fi
+          elif [[ "${TARGET}" == "flask" ]]; then
             if [[ "${GITHUB_REF}" != "refs/heads/main" && ! "${GITHUB_REF}" =~ ^refs/heads/release/ ]]; then
-              echo "::error::Production and flask uploads must run from refs/heads/main or refs/heads/release/* (current: ${GITHUB_REF})"
+              echo "::error::Flask uploads must run from refs/heads/main or refs/heads/release/* (current: ${GITHUB_REF})"
               exit 1
             fi
           fi

--- a/.github/workflows/upload-extension-to-amo.yml
+++ b/.github/workflows/upload-extension-to-amo.yml
@@ -39,7 +39,8 @@ name: Upload extension to Firefox AMO
 #
 # INFRA-3649 — sender verification (defense-in-depth; primary gate is IAM trust).
 # INFRA-3769 — release-team may workflow_dispatch production from release/* only.
-# Flask is orchestrator workflow_call only — workflow_dispatch + target=flask is rejected.
+# Flask is orchestrator-only: omitted from workflow_dispatch target options, and the sender check
+# rejects any human/non-Runway flask dispatch (event_name can't distinguish a workflow_call caller).
 #
 # Lambda invoke must use alias qualifier (dev | flask | production); unqualified invoke is denied.
 # AMO JWT secrets are read inside Lambda (assumes amo-submission-secrets-{env}), not by the runner.
@@ -117,12 +118,10 @@ jobs:
         run: |
           set -euo pipefail
           GITHUB_REF="${{ github.ref }}"
-          EVENT_NAME="${{ github.event_name }}"
-          # Flask is Runway/orchestrator-only. Keep workflow_dispatch for production (+ dev smoke).
-          if [[ "${EVENT_NAME}" == "workflow_dispatch" && "${TARGET}" == "flask" ]]; then
-            echo "::error::workflow_dispatch cannot target flask. Flask uploads run via the Runway orchestrator (workflow_call) only."
-            exit 1
-          fi
+          # Flask is Runway/orchestrator-only, enforced by the sender check below (human/non-Runway
+          # rejected) and by omitting flask from the workflow_dispatch target options. github.event_name
+          # cannot gate this: a workflow_call from the Runway orchestrator still reports the caller's
+          # workflow_dispatch, so an event_name check would also block the legitimate Phase 3 flask upload.
           if [[ "${TARGET}" == "dev" ]]; then
             if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
               echo "::error::Dev (amo-dev) uploads must run from refs/heads/main (current: ${GITHUB_REF})"

--- a/.github/workflows/upload-extension-to-amo.yml
+++ b/.github/workflows/upload-extension-to-amo.yml
@@ -27,19 +27,19 @@ name: Upload extension to Firefox AMO
 # dev (amo-dev): ref + job_workflow_ref pinned to main (human E2E).
 # PRD flask (amo-flask):
 #   ref              = refs/heads/main | refs/heads/release/*
-#   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/*
-#   actor            = runway-github[bot] OR @MetaMask/release-team member
-#   actor_id         = 73448015 (Runway) OR human release-team member
+#   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/main|release/*
+#   actor / actor_id = runway-github[bot] / 73448015 only (no human AssumeRole)
 # PRD production (amo-production):
-#   ref              = refs/heads/main ONLY (timing-sensitive; aligned with ~1% CWS rollout)
-#   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/*
-#   actor            = runway-github[bot] OR @MetaMask/release-team member
-#   actor_id         = 73448015 (Runway) OR human release-team member
+#   ref              = refs/heads/main | refs/heads/release/*
+#   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/main|release/*
+#   no actor pin — human workflow_dispatch after amo-production env approval (INFRA-3769)
 #
-# GitHub Environment deployment branches: amo-production → main only; amo-flask → main + release/*.
+# GitHub Environment deployment branches: amo-production and amo-flask → main + release/*.
+# amo-production keeps @MetaMask/release-team required reviewers. amo-flask has none (Runway + IAM).
 #
-# INFRA-3649 — sender verification (defense-in-depth; primary gate is IAM trust on amo-production/flask).
-# INFRA-3769 — @MetaMask/release-team members may dispatch production manually (main only).
+# INFRA-3649 — sender verification (defense-in-depth; primary gate is IAM trust).
+# INFRA-3769 — release-team may workflow_dispatch production (main or release/*).
+# Flask is orchestrator workflow_call only — workflow_dispatch + target=flask is rejected.
 #
 # Lambda invoke must use alias qualifier (dev | flask | production); unqualified invoke is denied.
 # AMO JWT secrets are read inside Lambda (assumes amo-submission-secrets-{env}), not by the runner.
@@ -54,14 +54,13 @@ on:
         required: true
         type: string
       target:
-        description: "AMO target — dev (UAT staging), production (PRD main), flask (PRD Flask build)"
+        description: "AMO target — production (PRD, release-team) or dev (UAT smoke). Flask is orchestrator-only."
         required: true
         type: choice
-        default: dev
+        default: production
         options:
-          - dev
           - production
-          - flask
+          - dev
       expected_sha256:
         description: "Optional SHA-256 of the release asset (64 lowercase hex). Default asset depends on target."
         required: false
@@ -79,7 +78,7 @@ on:
       target:
         required: true
         type: string
-        description: "AMO target — production or flask (orchestrator); dev allowed for manual workflow_call"
+        description: "AMO target — flask (orchestrator); production/dev also allowed via workflow_call"
       expected_sha256:
         required: false
         type: string
@@ -118,19 +117,20 @@ jobs:
         run: |
           set -euo pipefail
           GITHUB_REF="${{ github.ref }}"
+          EVENT_NAME="${{ github.event_name }}"
+          # Flask is Runway/orchestrator-only. Keep workflow_dispatch for production (+ dev smoke).
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" && "${TARGET}" == "flask" ]]; then
+            echo "::error::workflow_dispatch cannot target flask. Flask uploads run via the Runway orchestrator (workflow_call) only."
+            exit 1
+          fi
           if [[ "${TARGET}" == "dev" ]]; then
             if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
               echo "::error::Dev (amo-dev) uploads must run from refs/heads/main (current: ${GITHUB_REF})"
               exit 1
             fi
-          elif [[ "${TARGET}" == "production" ]]; then
-            if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
-              echo "::error::Production uploads must run from refs/heads/main only (current: ${GITHUB_REF}). AMO production is timing-sensitive; dispatch from main after the release is cut."
-              exit 1
-            fi
-          elif [[ "${TARGET}" == "flask" ]]; then
+          elif [[ "${TARGET}" == "production" || "${TARGET}" == "flask" ]]; then
             if [[ "${GITHUB_REF}" != "refs/heads/main" && ! "${GITHUB_REF}" =~ ^refs/heads/release/ ]]; then
-              echo "::error::Flask uploads must run from refs/heads/main or refs/heads/release/* (current: ${GITHUB_REF})"
+              echo "::error::Production and flask uploads must run from refs/heads/main or refs/heads/release/* (current: ${GITHUB_REF})"
               exit 1
             fi
           fi
@@ -231,31 +231,35 @@ jobs:
             echo "| Branch | \`${{ github.ref }}\` |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      # Defense-in-depth: production and flask dispatch must be Runway (automated path) or a human
-      # (manual path — INFRA-3769). Non-Runway bots are rejected before any AWS credential exchange.
-      # Human authorization is delegated to the amo-production/amo-flask GitHub Environment
-      # required-reviewers gate (configured by Platform to @MetaMask/release-team), which must be
-      # approved before this job runs. GITHUB_TOKEN does not carry read:org scope so team membership
-      # cannot be verified at the workflow layer. IAM trust is the authoritative technical control.
+      # Defense-in-depth: production/flask must be Runway (automated) or a human (AMO production manual
+      # path — INFRA-3769). Non-Runway bots are rejected before any AWS credential exchange.
+      # Human AMO production is gated by amo-production required reviewers (@MetaMask/release-team).
+      # Flask has no env reviewers; IAM pins Runway. GITHUB_TOKEN lacks read:org so team membership
+      # cannot be verified here — IAM trust is the authoritative technical control.
       - name: Verify authorized sender (production and flask)
         if: inputs.target == 'production' || inputs.target == 'flask'
         env:
           SENDER_ID: ${{ github.event.sender.id }}
           SENDER_LOGIN: ${{ github.event.sender.login }}
           SENDER_TYPE: ${{ github.event.sender.type }}
+          TARGET: ${{ inputs.target }}
           RUNWAY_ACTOR_ID: '73448015'
         run: |
           set -euo pipefail
-          echo "sender.type=${SENDER_TYPE} actor=${{ github.actor }} sender=${SENDER_LOGIN} (id=${SENDER_ID})"
+          echo "sender.type=${SENDER_TYPE} actor=${{ github.actor }} sender=${SENDER_LOGIN} (id=${SENDER_ID}) target=${TARGET}"
           if [[ "${SENDER_TYPE}" == "Bot" ]]; then
             if [[ "${SENDER_ID}" != "${RUNWAY_ACTOR_ID}" ]]; then
-              echo "::error::Non-Runway bot dispatch is not permitted for production/flask (sender_id=${SENDER_ID}). Automated uploads must use Runway (id=${RUNWAY_ACTOR_ID}); human dispatches require amo-production/amo-flask environment approval from @MetaMask/release-team."
+              echo "::error::Non-Runway bot dispatch is not permitted for production/flask (sender_id=${SENDER_ID}). Automated uploads must use Runway (id=${RUNWAY_ACTOR_ID})."
               exit 1
             fi
             echo "Runway bot verified (id=${SENDER_ID})."
             exit 0
           fi
-          echo "Human dispatch confirmed. Environment reviewer approval is recorded by GitHub before this job runs."
+          if [[ "${TARGET}" == "flask" ]]; then
+            echo "::error::Human dispatch is not permitted for flask. Use the Runway orchestrator (workflow_call). Flask IAM pins Runway only."
+            exit 1
+          fi
+          echo "Human production dispatch confirmed. amo-production environment reviewer approval is recorded by GitHub before this job runs."
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2

--- a/.github/workflows/upload-extension-to-amo.yml
+++ b/.github/workflows/upload-extension-to-amo.yml
@@ -26,15 +26,15 @@ name: Upload extension to Firefox AMO
 #   sub = repo:MetaMask/metamask-extension:environment:{amo-dev|amo-flask|amo-production}
 # dev (amo-dev): ref + job_workflow_ref pinned to main (human E2E).
 # PRD flask (amo-flask):
-#   ref              = refs/heads/main | refs/heads/release/*
-#   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/main|release/*
+#   ref              = refs/heads/release/* only
+#   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/release/*
 #   actor / actor_id = runway-github[bot] / 73448015 only (no human AssumeRole)
 # PRD production (amo-production):
 #   ref              = refs/heads/release/* only
 #   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/release/*
 #   no actor pin — human workflow_dispatch after amo-production env approval (INFRA-3769)
 #
-# GitHub Environment deployment branches: amo-flask → main + release/*; amo-production → release/* only.
+# GitHub Environment deployment branches: amo-flask and amo-production → release/* only.
 # amo-production keeps @MetaMask/release-team required reviewers. amo-flask has none (Runway + IAM).
 #
 # INFRA-3649 — sender verification (defense-in-depth; primary gate is IAM trust).
@@ -128,14 +128,9 @@ jobs:
               echo "::error::Dev (amo-dev) uploads must run from refs/heads/main (current: ${GITHUB_REF})"
               exit 1
             fi
-          elif [[ "${TARGET}" == "production" ]]; then
+          elif [[ "${TARGET}" == "production" || "${TARGET}" == "flask" ]]; then
             if [[ ! "${GITHUB_REF}" =~ ^refs/heads/release/ ]]; then
-              echo "::error::Production uploads must run from refs/heads/release/* (current: ${GITHUB_REF})"
-              exit 1
-            fi
-          elif [[ "${TARGET}" == "flask" ]]; then
-            if [[ "${GITHUB_REF}" != "refs/heads/main" && ! "${GITHUB_REF}" =~ ^refs/heads/release/ ]]; then
-              echo "::error::Flask uploads must run from refs/heads/main or refs/heads/release/* (current: ${GITHUB_REF})"
+              echo "::error::Production and flask uploads must run from refs/heads/release/* (current: ${GITHUB_REF})"
               exit 1
             fi
           fi


### PR DESCRIPTION
## **Description**

Align AMO **production** and **flask** to **`release/*` only** (not `main`) so uploads use the same workflow version as the cut.

Flask remains orchestrator-only: `flask` is removed from `workflow_dispatch` target options, and the sender check rejects any human/non-Runway flask dispatch. Do **not** gate on `github.event_name` — in a reusable workflow that value is the caller's trigger, so a Runway orchestrator `workflow_call` (itself `workflow_dispatch`) would falsely fail. Keep `workflow_call` for Runway Phase 3.

**Companion:** [infra PR #19](https://github.com/consensys-vertical-apps/va-mmc-extension-submission-infra/pull/19) (`amo-submission-flask` + `amo-submission-production` OIDC `release/*` only). Docs: [releases#32](https://github.com/MetaMask/releases/pull/32).

**GitHub Environment config (done):**
- [x] Remove required reviewers on `amo-flask`
- [x] Set `amo-flask` and `amo-production` deployment branches to **`release/*` only** (remove `main`)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: INFRA-3769

## **Manual testing steps**

1. On `release/X.Y.Z`, Actions → Upload extension to Firefox AMO — targets are `production` and `dev` only (`flask` not offered).
2. `target=production` on `release/*` passes the branch guard (then waits on `amo-production` approval).
3. `target=production` on `main` fails the branch guard.
4. Orchestrator `workflow_call` with `target=flask` still succeeds (sender = Runway; no env reviewers on `amo-flask`).
5. Human attempt at flask (API/`workflow_call` from a user) fails the sender check before AWS creds.

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.