### PR TITLE
test: fix flaky test `Perps Take Profit / Stop Loss simulates take-profit fill: TP set on ETH long then stream clears the position`

### DIFF
--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -1,14 +1,11 @@
+import { PERPS_ACTIVITY_ROUTE } from '../../../../ui/helpers/constants/routes';
 import type { Driver } from '../../webdriver/driver';
 import { PerpsActivityPage } from '../pages/perps/perps-activity-page';
-import { PerpsTab } from '../pages/home/perps-tab';
-import { PerpsMarketDetailPage } from '../pages/perps/perps-market-detail-page';
-import { PerpsMarketListPage } from '../pages/perps/perps-market-list-page';
 
 /**
  * After a simulated position change in E2E, pushes a `userFills` snapshot via
- * `pushUserFills`, navigates back to Perps home, then opens Perps Activity and
- * asserts a trade row appears with the expected title fragment (same navigation
- * pattern as other lifecycle tests).
+ * `pushUserFills`, opens Perps Activity, and asserts a trade row appears with
+ * the expected title fragment.
  *
  * @param options
  * @param options.driver
@@ -25,27 +22,18 @@ export async function assertPerpsActivityShowsCloseFill({
   /** Substring of the trade title, e.g. `Closed long` or `Closed short`. */
   expectedTitleContains: string;
 }): Promise<void> {
-  // Push while the market detail page is still mounted, so the fill can also
-  // reach the UI live: PerpsStreamBridge drops every emit made while no Perps
-  // view is active, and navigating back closes that window. The push is
-  // additionally recorded by the mock server, so Perps home still sees the fill
-  // when it queries `userFills` on mount.
   pushUserFills();
 
-  const marketDetailPage = new PerpsMarketDetailPage(driver);
-  await marketDetailPage.clickBack();
-  try {
-    const marketListPage = new PerpsMarketListPage(driver);
-    await marketListPage.clickBack();
-  } catch (error) {
-    console.error('Market list not displayed, moving on', error);
-  }
-
-  const perpsTab = new PerpsTab(driver);
-  await perpsTab.navigateToPerpsHome();
-
-  await perpsTab.waitForRecentActivitySection();
-  await perpsTab.clickRecentActivitySeeAll();
+  // Open Perps Activity by route rather than through Perps home. Home's
+  // "See All" only renders once Recent Activity has history, and Recent
+  // Activity reuses a coalesced snapshot taken at startup, before the fill
+  // exists — so reaching Activity that way depends on the pushed frame winning
+  // a race against navigation. This page fetches with `forceFreshOnMount`,
+  // which drops that snapshot and queries `userFills` on the wire, where the
+  // mock replays whatever `pushUserFills` last sent.
+  await driver.openNewURL(
+    `${driver.extensionUrl}/home.html#${PERPS_ACTIVITY_ROUTE}`,
+  );
 
   const activityPage = new PerpsActivityPage(driver);
   await activityPage.checkPageIsLoaded();

--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -5,9 +5,10 @@ import { PerpsMarketDetailPage } from '../pages/perps/perps-market-detail-page';
 import { PerpsMarketListPage } from '../pages/perps/perps-market-list-page';
 
 /**
- * After a simulated position change in E2E, pushes a `userFills` snapshot via
- * `pushUserFills`, then opens Perps Activity and asserts a trade row appears
- * with the expected title fragment (same navigation pattern as other lifecycle tests).
+ * After a simulated position change in E2E, navigates back to Perps home, pushes
+ * a `userFills` snapshot via `pushUserFills`, then opens Perps Activity and
+ * asserts a trade row appears with the expected title fragment (same navigation
+ * pattern as other lifecycle tests).
  *
  * @param options
  * @param options.driver
@@ -24,8 +25,6 @@ export async function assertPerpsActivityShowsCloseFill({
   /** Substring of the trade title, e.g. `Closed long` or `Closed short`. */
   expectedTitleContains: string;
 }): Promise<void> {
-  pushUserFills();
-
   const marketDetailPage = new PerpsMarketDetailPage(driver);
   await marketDetailPage.clickBack();
   try {
@@ -37,7 +36,15 @@ export async function assertPerpsActivityShowsCloseFill({
 
   const perpsTab = new PerpsTab(driver);
   await perpsTab.navigateToPerpsHome();
-  await perpsTab.checkPageIsLoaded();
+
+  // Push only once a Perps view is mounted and settled. PerpsStreamBridge drops
+  // every emit while `perpsViewActive` is false, and the boundary that owns that
+  // flag is torn down and re-created while navigating off the market detail page.
+  // A frame that lands in that window is discarded for good: the snapshot is
+  // sent once and the REST mocks never replay it, so Recent Activity would stay
+  // empty for the rest of the test.
+  pushUserFills();
+  await perpsTab.waitForRecentActivitySection();
   await perpsTab.clickRecentActivitySeeAll();
 
   const activityPage = new PerpsActivityPage(driver);

--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -5,10 +5,14 @@ import { PerpsMarketDetailPage } from '../pages/perps/perps-market-detail-page';
 import { PerpsMarketListPage } from '../pages/perps/perps-market-list-page';
 
 /**
- * After a simulated position change in E2E, navigates back to Perps home, pushes
- * a `userFills` snapshot via `pushUserFills`, then opens Perps Activity and
+ * After a simulated position change in E2E, pushes a `userFills` snapshot via
+ * `pushUserFills`, navigates back to Perps home, then opens Perps Activity and
  * asserts a trade row appears with the expected title fragment (same navigation
  * pattern as other lifecycle tests).
+ *
+ * `pushUserFills` is invoked more than once on purpose; see the comments below.
+ * It must therefore be safe to repeat, which holds because the snapshot it
+ * sends carries `isSnapshot: true` and so replaces any previous one.
  *
  * @param options
  * @param options.driver
@@ -25,6 +29,12 @@ export async function assertPerpsActivityShowsCloseFill({
   /** Substring of the trade title, e.g. `Closed long` or `Closed short`. */
   expectedTitleContains: string;
 }): Promise<void> {
+  // Push while the market detail page is still mounted. This is the last point
+  // where a Perps view is definitely active, and PerpsStreamBridge drops every
+  // emit while `perpsViewActive` is false. Pushing here also warms the
+  // controller's fills cache, which is what `perpsGetOrderFills` reads.
+  pushUserFills();
+
   const marketDetailPage = new PerpsMarketDetailPage(driver);
   await marketDetailPage.clickBack();
   try {
@@ -37,14 +47,22 @@ export async function assertPerpsActivityShowsCloseFill({
   const perpsTab = new PerpsTab(driver);
   await perpsTab.navigateToPerpsHome();
 
-  // Push only once a Perps view is mounted and settled. PerpsStreamBridge drops
-  // every emit while `perpsViewActive` is false, and the boundary that owns that
-  // flag is torn down and re-created while navigating off the market detail page.
-  // A frame that lands in that window is discarded for good: the snapshot is
-  // sent once and the REST mocks never replay it, so Recent Activity would stay
-  // empty for the rest of the test.
-  pushUserFills();
-  await perpsTab.waitForRecentActivitySection();
+  // Re-push until Perps home actually lists the fill, because the two ways it
+  // can learn about one are both raceable here. The live path is closed
+  // whenever no Perps view is mounted, and the frame is sent once — the mock
+  // never folds it into the `userFills` POST response the way the real server
+  // would. The fetch path is coalesced for 10s, so a mount that lands inside
+  // that window replays the empty response an earlier mount cached and never
+  // refetches. Re-emitting with Perps home mounted feeds PerpsStreamManager
+  // directly, which is merged ahead of the coalesced response.
+  await driver.waitUntil(
+    async () => {
+      pushUserFills();
+      return await perpsTab.isRecentActivityPopulated();
+    },
+    { timeout: 10000, interval: 200 },
+  );
+
   await perpsTab.clickRecentActivitySeeAll();
 
   const activityPage = new PerpsActivityPage(driver);

--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -10,10 +10,6 @@ import { PerpsMarketListPage } from '../pages/perps/perps-market-list-page';
  * asserts a trade row appears with the expected title fragment (same navigation
  * pattern as other lifecycle tests).
  *
- * `pushUserFills` is invoked more than once on purpose; see the comments below.
- * It must therefore be safe to repeat, which holds because the snapshot it
- * sends carries `isSnapshot: true` and so replaces any previous one.
- *
  * @param options
  * @param options.driver
  * @param options.pushUserFills
@@ -29,10 +25,11 @@ export async function assertPerpsActivityShowsCloseFill({
   /** Substring of the trade title, e.g. `Closed long` or `Closed short`. */
   expectedTitleContains: string;
 }): Promise<void> {
-  // Push while the market detail page is still mounted. This is the last point
-  // where a Perps view is definitely active, and PerpsStreamBridge drops every
-  // emit while `perpsViewActive` is false. Pushing here also warms the
-  // controller's fills cache, which is what `perpsGetOrderFills` reads.
+  // Push while the market detail page is still mounted, so the fill can also
+  // reach the UI live: PerpsStreamBridge drops every emit made while no Perps
+  // view is active, and navigating back closes that window. The push is
+  // additionally recorded by the mock server, so Perps home still sees the fill
+  // when it queries `userFills` on mount.
   pushUserFills();
 
   const marketDetailPage = new PerpsMarketDetailPage(driver);
@@ -47,22 +44,7 @@ export async function assertPerpsActivityShowsCloseFill({
   const perpsTab = new PerpsTab(driver);
   await perpsTab.navigateToPerpsHome();
 
-  // Re-push until Perps home actually lists the fill, because the two ways it
-  // can learn about one are both raceable here. The live path is closed
-  // whenever no Perps view is mounted, and the frame is sent once — the mock
-  // never folds it into the `userFills` POST response the way the real server
-  // would. The fetch path is coalesced for 10s, so a mount that lands inside
-  // that window replays the empty response an earlier mount cached and never
-  // refetches. Re-emitting with Perps home mounted feeds PerpsStreamManager
-  // directly, which is merged ahead of the coalesced response.
-  await driver.waitUntil(
-    async () => {
-      pushUserFills();
-      return await perpsTab.isRecentActivityPopulated();
-    },
-    { timeout: 10000, interval: 200 },
-  );
-
+  await perpsTab.waitForRecentActivitySection();
   await perpsTab.clickRecentActivitySeeAll();
 
   const activityPage = new PerpsActivityPage(driver);

--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -1,11 +1,14 @@
-import { PERPS_ACTIVITY_ROUTE } from '../../../../ui/helpers/constants/routes';
 import type { Driver } from '../../webdriver/driver';
 import { PerpsActivityPage } from '../pages/perps/perps-activity-page';
+import { PerpsTab } from '../pages/home/perps-tab';
+import { PerpsMarketDetailPage } from '../pages/perps/perps-market-detail-page';
+import { PerpsMarketListPage } from '../pages/perps/perps-market-list-page';
 
 /**
- * After a simulated position change in E2E, pushes a `userFills` snapshot via
- * `pushUserFills`, opens Perps Activity, and asserts a trade row appears with
- * the expected title fragment.
+ * After a simulated position change in E2E, navigates back to Perps home, opens
+ * Perps Activity and asserts a trade row appears with the expected title
+ * fragment (same navigation pattern as other lifecycle tests). A `userFills`
+ * snapshot is pushed via `pushUserFills` until the fill shows up.
  *
  * @param options
  * @param options.driver
@@ -22,21 +25,56 @@ export async function assertPerpsActivityShowsCloseFill({
   /** Substring of the trade title, e.g. `Closed long` or `Closed short`. */
   expectedTitleContains: string;
 }): Promise<void> {
+  // Push while the market detail page is still mounted, so the fill can also
+  // reach the UI live: PerpsStreamBridge drops every emit made while no Perps
+  // view is active, and navigating back closes that window.
   pushUserFills();
 
-  // Open Perps Activity by route rather than through Perps home. Home's
-  // "See All" only renders once Recent Activity has history, and Recent
-  // Activity reuses a coalesced snapshot taken at startup, before the fill
-  // exists — so reaching Activity that way depends on the pushed frame winning
-  // a race against navigation. This page fetches with `forceFreshOnMount`,
-  // which drops that snapshot and queries `userFills` on the wire, where the
-  // mock replays whatever `pushUserFills` last sent.
-  await driver.openNewURL(
-    `${driver.extensionUrl}/home.html#${PERPS_ACTIVITY_ROUTE}`,
+  const marketDetailPage = new PerpsMarketDetailPage(driver);
+  await marketDetailPage.clickBack();
+  try {
+    const marketListPage = new PerpsMarketListPage(driver);
+    await marketListPage.clickBack();
+  } catch (error) {
+    console.error('Market list not displayed, moving on', error);
+  }
+
+  const perpsTab = new PerpsTab(driver);
+  await perpsTab.navigateToPerpsHome();
+  await perpsTab.waitForRecentActivitySection();
+
+  // Re-push until the fill lands. A `userFills` snapshot both replaces the
+  // controller's fills cache and notifies live subscribers, but neither helps
+  // if it arrives while a view is mid-mount: the cache read happens once, and
+  // the live subscriber is not registered yet. The controller then answers
+  // `perpsGetOrderFills` from that initialized-but-empty cache without ever
+  // going to the wire, so nothing retries on its own. Pushing again once the
+  // view is up is delivered straight to the mounted subscriber. Snapshots
+  // replace rather than append, so repeating one is harmless.
+  await driver.waitUntil(
+    async () => {
+      if (await perpsTab.isRecentActivitySeeAllPresent()) {
+        return true;
+      }
+      pushUserFills();
+      return false;
+    },
+    { interval: 500, timeout: 30000 },
   );
+  await perpsTab.clickRecentActivitySeeAll();
 
   const activityPage = new PerpsActivityPage(driver);
   await activityPage.checkPageIsLoaded();
-  await activityPage.waitForAnyTransactionCard();
+  await driver.waitUntil(
+    async () => {
+      if (await activityPage.isAnyTransactionCardPresent()) {
+        return true;
+      }
+      pushUserFills();
+      return false;
+    },
+    { interval: 500, timeout: 30000 },
+  );
+
   await activityPage.waitForActivityTradeTitleContaining(expectedTitleContains);
 }

--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -32,35 +32,17 @@ export async function assertPerpsActivityShowsCloseFill({
 
   const marketDetailPage = new PerpsMarketDetailPage(driver);
   await marketDetailPage.clickBack();
-  try {
-    const marketListPage = new PerpsMarketListPage(driver);
+
+  // Back lands on the market list only when the test reached market detail
+  // through it; entering from a position card on Perps home skips it.
+  const marketListPage = new PerpsMarketListPage(driver);
+  if (await marketListPage.isBackButtonPresent()) {
     await marketListPage.clickBack();
-  } catch (error) {
-    console.error('Market list not displayed, moving on', error);
   }
 
   const perpsTab = new PerpsTab(driver);
   await perpsTab.navigateToPerpsHome();
-  await perpsTab.waitForRecentActivitySection();
-
-  // Re-push until the fill lands. A `userFills` snapshot both replaces the
-  // controller's fills cache and notifies live subscribers, but neither helps
-  // if it arrives while a view is mid-mount: the cache read happens once, and
-  // the live subscriber is not registered yet. The controller then answers
-  // `perpsGetOrderFills` from that initialized-but-empty cache without ever
-  // going to the wire, so nothing retries on its own. Pushing again once the
-  // view is up is delivered straight to the mounted subscriber. Snapshots
-  // replace rather than append, so repeating one is harmless.
-  await driver.waitUntil(
-    async () => {
-      if (await perpsTab.isRecentActivitySeeAllPresent()) {
-        return true;
-      }
-      pushUserFills();
-      return false;
-    },
-    { interval: 500, timeout: 30000 },
-  );
+  await perpsTab.checkPageIsLoaded();
   await perpsTab.clickRecentActivitySeeAll();
 
   const activityPage = new PerpsActivityPage(driver);

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -167,23 +167,6 @@ export class PerpsTab extends PerpsPositionsBase {
   }
 
   /**
-   * Resolves to whether Recent Activity currently lists history, without
-   * throwing when it is still in its empty state. Use this to poll while
-   * history is expected to arrive; use {@link waitForRecentActivitySection}
-   * when its absence should fail the test.
-   *
-   * @param timeout - How long to give the section to render, in ms.
-   */
-  async isRecentActivityPopulated(timeout = 1000): Promise<boolean> {
-    try {
-      await this.driver.waitForSelector(this.perpsRecentActivity, { timeout });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
    * Navigates to Perps Home by clicking the Perps tab on the account overview.
    * Requires the account overview to be visible (e.g. after login or driver.navigate()).
    * Waits for the Perps tab to be present, clicks it, then waits for the Perps Home view to load.

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -167,6 +167,23 @@ export class PerpsTab extends PerpsPositionsBase {
   }
 
   /**
+   * Resolves to whether Recent Activity currently lists history, without
+   * throwing when it is still in its empty state. Use this to poll while
+   * history is expected to arrive; use {@link waitForRecentActivitySection}
+   * when its absence should fail the test.
+   *
+   * @param timeout - How long to give the section to render, in ms.
+   */
+  async isRecentActivityPopulated(timeout = 1000): Promise<boolean> {
+    try {
+      await this.driver.waitForSelector(this.perpsRecentActivity, { timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Navigates to Perps Home by clicking the Perps tab on the account overview.
    * Requires the account overview to be visible (e.g. after login or driver.navigate()).
    * Waits for the Perps tab to be present, clicks it, then waits for the Perps Home view to load.

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -129,8 +129,7 @@ export class PerpsTab extends PerpsPositionsBase {
 
   /**
    * Clicks the "See All" link in the Recent Activity section (navigates to Perps Activity).
-   * Only rendered once there is history; the empty state has a plain header, so
-   * call {@link waitForRecentActivitySection} first when history is still arriving.
+   * Shown for both the populated list header and the empty-state header.
    */
   async clickRecentActivitySeeAll(): Promise<void> {
     await this.driver.clickElement(this.perpsRecentActivitySeeAll);

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -129,7 +129,8 @@ export class PerpsTab extends PerpsPositionsBase {
 
   /**
    * Clicks the "See All" link in the Recent Activity section (navigates to Perps Activity).
-   * Shown for both the populated list header and the empty-state header.
+   * Only rendered once there is history; the empty state has a plain header, so
+   * call {@link waitForRecentActivitySection} first when history is still arriving.
    */
   async clickRecentActivitySeeAll(): Promise<void> {
     await this.driver.clickElement(this.perpsRecentActivitySeeAll);

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -166,6 +166,20 @@ export class PerpsTab extends PerpsPositionsBase {
   }
 
   /**
+   * Non-blocking check for the Recent Activity "See All" link, for polling
+   * loops that need to retry an action (e.g. re-pushing a `userFills` frame)
+   * between attempts.
+   *
+   * @param timeout - How long to look before reporting absence, in ms.
+   */
+  async isRecentActivitySeeAllPresent(timeout: number = 1000): Promise<boolean> {
+    return await this.driver.isElementPresentAndVisible(
+      this.perpsRecentActivitySeeAll,
+      timeout,
+    );
+  }
+
+  /**
    * Navigates to Perps Home by clicking the Perps tab on the account overview.
    * Requires the account overview to be visible (e.g. after login or driver.navigate()).
    * Waits for the Perps tab to be present, clicks it, then waits for the Perps Home view to load.

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -129,7 +129,7 @@ export class PerpsTab extends PerpsPositionsBase {
 
   /**
    * Clicks the "See All" link in the Recent Activity section (navigates to Perps Activity).
-   * Shown for both the populated list header and the empty-state header.
+   * Only rendered once the section has history; the empty state has no header link.
    */
   async clickRecentActivitySeeAll(): Promise<void> {
     await this.driver.clickElement(this.perpsRecentActivitySeeAll);
@@ -172,7 +172,9 @@ export class PerpsTab extends PerpsPositionsBase {
    *
    * @param timeout - How long to look before reporting absence, in ms.
    */
-  async isRecentActivitySeeAllPresent(timeout: number = 1000): Promise<boolean> {
+  async isRecentActivitySeeAllPresent(
+    timeout: number = 1000,
+  ): Promise<boolean> {
     return await this.driver.isElementPresentAndVisible(
       this.perpsRecentActivitySeeAll,
       timeout,

--- a/test/e2e/page-objects/pages/perps/perps-activity-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-activity-page.ts
@@ -63,6 +63,19 @@ export class PerpsActivityPage {
   }
 
   /**
+   * Non-blocking check for a trade row, for polling loops that need to retry an
+   * action (e.g. re-pushing a `userFills` frame) between attempts.
+   *
+   * @param timeout - How long to look before reporting absence, in ms.
+   */
+  async isAnyTransactionCardPresent(timeout: number = 1000): Promise<boolean> {
+    return await this.driver.isElementPresentAndVisible(
+      this.anyTransactionCard,
+      timeout,
+    );
+  }
+
+  /**
    * Selects a filter option from the open dropdown.
    * Call `clickFilterButton()` first to open the dropdown.
    *

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -100,6 +100,19 @@ export class PerpsMarketListPage {
    * moving (watchlist mount / toast dismiss can shift layout), then clicks with
    * {@link Driver.clickElement}.
    */
+  /**
+   * Non-blocking check for the header back control, for callers that reach this
+   * page conditionally and must not pay a full find timeout when it is absent.
+   *
+   * @param timeout - How long to look before reporting absence, in ms.
+   */
+  async isBackButtonPresent(timeout: number = 2000): Promise<boolean> {
+    return await this.driver.isElementPresentAndVisible(
+      this.headerBackButton,
+      timeout,
+    );
+  }
+
   async navigateToMarketList(): Promise<void> {
     await this.driver.waitForSelector(this.exploreMarketsRow);
     await this.driver.clickElementSafe(this.perpsToastCloseButton, 2000);

--- a/test/e2e/tests/perps/mocks/websocketPositionMocks.ts
+++ b/test/e2e/tests/perps/mocks/websocketPositionMocks.ts
@@ -21,6 +21,42 @@ import {
 } from './websocketDefaultMocks';
 
 /**
+ * Fills recorded by `pushUserFillsClosePositionSnapshot` and replayed by
+ * `USER_FILLS_POST_MOCK`. A pushed frame is flagged `isSnapshot: true`, meaning
+ * it is the complete set of fills, so each push replaces the previous one.
+ */
+let pushedUserFills: unknown[] = [];
+
+/**
+ * Discards recorded fills. Wired to the perps service `onCleanup` so fills from
+ * one test are never served to the next.
+ */
+export function resetPushedUserFills(): void {
+  pushedUserFills = [];
+}
+
+/**
+ * Answers `userFills` info POSTs with whatever was last pushed, the way the real
+ * server folds a streamed fill into later queries. Without it these POSTs fall
+ * through to the generic catch-all, which answers `{}`, so a fill only ever
+ * reaches the UI if a Perps view happens to be subscribed when it is streamed.
+ *
+ * The closing quote in `"type":"userFills"` keeps this from also matching
+ * `userFillsByTime`, which is a separate query with its own consumers.
+ */
+const USER_FILLS_POST_MOCK: WebSocketMessageMock = {
+  messageIncludes: ['"method":"post"', '"type":"userFills"'],
+  dynamicResponse: (message: string) => {
+    const req = parseWsPost(message);
+    return req
+      ? buildWsPostResponse(req.id, req.type, [...pushedUserFills])
+      : null;
+  },
+  delay: 50,
+  logMessage: 'Perps userFills POST replaying pushed snapshot',
+};
+
+/**
  * Funded clearing-house state with 10 000 USDC, no open positions.
  * Use for tests that need to place a new order (open long/short) without
  * pre-existing positions.
@@ -175,6 +211,7 @@ export const WS_USER_WITH_ETH_LONG_POSITION: WebSocketMessageMock[] = [
     logMessage:
       'Perps ETH long mock: clearinghouseState POST with ETH position',
   },
+  USER_FILLS_POST_MOCK,
 ];
 
 /**
@@ -300,6 +337,7 @@ export const WS_USER_WITH_BTC_SHORT_POSITION: WebSocketMessageMock[] = [
     logMessage:
       'Perps BTC short mock: clearinghouseState POST with BTC position',
   },
+  USER_FILLS_POST_MOCK,
 ];
 
 /**
@@ -385,6 +423,7 @@ export const WS_USER_WITH_FUNDED_ACCOUNT: WebSocketMessageMock[] = [
     logMessage:
       'Perps funded account mock: clearinghouseState POST with 10000 USDC',
   },
+  USER_FILLS_POST_MOCK,
 ];
 
 /**
@@ -581,6 +620,9 @@ export type PushUserFillsClosePositionSnapshotOpts = {
  *
  * Shape matches `@nktkas/hyperliquid` `UserFillsEvent` (user + fills + isSnapshot).
  *
+ * The fill is also recorded so `userFills` info POSTs replay it, which keeps the
+ * UI from depending on being subscribed at the instant the frame is streamed.
+ *
  * @param server - The LocalWebSocketServer for the perps service
  * @param server.sendMessage
  * @param opts - Wire fill fields for one close (or partial-close) fill
@@ -611,6 +653,8 @@ export function pushUserFillsClosePositionSnapshot(
     feeToken: 'USDC',
     twapId: null,
   };
+
+  pushedUserFills = [fill];
 
   server.sendMessage(
     JSON.stringify({

--- a/test/e2e/tests/perps/perps-tpsl.spec.ts
+++ b/test/e2e/tests/perps/perps-tpsl.spec.ts
@@ -27,7 +27,7 @@ import {
   pushUserFillsClosePositionSnapshot,
 } from './mocks/websocketPositionMocks';
 
-describe('Perps Take Profit / Stop Loss', function (this: Suite) {
+describe('Perps Take Profit / Stop Loss TEST', function (this: Suite) {
   this.timeout(120000);
 
   it('simulates take-profit fill: TP set on ETH long then stream clears the position', async function () {

--- a/test/e2e/websocket/perps-mocks.ts
+++ b/test/e2e/websocket/perps-mocks.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_HYPERLIQUID_WS_MOCKS,
   getResponsePayload,
 } from '../tests/perps/mocks/websocketDefaultMocks';
+import { resetPushedUserFills } from '../tests/perps/mocks/websocketPositionMocks';
 import type { WebSocketMessageMock } from './types';
 import type { WebSocketServiceConfig } from './registry';
 import type LocalWebSocketServer from './server';
@@ -96,4 +97,5 @@ export const perpsWebSocketConfig: WebSocketServiceConfig = {
   name: WEBSOCKET_SERVICES.perps,
   port: PERPS_WS_PORT,
   setup: setupPerpsWebsocketMocks,
+  onCleanup: resetPushedUserFills,
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test failed because Perps home rendered "Recent activity — No transactions yet" instead of the populated list. 

The Perps close-fill E2E flow could only learn about the simulated fill from a single live WebSocket frame, which is dropped whenever no Perps view is mounted during the back-navigation to Perps home, and nothing recovered it afterwards because userFills POSTs fell through to a catch-all mock returning {} and home's Recent Activity reused a coalesced snapshot taken at startup, so "See All" never rendered and the test timed out.

Fixes:
- the mock server now records each pushed fill and replays it for userFills POSTs (reset per test via onCleanup)
- the flow opens Perps Activity directly by route instead of via home, since that page fetches with forceFreshOnMount and therefore always queries the wire, making the assertion independent of WebSocket timing.


See artifact:
<img width="1366" height="682" alt="image" src="https://github.com/user-attachments/assets/802efb3f-1114-4851-b75d-45b505183c41" />

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. ci was triggered with the e2e quality gate (changing the affected test) to verify the fix

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test and mock-server changes only; no production app behavior is modified.
> 
> **Overview**
> Addresses flaky **Perps Take Profit / Stop Loss** E2E where Activity never showed the simulated close fill because the test relied on a live `userFills` WebSocket frame and navigation through Perps home (empty/stale Recent Activity, no “See All”).
> 
> The perps WS mock now **records fills** from `pushUserFillsClosePositionSnapshot` and **replies to `userFills` info POSTs** with that snapshot (shared across position mock bundles), with **`resetPushedUserFills` on perps WS `onCleanup`** so state does not leak between tests.
> 
> `assertPerpsActivityShowsCloseFill` **drops the back-nav → home → “See All” path** and **opens Perps Activity directly** via `PERPS_ACTIVITY_ROUTE`, so the assertion uses a fresh `userFills` fetch instead of racing the stream against home’s coalesced preview.
> 
> The suite `describe` title was changed to append `TEST` (likely accidental debug naming).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 974160bd63f43245ae5b48371996f63206030541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->