### PR TITLE
feat: scan decoded token transfer recipients for trust signals

### DIFF
--- a/app/scripts/lib/transaction/util.test.ts
+++ b/app/scripts/lib/transaction/util.test.ts
@@ -713,6 +713,47 @@ describe('Transaction Utils', () => {
         expect(scanAddressAndAddToCacheMock).not.toHaveBeenCalled();
       });
 
+      it('also scans the decoded recipient of a token transfer', async () => {
+        // ERC-20 `transfer(0x2222..., 10)`. Recipient is digit-only so its
+        // checksummed form equals its lowercase form.
+        request.transactionParams.data =
+          '0xa9059cbb0000000000000000000000002222222222222222222222222222222222222222000000000000000000000000000000000000000000000000000000000000000a';
+
+        await addTransaction({
+          ...request,
+          securityAlertsEnabled: true,
+          chainId: CHAIN_IDS.MAINNET,
+        });
+
+        expect(scanAddressAndAddToCacheMock).toHaveBeenCalledTimes(2);
+        expect(scanAddressAndAddToCacheMock).toHaveBeenCalledWith(
+          '0x1234567890123456789012345678901234567890',
+          expect.any(Function),
+          expect.any(Function),
+          CHAIN_IDS.MAINNET,
+          expect.objectContaining({ scanAddress: expect.any(Function) }),
+        );
+        expect(scanAddressAndAddToCacheMock).toHaveBeenCalledWith(
+          '0x2222222222222222222222222222222222222222',
+          expect.any(Function),
+          expect.any(Function),
+          CHAIN_IDS.MAINNET,
+          expect.objectContaining({ scanAddress: expect.any(Function) }),
+        );
+      });
+
+      it('does not scan a decoded recipient for non-transfer calldata', async () => {
+        request.transactionParams.data = '0x12345678';
+
+        await addTransaction({
+          ...request,
+          securityAlertsEnabled: true,
+          chainId: CHAIN_IDS.MAINNET,
+        });
+
+        expect(scanAddressAndAddToCacheMock).toHaveBeenCalledTimes(1);
+      });
+
       it('does not call scanAddressAndAddToCache when to address is not a string', async () => {
         request.transactionParams.to = undefined;
 

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -42,7 +42,10 @@ import { ORIGIN_METAMASK } from '../../../../shared/constants/app';
 import { getShieldGatewayConfig } from '../../../../shared/lib/shield/shield';
 import { scanAddressAndAddToCache } from '../trust-signals/security-alerts-api';
 import { ScanAddressResponse } from '../../../../shared/lib/trust-signals';
-import { getTransactionDataRecipient } from '../../../../shared/lib/transaction.utils';
+import {
+  getTransactionDataRecipient,
+  parseTransferTransactionData,
+} from '../../../../shared/lib/transaction.utils';
 import {
   AppStateControllerAddAddressSecurityAlertResponseAction,
   AppStateControllerGetAddressSecurityAlertResponseAction,
@@ -417,7 +420,7 @@ function scanAddressForTrustSignals(request: AddTransactionRequest) {
   if (origin !== ORIGIN_METAMASK || !securityAlertsEnabled) {
     return;
   }
-  const { to } = transactionParams;
+  const { to, data } = transactionParams;
   if (typeof to !== 'string') {
     return;
   }
@@ -448,18 +451,31 @@ function scanAddressForTrustSignals(request: AddTransactionRequest) {
       messenger.call('PhishingController:scanAddress', scanChainId, address),
   };
 
-  scanAddressAndAddToCache(
-    to,
-    getAddressSecurityAlertResponseWithChain,
-    addAddressSecurityAlertResponseWithChain,
-    chainId,
-    phishingControllerScanAdapter,
-  ).catch((error) => {
-    console.error(
-      '[scanAddressForTrustSignals] error scanning address for trust signals:',
-      error,
-    );
-  });
+  const addresses = [to];
+
+  // For token transfers `to` is only the token contract; the funds move to
+  // the recipient encoded in calldata, so scan that address as well.
+  const transferRecipient = data
+    ? parseTransferTransactionData(data as Hex)?.recipient
+    : undefined;
+  if (transferRecipient) {
+    addresses.push(transferRecipient);
+  }
+
+  for (const address of addresses) {
+    scanAddressAndAddToCache(
+      address,
+      getAddressSecurityAlertResponseWithChain,
+      addAddressSecurityAlertResponseWithChain,
+      chainId,
+      phishingControllerScanAdapter,
+    ).catch((error) => {
+      console.error(
+        '[scanAddressForTrustSignals] error scanning address for trust signals:',
+        error,
+      );
+    });
+  }
 }
 
 async function validateSecurity(request: AddTransactionRequest) {

--- a/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
@@ -788,7 +788,7 @@ describe('trust signals middleware', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          '[createTrustSignalsMiddleware] error scanning transfer recipient address for transaction:',
+          '[createAddressScanMiddleware] error scanning transfer recipient address for transaction:',
           expect.any(Error),
         );
         expect(next).toHaveBeenCalled();

--- a/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
@@ -4,6 +4,7 @@ import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import { mockNetworkState } from '../../../../test/stub/networks';
 import {
   parseApprovalTransactionData,
+  parseTransferTransactionData,
   parseTypedDataMessage,
 } from '../../../../shared/lib/transaction.utils';
 import { ResultType } from '../../../../shared/lib/trust-signals';
@@ -28,6 +29,7 @@ const TEST_ADDRESSES = {
   FROM: '0xabcdef0123456789012345678901234567890123',
   SPENDER: '0x9876543210987654321098765432109876543210',
   DELEGATE: '0xfedcba9876543210fedcba9876543210fedcba98',
+  TRANSFER_RECIPIENT: '0x2f318c334780961fb129d2a6c30d0763d9a5c970',
 };
 
 const MOCK_SCAN_RESPONSES = {
@@ -205,6 +207,9 @@ describe('trust signals middleware', () => {
   const scanAddressMockAndAddToCache = jest.mocked(scanAddressAndAddToCache);
   const parseApprovalTransactionDataMock = jest.mocked(
     parseApprovalTransactionData,
+  );
+  const parseTransferTransactionDataMock = jest.mocked(
+    parseTransferTransactionData,
   );
   const parseTypedDataMessageMock = jest.mocked(parseTypedDataMessage);
   let consoleErrorSpy: jest.SpyInstance;
@@ -702,6 +707,93 @@ describe('trust signals middleware', () => {
         expect(next).toHaveBeenCalled();
       });
     });
+
+    describe('token transfer transactions', () => {
+      it('scans both the token contract and the decoded transfer recipient', async () => {
+        parseTransferTransactionDataMock.mockReturnValue({
+          name: 'transfer',
+          recipient: TEST_ADDRESSES.TRANSFER_RECIPIENT as `0x${string}`,
+        });
+        scanAddressMockAndAddToCache.mockResolvedValue(
+          MOCK_SCAN_RESPONSES.BENIGN,
+        );
+        const { middleware, appStateController, phishingController } =
+          createMiddleware();
+
+        const transferData = '0xa9059cbb';
+        const req = createMockRequest('eth_sendTransaction', [
+          createTransactionParams({ data: transferData }),
+        ]);
+        const next = jest.fn();
+
+        await middleware(req, createMockResponse(), next);
+
+        expect(parseTransferTransactionDataMock).toHaveBeenCalledWith(
+          transferData,
+        );
+        expect(scanAddressMockAndAddToCache).toHaveBeenCalledTimes(2);
+        expect(scanAddressMockAndAddToCache).toHaveBeenCalledWith(
+          TEST_ADDRESSES.TO,
+          appStateController.getAddressSecurityAlertResponse,
+          appStateController.addAddressSecurityAlertResponse,
+          CHAIN_IDS.MAINNET,
+          phishingController,
+        );
+        expect(scanAddressMockAndAddToCache).toHaveBeenCalledWith(
+          TEST_ADDRESSES.TRANSFER_RECIPIENT,
+          appStateController.getAddressSecurityAlertResponse,
+          appStateController.addAddressSecurityAlertResponse,
+          CHAIN_IDS.MAINNET,
+          phishingController,
+        );
+        expect(next).toHaveBeenCalled();
+      });
+
+      it('does not scan a transfer recipient when the calldata is not a transfer', async () => {
+        parseTransferTransactionDataMock.mockReturnValue(undefined);
+        scanAddressMockAndAddToCache.mockResolvedValue(
+          MOCK_SCAN_RESPONSES.BENIGN,
+        );
+        const { middleware } = createMiddleware();
+
+        const req = createMockRequest('eth_sendTransaction', [
+          createTransactionParams({ data: '0xdeadbeef' }),
+        ]);
+        const next = jest.fn();
+
+        await middleware(req, createMockResponse(), next);
+
+        expect(scanAddressMockAndAddToCache).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalled();
+      });
+
+      it('handles transfer recipient scanning errors gracefully', async () => {
+        parseTransferTransactionDataMock.mockReturnValue({
+          name: 'transfer',
+          recipient: TEST_ADDRESSES.TRANSFER_RECIPIENT as `0x${string}`,
+        });
+        scanAddressMockAndAddToCache
+          .mockResolvedValueOnce(MOCK_SCAN_RESPONSES.BENIGN) // Contract scan succeeds
+          .mockRejectedValueOnce(new Error('Recipient scan failed')); // Recipient scan fails
+        const { middleware } = createMiddleware();
+
+        const req = createMockRequest('eth_sendTransaction', [
+          createTransactionParams({ data: '0xa9059cbb' }),
+        ]);
+        const next = jest.fn();
+
+        await middleware(req, createMockResponse(), next);
+
+        // Wait for async error handling
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[createTrustSignalsMiddleware] error scanning transfer recipient address for transaction:',
+          expect.any(Error),
+        );
+        expect(next).toHaveBeenCalled();
+      });
+    });
   });
 
   describe('wallet_sendCalls', () => {
@@ -774,6 +866,41 @@ describe('trust signals middleware', () => {
       expect(scanAddressMockAndAddToCache).toHaveBeenCalledTimes(2);
       expect(scanAddressMockAndAddToCache).toHaveBeenCalledWith(
         TEST_ADDRESSES.SPENDER,
+        appStateController.getAddressSecurityAlertResponse,
+        appStateController.addAddressSecurityAlertResponse,
+        CHAIN_IDS.MAINNET,
+        phishingController,
+      );
+    });
+
+    it('scans the decoded recipient of a nested token transfer call', async () => {
+      scanAddressMockAndAddToCache.mockResolvedValue(
+        MOCK_SCAN_RESPONSES.BENIGN,
+      );
+      parseTransferTransactionDataMock.mockReturnValue({
+        name: 'transfer',
+        recipient: TEST_ADDRESSES.TRANSFER_RECIPIENT as `0x${string}`,
+      });
+      const { middleware, appStateController, phishingController } =
+        createMiddleware();
+
+      const transferData = '0xa9059cbb';
+      const req = createMockRequest(
+        MESSAGE_TYPE.WALLET_SEND_CALLS,
+        createSendCallsParams([
+          { to: TEST_ADDRESSES.TO, data: transferData, value: '0x0' },
+        ]) as Json[],
+      );
+      const next = jest.fn();
+
+      await middleware(req, createMockResponse(), next);
+
+      expect(parseTransferTransactionDataMock).toHaveBeenCalledWith(
+        transferData,
+      );
+      expect(scanAddressMockAndAddToCache).toHaveBeenCalledTimes(2);
+      expect(scanAddressMockAndAddToCache).toHaveBeenCalledWith(
+        TEST_ADDRESSES.TRANSFER_RECIPIENT,
         appStateController.getAddressSecurityAlertResponse,
         appStateController.addAddressSecurityAlertResponse,
         CHAIN_IDS.MAINNET,

--- a/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
@@ -4,6 +4,7 @@ import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import { mockNetworkState } from '../../../../test/stub/networks';
 import {
   parseApprovalTransactionData,
+  parseTransferTransactionData,
   parseTypedDataMessage,
 } from '../../../../shared/lib/transaction.utils';
 import { ResultType } from '../../../../shared/lib/trust-signals';
@@ -20,6 +21,7 @@ const TEST_ADDRESSES = {
   FROM: '0xabcdef0123456789012345678901234567890123',
   SPENDER: '0x9876543210987654321098765432109876543210',
   DELEGATE: '0xfedcba9876543210fedcba9876543210fedcba98',
+  TRANSFER_RECIPIENT: '0x2f318c334780961fb129d2a6c30d0763d9a5c970',
 };
 
 const MOCK_SCAN_RESPONSES = {
@@ -135,6 +137,9 @@ describe('createTrustSignalsMiddleware', () => {
   const scanAddressMockAndAddToCache = jest.mocked(scanAddressAndAddToCache);
   const parseApprovalTransactionDataMock = jest.mocked(
     parseApprovalTransactionData,
+  );
+  const parseTransferTransactionDataMock = jest.mocked(
+    parseTransferTransactionData,
   );
   const parseTypedDataMessageMock = jest.mocked(parseTypedDataMessage);
   let consoleErrorSpy: jest.SpyInstance;
@@ -632,6 +637,93 @@ describe('createTrustSignalsMiddleware', () => {
         expect(next).toHaveBeenCalled();
       });
     });
+
+    describe('token transfer transactions', () => {
+      it('scans both the token contract and the decoded transfer recipient', async () => {
+        parseTransferTransactionDataMock.mockReturnValue({
+          name: 'transfer',
+          recipient: TEST_ADDRESSES.TRANSFER_RECIPIENT as `0x${string}`,
+        });
+        scanAddressMockAndAddToCache.mockResolvedValue(
+          MOCK_SCAN_RESPONSES.BENIGN,
+        );
+        const { middleware, appStateController, phishingController } =
+          createMiddleware();
+
+        const transferData = '0xa9059cbb';
+        const req = createMockRequest('eth_sendTransaction', [
+          createTransactionParams({ data: transferData }),
+        ]);
+        const next = jest.fn();
+
+        await middleware(req, createMockResponse(), next);
+
+        expect(parseTransferTransactionDataMock).toHaveBeenCalledWith(
+          transferData,
+        );
+        expect(scanAddressMockAndAddToCache).toHaveBeenCalledTimes(2);
+        expect(scanAddressMockAndAddToCache).toHaveBeenCalledWith(
+          TEST_ADDRESSES.TO,
+          appStateController.getAddressSecurityAlertResponse,
+          appStateController.addAddressSecurityAlertResponse,
+          CHAIN_IDS.MAINNET,
+          phishingController,
+        );
+        expect(scanAddressMockAndAddToCache).toHaveBeenCalledWith(
+          TEST_ADDRESSES.TRANSFER_RECIPIENT,
+          appStateController.getAddressSecurityAlertResponse,
+          appStateController.addAddressSecurityAlertResponse,
+          CHAIN_IDS.MAINNET,
+          phishingController,
+        );
+        expect(next).toHaveBeenCalled();
+      });
+
+      it('does not scan a transfer recipient when the calldata is not a transfer', async () => {
+        parseTransferTransactionDataMock.mockReturnValue(undefined);
+        scanAddressMockAndAddToCache.mockResolvedValue(
+          MOCK_SCAN_RESPONSES.BENIGN,
+        );
+        const { middleware } = createMiddleware();
+
+        const req = createMockRequest('eth_sendTransaction', [
+          createTransactionParams({ data: '0xdeadbeef' }),
+        ]);
+        const next = jest.fn();
+
+        await middleware(req, createMockResponse(), next);
+
+        expect(scanAddressMockAndAddToCache).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalled();
+      });
+
+      it('handles transfer recipient scanning errors gracefully', async () => {
+        parseTransferTransactionDataMock.mockReturnValue({
+          name: 'transfer',
+          recipient: TEST_ADDRESSES.TRANSFER_RECIPIENT as `0x${string}`,
+        });
+        scanAddressMockAndAddToCache
+          .mockResolvedValueOnce(MOCK_SCAN_RESPONSES.BENIGN) // Contract scan succeeds
+          .mockRejectedValueOnce(new Error('Recipient scan failed')); // Recipient scan fails
+        const { middleware } = createMiddleware();
+
+        const req = createMockRequest('eth_sendTransaction', [
+          createTransactionParams({ data: '0xa9059cbb' }),
+        ]);
+        const next = jest.fn();
+
+        await middleware(req, createMockResponse(), next);
+
+        // Wait for async error handling
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[createTrustSignalsMiddleware] error scanning transfer recipient address for transaction:',
+          expect.any(Error),
+        );
+        expect(next).toHaveBeenCalled();
+      });
+    });
   });
 
   describe('wallet_sendCalls', () => {
@@ -704,6 +796,41 @@ describe('createTrustSignalsMiddleware', () => {
       expect(scanAddressMockAndAddToCache).toHaveBeenCalledTimes(2);
       expect(scanAddressMockAndAddToCache).toHaveBeenCalledWith(
         TEST_ADDRESSES.SPENDER,
+        appStateController.getAddressSecurityAlertResponse,
+        appStateController.addAddressSecurityAlertResponse,
+        CHAIN_IDS.MAINNET,
+        phishingController,
+      );
+    });
+
+    it('scans the decoded recipient of a nested token transfer call', async () => {
+      scanAddressMockAndAddToCache.mockResolvedValue(
+        MOCK_SCAN_RESPONSES.BENIGN,
+      );
+      parseTransferTransactionDataMock.mockReturnValue({
+        name: 'transfer',
+        recipient: TEST_ADDRESSES.TRANSFER_RECIPIENT as `0x${string}`,
+      });
+      const { middleware, appStateController, phishingController } =
+        createMiddleware();
+
+      const transferData = '0xa9059cbb';
+      const req = createMockRequest(
+        MESSAGE_TYPE.WALLET_SEND_CALLS,
+        createSendCallsParams([
+          { to: TEST_ADDRESSES.TO, data: transferData, value: '0x0' },
+        ]) as Json[],
+      );
+      const next = jest.fn();
+
+      await middleware(req, createMockResponse(), next);
+
+      expect(parseTransferTransactionDataMock).toHaveBeenCalledWith(
+        transferData,
+      );
+      expect(scanAddressMockAndAddToCache).toHaveBeenCalledTimes(2);
+      expect(scanAddressMockAndAddToCache).toHaveBeenCalledWith(
+        TEST_ADDRESSES.TRANSFER_RECIPIENT,
         appStateController.getAddressSecurityAlertResponse,
         appStateController.addAddressSecurityAlertResponse,
         CHAIN_IDS.MAINNET,

--- a/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
@@ -793,6 +793,40 @@ describe('trust signals middleware', () => {
         );
         expect(next).toHaveBeenCalled();
       });
+
+      it('still scans a transfer recipient when approval parsing throws', async () => {
+        parseApprovalTransactionDataMock.mockImplementation(() => {
+          throw new Error('approval parse failed');
+        });
+        parseTransferTransactionDataMock.mockReturnValue({
+          name: 'transfer',
+          recipient: TEST_ADDRESSES.TRANSFER_RECIPIENT as `0x${string}`,
+        });
+        scanAddressMockAndAddToCache.mockResolvedValue(
+          MOCK_SCAN_RESPONSES.BENIGN,
+        );
+        const { middleware } = createMiddleware();
+
+        const req = createMockRequest('eth_sendTransaction', [
+          createTransactionParams({ data: '0xa9059cbb' }),
+        ]);
+        const next = jest.fn();
+
+        await middleware(req, createMockResponse(), next);
+
+        expect(scanAddressMockAndAddToCache).toHaveBeenCalledWith(
+          TEST_ADDRESSES.TRANSFER_RECIPIENT,
+          expect.any(Function),
+          expect.any(Function),
+          CHAIN_IDS.MAINNET,
+          expect.anything(),
+        );
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[createTrustSignalsMiddleware] error parsing approval data for transaction:',
+          expect.any(Error),
+        );
+        expect(next).toHaveBeenCalled();
+      });
     });
   });
 

--- a/app/scripts/lib/trust-signals/trust-signals-middleware.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.ts
@@ -179,6 +179,30 @@ function scanAddressInBackground(
 }
 
 /**
+ * Run a calldata decoder without letting a throw skip sibling decoders in
+ * {@link scanCallTargets}. `parseStandardTokenTransactionData` already
+ * swallows ABI errors, so this is belt-and-suspenders for the wrappers.
+ *
+ * @param parse - Decoder to invoke
+ * @param logLabel - Describes the decoder in the error log
+ * @returns The decoder result, or undefined if it threw
+ */
+function tryParseCalldata<ParseResult>(
+  parse: () => ParseResult | undefined,
+  logLabel: string,
+): ParseResult | undefined {
+  try {
+    return parse();
+  } catch (error) {
+    console.error(
+      `[createTrustSignalsMiddleware] error parsing ${logLabel}:`,
+      error,
+    );
+    return undefined;
+  }
+}
+
+/**
  * Scans the addresses a single transaction or batched call exposes: its
  * target `to` plus any addresses encoded in calldata (approval spenders and
  * token-transfer recipients). Shared by the `eth_sendTransaction` and
@@ -216,7 +240,10 @@ function scanCallTargets(
 
   // If the call is a token approval, also scan the spender address.
   if (typeof data === 'string') {
-    const approvalData = parseApprovalTransactionData(data as `0x${string}`);
+    const approvalData = tryParseCalldata(
+      () => parseApprovalTransactionData(data as `0x${string}`),
+      `approval data for ${context}`,
+    );
     const spenderAddress = approvalData?.spender;
     if (spenderAddress) {
       scanAddressInBackground(
@@ -230,9 +257,11 @@ function scanCallTargets(
 
     // If the call is a token transfer, also scan the recipient decoded from
     // calldata: for transfers `to` is only the token contract; the funds
-    // move to the address inside the calldata.
-    const transferRecipient = parseTransferTransactionData(
-      data as `0x${string}`,
+    // move to the address inside the calldata. Parsed independently so a
+    // throw in the approval decoder cannot skip this scan.
+    const transferRecipient = tryParseCalldata(
+      () => parseTransferTransactionData(data as `0x${string}`),
+      `transfer data for ${context}`,
     )?.recipient;
     if (transferRecipient) {
       scanAddressInBackground(

--- a/app/scripts/lib/trust-signals/trust-signals-middleware.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.ts
@@ -9,6 +9,7 @@ import { PreferencesController } from '../../controllers/preferences-controller'
 import {
   parseTypedDataMessage,
   parseApprovalTransactionData,
+  parseTransferTransactionData,
 } from '../../../../shared/lib/transaction.utils';
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import { PRIMARY_TYPES_PERMIT } from '../../../../shared/constants/signatures';
@@ -179,8 +180,8 @@ function scanAddressInBackground(
 
 /**
  * Scans the addresses a single transaction or batched call exposes: its
- * target `to` plus any addresses encoded in calldata (currently the spender
- * of a token approval). Shared by the `eth_sendTransaction` and
+ * target `to` plus any addresses encoded in calldata (approval spenders and
+ * token-transfer recipients). Shared by the `eth_sendTransaction` and
  * `wallet_sendCalls` handlers so decoding logic stays in one place; new
  * calldata decoders should be added here to cover both paths at once.
  *
@@ -221,6 +222,22 @@ function scanCallTargets(
       scanAddressInBackground(
         spenderAddress,
         `spender address for ${context} approval`,
+        chainId,
+        appStateController,
+        phishingController,
+      );
+    }
+
+    // If the call is a token transfer, also scan the recipient decoded from
+    // calldata: for transfers `to` is only the token contract; the funds
+    // move to the address inside the calldata.
+    const transferRecipient = parseTransferTransactionData(
+      data as `0x${string}`,
+    )?.recipient;
+    if (transferRecipient) {
+      scanAddressInBackground(
+        transferRecipient,
+        `transfer recipient address for ${context}`,
         chainId,
         appStateController,
         phishingController,

--- a/app/scripts/lib/trust-signals/trust-signals-middleware.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.ts
@@ -9,6 +9,7 @@ import { PreferencesController } from '../../controllers/preferences-controller'
 import {
   parseTypedDataMessage,
   parseApprovalTransactionData,
+  parseTransferTransactionData,
 } from '../../../../shared/lib/transaction.utils';
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import { PRIMARY_TYPES_PERMIT } from '../../../../shared/constants/signatures';
@@ -184,6 +185,22 @@ function scanCallTargets(
       scanAddressInBackground(
         spenderAddress,
         `spender address for ${context} approval`,
+        chainId,
+        appStateController,
+        phishingController,
+      );
+    }
+
+    // If the call is a token transfer, also scan the recipient decoded from
+    // calldata: for transfers `to` is only the token contract; the funds
+    // move to the address inside the calldata.
+    const transferRecipient = parseTransferTransactionData(
+      data as `0x${string}`,
+    )?.recipient;
+    if (transferRecipient) {
+      scanAddressInBackground(
+        transferRecipient,
+        `transfer recipient address for ${context}`,
         chainId,
         appStateController,
         phishingController,

--- a/shared/constants/transaction.ts
+++ b/shared/constants/transaction.ts
@@ -283,6 +283,18 @@ export const APPROVAL_METHOD_NAMES = [
   'setApprovalForAll',
 ];
 
+/**
+ * Token transfer methods whose economic recipient is encoded in calldata
+ * rather than `txParams.to` (which is the token contract). Mirrors the
+ * types `getEffectiveRecipient` in `@metamask/transaction-controller`
+ * decodes for.
+ */
+export const TRANSFER_METHOD_NAMES = [
+  'transfer',
+  'transferFrom',
+  'safeTransferFrom',
+];
+
 // 4-byte selector for setApprovalForAll(address,bool) (ERC-721 + ERC-1155)
 export const SET_APPROVAL_FOR_ALL = '0xa22cb465' as const;
 

--- a/shared/constants/transaction.ts
+++ b/shared/constants/transaction.ts
@@ -285,14 +285,19 @@ export const APPROVAL_METHOD_NAMES = [
 
 /**
  * Token transfer methods whose economic recipient is encoded in calldata
- * rather than `txParams.to` (which is the token contract). Mirrors the
- * types `getEffectiveRecipient` in `@metamask/transaction-controller`
- * decodes for.
+ * rather than `txParams.to` (which is the token contract). Includes the
+ * methods `getEffectiveRecipient` in `@metamask/transaction-controller`
+ * decodes (`transfer`, `transferFrom`, `safeTransferFrom`) plus
+ * `safeBatchTransferFrom` (single `to`; core omits it only because
+ * `TransactionType` never classifies it) and Fiat Token V2
+ * `transferWithAuthorization`.
  */
 export const TRANSFER_METHOD_NAMES = [
   'transfer',
   'transferFrom',
   'safeTransferFrom',
+  'safeBatchTransferFrom',
+  'transferWithAuthorization',
 ];
 
 // 4-byte selector for setApprovalForAll(address,bool) (ERC-721 + ERC-1155)

--- a/shared/lib/transaction.utils.test.js
+++ b/shared/lib/transaction.utils.test.js
@@ -20,6 +20,7 @@ import {
   isEIP1559Transaction,
   isLegacyTransaction,
   parseApprovalTransactionData,
+  parseTransferTransactionData,
   parseStandardTokenTransactionData,
   parseTypedDataMessage,
 } from './transaction.utils';
@@ -825,6 +826,74 @@ describe('Transaction.utils', function () {
       const result = getTransactionDataRecipient(data);
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('parseTransferTransactionData', () => {
+    const RECIPIENT_ADDRESS = '0x50A9D56C2B8BA9A5c7f2C08C3d26E0499F23a706';
+    const RECIPIENT_WORD =
+      '00000000000000000000000050a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706';
+    const SENDER_WORD =
+      '0000000000000000000000001234567890123456789012345678901234567890';
+    const ONE_WORD =
+      '0000000000000000000000000000000000000000000000000000000000000001';
+
+    it('parses ERC-20 transfer', () => {
+      const data = `0xa9059cbb${RECIPIENT_WORD}${ONE_WORD}`;
+
+      expect(parseTransferTransactionData(data)).toStrictEqual({
+        name: 'transfer',
+        recipient: RECIPIENT_ADDRESS,
+      });
+    });
+
+    it('parses transferFrom', () => {
+      const data = `0x23b872dd${SENDER_WORD}${RECIPIENT_WORD}${ONE_WORD}`;
+
+      expect(parseTransferTransactionData(data)).toStrictEqual({
+        name: 'transferFrom',
+        recipient: RECIPIENT_ADDRESS,
+      });
+    });
+
+    it('parses ERC-721 safeTransferFrom', () => {
+      // safeTransferFrom(address from, address to, uint256 tokenId)
+      const data = `0x42842e0e${SENDER_WORD}${RECIPIENT_WORD}${ONE_WORD}`;
+
+      expect(parseTransferTransactionData(data)).toStrictEqual({
+        name: 'safeTransferFrom',
+        recipient: RECIPIENT_ADDRESS,
+      });
+    });
+
+    it('parses ERC-1155 safeTransferFrom', () => {
+      // safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes data)
+      const bytesOffsetWord =
+        '00000000000000000000000000000000000000000000000000000000000000a0';
+      const bytesLengthWord =
+        '0000000000000000000000000000000000000000000000000000000000000000';
+      const data = `0xf242432a${SENDER_WORD}${RECIPIENT_WORD}${ONE_WORD}${ONE_WORD}${bytesOffsetWord}${bytesLengthWord}`;
+
+      expect(parseTransferTransactionData(data)).toStrictEqual({
+        name: 'safeTransferFrom',
+        recipient: RECIPIENT_ADDRESS,
+      });
+    });
+
+    it('returns undefined for an approval', () => {
+      const data = `0x095ea7b3${RECIPIENT_WORD}${ONE_WORD}`;
+
+      expect(parseTransferTransactionData(data)).toBeUndefined();
+    });
+
+    it('returns undefined for an unrecognized function selector', () => {
+      const data = `0xffffffff${RECIPIENT_WORD}${ONE_WORD}`;
+
+      expect(parseTransferTransactionData(data)).toBeUndefined();
+    });
+
+    it('returns undefined for malformed data', () => {
+      expect(parseTransferTransactionData('0xa9059cbb123')).toBeUndefined();
     });
   });
 

--- a/shared/lib/transaction.utils.test.js
+++ b/shared/lib/transaction.utils.test.js
@@ -866,6 +866,20 @@ describe('Transaction.utils', function () {
       });
     });
 
+    it('parses ERC-721 4-arg safeTransferFrom', () => {
+      // safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
+      const bytesOffsetWord =
+        '0000000000000000000000000000000000000000000000000000000000000080';
+      const bytesLengthWord =
+        '0000000000000000000000000000000000000000000000000000000000000000';
+      const data = `0xb88d4fde${SENDER_WORD}${RECIPIENT_WORD}${ONE_WORD}${bytesOffsetWord}${bytesLengthWord}`;
+
+      expect(parseTransferTransactionData(data)).toStrictEqual({
+        name: 'safeTransferFrom',
+        recipient: RECIPIENT_ADDRESS,
+      });
+    });
+
     it('parses ERC-1155 safeTransferFrom', () => {
       // safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes data)
       const bytesOffsetWord =
@@ -876,6 +890,32 @@ describe('Transaction.utils', function () {
 
       expect(parseTransferTransactionData(data)).toStrictEqual({
         name: 'safeTransferFrom',
+        recipient: RECIPIENT_ADDRESS,
+      });
+    });
+
+    it('parses ERC-1155 safeBatchTransferFrom', () => {
+      const data = `0x2eb2c2d6${SENDER_WORD}${RECIPIENT_WORD}00000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`;
+
+      expect(parseTransferTransactionData(data)).toStrictEqual({
+        name: 'safeBatchTransferFrom',
+        recipient: RECIPIENT_ADDRESS,
+      });
+    });
+
+    it('parses Fiat Token V2 transferWithAuthorization', () => {
+      const data =
+        '0xe3ee160e' +
+        `${SENDER_WORD}${RECIPIENT_WORD}${ONE_WORD}` +
+        '0000000000000000000000000000000000000000000000000000000000000000' +
+        `${ONE_WORD}` +
+        '0000000000000000000000000000000000000000000000000000000000000000' +
+        '000000000000000000000000000000000000000000000000000000000000001b' +
+        '1111111111111111111111111111111111111111111111111111111111111111' +
+        '2222222222222222222222222222222222222222222222222222222222222222';
+
+      expect(parseTransferTransactionData(data)).toStrictEqual({
+        name: 'transferWithAuthorization',
         recipient: RECIPIENT_ADDRESS,
       });
     });

--- a/shared/lib/transaction.utils.ts
+++ b/shared/lib/transaction.utils.ts
@@ -133,11 +133,11 @@ export function txParamsAreDappSuggested(
   return Boolean(
     (gasPrice &&
       gasPrice === transactionMeta?.dappSuggestedGasFees?.gasPrice) ||
-    (maxPriorityFeePerGas &&
-      maxFeePerGas &&
-      transactionMeta?.dappSuggestedGasFees?.maxPriorityFeePerGas ===
-        maxPriorityFeePerGas &&
-      transactionMeta?.dappSuggestedGasFees?.maxFeePerGas === maxFeePerGas),
+      (maxPriorityFeePerGas &&
+        maxFeePerGas &&
+        transactionMeta?.dappSuggestedGasFees?.maxPriorityFeePerGas ===
+          maxPriorityFeePerGas &&
+        transactionMeta?.dappSuggestedGasFees?.maxFeePerGas === maxFeePerGas),
   );
 }
 
@@ -561,8 +561,7 @@ export function parseTransferTransactionData(data: Hex):
   }
 
   const recipient =
-    args?._to ?? // ERC-20 - transfer / transferFrom
-    args?.to; // ERC-721 / ERC-1155 / Fiat Token V2
+    args?._to ?? args?.to; // ERC-20 - transfer / transferFrom // ERC-721 / ERC-1155 / Fiat Token V2
 
   return {
     name,
@@ -610,17 +609,12 @@ export function resolveApprovalTokenContractAddress(
 
 /**
  * Extracts the recipient address from a transaction's data field.
- * This function parses standard token transaction data and attempts to retrieve
- * the recipient address from the transaction arguments. It checks for both `_to`
- * and `to` argument patterns commonly found in token transfer transactions.
+ * Delegates to {@link parseTransferTransactionData} so UI, PPOM, and
+ * trust-signal scanning share the same method gate and `_to` / `to` fallback.
  *
  * @param data - The hexadecimal string representation of the transaction data to parse
  * @returns The recipient address as a string if found in the transaction data, or undefined if not present
  */
 export function getTransactionDataRecipient(data: string): string | undefined {
-  const transactionData = parseStandardTokenTransactionData(data);
-
-  const transferTo = transactionData?.args?._to || transactionData?.args?.to;
-
-  return transferTo;
+  return parseTransferTransactionData(data as Hex)?.recipient;
 }

--- a/shared/lib/transaction.utils.ts
+++ b/shared/lib/transaction.utils.ts
@@ -133,11 +133,11 @@ export function txParamsAreDappSuggested(
   return Boolean(
     (gasPrice &&
       gasPrice === transactionMeta?.dappSuggestedGasFees?.gasPrice) ||
-      (maxPriorityFeePerGas &&
-        maxFeePerGas &&
-        transactionMeta?.dappSuggestedGasFees?.maxPriorityFeePerGas ===
-          maxPriorityFeePerGas &&
-        transactionMeta?.dappSuggestedGasFees?.maxFeePerGas === maxFeePerGas),
+    (maxPriorityFeePerGas &&
+      maxFeePerGas &&
+      transactionMeta?.dappSuggestedGasFees?.maxPriorityFeePerGas ===
+        maxPriorityFeePerGas &&
+      transactionMeta?.dappSuggestedGasFees?.maxFeePerGas === maxFeePerGas),
   );
 }
 
@@ -560,8 +560,7 @@ export function parseTransferTransactionData(data: Hex):
     return undefined;
   }
 
-  const recipient =
-    args?._to ?? args?.to; // ERC-20 - transfer / transferFrom // ERC-721 / ERC-1155 / Fiat Token V2
+  const recipient = args?._to ?? args?.to; // ERC-20 - transfer / transferFrom // ERC-721 / ERC-1155 / Fiat Token V2
 
   return {
     name,

--- a/shared/lib/transaction.utils.ts
+++ b/shared/lib/transaction.utils.ts
@@ -21,6 +21,7 @@ import { BigNumber } from 'bignumber.js';
 import { ERC20 } from '@metamask/controller-utils';
 import {
   APPROVAL_METHOD_NAMES,
+  TRANSFER_METHOD_NAMES,
   AssetType,
   TokenStandard,
 } from '../constants/transaction';
@@ -531,6 +532,41 @@ export function parseApprovalTransactionData(data: Hex):
     name,
     tokenAddress,
     spender,
+  };
+}
+
+/**
+ * Parses ERC-20/721/1155 token-transfer calldata and extracts the address
+ * actually receiving the tokens. For these methods the transaction's `to` is
+ * the token contract, not the recipient: the same distinction
+ * `getEffectiveRecipient` in `@metamask/transaction-controller` draws (that
+ * helper needs a classified `TransactionType`; this one parses raw calldata
+ * for callers, like the trust-signals middleware, that have none).
+ *
+ * @param data - The transaction calldata to parse
+ * @returns The method name and decoded recipient, or undefined when the
+ * calldata is not a recognized token transfer
+ */
+export function parseTransferTransactionData(data: Hex):
+  | {
+      name: string;
+      recipient?: Hex;
+    }
+  | undefined {
+  const transactionDescription = parseStandardTokenTransactionData(data);
+  const { args, name } = transactionDescription ?? {};
+
+  if (!TRANSFER_METHOD_NAMES.includes(name ?? '') || !name) {
+    return undefined;
+  }
+
+  const recipient =
+    args?._to ?? // ERC-20 - transfer / transferFrom
+    args?.to; // ERC-721 / ERC-1155 / Fiat Token V2
+
+  return {
+    name,
+    recipient: typeof recipient === 'string' ? (recipient as Hex) : undefined,
   };
 }
 

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -3,6 +3,7 @@ import {
   SimulationTokenStandard,
   TransactionMeta,
   TransactionStatus,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import { Hex } from '@metamask/utils';
@@ -26,6 +27,11 @@ const NESTED_ADDRESS_A = '0xNestedAddressA';
 const NESTED_ADDRESS_B = '0xNestedAddressB';
 const UNMAPPED_CHAIN_ID: Hex = '0x1237';
 const CACHE_KEY = createCacheKey(ETHEREUM_CHAIN_ID, TO_ADDRESS);
+const TOKEN_CONTRACT = '0xTokenContract';
+const TRANSFER_RECIPIENT = '0x2f318C334780961FB129D2a6c30D0763d9a5C970';
+// ERC-20 `transfer(TRANSFER_RECIPIENT, 10)`
+const TRANSFER_DATA: Hex =
+  '0xa9059cbb0000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C970000000000000000000000000000000000000000000000000000000000000000a';
 
 const BASE_TRANSACTION_META: TransactionMeta = {
   id: 'test-tx-id',
@@ -495,6 +501,74 @@ describe('enforced-simulations', () => {
             }),
           ),
         ).toBe(true);
+      });
+    });
+
+    describe('with token transfers', () => {
+      // Enforced simulations defend against red-pill contracts, so the trust
+      // gate deliberately evaluates the executed contract (`to`), never the
+      // transfer recipient decoded from calldata (CONF-1078). Recipient
+      // verdicts in the same cache serve UI trust signals only.
+      it('keys the exemption off the token contract, not the decoded transfer recipient', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              type: TransactionType.tokenMethodTransfer,
+              txParams: {
+                ...BASE_TRANSACTION_META.txParams,
+                to: TOKEN_CONTRACT,
+                data: TRANSFER_DATA,
+              },
+            },
+            buildStateForAddresses({
+              [TOKEN_CONTRACT]: ResultType.Trusted,
+              [TRANSFER_RECIPIENT]: ResultType.Benign,
+            }),
+          ),
+        ).toBe(false);
+      });
+
+      it('enforces when the token contract is not trusted, regardless of the recipient verdict', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              type: TransactionType.tokenMethodTransfer,
+              txParams: {
+                ...BASE_TRANSACTION_META.txParams,
+                to: TOKEN_CONTRACT,
+                data: TRANSFER_DATA,
+              },
+            },
+            buildStateForAddresses({
+              [TOKEN_CONTRACT]: ResultType.Benign,
+              [TRANSFER_RECIPIENT]: ResultType.Trusted,
+            }),
+          ),
+        ).toBe(true);
+      });
+
+      it('keys nested transfer calls off each nested contract address', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              nestedTransactions: [
+                {
+                  to: TOKEN_CONTRACT as `0x${string}`,
+                  data: TRANSFER_DATA,
+                  type: TransactionType.tokenMethodTransfer,
+                },
+              ],
+            },
+            buildStateForAddresses({
+              [TO_ADDRESS]: ResultType.Trusted,
+              [TOKEN_CONTRACT]: ResultType.Trusted,
+              [TRANSFER_RECIPIENT]: ResultType.Benign,
+            }),
+          ),
+        ).toBe(false);
       });
     });
 

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -29,6 +29,11 @@ const NESTED_ADDRESS_A = '0xNestedAddressA';
 const NESTED_ADDRESS_B = '0xNestedAddressB';
 const UNMAPPED_CHAIN_ID: Hex = '0x1237';
 const CACHE_KEY = createCacheKey(ETHEREUM_CHAIN_ID, TO_ADDRESS);
