### PR TITLE
fix: preserve enabled networks when adding a non-popular network

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2456,11 +2456,18 @@ export default class MetamaskController extends EventEmitter {
    * @param {object} networkConfiguration - The network configuration to add.
    * @param {object} [options0] - Options for post-add behavior.
    * @param {boolean} [options0.setActive] - Whether to switch to the added network.
+   * @param {boolean} [options0.enableNetwork] - When `setActive` is false, whether
+   * to additionally mark the added network as enabled (in addition to restoring
+   * every other network's prior enabled state). Without this,
+   * `NetworkEnablementController#onAddNetwork`'s exclusive-switch side effect is
+   * fully undone, including for the network just added, so it ends up added but
+   * disabled. Needed for callers where the user expects the network they just
+   * picked to show up immediately, without disabling their other enabled networks.
    * @returns {Promise<object>} The added network configuration.
    */
   async _addNetworkAndSetActive(
     networkConfiguration,
-    { setActive = true } = {},
+    { setActive = true, enableNetwork = false } = {},
   ) {
     if (setActive) {
       const addedNetwork =
@@ -2481,8 +2488,17 @@ export default class MetamaskController extends EventEmitter {
         'NetworkEnablementController:stateChange',
         restorePreviousEnabledNetworkMap,
       );
+      const enabledNetworkMapToRestore = enableNetwork
+        ? {
+            ...previousEnabledNetworkMap,
+            eip155: {
+              ...previousEnabledNetworkMap.eip155,
+              [networkConfiguration.chainId]: true,
+            },
+          }
+        : previousEnabledNetworkMap;
       this.networkEnablementController.restoreEnabledNetworkMap(
-        previousEnabledNetworkMap,
+        enabledNetworkMapToRestore,
       );
     };
 

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -500,7 +500,13 @@ const HomeNetworkFilterModalContent = ({
 
   const handleAddNetwork = useCallback(
     async (network: AddNetworkFields) => {
-      await dispatch(addNetwork(network));
+      // setActive: false + enableNetwork: true adds and enables this network
+      // without disabling every other currently-enabled network, which is
+      // NetworkEnablementController#onAddNetwork's default side effect for
+      // any non-popular (e.g. Base Enablement) network.
+      await dispatch(
+        addNetwork(network, { setActive: false, enableNetwork: true }),
+      );
       onClose();
     },
     [dispatch, onClose],

--- a/ui/components/multichain/network-manager/hooks/useAdditionalNetworkHandlers.ts
+++ b/ui/components/multichain/network-manager/hooks/useAdditionalNetworkHandlers.ts
@@ -11,8 +11,13 @@ export const useAdditionalNetworkHandlers = () => {
     async (network: UpdateNetworkFields) => {
       await dispatch(hideModal());
 
-      // First add the network to user's configuration
-      await dispatch(addNetwork(network));
+      // setActive: false + enableNetwork: true adds and enables this network
+      // without disabling every other currently-enabled network, which is
+      // NetworkEnablementController#onAddNetwork's default side effect for
+      // any non-popular (e.g. Base Enablement) network.
+      await dispatch(
+        addNetwork(network, { setActive: false, enableNetwork: true }),
+      );
     },
     [dispatch],
   );

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2357,7 +2357,7 @@ export function deleteExpiredNotifications(): ThunkAction<
 
         return Boolean(
           notification.readDate &&
-          new Date(notification.readDate) < expirationTime,
+            new Date(notification.readDate) < expirationTime,
         );
       })
       .map(({ id }) => id);
@@ -3615,7 +3615,7 @@ export function createSpeedUpTransaction(
 }
 export function addNetwork(
   networkConfiguration: AddNetworkFields | UpdateNetworkFields,
-  options: { setActive?: boolean } = {},
+  options: { setActive?: boolean; enableNetwork?: boolean } = {},
 ): ThunkAction<
   Promise<NetworkConfiguration>,
   MetaMaskReduxState,


### PR DESCRIPTION
NetworkEnablementController#onAddNetwork disables every currently-enabled network across all namespaces (EVM and non-EVM alike) whenever a non-popular network is added, since `shouldKeepCurrentSelection` requires the network being added to itself be popular/featured. A custom network (e.g. a Base Enablement candidate) never satisfies that, so adding one always wipes the enabled state of every other network the user had on, including built-in defaults and other custom networks, non-EVM chains like Solana/Bitcoin included.

The Home network filter modal and Network Manager's "Add network" flows called `addNetwork()` with no options, defaulting to `setActive: true`, which skips the extension's existing enabled-network snapshot/restore logic entirely. Even switching to `setActive: false` wasn't enough on its own: restoring the previous enabled-network snapshot fully undoes the controller's switch, including for the network that was just added, so it ends up added but disabled.

Add an `enableNetwork` option to `addNetwork`/`_addNetworkAndSetActive` so that, on the `setActive: false` path, we restore every other network's prior enabled state AND explicitly enable the newly-added network. Update both UI callers to pass `{ setActive: false, enableNetwork: true }`.

Manual test steps:
1. Enable more than one network that isn't part of the "select all default networks" set, e.g. enable Ethereum Mainnet and Solana together (or enable two custom/non-featured networks).
2. Open the network filter (home asset list network dropdown) or Network Manager and confirm both show as enabled/checked.
3. Add a brand new custom network via "Add network" in either surface.
4. Before this fix: reopening the network filter shows only the newly-added network checked; Ethereum Mainnet/Solana (or whichever networks were enabled) are now unchecked, and their balances/activity drop out of aggregated views (portfolio total, Activity tab) until manually re-enabled. After this fix: the previously-enabled networks remain checked, and the newly-added network is checked too.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
