### PR TITLE
fix(ci): grant orchestrator callees the attestations permissions they request

### DIFF
--- a/.github/workflows/runway-extension-release-and-submit.yml
+++ b/.github/workflows/runway-extension-release-and-submit.yml
@@ -193,6 +193,14 @@ jobs:
         !inputs.skip_publish &&
         needs.validate.outputs.release_exists != 'true'
       }}
+    # A called workflow cannot exceed the calling job's permissions, so this must
+    # cover the whole callee (top-level plus its publish-release job).
+    permissions:
+      contents: read
+      statuses: read
+      actions: read
+      id-token: write
+      attestations: write # Required by actions/attest-build-provenance in the callee
     uses: ./.github/workflows/publish-release-from-release-head.yml
     secrets: inherit
 
@@ -209,6 +217,10 @@ jobs:
         needs.validate.result == 'success' &&
         (needs.publish-release.result == 'success' || needs.publish-release.result == 'skipped')
       }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: read # Required by gh attestation verify in the callee
     uses: ./.github/workflows/upload-extension-to-cws.yml
     with:
       version: ${{ needs.validate.outputs.version }}
@@ -229,6 +241,10 @@ jobs:
         needs.validate.result == 'success' &&
         (needs.publish-release.result == 'success' || needs.publish-release.result == 'skipped')
       }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: read # Required by gh attestation verify in the callee
     uses: ./.github/workflows/upload-extension-to-cws.yml
     with:
       version: ${{ needs.validate.outputs.version }}
@@ -300,6 +316,6 @@ jobs:
             if [[ "${EXECUTE_STORE}" != "true" ]]; then
               echo "Store phases were **not requested** (\`execute_store_phases=false\`)."
               echo ""
-              echo "**Recovery:** use **Re-run failed jobs** on the same run, or re-dispatch with the same \`version\` / \`release_sha\` (completed phases auto-skip)."
+              echo "**Recovery:** use **Re-run failed jobs** on the same run, or re-dispatch from the same release branch with the same \`release_sha\` (completed phases auto-skip)."
             fi
           } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## **Description**

The Runway release orchestrator (`runway-extension-release-and-submit.yml`) fails at run creation, before any job starts:

```
Error calling workflow '.../publish-release-from-release-head.yml@eab4097'.
The nested job 'publish-release' is requesting 'attestations: write',
but is only allowed 'attestations: none'.
```

A called workflow can never hold more permission than the job that calls it. The orchestrator's calling jobs inherited only `contents/statuses/actions: read` + `id-token: write`, but two callees ask for attestation scopes:

| Callee | Needs | Why |
| --- | --- | --- |
| `publish-release-from-release-head.yml` | `attestations: write` | `actions/attest-build-provenance` (INFRA-2665) |
| `upload-extension-to-cws.yml` | `attestations: read` | `gh attestation verify` (INFRA-3661) |

This grants those scopes on the calling jobs rather than workflow-wide, so `validate` and the AMO phase keep the narrower set. Because a job-level `permissions:` block replaces the workflow-level one, each block lists the full union the callee needs.

Also removes a reference to a `version` input from the recovery text in the orchestrator summary. There is no `version` input; the version is derived from the `release/X.Y.Z` branch the workflow runs on.

Not addressed here: `actionlint` and `zizmor` lint one file at a time and do not inspect the reusable-workflow call graph, so no linter catches this class of error. It only surfaces on dispatch.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: INFRA-3735 follow-up (orchestrator was never dispatched end-to-end before 13.43.0)

## **Manual testing steps**

1. Dispatch **Runway extension release and store submit** on a `release/*` branch with `execute_store_phases=false` (validation-only run).
2. Confirm the run is created, i.e. no `The workflow is not valid ... attestations: none` error. On `main` today, run creation fails at this point.
3. Confirm Phase 0 validation passes and Phases 1 to 3 are skipped.
4. Open the orchestrator summary and confirm the recovery line reads "re-dispatch from the same release branch with the same `release_sha`".

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)