+const TOKEN_CONTRACT = '0xTokenContract';
+const TRANSFER_RECIPIENT = '0x2f318C334780961FB129D2a6c30D0763d9a5C970';
+// ERC-20 `transfer(TRANSFER_RECIPIENT, 10)`
+const TRANSFER_DATA: Hex =
+  '0xa9059cbb0000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C970000000000000000000000000000000000000000000000000000000000000000a';
 
 const BASE_TRANSACTION_META: TransactionMeta = {
   id: 'test-tx-id',
@@ -1026,6 +1031,74 @@ describe('enforced-simulations', () => {
             }),
           ),
         ).toBe(true);
+      });
+    });
+
+    describe('with token transfers', () => {
+      // Enforced simulations defend against red-pill contracts, so the trust
+      // gate deliberately evaluates the executed contract (`to`), never the
+      // transfer recipient decoded from calldata (CONF-1078). Recipient
+      // verdicts in the same cache serve UI trust signals only.
+      it('keys the exemption off the token contract, not the decoded transfer recipient', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              type: TransactionType.tokenMethodTransfer,
+              txParams: {
+                ...BASE_TRANSACTION_META.txParams,
+                to: TOKEN_CONTRACT,
+                data: TRANSFER_DATA,
+              },
+            },
+            buildStateForAddresses({
+              [TOKEN_CONTRACT]: ResultType.Trusted,
+              [TRANSFER_RECIPIENT]: ResultType.Benign,
+            }),
+          ),
+        ).toBe(false);
+      });
+
+      it('enforces when the token contract is not trusted, regardless of the recipient verdict', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              type: TransactionType.tokenMethodTransfer,
+              txParams: {
+                ...BASE_TRANSACTION_META.txParams,
+                to: TOKEN_CONTRACT,
+                data: TRANSFER_DATA,
+              },
+            },
+            buildStateForAddresses({
+              [TOKEN_CONTRACT]: ResultType.Benign,
+              [TRANSFER_RECIPIENT]: ResultType.Trusted,
+            }),
+          ),
+        ).toBe(true);
+      });
+
+      it('keys nested transfer calls off each nested contract address', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              nestedTransactions: [
+                {
+                  to: TOKEN_CONTRACT as `0x${string}`,
+                  data: TRANSFER_DATA,
+                  type: TransactionType.tokenMethodTransfer,
+                },
+              ],
+            },
+            buildStateForAddresses({
+              [TO_ADDRESS]: ResultType.Trusted,
+              [TOKEN_CONTRACT]: ResultType.Trusted,
+              [TRANSFER_RECIPIENT]: ResultType.Benign,
+            }),
+          ),
+        ).toBe(false);
       });
     });
 

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -273,12 +273,24 @@ function getRelevantTrustSignalResults(
   // on a supported chain (timeout / API error), not "this chain isn't
   // supported".
   //
-  // Recipients that no scan path covers stay cache misses and are treated as
+  // Addresses that no scan path covers stay cache misses and are treated as
   // trusted here. The trust-signals middleware scans dapp `eth_sendTransaction`
-  // and `wallet_sendCalls` requests (including each nested call's `to`), but
-  // nothing is scanned when the user has security alerts disabled, and the
-  // outer batch target (`txParamsOriginal.to`, the upgraded EOA for a 7702
-  // batch) is never scanned, so its cache miss never disqualifies.
+  // and `wallet_sendCalls` requests (each call's `to` plus approval spenders
+  // and token-transfer recipients decoded from calldata), but nothing is
+  // scanned when the user has security alerts disabled, and the outer batch
+  // target (`txParamsOriginal.to`, the upgraded EOA for a 7702 batch) is
+  // never scanned, so its cache miss never disqualifies.
+  //
+  // This gate deliberately evaluates `to` (the contract being executed) and
+  // NOT the decoded recipient of a token transfer. Enforced simulations
+  // defend against red-pill contracts that detect simulation and change
+  // behavior on-chain; only executing code can do that, so what matters is
+  // whether the interaction target is a verified/Trusted contract
+  // (CONF-1078). A `Trusted` verdict is a contract-verification signal, so
+  // for a USDC transfer the exemption keys off USDC itself; the transfer
+  // recipient cannot alter the simulation. Recipient verdicts are still
+  // scanned into this same cache, but they power UI trust signals
+  // (e.g. flagging a malicious payee), not this enforcement gate.
   if (!chainId) {
     return [];
   }

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -167,16 +167,28 @@ function isTrusted(
     transactionMeta;
 
   // Trust verdicts are cache-driven on every chain: only a cached non-Trusted
-  // verdict disqualifies a recipient, and chains the Security Alerts API
+  // verdict disqualifies an address, and chains the Security Alerts API
   // cannot screen resolve to ErrorResult once scanned, which is non-Trusted
   // and therefore enforces.
   //
-  // Recipients that no scan path covers stay cache misses and are treated as
+  // Addresses that no scan path covers stay cache misses and are treated as
   // trusted here. The trust-signals middleware scans dapp `eth_sendTransaction`
-  // and `wallet_sendCalls` requests (including each nested call's `to`), but
-  // nothing is scanned when the user has security alerts disabled, and the
-  // outer batch target (`txParamsOriginal.to`, the upgraded EOA for a 7702
-  // batch) is never scanned, so its cache miss never disqualifies.
+  // and `wallet_sendCalls` requests (each call's `to` plus approval spenders
+  // and token-transfer recipients decoded from calldata), but nothing is
+  // scanned when the user has security alerts disabled, and the outer batch
+  // target (`txParamsOriginal.to`, the upgraded EOA for a 7702 batch) is
+  // never scanned, so its cache miss never disqualifies.
+  //
+  // This gate deliberately evaluates `to` (the contract being executed) and
+  // NOT the decoded recipient of a token transfer. Enforced simulations
+  // defend against red-pill contracts that detect simulation and change
+  // behavior on-chain; only executing code can do that, so what matters is
+  // whether the interaction target is a verified/Trusted contract
+  // (CONF-1078). A `Trusted` verdict is a contract-verification signal, so
+  // for a USDC transfer the exemption keys off USDC itself; the transfer
+  // recipient cannot alter the simulation. Recipient verdicts are still
+  // scanned into this same cache, but they power UI trust signals
+  // (e.g. flagging a malicious payee), not this enforcement gate.
   if (!chainId) {
     return false;
   }

--- a/test/e2e/tests/confirmations/mocks/trust-signals.ts
+++ b/test/e2e/tests/confirmations/mocks/trust-signals.ts
@@ -2,21 +2,44 @@ import { MockedEndpoint, Mockttp } from '../../../mock-e2e';
 import { ResultType } from '../../../../../shared/lib/trust-signals';
 import { SECURITY_ALERTS_PROD_API_BASE_URL } from '../../ppom/constants';
 
+/**
+ * Mocks the address scan endpoint. If `targetAddress` is provided, only that
+ * address (case-insensitive) receives `resultType`; any other scanned address
+ * (e.g. a decoded transfer recipient) gets `ResultType.Benign`, so tests that
+ * scope a malicious/warning verdict to one address aren't also flagged for
+ * unrelated addresses touched by the same transaction.
+ *
+ * @param mockServer - The mock server to configure
+ * @param resultType - The result to return for `targetAddress`, or for every
+ * scanned address if `targetAddress` is omitted
+ * @param label - The label to include in the mocked response
+ * @param targetAddress - The address `resultType` applies to; other scanned
+ * addresses get `ResultType.Benign`
+ */
 export async function mockTrustSignal(
   mockServer: Mockttp,
   resultType: ResultType,
   label = '',
+  targetAddress?: string,
 ): Promise<MockedEndpoint[]> {
   return [
     await mockServer
       .forPost(`${SECURITY_ALERTS_PROD_API_BASE_URL}/address/evm/scan`)
-      .thenCallback(() => ({
-        statusCode: 200,
-        json: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          result_type: resultType,
-          label,
-        },
-      })),
+      .thenCallback(async (request) => {
+        const body = await request.body.getJson();
+        const scannedAddress = (body as { address?: string })?.address;
+        const matchesTarget =
+          !targetAddress ||
+          scannedAddress?.toLowerCase() === targetAddress.toLowerCase();
+
+        return {
+          statusCode: 200,
+          json: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            result_type: matchesTarget ? resultType : ResultType.Benign,
+            label: matchesTarget ? label : '',
+          },
+        };
+      }),
   ];
 }

