### PR TITLE
feat: add rpc-error-utils and ledgerDmk feature-flag plumbing

### DIFF
--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -314,9 +314,8 @@ import {
   isUserRejectedHardwareWalletError,
   toHardwareWalletError,
 } from '../../../shared/lib/hardware-wallets';
-import { ENABLE_DMK_FEATURE_FLAG } from '../../../shared/lib/hardware-wallets/feature-flags';
+import { isDmkFeatureEnabled } from '../../../shared/lib/hardware-wallets/feature-flags';
 import { getManifestFlags } from '../../../shared/lib/manifestFlags';
-import { getBooleanFeatureFlag } from '../../../shared/lib/remote-feature-flag-utils';
 import { getProviderConfig } from '../../../shared/lib/selectors/networks';
 import {
   LatticeKeyringV2,
@@ -2327,7 +2326,7 @@ export class LegacyBackgroundApiService {
       state.remoteFeatureFlags ?? {},
       getManifestFlags().remoteFeatureFlags ?? {},
     );
-    return getBooleanFeatureFlag(merged[ENABLE_DMK_FEATURE_FLAG], false)
+    return isDmkFeatureEnabled(merged)
       ? LedgerHandlerMode.DMK
       : LedgerHandlerMode.Legacy;
   }

--- a/shared/lib/hardware-wallets/feature-flags.test.ts
+++ b/shared/lib/hardware-wallets/feature-flags.test.ts
@@ -1,0 +1,82 @@
+import { ENABLE_DMK_FEATURE_FLAG, isDmkFeatureEnabled } from './feature-flags';
+
+describe('hardware-wallets/feature-flags', () => {
+  describe('ENABLE_DMK_FEATURE_FLAG', () => {
+    it('is the ledgerDmk remote flag key', () => {
+      expect(ENABLE_DMK_FEATURE_FLAG).toBe('ledgerDmk');
+    });
+  });
+
+  describe('isDmkFeatureEnabled', () => {
+    it('returns false when remoteFeatureFlags is missing', () => {
+      expect(isDmkFeatureEnabled(undefined)).toBe(false);
+      expect(isDmkFeatureEnabled(null)).toBe(false);
+    });
+
+    it('returns false when ledgerDmk is absent', () => {
+      expect(isDmkFeatureEnabled({})).toBe(false);
+    });
+
+    it('returns false for the production disabled variant', () => {
+      expect(
+        isDmkFeatureEnabled({
+          [ENABLE_DMK_FEATURE_FLAG]: {
+            enabled: false,
+            featureVersion: null,
+            minimumVersion: null,
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('returns true when ledgerDmk is enabled and version requirements are met', () => {
+      expect(
+        isDmkFeatureEnabled({
+          [ENABLE_DMK_FEATURE_FLAG]: {
+            enabled: true,
+            featureVersion: '13.0.0',
+            minimumVersion: '13.0.0',
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when ledgerDmk is enabled but minimumVersion is unmet', () => {
+      expect(
+        isDmkFeatureEnabled({
+          [ENABLE_DMK_FEATURE_FLAG]: {
+            enabled: true,
+            featureVersion: '100.0.0',
+            minimumVersion: '100.0.0',
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when enabled is true without a string minimumVersion', () => {
+      expect(
+        isDmkFeatureEnabled({
+          [ENABLE_DMK_FEATURE_FLAG]: {
+            enabled: true,
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('returns true for a plain boolean true flag', () => {
+      expect(
+        isDmkFeatureEnabled({
+          [ENABLE_DMK_FEATURE_FLAG]: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false for a plain boolean false flag', () => {
+      expect(
+        isDmkFeatureEnabled({
+          [ENABLE_DMK_FEATURE_FLAG]: false,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/shared/lib/hardware-wallets/feature-flags.ts
+++ b/shared/lib/hardware-wallets/feature-flags.ts
@@ -1,3 +1,5 @@
+import { getBooleanFeatureFlag } from '../remote-feature-flag-utils';
+
 /**
  * Hardware Wallet Feature Flag constants.
  *
@@ -13,8 +15,23 @@
  * Enabled variant: `{ enabled: true, featureVersion: '13.42.0', minimumVersion: '13.42.0' }`
  * Disabled (production default): `{ enabled: false, featureVersion: null, minimumVersion: null }`
  *
- * Use `getBooleanFeatureFlag` to resolve the value at runtime; it returns
- * `false` for the disabled variant and only returns `true` when the current
- * extension version meets `minimumVersion`.
+ * Use `getBooleanFeatureFlag` / `isDmkFeatureEnabled` to resolve the value at
+ * runtime; they return `false` for the disabled variant and only return `true`
+ * when the current extension version meets `minimumVersion`.
  */
 export const ENABLE_DMK_FEATURE_FLAG = 'ledgerDmk';
+
+/**
+ * Resolves whether the Ledger DMK remote feature flag is enabled.
+ *
+ * @param remoteFeatureFlags - Remote feature flag map (controller or Redux).
+ * @returns True when `ledgerDmk` is enabled for the current extension version.
+ */
+export function isDmkFeatureEnabled(
+  remoteFeatureFlags: Record<string, unknown> | undefined | null,
+): boolean {
+  return getBooleanFeatureFlag(
+    remoteFeatureFlags?.[ENABLE_DMK_FEATURE_FLAG],
+    false,
+  );
+}

--- a/shared/lib/hardware-wallets/index.ts
+++ b/shared/lib/hardware-wallets/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared hardware-wallet utilities safe for background and UI.
+ */
 export { HardwareWalletType } from './types';
 export { createHardwareWalletError } from './errors';
 export * from './rpc-error-utils';
+export { ENABLE_DMK_FEATURE_FLAG, isDmkFeatureEnabled } from './feature-flags';

--- a/shared/lib/hardware-wallets/rpc-error-utils.test.ts
+++ b/shared/lib/hardware-wallets/rpc-error-utils.test.ts
@@ -802,6 +802,27 @@ describe('rpc-error-utils', () => {
       expect(result.code).toBe(ErrorCode.AuthenticationDeviceLocked);
       expect(result.message).toContain('0x5515');
     });
+
+    it('maps Ledger offscreen/runtime bridge failures to ConnectionTransportMissing', () => {
+      const messages = [
+        'Could not establish connection. Receiving end does not exist.',
+        'Could not establish connection.',
+        'The offscreen document is not available.',
+      ];
+
+      for (const message of messages) {
+        const result = toHardwareWalletError(
+          new Error(message),
+          HardwareWalletType.Ledger,
+        );
+
+        expect(result).toBeInstanceOf(HardwareWalletError);
+        expect(result.code).toBe(ErrorCode.ConnectionTransportMissing);
+        expect(result.message).toBe(
+          'Ledger hardware wallet service is not available. Please try again.',
+        );
+      }
+    });
   });
 
   describe('isHardwareWalletError', () => {

--- a/shared/lib/hardware-wallets/rpc-error-utils.test.ts
+++ b/shared/lib/hardware-wallets/rpc-error-utils.test.ts
@@ -818,9 +818,9 @@ describe('rpc-error-utils', () => {
 
         expect(result).toBeInstanceOf(HardwareWalletError);
         expect(result.code).toBe(ErrorCode.ConnectionTransportMissing);
-        expect(result.message).toBe(
-          'Ledger hardware wallet service is not available. Please try again.',
-        );
+        // Preserve the original diagnostic message; localized UX is driven by
+        // ErrorCode in the UI (buildErrorContent), not this shared string.
+        expect(result.message).toBe(message);
       }
     });
   });

--- a/shared/lib/hardware-wallets/rpc-error-utils.ts
+++ b/shared/lib/hardware-wallets/rpc-error-utils.ts
@@ -882,6 +882,22 @@ function tryFromLedgerErrorMessage(
 
   // Status code may be in the message, e.g. "Device is locked (... (0x5515))"
   const errorMessage = getErrorMessage(error);
+  const normalizedMessage = errorMessage.toLowerCase();
+
+  // Chrome runtime / offscreen bridge unavailable (DMK or legacy path).
+  if (
+    normalizedMessage.includes('receiving end does not exist') ||
+    normalizedMessage.includes('could not establish connection') ||
+    normalizedMessage.includes('offscreen document is not available')
+  ) {
+    return createHardwareWalletError(
+      ErrorCode.ConnectionTransportMissing,
+      walletType,
+      'Ledger hardware wallet service is not available. Please try again.',
+      { cause: getErrorCause(error) },
+    );
+  }
+
   const hexStatusCode = extractHexStatusCodeFromMessage(errorMessage);
   if (!hexStatusCode) {
     return null;

--- a/shared/lib/hardware-wallets/rpc-error-utils.ts
+++ b/shared/lib/hardware-wallets/rpc-error-utils.ts
@@ -885,6 +885,8 @@ function tryFromLedgerErrorMessage(
   const normalizedMessage = errorMessage.toLowerCase();
 
   // Chrome runtime / offscreen bridge unavailable (DMK or legacy path).
+  // Map to ErrorCode only; user-facing copy is localized in the UI via
+  // buildErrorContent(ErrorCode.ConnectionTransportMissing).
   if (
     normalizedMessage.includes('receiving end does not exist') ||
     normalizedMessage.includes('could not establish connection') ||
@@ -893,7 +895,7 @@ function tryFromLedgerErrorMessage(
     return createHardwareWalletError(
       ErrorCode.ConnectionTransportMissing,
       walletType,
-      'Ledger hardware wallet service is not available. Please try again.',
+      errorMessage,
       { cause: getErrorCause(error) },
     );
   }

--- a/ui/selectors/hardware-wallets/feature-flags.ts
+++ b/ui/selectors/hardware-wallets/feature-flags.ts
@@ -12,13 +12,12 @@
 
 import { createSelector } from 'reselect';
 import { getRemoteFeatureFlags } from '../../../shared/lib/selectors/remote-feature-flags';
-import { getBooleanFeatureFlag } from '../../../shared/lib/remote-feature-flag-utils';
-import { ENABLE_DMK_FEATURE_FLAG } from '../../../shared/lib/hardware-wallets/feature-flags';
+import { isDmkFeatureEnabled } from '../../../shared/lib/hardware-wallets/feature-flags';
 
 /**
  * Select whether the Ledger DMK (Device Management Key) rollout is enabled.
  *
- * Resolves the `enableDmk` remote flag with `getBooleanFeatureFlag`, which:
+ * Resolves the `ledgerDmk` remote flag with `isDmkFeatureEnabled`, which:
  * Returns `false` for the disabled variant
  * `{ enabled: false, featureVersion: null, minimumVersion: null }`.
  * Returns `true` only when `enabled: true` AND the current extension
@@ -27,6 +26,5 @@ import { ENABLE_DMK_FEATURE_FLAG } from '../../../shared/lib/hardware-wallets/fe
  */
 export const getIsDmkEnabled = createSelector(
   getRemoteFeatureFlags,
-  (remoteFeatureFlags): boolean =>
-    getBooleanFeatureFlag(remoteFeatureFlags[ENABLE_DMK_FEATURE_FLAG], false),
+  (remoteFeatureFlags): boolean => isDmkFeatureEnabled(remoteFeatureFlags),
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This is **PR 2 of 5** in the iterative split of [#44773](https://github.com/MetaMask/metamask-extension/pull/44773), stacked on the merged dependencies PR [#45044](https://github.com/MetaMask/metamask-extension/pull/45044).

This PR introduces a shared helper for resolving the `ledgerDmk` remote flag (background + UI) and clearer mapping when the Chrome runtime / offscreen Ledger bridge is unavailable.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-2111

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Ledger handler mode selection via remote flags and changes how bridge-unavailable errors are classified for UX; logic is refactored with tests but affects hardware-wallet flows.
> 
> **Overview**
> Introduces **`isDmkFeatureEnabled`** so background (`getLedgerMode`) and the UI **`getIsDmkEnabled`** selector resolve the **`ledgerDmk`** remote flag the same way, instead of each caller using **`getBooleanFeatureFlag`** directly. The helper is re-exported from **`shared/lib/hardware-wallets`** and covered by new unit tests.
> 
> For **Ledger** errors, **`tryFromLedgerErrorMessage`** now classifies Chrome runtime / offscreen failures (e.g. “receiving end does not exist”, “could not establish connection”, “offscreen document is not available”) as **`ConnectionTransportMissing`**, preserving the original message for diagnostics while UI copy stays localized via **`ErrorCode`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d27142b70c3d0a0aebe4ce9bbf650f0896a3814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->