### PR TITLE
feat: AB test for chain value ordering in swaps network picker

### DIFF
--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -65,6 +65,7 @@ import { KeyringType } from '../../../shared/constants/keyring';
 import type { captureException } from '../../../shared/lib/sentry';
 import type { FlattenedBackgroundStateProxy } from '../../../shared/types';
 import { registerABTestAnalyticsMapping } from '../../../shared/lib/ab-testing/ab-test-analytics';
+import { CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING } from '../../../shared/lib/ab-testing/configs/chain-value-order';
 import { PERPS_TAB_BADGE_AB_TEST_ANALYTICS_MAPPING } from '../../../shared/lib/ab-testing/configs/perps-tab-badge';
 import { getTokensControllerAllTokens } from '../../../shared/lib/selectors/assets-migration';
 import { isMain } from '../../../shared/lib/build-types';
@@ -400,6 +401,9 @@ export class MetaMetricsController extends BaseController<
 
     // Register A/B test analytics mappings so that matching events are
     // enriched with their `active_ab_tests` assignment.
+    registerABTestAnalyticsMapping(
+      CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING,
+    );
     registerABTestAnalyticsMapping(PERPS_TAB_BADGE_AB_TEST_ANALYTICS_MAPPING);
 
     this.messenger.registerMethodActionHandlers(

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -401,9 +401,7 @@ export class MetaMetricsController extends BaseController<
 
     // Register A/B test analytics mappings so that matching events are
     // enriched with their `active_ab_tests` assignment.
-    registerABTestAnalyticsMapping(
-      CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING,
-    );
+    registerABTestAnalyticsMapping(CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING);
     registerABTestAnalyticsMapping(PERPS_TAB_BADGE_AB_TEST_ANALYTICS_MAPPING);
 
     this.messenger.registerMethodActionHandlers(

--- a/shared/lib/ab-testing/configs/chain-value-order.test.ts
+++ b/shared/lib/ab-testing/configs/chain-value-order.test.ts
@@ -64,9 +64,7 @@ describe('chain-value-order config', () => {
   });
 
   it('enriches mapped events with the canonical assignment', () => {
-    registerABTestAnalyticsMapping(
-      CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING,
-    );
+    registerABTestAnalyticsMapping(CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING);
 
     const result = enrichWithABTests(
       createEvent(UnifiedSwapBridgeEventName.Submitted),
@@ -81,9 +79,7 @@ describe('chain-value-order config', () => {
   });
 
   it('does not enrich unrelated events', () => {
-    registerABTestAnalyticsMapping(
-      CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING,
-    );
+    registerABTestAnalyticsMapping(CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING);
 
     const result = enrichWithABTests(createEvent('Unrelated Event'), {
       [CHAIN_VALUE_ORDER_AB_KEY]: { name: 'treatment' },

--- a/shared/lib/ab-testing/configs/chain-value-order.test.ts
+++ b/shared/lib/ab-testing/configs/chain-value-order.test.ts
@@ -1,0 +1,94 @@
+import { UnifiedSwapBridgeEventName } from '@metamask/bridge-controller';
+import type { AnalyticsEvent } from '../../analytics/create-event-builder';
+import {
+  enrichWithABTests,
+  registerABTestAnalyticsMapping,
+  clearABTestAnalyticsMappings,
+} from '../ab-test-analytics';
+import { createActiveABTestAssignment } from '../active-ab-test-assignment';
+import { ABTestVariant } from '../variants';
+import {
+  CHAIN_VALUE_ORDER_AB_KEY,
+  CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING,
+  CHAIN_VALUE_ORDER_AB_TEST_EXPOSURE_METADATA,
+  CHAIN_VALUE_ORDER_AB_TEST_VARIANTS,
+} from './chain-value-order';
+
+function createEvent(name: string): AnalyticsEvent {
+  return {
+    name,
+    properties: {},
+    sensitiveProperties: {},
+  };
+}
+
+describe('chain-value-order config', () => {
+  afterEach(() => clearABTestAnalyticsMappings());
+
+  it('uses the SWAPS-4827 Extension experiment key', () => {
+    expect(CHAIN_VALUE_ORDER_AB_KEY).toBe(
+      'swapsSWAPS4827AbtestChainValueOrder',
+    );
+  });
+
+  it('defines control and treatment behavior', () => {
+    expect(CHAIN_VALUE_ORDER_AB_TEST_VARIANTS).toStrictEqual({
+      control: { orderByValue: false },
+      treatment: { orderByValue: true },
+    });
+  });
+
+  it('defines descriptive exposure metadata for both variants', () => {
+    expect(CHAIN_VALUE_ORDER_AB_TEST_EXPOSURE_METADATA).toStrictEqual({
+      experimentName: 'Chain Value Order',
+      variationNames: {
+        control: 'LaunchDarkly chain ranking',
+        treatment: 'Holdings value with remote position overrides',
+      },
+    });
+  });
+
+  it('maps all Unified Swaps funnel events', () => {
+    expect(CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING).toStrictEqual({
+      flagKey: CHAIN_VALUE_ORDER_AB_KEY,
+      validVariants: [ABTestVariant.Control, ABTestVariant.Treatment],
+      eventNames: [
+        UnifiedSwapBridgeEventName.PageViewed,
+        UnifiedSwapBridgeEventName.AssetPickerOpened,
+        UnifiedSwapBridgeEventName.QuotesRequested,
+        UnifiedSwapBridgeEventName.QuotesReceived,
+        UnifiedSwapBridgeEventName.Submitted,
+        UnifiedSwapBridgeEventName.Completed,
+      ],
+    });
+  });
+
+  it('enriches mapped events with the canonical assignment', () => {
+    registerABTestAnalyticsMapping(
+      CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING,
+    );
+
+    const result = enrichWithABTests(
+      createEvent(UnifiedSwapBridgeEventName.Submitted),
+      {
+        [CHAIN_VALUE_ORDER_AB_KEY]: { name: 'treatment' },
+      },
+    );
+
+    expect(result.properties?.active_ab_tests).toStrictEqual([
+      createActiveABTestAssignment(CHAIN_VALUE_ORDER_AB_KEY, 'treatment'),
+    ]);
+  });
+
+  it('does not enrich unrelated events', () => {
+    registerABTestAnalyticsMapping(
+      CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING,
+    );
+
+    const result = enrichWithABTests(createEvent('Unrelated Event'), {
+      [CHAIN_VALUE_ORDER_AB_KEY]: { name: 'treatment' },
+    });
+
+    expect(result.properties?.active_ab_tests).toBeUndefined();
+  });
+});

--- a/shared/lib/ab-testing/configs/chain-value-order.ts
+++ b/shared/lib/ab-testing/configs/chain-value-order.ts
@@ -1,0 +1,45 @@
+import { UnifiedSwapBridgeEventName } from '@metamask/bridge-controller';
+import type { ABTestAnalyticsMapping } from '../ab-test-analytics';
+import { ABTestVariant, type ABTestVariantName } from '../variants';
+
+export const CHAIN_VALUE_ORDER_AB_KEY =
+  'swapsSWAPS4827AbtestChainValueOrder';
+
+type ChainValueOrderVariantConfig = {
+  orderByValue: boolean;
+};
+
+export const CHAIN_VALUE_ORDER_AB_TEST_VARIANTS: Record<
+  ABTestVariantName,
+  ChainValueOrderVariantConfig
+> = {
+  [ABTestVariant.Control]: {
+    orderByValue: false,
+  },
+  [ABTestVariant.Treatment]: {
+    orderByValue: true,
+  },
+};
+
+export const CHAIN_VALUE_ORDER_AB_TEST_EXPOSURE_METADATA = {
+  experimentName: 'Chain Value Order',
+  variationNames: {
+    [ABTestVariant.Control]: 'LaunchDarkly chain ranking',
+    [ABTestVariant.Treatment]:
+      'Holdings value with remote position overrides',
+  },
+} as const;
+
+export const CHAIN_VALUE_ORDER_AB_TEST_ANALYTICS_MAPPING: ABTestAnalyticsMapping =
+  {
+    flagKey: CHAIN_VALUE_ORDER_AB_KEY,
+    validVariants: [ABTestVariant.Control, ABTestVariant.Treatment],
+    eventNames: [
+      UnifiedSwapBridgeEventName.PageViewed,
+      UnifiedSwapBridgeEventName.AssetPickerOpened,
+      UnifiedSwapBridgeEventName.QuotesRequested,
+      UnifiedSwapBridgeEventName.QuotesReceived,
+      UnifiedSwapBridgeEventName.Submitted,
+      UnifiedSwapBridgeEventName.Completed,
+    ],
+  };

--- a/shared/lib/ab-testing/configs/chain-value-order.ts
+++ b/shared/lib/ab-testing/configs/chain-value-order.ts
@@ -2,8 +2,7 @@ import { UnifiedSwapBridgeEventName } from '@metamask/bridge-controller';
 import type { ABTestAnalyticsMapping } from '../ab-test-analytics';
 import { ABTestVariant, type ABTestVariantName } from '../variants';
 
-export const CHAIN_VALUE_ORDER_AB_KEY =
-  'swapsSWAPS4827AbtestChainValueOrder';
+export const CHAIN_VALUE_ORDER_AB_KEY = 'swapsSWAPS4827AbtestChainValueOrder';
 
 type ChainValueOrderVariantConfig = {
   orderByValue: boolean;
@@ -25,8 +24,7 @@ export const CHAIN_VALUE_ORDER_AB_TEST_EXPOSURE_METADATA = {
   experimentName: 'Chain Value Order',
   variationNames: {
     [ABTestVariant.Control]: 'LaunchDarkly chain ranking',
-    [ABTestVariant.Treatment]:
-      'Holdings value with remote position overrides',
+    [ABTestVariant.Treatment]: 'Holdings value with remote position overrides',
   },
 } as const;
 

--- a/shared/lib/bridge/chain-value-order.test.ts
+++ b/shared/lib/bridge/chain-value-order.test.ts
@@ -1,0 +1,152 @@
+import type { CaipChainId } from '@metamask/utils';
+import {
+  type ChainRankingEntry,
+  getChainValueOrder,
+  parsePositionOverrides,
+} from './chain-value-order';
+
+const ETHEREUM = 'eip155:1';
+const OPTIMISM = 'eip155:10';
+const BASE = 'eip155:8453';
+const SOLANA = 'solana:mainnet';
+const UNKNOWN_CHAIN: CaipChainId = 'eip155:999999';
+
+const chainRanking: ChainRankingEntry[] = [
+  { chainId: ETHEREUM, name: 'Ethereum' },
+  { chainId: OPTIMISM, name: 'Optimism' },
+  { chainId: BASE, name: 'Base' },
+  { chainId: SOLANA, name: 'Solana' },
+];
+
+describe('parsePositionOverrides', () => {
+  it('returns valid entries in array order and keeps the first duplicate', () => {
+    expect(
+      parsePositionOverrides({
+        positionOverrides: [
+          { chainId: BASE, name: 'Base' },
+          { chainId: ETHEREUM, name: 'Ethereum' },
+          { chainId: BASE, name: 'Duplicate Base' },
+        ],
+      }),
+    ).toStrictEqual([
+      { chainId: BASE, name: 'Base' },
+      { chainId: ETHEREUM, name: 'Ethereum' },
+    ]);
+  });
+
+  // @ts-expect-error - each is a valid test function
+  it.each([
+    undefined,
+    null,
+    {},
+    { positionOverrides: 'invalid' },
+    { positionOverrides: [] },
+  ])(
+    'returns the same empty list for an empty or malformed value',
+    (value: unknown) => {
+      const firstResult = parsePositionOverrides(value);
+      const secondResult = parsePositionOverrides(value);
+
+      expect(firstResult).toStrictEqual([]);
+      expect(firstResult).toBe(secondResult);
+    },
+  );
+
+  it('skips malformed entries individually', () => {
+    expect(
+      parsePositionOverrides({
+        positionOverrides: [
+          null,
+          { chainId: 'invalid', name: 'Invalid chain' },
+          { chainId: 'eip155:999999', name: 'Unknown chain' },
+          { chainId: BASE, name: '' },
+          { chainId: OPTIMISM, name: '  ' },
+          { chainId: ETHEREUM, name: 'Ethereum' },
+        ],
+      }),
+    ).toStrictEqual([{ chainId: ETHEREUM, name: 'Ethereum' }]);
+  });
+});
+
+describe('getChainValueOrder', () => {
+  it('orders chains by descending holdings value', () => {
+    expect(
+      getChainValueOrder(
+        chainRanking,
+        {
+          [ETHEREUM]: 25,
+          [OPTIMISM]: 100,
+          [BASE]: 50,
+        },
+        [],
+      ).map(({ chainId }) => chainId),
+    ).toStrictEqual([OPTIMISM, BASE, ETHEREUM, SOLANA]);
+  });
+
+  it('preserves LaunchDarkly order for ties and zero balances', () => {
+    expect(
+      getChainValueOrder(
+        chainRanking,
+        {
+          [ETHEREUM]: 10,
+          [OPTIMISM]: 10,
+        },
+        [],
+      ).map(({ chainId }) => chainId),
+    ).toStrictEqual([ETHEREUM, OPTIMISM, BASE, SOLANA]);
+  });
+
+  it('treats non-finite and non-positive holdings as zero', () => {
+    expect(
+      getChainValueOrder(
+        chainRanking,
+        {
+          [ETHEREUM]: Number.NaN,
+          [OPTIMISM]: Number.POSITIVE_INFINITY,
+          [BASE]: -1,
+          [SOLANA]: 1,
+        },
+        [],
+      ).map(({ chainId }) => chainId),
+    ).toStrictEqual([SOLANA, ETHEREUM, OPTIMISM, BASE]);
+  });
+
+  it('promotes known chains in override order and skips unknown chains', () => {
+    expect(
+      getChainValueOrder(
+        chainRanking,
+        {
+          [ETHEREUM]: 100,
+          [OPTIMISM]: 75,
+          [BASE]: 50,
+        },
+        [
+          { chainId: BASE, name: 'Base' },
+          { chainId: UNKNOWN_CHAIN, name: 'Unknown' },
+          { chainId: OPTIMISM, name: 'Optimism' },
+        ],
+      ).map(({ chainId }) => chainId),
+    ).toStrictEqual([BASE, OPTIMISM, ETHEREUM, SOLANA]);
+  });
+
+  it('does not mutate its inputs or remove chains', () => {
+    const ranking = chainRanking.map((chain) => ({ ...chain }));
+    const holdings = { [BASE]: 100 };
+    const promotions: ChainRankingEntry[] = [
+      { chainId: ETHEREUM, name: 'Ethereum' },
+    ];
+    const originalRanking = ranking.map((chain) => ({ ...chain }));
+    const originalHoldings = { ...holdings };
+    const originalPromotions = promotions.map((chain) => ({ ...chain }));
+
+    const result = getChainValueOrder(ranking, holdings, promotions);
+
+    expect(ranking).toStrictEqual(originalRanking);
+    expect(holdings).toStrictEqual(originalHoldings);
+    expect(promotions).toStrictEqual(originalPromotions);
+    expect(result).toHaveLength(ranking.length);
+    expect(new Set(result.map(({ chainId }) => chainId))).toStrictEqual(
+      new Set(ranking.map(({ chainId }) => chainId)),
+    );
+  });
+});

--- a/shared/lib/bridge/chain-value-order.ts
+++ b/shared/lib/bridge/chain-value-order.ts
@@ -7,8 +7,7 @@ import {
 } from '@metamask/utils';
 import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../constants/bridge';
 
-export const CHAIN_VALUE_ORDER_OVERRIDE_KEY =
-  'swapsChainValueOrderOverride';
+export const CHAIN_VALUE_ORDER_OVERRIDE_KEY = 'swapsChainValueOrderOverride';
 
 export type ChainRankingEntry = {
   chainId: CaipChainId;
@@ -72,9 +71,7 @@ export function parsePositionOverrides(
     });
   }
 
-  return promotedChains.length > 0
-    ? promotedChains
-    : EMPTY_POSITION_OVERRIDES;
+  return promotedChains.length > 0 ? promotedChains : EMPTY_POSITION_OVERRIDES;
 }
 
 function getHoldingsValue(
@@ -114,10 +111,7 @@ export function getChainValueOrder(
     );
 
   const rankedChainsById = new Map(
-    rankedChains.map((rankedChain) => [
-      rankedChain.chain.chainId,
-      rankedChain,
-    ]),
+    rankedChains.map((rankedChain) => [rankedChain.chain.chainId, rankedChain]),
   );
   const promotedChainIds = new Set<CaipChainId>();
   const promotedPrefix = promotedChains.flatMap(({ chainId }) => {
@@ -133,8 +127,6 @@ export function getChainValueOrder(
 
   return [
     ...promotedPrefix,
-    ...rankedChains.filter(
-      ({ chain }) => !promotedChainIds.has(chain.chainId),
-    ),
+    ...rankedChains.filter(({ chain }) => !promotedChainIds.has(chain.chainId)),
   ].map(({ chain }) => chain);
 }

--- a/shared/lib/bridge/chain-value-order.ts
+++ b/shared/lib/bridge/chain-value-order.ts
@@ -1,0 +1,140 @@
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
+import {
+  type CaipChainId,
+  hasProperty,
+  isCaipChainId,
+  isPlainObject,
+} from '@metamask/utils';
+import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../constants/bridge';
+
+export const CHAIN_VALUE_ORDER_OVERRIDE_KEY =
+  'swapsChainValueOrderOverride';
+
+export type ChainRankingEntry = {
+  chainId: CaipChainId;
+  name: string;
+};
+
+export type PromotedChain = ChainRankingEntry;
+
+export type ChainValueOrderOverride = {
+  positionOverrides: PromotedChain[];
+};
+
+export type HoldingsByChain = Partial<Record<CaipChainId, number>>;
+
+const EMPTY_POSITION_OVERRIDES: readonly PromotedChain[] = Object.freeze([]);
+const ALLOWED_CAIP_CHAIN_IDS = new Set(
+  ALLOWED_BRIDGE_CHAIN_IDS.map(formatChainIdToCaip),
+);
+
+function isPromotedChain(value: unknown): value is PromotedChain {
+  return (
+    isPlainObject(value) &&
+    hasProperty(value, 'chainId') &&
+    isCaipChainId(value.chainId) &&
+    ALLOWED_CAIP_CHAIN_IDS.has(value.chainId) &&
+    hasProperty(value, 'name') &&
+    typeof value.name === 'string' &&
+    value.name.trim().length > 0
+  );
+}
+
+/**
+ * Parses the controller-processed chain-order override configuration.
+ *
+ * @param value - Processed remote feature flag value.
+ * @returns Ordered, valid chain promotions.
+ */
+export function parsePositionOverrides(
+  value: unknown,
+): readonly PromotedChain[] {
+  if (
+    !isPlainObject(value) ||
+    !hasProperty(value, 'positionOverrides') ||
+    !Array.isArray(value.positionOverrides)
+  ) {
+    return EMPTY_POSITION_OVERRIDES;
+  }
+
+  const seenChainIds = new Set<CaipChainId>();
+  const promotedChains: PromotedChain[] = [];
+
+  for (const entry of value.positionOverrides) {
+    if (!isPromotedChain(entry) || seenChainIds.has(entry.chainId)) {
+      continue;
+    }
+
+    seenChainIds.add(entry.chainId);
+    promotedChains.push({
+      chainId: entry.chainId,
+      name: entry.name,
+    });
+  }
+
+  return promotedChains.length > 0
+    ? promotedChains
+    : EMPTY_POSITION_OVERRIDES;
+}
+
+function getHoldingsValue(
+  holdingsByChain: HoldingsByChain,
+  chainId: CaipChainId,
+): number {
+  const value = holdingsByChain[chainId];
+
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : 0;
+}
+
+/**
+ * Orders allowed chains by holdings value, then applies remote promotions.
+ *
+ * @param chainRanking - Allowed chains in LaunchDarkly ranking order.
+ * @param holdingsByChain - Selected-account-group fiat totals by chain.
+ * @param promotedChains - Ordered remote promotion list.
+ * @returns A new ordered chain array.
+ */
+export function getChainValueOrder(
+  chainRanking: readonly ChainRankingEntry[],
+  holdingsByChain: HoldingsByChain,
+  promotedChains: readonly PromotedChain[],
+): ChainRankingEntry[] {
+  const rankedChains = chainRanking
+    .map((chain, rankingIndex) => ({
+      chain,
+      holdingsValue: getHoldingsValue(holdingsByChain, chain.chainId),
+      rankingIndex,
+    }))
+    .sort(
+      (first, second) =>
+        second.holdingsValue - first.holdingsValue ||
+        first.rankingIndex - second.rankingIndex,
+    );
+
+  const rankedChainsById = new Map(
+    rankedChains.map((rankedChain) => [
+      rankedChain.chain.chainId,
+      rankedChain,
+    ]),
+  );
+  const promotedChainIds = new Set<CaipChainId>();
+  const promotedPrefix = promotedChains.flatMap(({ chainId }) => {
+    const rankedChain = rankedChainsById.get(chainId);
+
+    if (!rankedChain || promotedChainIds.has(chainId)) {
+      return [];
+    }
+
+    promotedChainIds.add(chainId);
+    return [rankedChain];
+  });
+
+  return [
+    ...promotedPrefix,
+    ...rankedChains.filter(
+      ({ chain }) => !promotedChainIds.has(chain.chainId),
+    ),
+  ].map(({ chain }) => chain);
+}

--- a/shared/lib/bridge/chain-value-order.ts
+++ b/shared/lib/bridge/chain-value-order.ts
@@ -7,8 +7,6 @@ import {
 } from '@metamask/utils';
 import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../constants/bridge';
 
-export const CHAIN_VALUE_ORDER_OVERRIDE_KEY = 'swapsChainValueOrderOverride';
-
 export type ChainRankingEntry = {
   chainId: CaipChainId;
   name: string;

--- a/test/data/bridge/mock-bridge-store.ts
+++ b/test/data/bridge/mock-bridge-store.ts
@@ -17,6 +17,7 @@ import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { EthAccountType, EthScope } from '@metamask/keyring-api';
 import { ETH_SCOPE_EOA } from '@metamask/keyring-utils';
 import type { SmartTransactionsNetworks } from '../../../shared/lib/selectors/feature-flags';
+import type { ChainValueOrderOverride } from '../../../shared/lib/bridge/chain-value-order';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import type { BridgeAppState } from '../../../ui/ducks/bridge/selectors';
 import { createSwapsMockStore } from '../../jest/mock-store';
@@ -186,11 +187,12 @@ export const createBridgeMockStore = ({
   stateOverrides = {},
 }: {
   featureFlagOverrides?: {
-    bridgeConfig: Partial<Omit<FeatureFlagResponse, 'chainRanking'>> & {
+    bridgeConfig?: Partial<Omit<FeatureFlagResponse, 'chainRanking'>> & {
       chainRanking?: { chainId: CaipChainId; name?: string }[];
     };
     smartTransactionsNetworks?: SmartTransactionsNetworks;
     gasFeesSponsoredNetwork?: { [chainId: Hex]: boolean };
+    swapsChainValueOrderOverride?: ChainValueOrderOverride;
   };
   bridgeStateOverrides?: Partial<
     Omit<BridgeControllerState, 'quoteRequest'>

--- a/test/e2e/feature-flags/feature-flag-registry.ts
+++ b/test/e2e/feature-flags/feature-flag-registry.ts
@@ -3043,6 +3043,39 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  swapsSWAPS4827AbtestChainValueOrder: {
+    name: 'swapsSWAPS4827AbtestChainValueOrder',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        name: 'control',
+        scope: {
+          type: 'threshold',
+          value: 0.5,
+        },
+      },
+      {
+        name: 'treatment',
+        scope: {
+          type: 'threshold',
+          value: 1,
+        },
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  swapsChainValueOrderOverride: {
+    name: 'swapsChainValueOrderOverride',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      positionOverrides: [],
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   perpsTAT3382AbtestTabBadge: {
     name: 'perpsTAT3382AbtestTabBadge',
     type: FeatureFlagType.Remote,

--- a/ui/ducks/bridge-status/actions.ts
+++ b/ui/ducks/bridge-status/actions.ts
@@ -7,6 +7,7 @@ import { forceUpdateMetamaskState } from '../../store/actions';
 import { submitRequestToBackground } from '../../store/background-connection';
 import { MetaMaskReduxDispatch } from '../../store/store';
 import { MetaMetricsSwapsEventSource } from '../../../shared/constants/metametrics';
+import type { ActiveABTestAssignment } from '../../../shared/lib/ab-testing/active-ab-test-assignment';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -30,6 +31,7 @@ const callBridgeStatusControllerMethod = <T extends unknown[]>(
  * @param context - Metrics context captured when quotes were received.
  * @param location - Entry point from which the user initiated the swap or bridge.
  * @param tokenSecurityTypeDestination - Security classification of the destination token (e.g. "Malicious", "Warning"), or null when unavailable.
+ * @param activeAbTests - Active experiment assignments for transaction attribution.
  * @returns A thunk that dispatches the `submitTx` bridge status action.
  */
 export const submitBridgeTx = (
@@ -39,6 +41,7 @@ export const submitBridgeTx = (
   context: RequiredEventContextFromClient[UnifiedSwapBridgeEventName.QuotesReceived],
   location: MetaMetricsSwapsEventSource,
   tokenSecurityTypeDestination: string | null,
+  activeAbTests?: ActiveABTestAssignment[],
 ) =>
   callBridgeStatusControllerMethod<
     [
@@ -48,7 +51,7 @@ export const submitBridgeTx = (
       RequiredEventContextFromClient[UnifiedSwapBridgeEventName.QuotesReceived],
       MetaMetricsSwapsEventSource,
       undefined,
-      undefined,
+      ActiveABTestAssignment[] | undefined,
       string | null,
     ]
   >('submitTx', [
@@ -58,7 +61,7 @@ export const submitBridgeTx = (
     context,
     location,
     undefined,
-    undefined,
+    activeAbTests,
     tokenSecurityTypeDestination,
   ]);
 
@@ -70,6 +73,7 @@ export const submitBridgeTx = (
  * @param params.accountAddress - Account submitting the signed intent.
  * @param params.location - Entry point from which the user initiated the swap or bridge.
  * @param params.tokenSecurityTypeDestination - Security classification of the destination token (e.g. "Malicious", "Warning"), or null when unavailable.
+ * @param params.activeAbTests - Active experiment assignments for transaction attribution.
  * @returns A thunk that dispatches the `submitIntent` bridge status action.
  */
 export const submitBridgeIntent = (params: {
@@ -77,6 +81,7 @@ export const submitBridgeIntent = (params: {
   accountAddress: string;
   location: MetaMetricsSwapsEventSource;
   tokenSecurityTypeDestination?: string | null;
+  activeAbTests?: ActiveABTestAssignment[];
 }) =>
   callBridgeStatusControllerMethod<[typeof params]>('submitIntent', [params]);
 

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -76,6 +76,7 @@ import {
   getWarningLabels,
   getBridgeUnavailableQuoteReason,
   resolveMinimumBalanceToKeep,
+  getChainValueOrderOverride,
 } from './selectors';
 import { toBridgeToken } from './utils';
 
@@ -355,6 +356,44 @@ describe('Bridge selectors', () => {
         chainId: 'eip155:1',
         name: 'Test',
       });
+    });
+  });
+
+  describe('getChainValueOrderOverride', () => {
+    it('returns valid controller-processed promotions', () => {
+      const state = createBridgeMockStore({
+        featureFlagOverrides: {
+          swapsChainValueOrderOverride: {
+            positionOverrides: [
+              { chainId: 'eip155:8453', name: 'Base' },
+              { chainId: 'eip155:1', name: 'Ethereum' },
+            ],
+          },
+        },
+      });
+
+      expect(getChainValueOrderOverride(state as never)).toStrictEqual([
+        { chainId: 'eip155:8453', name: 'Base' },
+        { chainId: 'eip155:1', name: 'Ethereum' },
+      ]);
+    });
+
+    it('returns an empty list for malformed promotions', () => {
+      const state = createBridgeMockStore({
+        featureFlagOverrides: {
+          swapsChainValueOrderOverride: {
+            positionOverrides: [
+              {
+                // @ts-expect-error - intentionally malformed remote flag value
+                chainId: 'invalid',
+                name: 'Invalid',
+              },
+            ],
+          },
+        },
+      });
+
+      expect(getChainValueOrderOverride(state as never)).toStrictEqual([]);
     });
   });
 

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -111,6 +111,10 @@ import {
   formatPriceImpactFiat,
   formatPriceImpactPercentage,
 } from '../../pages/bridge/utils/price-impact';
+import {
+  CHAIN_VALUE_ORDER_OVERRIDE_KEY,
+  parsePositionOverrides,
+} from '../../../shared/lib/bridge/chain-value-order';
 import { getCurrentCurrency } from '../metamask/metamask';
 import type { MetaMaskReduxState } from '../../store/store';
 import {
@@ -206,6 +210,14 @@ export const getBridgeFeatureFlags = createDeepEqualSelector(
     });
     return validatedFlags;
   },
+);
+
+export const getChainValueOrderOverride = createSelector(
+  [
+    (state: BridgeAppState) =>
+      getRemoteFeatureFlags(state)[CHAIN_VALUE_ORDER_OVERRIDE_KEY],
+  ],
+  parsePositionOverrides,
 );
 
 const getChainRanking = (state: BridgeAppState) =>

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -111,10 +111,7 @@ import {
   formatPriceImpactFiat,
   formatPriceImpactPercentage,
 } from '../../pages/bridge/utils/price-impact';
-import {
-  CHAIN_VALUE_ORDER_OVERRIDE_KEY,
-  parsePositionOverrides,
-} from '../../../shared/lib/bridge/chain-value-order';
+import { parsePositionOverrides } from '../../../shared/lib/bridge/chain-value-order';
 import { getCurrentCurrency } from '../metamask/metamask';
 import type { MetaMaskReduxState } from '../../store/store';
 import {
@@ -215,7 +212,7 @@ export const getBridgeFeatureFlags = createDeepEqualSelector(
 export const getChainValueOrderOverride = createSelector(
   [
     (state: BridgeAppState) =>
-      getRemoteFeatureFlags(state)[CHAIN_VALUE_ORDER_OVERRIDE_KEY],
+      getRemoteFeatureFlags(state).swapsChainValueOrderOverride,
   ],
   parsePositionOverrides,
 );

--- a/ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx
+++ b/ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx
@@ -29,6 +29,8 @@ import * as bridgeStatusActions from '../../ducks/bridge-status/actions';
 import * as bridgeActions from '../../ducks/bridge/actions';
 import { setBackgroundConnection } from '../../store/background-connection';
 import { HardwareWalletProvider } from '../../contexts/hardware-wallets';
+import { createActiveABTestAssignment } from '../../../shared/lib/ab-testing/active-ab-test-assignment';
+import { CHAIN_VALUE_ORDER_AB_KEY } from '../../../shared/lib/ab-testing/configs/chain-value-order';
 import useSubmitBridgeTransaction from './useSubmitBridgeTransaction';
 
 jest.mock('../../../shared/lib/sentry', () => ({
@@ -605,6 +607,7 @@ describe('ui/hooks/bridge/useSubmitBridgeTransaction', () => {
         accountAddress: expect.any(String),
         location: 'Main View',
         tokenSecurityTypeDestination: null,
+        activeAbTests: undefined,
       });
       expect(submitTxSpy).not.toHaveBeenCalled();
       expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
@@ -616,6 +619,129 @@ describe('ui/hooks/bridge/useSubmitBridgeTransaction', () => {
       expect(resetBridgeStoreSpy).not.toHaveBeenCalled();
       expect(mockResetState).not.toHaveBeenCalled();
     });
+
+    it('forwards the chain value order assignment to regular submissions', async () => {
+      const store = makeMockStore({
+        featureFlagOverrides: {
+          // @ts-expect-error - the mock store type only declares bridgeConfig
+          [CHAIN_VALUE_ORDER_AB_KEY]: {
+            name: 'treatment',
+          },
+        },
+      });
+      const { result } = renderHook(() => useSubmitBridgeTransaction(), {
+        wrapper: makeWrapper(store),
+      });
+      const quote = DummyQuotesNoApproval.OP_0_005_ETH_TO_ARB[0];
+      const quoteWithCurrentMetricsShape = {
+        ...quote,
+        ...OP_0_005_ETH_TO_ARB_METADATA,
+        quote: {
+          ...quote.quote,
+          src: { asset: quote.quote.srcAsset },
+          dest: { asset: quote.quote.destAsset },
+        },
+      } as never;
+
+      await act(async () => {
+        await result.current.submitBridgeTransaction(
+          quoteWithCurrentMetricsShape,
+        );
+      });
+
+      expect(submitTxSpy.mock.calls[0][6]).toStrictEqual([
+        createActiveABTestAssignment(
+          CHAIN_VALUE_ORDER_AB_KEY,
+          'treatment',
+        ),
+      ]);
+    });
+
+    it('forwards the chain value order assignment to intent submissions', async () => {
+      const store = makeMockStore({
+        featureFlagOverrides: {
+          // @ts-expect-error - the mock store type only declares bridgeConfig
+          [CHAIN_VALUE_ORDER_AB_KEY]: {
+            name: 'control',
+          },
+        },
+      });
+      submitIntentSpy.mockReturnValueOnce((async () => undefined) as never);
+      const { result } = renderHook(() => useSubmitBridgeTransaction(), {
+        wrapper: makeWrapper(store),
+      });
+      const quoteWithIntent = {
+        ...DummyQuotesWithApproval.ETH_11_USDC_TO_ARB[0],
+        quote: {
+          ...DummyQuotesWithApproval.ETH_11_USDC_TO_ARB[0].quote,
+          intent: {
+            order: {},
+          } as never,
+        },
+      };
+
+      await act(async () => {
+        await result.current.submitBridgeTransaction(quoteWithIntent);
+      });
+
+      expect(submitIntentSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeAbTests: [
+            createActiveABTestAssignment(
+              CHAIN_VALUE_ORDER_AB_KEY,
+              'control',
+            ),
+          ],
+        }),
+      );
+    });
+
+    // @ts-expect-error - each is a valid test function
+    it.each([undefined, { name: 'invalid' }])(
+      'forwards no assignment for a missing or malformed experiment value',
+      async (
+        experimentValue: undefined | {
+          name: string;
+        },
+      ) => {
+        const store = makeMockStore({
+          featureFlagOverrides: {
+            // @ts-expect-error - the mock store type only declares bridgeConfig
+            [CHAIN_VALUE_ORDER_AB_KEY]: experimentValue,
+          },
+        });
+        const { result } = renderHook(
+          () => useSubmitBridgeTransaction(),
+          {
+            wrapper: makeWrapper(store),
+          },
+        );
+        const quoteWithIntent = {
+          ...DummyQuotesWithApproval.ETH_11_USDC_TO_ARB[0],
+          quote: {
+            ...DummyQuotesWithApproval.ETH_11_USDC_TO_ARB[0].quote,
+            intent: {
+              order: {},
+            } as never,
+          },
+        };
+
+        await act(async () => {
+          await result.current.submitBridgeTransaction(quoteWithIntent);
+        });
+
+        expect(submitIntentSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            activeAbTests: undefined,
+          }),
+        );
+        expect(store.getActions()).not.toContainEqual(
+          expect.objectContaining({
+            type: expect.stringContaining('Experiment'),
+          }),
+        );
+      },
+    );
 
     it('routes to default route with replace when non-HW intent submission fails', async () => {
       const store = makeMockStore();

--- a/ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx
+++ b/ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx
@@ -200,6 +200,8 @@ const makeWrapper = (
   );
 };
 
+const originalSubmitBridgeTx = bridgeStatusActions.submitBridgeTx;
+const originalSubmitBridgeIntent = bridgeStatusActions.submitBridgeIntent;
 const submitTxSpy = jest.spyOn(bridgeStatusActions, 'submitBridgeTx');
 const submitIntentSpy = jest.spyOn(bridgeStatusActions, 'submitBridgeIntent');
 const isHardwareWalletSpy = keyringSelectors.isHardwareWallet as jest.Mock;
@@ -211,6 +213,8 @@ describe('ui/hooks/bridge/useSubmitBridgeTransaction', () => {
   describe('submitBridgeTransaction', () => {
     beforeEach(() => {
       jest.clearAllMocks();
+      submitTxSpy.mockImplementation(originalSubmitBridgeTx);
+      submitIntentSpy.mockImplementation(originalSubmitBridgeIntent);
       isHardwareWalletSpy.mockImplementation(() => false);
       mockEnsureDeviceReady.mockResolvedValue(true);
       captureExceptionSpy.mockReturnValue(undefined);
@@ -632,28 +636,17 @@ describe('ui/hooks/bridge/useSubmitBridgeTransaction', () => {
       const { result } = renderHook(() => useSubmitBridgeTransaction(), {
         wrapper: makeWrapper(store),
       });
-      const quote = DummyQuotesNoApproval.OP_0_005_ETH_TO_ARB[0];
-      const quoteWithCurrentMetricsShape = {
-        ...quote,
+      const quoteWithMetadata = {
+        ...DummyQuotesNoApproval.OP_0_005_ETH_TO_ARB[0],
         ...OP_0_005_ETH_TO_ARB_METADATA,
-        quote: {
-          ...quote.quote,
-          src: { asset: quote.quote.srcAsset },
-          dest: { asset: quote.quote.destAsset },
-        },
-      } as never;
+      };
 
       await act(async () => {
-        await result.current.submitBridgeTransaction(
-          quoteWithCurrentMetricsShape,
-        );
+        await result.current.submitBridgeTransaction(quoteWithMetadata);
       });
 
       expect(submitTxSpy.mock.calls[0][6]).toStrictEqual([
-        createActiveABTestAssignment(
-          CHAIN_VALUE_ORDER_AB_KEY,
-          'treatment',
-        ),
+        createActiveABTestAssignment(CHAIN_VALUE_ORDER_AB_KEY, 'treatment'),
       ]);
     });
 
@@ -687,10 +680,7 @@ describe('ui/hooks/bridge/useSubmitBridgeTransaction', () => {
       expect(submitIntentSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           activeAbTests: [
-            createActiveABTestAssignment(
-              CHAIN_VALUE_ORDER_AB_KEY,
-              'control',
-            ),
+            createActiveABTestAssignment(CHAIN_VALUE_ORDER_AB_KEY, 'control'),
           ],
         }),
       );
@@ -700,9 +690,11 @@ describe('ui/hooks/bridge/useSubmitBridgeTransaction', () => {
     it.each([undefined, { name: 'invalid' }])(
       'forwards no assignment for a missing or malformed experiment value',
       async (
-        experimentValue: undefined | {
-          name: string;
-        },
+        experimentValue:
+          | undefined
+          | {
+              name: string;
+            },
       ) => {
         const store = makeMockStore({
           featureFlagOverrides: {
@@ -710,12 +702,9 @@ describe('ui/hooks/bridge/useSubmitBridgeTransaction', () => {
             [CHAIN_VALUE_ORDER_AB_KEY]: experimentValue,
           },
         });
-        const { result } = renderHook(
-          () => useSubmitBridgeTransaction(),
-          {
-            wrapper: makeWrapper(store),
-          },
-        );
+        const { result } = renderHook(() => useSubmitBridgeTransaction(), {
+          wrapper: makeWrapper(store),
+        });
         const quoteWithIntent = {
           ...DummyQuotesWithApproval.ETH_11_USDC_TO_ARB[0],
           quote: {

--- a/ui/hooks/bridge/useSubmitBridgeTransaction.ts
+++ b/ui/hooks/bridge/useSubmitBridgeTransaction.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import {
   getQuotesReceivedProperties,
@@ -39,6 +39,12 @@ import {
 import { useDispatch } from '../../store/store';
 import { isHardwareWalletUserRejection } from '../../pages/bridge/utils/hardware-wallet-errors';
 import { getDestChainId } from '../../pages/bridge/utils/quote';
+import {
+  CHAIN_VALUE_ORDER_AB_KEY,
+  CHAIN_VALUE_ORDER_AB_TEST_VARIANTS,
+} from '../../../shared/lib/ab-testing/configs/chain-value-order';
+import { createActiveABTestAssignment } from '../../../shared/lib/ab-testing/active-ab-test-assignment';
+import { useABTest } from '../useABTest';
 import { useBridgeNavigation } from './useBridgeNavigation';
 import { useHasSufficientGasForQuoteForMetrics } from './useHasSufficientGasForQuoteForMetrics';
 import { useEnableMissingNetwork } from './useEnableMissingNetwork';
@@ -72,6 +78,27 @@ export default function useSubmitBridgeTransaction() {
   const { ensureDeviceReady } = useHardwareWalletActions();
   const { connectionState } = useHardwareWalletState();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const {
+    variantName: chainValueOrderVariantName,
+    isActive: isChainValueOrderExperimentActive,
+  } = useABTest(
+    CHAIN_VALUE_ORDER_AB_KEY,
+    CHAIN_VALUE_ORDER_AB_TEST_VARIANTS,
+    undefined,
+    { trackExposure: false },
+  );
+  const activeAbTests = useMemo(
+    () =>
+      isChainValueOrderExperimentActive
+        ? [
+            createActiveABTestAssignment(
+              CHAIN_VALUE_ORDER_AB_KEY,
+              chainValueOrderVariantName,
+            ),
+          ]
+        : undefined,
+    [chainValueOrderVariantName, isChainValueOrderExperimentActive],
+  );
   // Tracks an in-flight submitBridgeTx so Promise.race timeouts cannot leave a
   // live dispatch that a hardware-wallet retry would duplicate.
   const inFlightSubmitBridgeTxRef = useRef<{
@@ -96,6 +123,7 @@ export default function useSubmitBridgeTransaction() {
             accountAddress: fromAccount.address,
             location,
             tokenSecurityTypeDestination: toToken?.securityData?.type ?? null,
+            activeAbTests,
           }),
         );
         return;
@@ -123,6 +151,7 @@ export default function useSubmitBridgeTransaction() {
             ),
             location,
             toToken?.securityData?.type ?? null,
+            activeAbTests,
           ),
         );
         const tracked = { requestId, promise: rpcPromise };

--- a/ui/pages/bridge/hooks/useChainValueOrder.ts
+++ b/ui/pages/bridge/hooks/useChainValueOrder.ts
@@ -30,8 +30,7 @@ export function useChainValueOrder(
   const promotedChains = useSelector(getChainValueOrderOverride);
 
   return useMemo(
-    () =>
-      getChainValueOrder(chainRanking, holdingsByChain, promotedChains),
+    () => getChainValueOrder(chainRanking, holdingsByChain, promotedChains),
     [chainRanking, holdingsByChain, promotedChains],
   );
 }

--- a/ui/pages/bridge/hooks/useChainValueOrder.ts
+++ b/ui/pages/bridge/hooks/useChainValueOrder.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  type ChainRankingEntry,
+  getChainValueOrder,
+} from '../../../../shared/lib/bridge/chain-value-order';
+import { getBridgeBalancesByChainId } from '../../../ducks/bridge/asset-selectors';
+import {
+  type BridgeAppState,
+  getChainValueOrderOverride,
+} from '../../../ducks/bridge/selectors';
+import { getSelectedAccountGroup } from '../../../selectors/multichain-accounts/account-tree';
+
+/**
+ * Returns allowed chains ordered by selected-account-group fiat holdings and
+ * remote position overrides.
+ *
+ * This hook must only be mounted for the treatment variant.
+ *
+ * @param chainRanking - Allowed chains in LaunchDarkly ranking order.
+ * @returns Chains ordered for the treatment experience.
+ */
+export function useChainValueOrder(
+  chainRanking: readonly ChainRankingEntry[],
+): ChainRankingEntry[] {
+  const selectedAccountGroup = useSelector(getSelectedAccountGroup);
+  const holdingsByChain = useSelector((state: BridgeAppState) =>
+    getBridgeBalancesByChainId(state, selectedAccountGroup),
+  );
+  const promotedChains = useSelector(getChainValueOrderOverride);
+
+  return useMemo(
+    () =>
+      getChainValueOrder(chainRanking, holdingsByChain, promotedChains),
+    [chainRanking, holdingsByChain, promotedChains],
+  );
+}

--- a/ui/pages/bridge/prepare/bridge-input-group.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.test.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import {
+  FeatureId,
   RequestStatus,
+  UnifiedSwapBridgeEventName,
   formatChainIdToCaip,
 } from '@metamask/bridge-controller';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
@@ -25,6 +27,7 @@ import {
 } from '../../../ducks/bridge/selectors';
 import * as actions from '../../../ducks/bridge/actions';
 import configureStore from '../../../store/store';
+import { setBackgroundConnection } from '../../../store/background-connection';
 import { toBridgeToken } from '../../../ducks/bridge/utils';
 import { BridgeInputGroup } from './bridge-input-group';
 import BridgeAssetPickerPage from './bridge-asset-picker-page';
@@ -34,6 +37,7 @@ const BRIDGE_ASSET_ROW_TEST_ID = /^bridge-asset--/u;
 
 const mockUseVirtualizer = jest.fn();
 const mockNavigate = jest.fn();
+const mockTrackUnifiedSwapBridgeEvent = jest.fn();
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -246,6 +250,11 @@ describe('BridgeInputGroup', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     jest.resetAllMocks();
+    mockTrackUnifiedSwapBridgeEvent.mockResolvedValue(undefined);
+    setBackgroundConnection({
+      trackUnifiedSwapBridgeEvent: mockTrackUnifiedSwapBridgeEvent,
+      getStatePatches: jest.fn(),
+    } as never);
     mockUseVirtualizer.mockReturnValue({
       getVirtualItems: () =>
         tokens.map((token, index) => ({
@@ -257,6 +266,48 @@ describe('BridgeInputGroup', () => {
       measureElement: () => 78,
     });
   });
+
+  // @ts-expect-error - each is a valid test function
+  it.each([
+    [false, 'source'],
+    [true, 'destination'],
+  ] as const)(
+    'tracks opening the %s asset picker',
+    async (
+      isDestination: boolean,
+      assetLocation: 'source' | 'destination',
+    ) => {
+      renderBridgeInputGroup(
+        {
+          featureFlagOverrides: {
+            // @ts-expect-error - the mock store type only declares bridgeConfig
+            extensionUxNetworkManagement: {
+              enabled: true,
+              minimumVersion: '0.0.0',
+            },
+          },
+        },
+        { isDestination },
+      );
+
+      await act(async () => {
+        await userEvent.click(
+          screen.getByTestId(ASSET_PICKER_BUTTON_TEST_ID),
+        );
+      });
+      await flushPromises();
+
+      expect(mockTrackUnifiedSwapBridgeEvent).toHaveBeenCalledWith(
+        UnifiedSwapBridgeEventName.AssetPickerOpened,
+        {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          asset_location: assetLocation,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          feature_id: FeatureId.UNIFIED_SWAP_BRIDGE,
+        },
+      );
+    },
+  );
 
   it('passes fetched security metadata to the selected asset button', () => {
     const { getByTestId } = renderBridgeInputGroup(

--- a/ui/pages/bridge/prepare/bridge-input-group.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.test.tsx
@@ -273,10 +273,7 @@ describe('BridgeInputGroup', () => {
     [true, 'destination'],
   ] as const)(
     'tracks opening the %s asset picker',
-    async (
-      isDestination: boolean,
-      assetLocation: 'source' | 'destination',
-    ) => {
+    async (isDestination: boolean, assetLocation: 'source' | 'destination') => {
       renderBridgeInputGroup(
         {
           featureFlagOverrides: {
@@ -291,9 +288,7 @@ describe('BridgeInputGroup', () => {
       );
 
       await act(async () => {
-        await userEvent.click(
-          screen.getByTestId(ASSET_PICKER_BUTTON_TEST_ID),
-        );
+        await userEvent.click(screen.getByTestId(ASSET_PICKER_BUTTON_TEST_ID));
       });
       await flushPromises();
 

--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -3,10 +3,12 @@ import { BigNumber } from 'bignumber.js';
 import { useSelector, shallowEqual } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
+  FeatureId,
   formatChainIdToCaip,
   formatChainIdToHex,
   isNativeAddress,
   isNonEvmChainId,
+  UnifiedSwapBridgeEventName,
 } from '@metamask/bridge-controller';
 import { getAccountLink } from '@metamask/etherscan-link';
 import { parseCaipAssetType } from '@metamask/utils';
@@ -46,6 +48,8 @@ import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from '../../../../s
 import { formatBlockExplorerAddressUrl } from '../../../../shared/lib/multichain/networks';
 import { CAIP_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../shared/constants/common';
 import type { BridgeNetwork, BridgeToken } from '../../../ducks/bridge/types';
+import { trackUnifiedSwapBridgeEvent } from '../../../ducks/bridge/actions';
+import { useDispatch } from '../../../store/hooks';
 import { SelectedAssetButton } from './components/bridge-asset-picker/selected-asset-button';
 import { BridgeAssetPicker } from './components/bridge-asset-picker';
 
@@ -94,6 +98,7 @@ export const BridgeInputGroup = ({
   | 'isDestination'
 >) => {
   const t = useI18nContext();
+  const dispatch = useDispatch();
   const navigate = useNavigate();
   const isNetworkManagementEnabled = useSelector(getIsNetworkManagementEnabled);
 
@@ -298,6 +303,19 @@ export const BridgeInputGroup = ({
         )}
         <SelectedAssetButton
           onClick={() => {
+            dispatch(
+              trackUnifiedSwapBridgeEvent(
+                UnifiedSwapBridgeEventName.AssetPickerOpened,
+                {
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  asset_location: isDestination ? 'destination' : 'source',
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  feature_id: FeatureId.UNIFIED_SWAP_BRIDGE,
+                },
+              ),
+            );
             setIsAssetPickerOpen(true);
             if (isNetworkManagementEnabled) {
               navigate(SWAP_ASSETS_PATH);

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.test.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.test.tsx
@@ -12,8 +12,7 @@ jest.mock('../../../../../hooks/useABTest', () => ({
 }));
 
 jest.mock('../../../hooks/useChainValueOrder', () => ({
-  useChainValueOrder: (...args: unknown[]) =>
-    mockUseChainValueOrder(...args),
+  useChainValueOrder: (...args: unknown[]) => mockUseChainValueOrder(...args),
 }));
 
 const chains = [

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.test.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import { createBridgeMockStore } from '../../../../../../test/data/bridge/mock-bridge-store';
+import configureStore from '../../../../../store/store';
+import { NetworkPicker } from './network-picker';
+
+const mockUseABTest = jest.fn();
+const mockUseChainValueOrder = jest.fn();
+
+jest.mock('../../../../../hooks/useABTest', () => ({
+  useABTest: (...args: unknown[]) => mockUseABTest(...args),
+}));
+
+jest.mock('../../../hooks/useChainValueOrder', () => ({
+  useChainValueOrder: (...args: unknown[]) =>
+    mockUseChainValueOrder(...args),
+}));
+
+const chains = [
+  { chainId: 'eip155:1' as const, name: 'Ethereum' },
+  { chainId: 'eip155:8453' as const, name: 'Base' },
+];
+
+const defaultProps = {
+  chains,
+  selectedChainId: null,
+  onNetworkChange: jest.fn(),
+  isOpen: true,
+  onClose: jest.fn(),
+  testId: 'network-picker',
+};
+
+function renderNetworkPicker({
+  isNetworkManagementEnabled = false,
+  isOpen = true,
+}: {
+  isNetworkManagementEnabled?: boolean;
+  isOpen?: boolean;
+} = {}) {
+  const state = createBridgeMockStore({
+    featureFlagOverrides: {
+      // @ts-expect-error - the mock store type only declares bridgeConfig
+      extensionUxNetworkManagement: {
+        enabled: isNetworkManagementEnabled,
+        minimumVersion: '0.0.0',
+      },
+    },
+  });
+
+  return renderWithProvider(
+    <NetworkPicker {...defaultProps} isOpen={isOpen} />,
+    configureStore(state),
+  );
+}
+
+describe('NetworkPicker chain value order experiment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseABTest.mockReturnValue({
+      variant: { orderByValue: false },
+      variantName: 'control',
+      isActive: true,
+    });
+    mockUseChainValueOrder.mockReturnValue([...chains].reverse());
+  });
+
+  it('preserves LaunchDarkly order and avoids holdings subscriptions in control', () => {
+    renderNetworkPicker();
+
+    expect(document.body.textContent?.indexOf('Ethereum')).toBeLessThan(
+      document.body.textContent?.indexOf('Base') ?? 0,
+    );
+    expect(mockUseChainValueOrder).not.toHaveBeenCalled();
+  });
+
+  // @ts-expect-error - each is a valid test function
+  it.each([false, true])(
+    'renders treatment order when network management is %s',
+    (isNetworkManagementEnabled: boolean) => {
+      mockUseABTest.mockReturnValue({
+        variant: { orderByValue: true },
+        variantName: 'treatment',
+        isActive: true,
+      });
+
+      renderNetworkPicker({
+        isNetworkManagementEnabled,
+      });
+
+      expect(document.body.textContent?.indexOf('Base')).toBeLessThan(
+        document.body.textContent?.indexOf('Ethereum') ?? 0,
+      );
+      expect(mockUseChainValueOrder).toHaveBeenCalledWith(chains);
+    },
+  );
+
+  it('only mounts the treatment ordering hook while the list is open', () => {
+    mockUseABTest.mockReturnValue({
+      variant: { orderByValue: true },
+      variantName: 'treatment',
+      isActive: true,
+    });
+
+    renderNetworkPicker({ isOpen: false });
+
+    expect(mockUseChainValueOrder).not.toHaveBeenCalled();
+    expect(mockUseABTest).toHaveBeenLastCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Object),
+      { trackExposure: false },
+    );
+  });
+
+  it('enables exposure tracking when the list is open', () => {
+    renderNetworkPicker();
+
+    expect(mockUseABTest).toHaveBeenLastCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Object),
+      { trackExposure: true },
+    );
+  });
+});

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.tsx
@@ -25,17 +25,15 @@ import {
   BackgroundColor,
   BorderRadius,
 } from '../../../../../helpers/constants/design-system';
+import {
+  CHAIN_VALUE_ORDER_AB_KEY,
+  CHAIN_VALUE_ORDER_AB_TEST_EXPOSURE_METADATA,
+  CHAIN_VALUE_ORDER_AB_TEST_VARIANTS,
+} from '../../../../../../shared/lib/ab-testing/configs/chain-value-order';
+import { useABTest } from '../../../../../hooks/useABTest';
+import { useChainValueOrder } from '../../../hooks/useChainValueOrder';
 
-export const NetworkPicker = ({
-  chains,
-  selectedChainId,
-  disabledChainId,
-  onNetworkChange,
-  buttonElement,
-  isOpen,
-  onClose,
-  testId,
-}: {
+type NetworkPickerProps = {
   chains: { chainId: CaipChainId; name: string }[];
   selectedChainId: CaipChainId | null;
   disabledChainId?: CaipChainId;
@@ -44,7 +42,18 @@ export const NetworkPicker = ({
   isOpen: boolean;
   onClose: () => void;
   testId: string;
-}) => {
+};
+
+const NetworkPickerContent = ({
+  chains,
+  selectedChainId,
+  disabledChainId,
+  onNetworkChange,
+  buttonElement,
+  isOpen,
+  onClose,
+  testId,
+}: NetworkPickerProps) => {
   const t = useI18nContext();
   const isNetworkManagementEnabled = useSelector(getIsNetworkManagementEnabled);
 
@@ -158,4 +167,25 @@ export const NetworkPicker = ({
       ))}
     </Popover>
   );
+};
+
+const NetworkValueOrderedPicker = (props: NetworkPickerProps) => {
+  const orderedChains = useChainValueOrder(props.chains);
+
+  return <NetworkPickerContent {...props} chains={orderedChains} />;
+};
+
+export const NetworkPicker = (props: NetworkPickerProps) => {
+  const { variant } = useABTest(
+    CHAIN_VALUE_ORDER_AB_KEY,
+    CHAIN_VALUE_ORDER_AB_TEST_VARIANTS,
+    CHAIN_VALUE_ORDER_AB_TEST_EXPOSURE_METADATA,
+    { trackExposure: props.isOpen },
+  );
+
+  if (props.isOpen && variant.orderByValue) {
+    return <NetworkValueOrderedPicker {...props} />;
+  }
+
+  return <NetworkPickerContent {...props} />;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds the SWAPS-4827 chain-value-order experiment to the Unified Swaps source and destination network pickers.

The control variant preserves the existing `bridgeConfig.chainRanking` order. The treatment variant sorts allowed chains by the selected account group's positive fiat holdings, preserves the existing order for ties and zero balances, and applies validated remote position overrides. Treatment-only holdings and override subscriptions are mounted only while a network picker is open.

This also registers the experiment and override feature flags, enriches Unified Swaps funnel events with canonical `active_ab_tests` assignments, emits `AssetPickerOpened`, and forwards the assignment to regular and intent submissions.

Automated verification completed:

- `yarn lint:changed:fix`
- `yarn lint:tsc`
- Focused Jest coverage for ordering, experiment configuration, selectors, both network-picker presentations, picker-open analytics, submission attribution, and the feature-flag registry
- A/B testing compliance checker

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added value-based network ordering for eligible Unified Swaps users.

## **Related issues**

Fixes: SWAPS-4827

## **Manual testing steps**

1. Build and load the extension, then open Unified Swaps.
2. Assign `swapsSWAPS4827AbtestChainValueOrder` to `control`, open both source and destination network pickers, and verify they retain the existing configured chain ranking.
3. Assign the experiment to `treatment`, ensure the selected account group has fiat holdings on multiple supported chains, and verify both pickers order those chains by descending fiat value.
4. Add valid entries to `swapsChainValueOrderOverride.positionOverrides` and verify those chains move to the front in configured order without changing the available chain set.
5. Request and submit a quote, then verify Unified Swaps analytics use `active_ab_tests` for the experiment assignment.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="478" height="992" alt="Screenshot 2026-08-06 at 3 46 58 PM" src="https://github.com/user-attachments/assets/b862946a-57c2-4ddf-afb4-9588c0da6437" />


### **After**

<!-- [screenshots/recordings] -->

<img width="486" height="990" alt="Screenshot 2026-08-06 at 3 45 48 PM" src="https://github.com/user-attachments/assets/1d1a6ad5-6418-4606-9a22-63d231164b58" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes visible swap/bridge network ordering and submission analytics attribution, but behavior is flag-gated and covered by focused tests.
> 
> **Overview**
> Introduces the **SWAPS-4827** chain-value-order experiment for Unified Swaps **source and destination network pickers**. **Control** keeps existing `bridgeConfig.chainRanking` order; **treatment** reorders allowed chains by the selected account group’s positive fiat holdings (ties/zero balances keep LaunchDarkly order), then applies validated remote **`swapsChainValueOrderOverride.positionOverrides`** promotions.
> 
> Treatment-only holdings and override wiring run **only while a picker is open** (`NetworkPicker` mounts `useChainValueOrder` when treatment + open). Shared helpers **`getChainValueOrder`** / **`parsePositionOverrides`** implement sorting and flag parsing; **`getChainValueOrderOverride`** exposes overrides from remote flags.
> 
> Registers the experiment and override flags (including e2e registry), enriches **Unified Swaps funnel** events with **`active_ab_tests`** via MetaMetrics mapping, emits **`AssetPickerOpened`** from the bridge input group, and forwards the assignment on **regular and intent** submissions through bridge-status actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa9f91f12cd8b3b277a31f36a41974a48128b925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->