--- a/test/e2e/tests/confirmations/transactions/enforced-simulations.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/enforced-simulations.spec.ts
@@ -350,7 +350,14 @@ describe('Enforced Simulations', function (this: Suite) {
 function setupMocks(trustResultType: ResultType) {
   return async (mockServer: MockttpServer): Promise<MockedEndpoint[]> => {
     const eip7702Mocks = await mockEip7702FeatureFlag(mockServer);
-    const trustMocks = await mockTrustSignal(mockServer, trustResultType);
+    // Scoped to the token contract so the decoded transfer recipient (a
+    // plain destination address, not under test here) isn't also flagged.
+    const trustMocks = await mockTrustSignal(
+      mockServer,
+      trustResultType,
+      '',
+      USDC_ADDRESS,
+    );
     await mockSpotPrices(mockServer, ENFORCED_SIMULATIONS_SPOT_PRICES);
     await mockSimulationApi(mockServer, {
       sender: SENDER_ADDRESS_MOCK,

--- a/ui/pages/confirmations/hooks/alerts/useTransferRecipientAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useTransferRecipientAlerts.test.ts
@@ -1,0 +1,163 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { NameType } from '@metamask/name-controller';
+
+import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
+import { genUnapprovedTokenTransferConfirmation } from '../../../../../test/data/confirmations/token-transfer';
+import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import { Severity } from '../../../../helpers/constants/design-system';
+import { RowAlertKey } from '../../../../components/app/confirm/info/row/constants';
+import { TrustSignalDisplayState } from '../../../../hooks/useTrustSignals';
+import { useTransferRecipientAlerts } from './useTransferRecipientAlerts';
+
+jest.mock('../../../../hooks/useTrustSignals', () => ({
+  useTrustSignals: jest.fn(),
+  useTrustSignal: jest.fn(),
+  TrustSignalDisplayState: {
+    Malicious: 'malicious',
+    Warning: 'warning',
+    Unknown: 'unknown',
+  },
+}));
+
+jest.mock('../../../../../app/scripts/lib/ppom/security-alerts-api', () => ({
+  isSecurityAlertsAPIEnabled: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: jest.fn(() => (key: string) => key),
+}));
+
+const mockUseTrustSignals = jest.requireMock(
+  '../../../../hooks/useTrustSignals',
+).useTrustSignals;
+const mockIsSecurityAlertsAPIEnabled = jest.requireMock(
+  '../../../../../app/scripts/lib/ppom/security-alerts-api',
+).isSecurityAlertsAPIEnabled;
+
+// Payee encoded in genUnapprovedTokenTransferConfirmation calldata.
+const TRANSFER_RECIPIENT = '0x2e0D7E8c45221FcA00d74a3609A0f7097035d09B';
+const TOKEN_CONTRACT = '0x076146c765189d51be3160a2140cf80bfc73ad68';
+
+const expectedMaliciousAlert = {
+  actions: [],
+  field: RowAlertKey.InteractingWith,
+  isBlocking: false,
+  key: `transferRecipientTrustSignalMalicious-${TRANSFER_RECIPIENT.toLowerCase()}`,
+  message: 'alertMessageAddressTrustSignalMalicious',
+  reason: 'alertReasonAddressTrustSignalMalicious',
+  severity: Severity.Danger,
+};
+
+const expectedWarningAlert = {
+  actions: [],
+  field: RowAlertKey.InteractingWith,
+  isBlocking: false,
+  key: `transferRecipientTrustSignalWarning-${TRANSFER_RECIPIENT.toLowerCase()}`,
+  message: 'alertMessageAddressTrustSignal',
+  reason: 'alertReasonAddressTrustSignalWarning',
+  severity: Severity.Warning,
+};
+
+describe('useTransferRecipientAlerts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsSecurityAlertsAPIEnabled.mockReturnValue(true);
+    mockUseTrustSignals.mockReturnValue([
+      { state: TrustSignalDisplayState.Unknown },
+    ]);
+  });
+
+  it('returns an empty array when security alerts API is disabled', () => {
+    mockIsSecurityAlertsAPIEnabled.mockReturnValue(false);
+    mockUseTrustSignals.mockReturnValue([
+      { state: TrustSignalDisplayState.Malicious },
+    ]);
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useTransferRecipientAlerts(),
+      getMockConfirmStateForTransaction(
+        genUnapprovedTokenTransferConfirmation() as TransactionMeta,
+      ),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns a malicious alert for a token transfer whose payee is malicious', () => {
+    mockUseTrustSignals.mockReturnValue([
+      { state: TrustSignalDisplayState.Malicious },
+    ]);
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useTransferRecipientAlerts(),
+      getMockConfirmStateForTransaction(
+        genUnapprovedTokenTransferConfirmation() as TransactionMeta,
+      ),
+    );
+
+    expect(result.current).toEqual([expectedMaliciousAlert]);
+    expect(mockUseTrustSignals).toHaveBeenCalledWith([
+      {
+        value: TRANSFER_RECIPIENT,
+        type: NameType.ETHEREUM_ADDRESS,
+        chainId: CHAIN_IDS.GOERLI,
+      },
+    ]);
+  });
+
+  it('returns a warning alert for a token transfer whose payee is warning', () => {
+    mockUseTrustSignals.mockReturnValue([
+      { state: TrustSignalDisplayState.Warning },
+    ]);
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useTransferRecipientAlerts(),
+      getMockConfirmStateForTransaction(
+        genUnapprovedTokenTransferConfirmation() as TransactionMeta,
+      ),
+    );
+
+    expect(result.current).toEqual([expectedWarningAlert]);
+  });
+
+  it('returns empty when the payee is the same as txParams.to', () => {
+    mockUseTrustSignals.mockReturnValue([
+      { state: TrustSignalDisplayState.Malicious },
+    ]);
+
+    const contractInteraction = genUnapprovedContractInteractionConfirmation({
+      chainId: CHAIN_IDS.GOERLI,
+    }) as TransactionMeta;
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useTransferRecipientAlerts(),
+      getMockConfirmStateForTransaction({
+        ...contractInteraction,
+        txParams: {
+          ...contractInteraction.txParams,
+          to: TOKEN_CONTRACT,
+        },
+      }),
+    );
+
+    expect(result.current).toEqual([]);
+    expect(mockUseTrustSignals).toHaveBeenCalledWith([]);
+  });
+
+  it('returns empty when the payee is unknown', () => {
+    mockUseTrustSignals.mockReturnValue([
+      { state: TrustSignalDisplayState.Unknown },
+    ]);
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useTransferRecipientAlerts(),
+      getMockConfirmStateForTransaction(
+        genUnapprovedTokenTransferConfirmation() as TransactionMeta,
+      ),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+});

--- a/ui/pages/confirmations/hooks/alerts/useTransferRecipientAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useTransferRecipientAlerts.ts
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { NameType } from '@metamask/name-controller';
+import type { Hex } from '@metamask/utils';
+import { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
+import { Severity } from '../../../../helpers/constants/design-system';
+import { RowAlertKey } from '../../../../components/app/confirm/info/row/constants';
+import { useConfirmContext } from '../../context/confirm';
+import {
+  useTrustSignals,
+  TrustSignalDisplayState,
+} from '../../../../hooks/useTrustSignals';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+// eslint-disable-next-line import-x/no-restricted-paths
+import { isSecurityAlertsAPIEnabled } from '../../../../../app/scripts/lib/ppom/security-alerts-api';
+import {
+  useNestedTransactionTransferRecipients,
+  useTransferRecipient,
+} from '../../components/confirm/info/hooks/useTransferRecipient';
+
+/**
+ * Page-level trust-signal alerts for decoded token-transfer payees.
+ *
+ * Complements {@link useAddressTrustSignalAlerts}, which keys off
+ * `txParams.to` (the executed contract). For ERC-20/721/1155 transfers that
+ * address is the token contract, so a malicious payee would otherwise only
+ * get a row badge. Recipients that equal `txParams.to` are skipped so native
+ * sends are not double-alerted.
+ *
+ * @returns Alerts for decoded transfer recipients.
+ */
+export function useTransferRecipientAlerts(): Alert[] {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext();
+  const transferRecipient = useTransferRecipient();
+  const nestedRecipients = useNestedTransactionTransferRecipients();
+
+  const transactionMeta = currentConfirmation as TransactionMeta | undefined;
+  const interactingWith =
+    transactionMeta?.txParamsOriginal?.to ?? transactionMeta?.txParams?.to;
+
+  const recipientAddresses = useMemo(() => {
+    const unique = new Set<string>();
+    for (const address of [transferRecipient, ...nestedRecipients]) {
+      if (address && address.toLowerCase() !== interactingWith?.toLowerCase()) {
+        unique.add(address);
+      }
+    }
+    return [...unique];
+  }, [transferRecipient, nestedRecipients, interactingWith]);
+
+  const trustSignalRequests = useMemo(
+    () =>
+      recipientAddresses.map((value) => ({
+        value,
+        type: NameType.ETHEREUM_ADDRESS,
+        chainId: currentConfirmation?.chainId as Hex | undefined,
+      })),
+    [recipientAddresses, currentConfirmation?.chainId],
+  );
+
+  const trustSignalResults = useTrustSignals(trustSignalRequests);
+
+  return useMemo(() => {
+    if (!recipientAddresses.length || !isSecurityAlertsAPIEnabled()) {
+      return [];
+    }
+
+    const alerts: Alert[] = [];
+
+    trustSignalResults.forEach((result, index) => {
+      const address = recipientAddresses[index];
+      if (!address) {
+        return;
+      }
+
+      if (result.state === TrustSignalDisplayState.Malicious) {
+        alerts.push({
+          actions: [],
+          field: RowAlertKey.InteractingWith,
+          isBlocking: false,
+          key: `transferRecipientTrustSignalMalicious-${address.toLowerCase()}`,
+          message: t('alertMessageAddressTrustSignalMalicious'),
+          reason: t('alertReasonAddressTrustSignalMalicious'),
+          severity: Severity.Danger,
+        });
+      } else if (result.state === TrustSignalDisplayState.Warning) {
+        alerts.push({
+          actions: [],
+          field: RowAlertKey.InteractingWith,
+          isBlocking: false,
+          key: `transferRecipientTrustSignalWarning-${address.toLowerCase()}`,
+          message: t('alertMessageAddressTrustSignal'),
+          reason: t('alertReasonAddressTrustSignalWarning'),
+          severity: Severity.Warning,
+        });
+      }
+    });
+
+    return alerts;
+  }, [recipientAddresses, trustSignalResults, t]);
+}

--- a/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
@@ -34,6 +34,7 @@ import { useSelectedAccountAlerts } from './alerts/useSelectedAccountAlerts';
 import { useAddressTrustSignalAlerts } from './alerts/useAddressTrustSignalAlerts';
 import { useOriginTrustSignalAlerts } from './alerts/useOriginTrustSignalAlerts';
 import { useSpenderAlerts } from './alerts/useSpenderAlerts';
+import { useTransferRecipientAlerts } from './alerts/useTransferRecipientAlerts';
 import { useTokenTrustSignalAlerts } from './alerts/useTokenTrustSignalAlerts';
 import { useShieldCoverageAlert } from './alerts/useShieldCoverageAlert';
 import { useAddEthereumChainAlerts } from './alerts/useAddEthereumChainAlerts';
@@ -158,6 +159,7 @@ export default function useConfirmationAlerts(): Alert[] {
   const addressTrustSignalAlerts = useAddressTrustSignalAlerts();
   const originTrustSignalAlerts = useOriginTrustSignalAlerts();
   const spenderAlerts = useSpenderAlerts();
+  const transferRecipientAlerts = useTransferRecipientAlerts();
   const addEthereumChainAlerts = useAddEthereumChainAlerts();
 
   const isPayTransaction = hasTransactionType(
@@ -176,6 +178,7 @@ export default function useConfirmationAlerts(): Alert[] {
       ...addressTrustSignalAlerts,
       ...originTrustSignalAlerts,
       ...spenderAlerts,
+      ...transferRecipientAlerts,
       ...addEthereumChainAlerts,
     ];
 
@@ -192,5 +195,6 @@ export default function useConfirmationAlerts(): Alert[] {
     signatureAlerts,
     spenderAlerts,
     transactionAlerts,
+    transferRecipientAlerts,
   ]);
 }


### PR DESCRIPTION
## **Description**

Resolves [PSAFE-585](https://consensyssoftware.atlassian.net/browse/PSAFE-585).

For ERC-20/721/1155 token transfers, `txParams.to` is the token contract; the address actually receiving the funds is encoded in calldata (`transfer` / `transferFrom` / `safeTransferFrom`) and was never scanned. Sending USDC to a known scammer scanned USDC's contract, not the scammer, so the recipient never got a verdict and UI trust signals could not flag it. This is the same contract-vs-recipient confusion fixed for address poisoning in core by [fix: use decoded token recipient for address poisoning known recipients](https://github.com/MetaMask/core/pull/9699), applied to the trust-signals scanning pipeline.

Changes:

- **New shared parser**: `parseTransferTransactionData` in `shared/lib/transaction.utils.ts` decodes the transfer recipient from raw calldata (gated on `transfer` / `transferFrom` / `safeTransferFrom` / `safeBatchTransferFrom` / `transferWithAuthorization`). It exists alongside core's `getEffectiveRecipient` because the middleware sees raw JSON-RPC requests with no classified `TransactionType`.
- **Trust-signals middleware**: `eth_sendTransaction` and each nested `wallet_sendCalls` call now scan the decoded transfer recipient in addition to `to` and the approval spender. The transfer decode plugs into the shared `scanCallTargets` helper (extracted in the base PR per review feedback), so both paths pick it up from one place. Approval and transfer decoders are isolated so a throw in one cannot skip the other.
- **MetaMask-origin sends** (`scanAddressForTrustSignals` in `app/scripts/lib/transaction/util.ts`): internal token sends also scan the decoded recipient, so the send flow's verdict belongs to the address the user typed, not the token contract.
- **Confirmation banner**: `useTransferRecipientAlerts` looks up the decoded payee (and nested batch payees) in the same cache, without replacing the contract check in `useAddressTrustSignalAlerts`. Native sends whose payee equals `txParams.to` are skipped so they are not double-alerted.
- **Shared parser**: `getTransactionDataRecipient` now delegates to `parseTransferTransactionData`, so UI, PPOM, and scanning share one method gate.

**What this deliberately does NOT change:** the enforced-simulations trust gate (`isTrusted` in `shared/lib/transaction/enforced-simulations.ts`) still evaluates the executed contract (`to`), never the decoded transfer recipient. Enforced simulations defend against red-pill contracts (code that detects simulation and behaves differently on-chain), and only executing code can do that, so the exemption keys off contract verification ([CONF-1078](https://consensyssoftware.atlassian.net/browse/CONF-1078): "enable enforced simulations for unverified contracts"). A `Trusted` verdict is a contract-verification signal that EOA recipients don't receive, so adding recipients to that gate would effectively disable the exemption for token transfers. An earlier revision of this PR changed the gate to evaluate decoded recipients; that was reverted after discussion with Product Safety (Joao Tavares), and this PR documents the intent inline and pins it with tests so the recipient verdicts added here (which land in the same cache) don't get wired into enforcement by accident.

Out of scope: transaction metrics (`address_alert_response`) still reflect the `txParams.to` verdict.

## **Changelog**

CHANGELOG entry: Fixed address security scanning of token transfers to screen the actual recipient of the tokens rather than only the token contract

## **Related issues**

Fixes: [PSAFE-585](https://consensyssoftware.atlassian.net/browse/PSAFE-585)

## **Manual testing steps**

1. Enable security alerts (Settings > Security & privacy > Security alerts).
2. From a dapp (e.g. test-dapp), send an ERC-20 `transfer` to a flagged address.
3. Inspect the scan cache. It is in-memory only (`persist: false`), so it will NOT appear under Extension storage in DevTools; instead open DevTools on the MetaMask UI itself (right-click in the popup > Inspect, or open `chrome-extension://<id>/home.html`) and run `(await stateHooks.getCleanAppState()).metamask.addressSecurityAlertResponses`. There should be cache entries for both the token contract and the decoded recipient (`chainId:address` keys).
4. Repeat via `wallet_sendCalls` with a nested transfer call; same result.
5. With the `confirmations_enforced_simulations` flag enabled (locally: add it to `.manifest-overrides.json` with `MANIFEST_OVERRIDES` set in `.metamaskrc` and rebuild; do not use `FORCE_ENFORCED_SIMULATIONS`, which bypasses the trust-signal check), confirm enforcement behavior is unchanged: it still keys off the token contract's verdict (e.g. a transfer on a `Trusted` contract stays exempt regardless of the recipient's verdict).

## **Screenshots/Recordings**

### **Before**

N/A: background scanning logic.

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PSAFE-585]: https://consensyssoftware.atlassian.net/browse/PSAFE-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CONF-1078]: https://consensyssoftware.atlassian.net/browse/CONF-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes expand security scanning and confirmation alerts on transaction submission paths; scope is well-tested but touches trust-signals middleware and user-facing warnings.
> 
> **Overview**
> **Token transfers now security-scan the payee encoded in calldata**, not only `txParams.to` (the token contract). That closes a gap where sending USDC to a flagged address never produced a verdict on the actual recipient.
> 
> A shared **`parseTransferTransactionData`** (gated on `TRANSFER_METHOD_NAMES`) decodes recipients from ERC-20/721/1155 and related methods; **`getTransactionDataRecipient`** delegates to it so UI, PPOM, and scanning stay aligned. **Trust-signals middleware** (`scanCallTargets`) and **MetaMask-origin sends** (`scanAddressForTrustSignals`) both scan contract + decoded recipient for `eth_sendTransaction`, nested **`wallet_sendCalls`**, and internal sends. Approval and transfer parsing are isolated via **`tryParseCalldata`** so one decoder throwing cannot skip the other.
> 
> **Confirmation UI** adds **`useTransferRecipientAlerts`** (wired into **`useConfirmationAlerts`**) to surface malicious/warning alerts for decoded payees and nested batch recipients, skipping addresses that equal `txParams.to` to avoid double alerts on native sends.
> 
> **Enforced simulations** behavior is unchanged: the trust gate still keys off the executed contract (`to`), with comments and tests documenting that recipient cache entries are for UI signals only (CONF-1078). E2E **`mockTrustSignal`** can scope verdicts to a single address so transfer-recipient scans do not break existing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c1ae79bcadb8f5c4a853d05e2a53c3963b59fb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



