### PR TITLE
test: fix flaky test `Deep Link - /asset Route redirects to home when a Solana asset deeplink opens with an EVM-only account selected`

### DIFF
--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -59,7 +59,7 @@ class AccountListPage {
     'header button[aria-label="Close"]';
 
   private readonly closeMultichainAccountsPageButton =
-    '.multichain-page-header button[aria-label="Back"]';
+    '[data-testid="account-list-page-back-button"]';
 
   private readonly currentSelectedAccount =
     '.multichain-account-list-item--selected';
@@ -806,7 +806,9 @@ class AccountListPage {
 
   async closeChooseWalletTypePage(): Promise<void> {
     console.log(`Navigate back from choose wallet type page`);
-    await this.driver.clickElement(this.chooseWalletTypeBackButton);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.chooseWalletTypeBackButton,
+    );
   }
 
   async closeMultichainAccountsPage(): Promise<void> {

--- a/test/e2e/tests/deep-link/deep-link-route-asset.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link-route-asset.spec.ts
@@ -44,7 +44,7 @@ async function mockSolanaAssetMetadata(server: Mockttp): Promise<void> {
     ]);
 }
 
-describe('Deep Link - /asset Route TEST', function () {
+describe('Deep Link - /asset Route', function () {
   it('redirects to home when a Solana asset deeplink opens with an EVM-only account selected', async function () {
     const keyPair = await generateECDSAKeyPair();
     const deepLinkPublicKey = bytesToB64(

--- a/test/e2e/tests/deep-link/deep-link-route-asset.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link-route-asset.spec.ts
@@ -44,7 +44,7 @@ async function mockSolanaAssetMetadata(server: Mockttp): Promise<void> {
     ]);
 }
 
-describe('Deep Link - /asset Route', function () {
+describe('Deep Link - /asset Route TEST', function () {
   it('redirects to home when a Solana asset deeplink opens with an EVM-only account selected', async function () {
     const keyPair = await generateECDSAKeyPair();
     const deepLinkPublicKey = bytesToB64(

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -145,6 +145,7 @@ export const AccountList = () => {
             ariaLabel={t('back')}
             iconName={IconName.ArrowLeft}
             onClick={handleBack}
+            data-testid="account-list-page-back-button"
           />
         }
       >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


The back-button selector .multichain-page-header button[aria-label="Back"] matched three sibling pages' headers, so the driver grabbed the choose-wallet-type page's button (which closeChooseWalletTypePage hadn't waited to unmount) and it went stale mid-click; fixed by giving the account list's back button its own data-testid and making closeChooseWalletTypePage wait for the page to disappear.

<img width="1291" height="211" alt="image" src="https://github.com/user-attachments/assets/8be69fae-91cd-4661-aef3-f4a8f133a412" />


See how we stayed in the Accounts list page in the failing artifact

<img width="1366" height="682" alt="image" src="https://github.com/user-attachments/assets/5336c1ab-9c60-4f72-ae44-8be077066dd0" />

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a test id on a back button and tightens E2E waits; no production navigation or account logic changes beyond the hook attribute.
> 
> **Overview**
> Fixes flaky deep-link E2E failures where closing the multichain accounts flow could click the wrong back control or race an unmounting choose-wallet-type screen.
> 
> The account list header back `ButtonIcon` now exposes **`data-testid="account-list-page-back-button"`**, and **`AccountListPage`** uses that instead of the shared `.multichain-page-header button[aria-label="Back"]` selector that also matched other stacked multichain pages. **`closeChooseWalletTypePage`** now uses **`clickElementAndWaitToDisappear`** on the choose-wallet-type back button (same pattern as closing the accounts page), so the driver does not interact with a stale element while the previous view is still in the DOM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d39ef4bf5f0a6bc84399ebdfe16104e433a37a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->