### PR TITLE
fix: show native BTC icon and disabled toggle in Manage Tokens search

### DIFF
--- a/ui/components/app/assets/asset-list/cells/asset-cell-badge.test.ts
+++ b/ui/components/app/assets/asset-list/cells/asset-cell-badge.test.ts
@@ -38,4 +38,17 @@ describe('getAvatarTokenSrc', () => {
       }),
     ).toBe(mockMainnetImage);
   });
+
+  it('falls back to the static CDN icon for native non-EVM tokens without an image', () => {
+    expect(
+      getAvatarTokenSrc({
+        chainId: 'bip122:000000000019d6689c085ae165831e93',
+        isNative: true,
+        tokenImage: '',
+        assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+      }),
+    ).toBe(
+      'https://static.cx.metamask.io/api/v2/tokenIcons/assets/bip122/000000000019d6689c085ae165831e93/slip44/0.png',
+    );
+  });
 });

--- a/ui/components/app/assets/asset-list/cells/asset-cell-badge.tsx
+++ b/ui/components/app/assets/asset-list/cells/asset-cell-badge.tsx
@@ -37,7 +37,9 @@ export const getAvatarTokenSrc = (
       return getNativeCurrencyForChain(opts.chainId) ?? opts.tokenImage ?? '';
     }
 
-    if (!opts.tokenImage && opts.assetId && !opts.isNative) {
+    // Fall back to the static CDN icon for any asset (including non-EVM natives
+    // like BTC) when the API/search payload omits an image URL.
+    if (!opts.tokenImage && opts.assetId) {
       return getAssetImageUrl(opts.assetId, opts.chainId) ?? '';
     }
 

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -1257,7 +1257,7 @@ export const TokenManagementPage = () => {
           disabled={payload.isNative || isPending}
           isLoading={isPending}
           onToggle={(nextValue) => handleSearchResultToggle(payload, nextValue)}
-          showToggle={!payload.isNative}
+          showToggle
           testIdSuffix={`search-${lowerAssetId}`}
         />
       );


### PR DESCRIPTION
This PR is to update the static CDN icon fallback for native non-EVM assets when search omits iconUrl, and always render the toggle for search rows (natives stay disabled) so search matches the owned-token list behavior.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Should show token image and disabled toggle when user enters a non evm token in search

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/27b931a2-8b72-4135-a88e-8e7211f60943


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only changes to avatar URL resolution and toggle visibility, with a focused unit test and no auth or data-path changes.
> 
> **Overview**
> Fixes **Manage Tokens** search when API results omit `iconUrl`, especially for **native non-EVM assets** (e.g. BTC).
> 
> `getAvatarTokenSrc` now uses the static CDN via `getAssetImageUrl` whenever `tokenImage` is missing and `assetId` is present—including native tokens—instead of skipping natives after the EVM native path. A unit test covers Bitcoin mainnet native with an empty image.
> 
> On the token management page, search result rows **always show the visibility toggle** (`showToggle`), aligned with the owned-token list. Native search hits stay **non-interactive** via existing `disabled={payload.isNative || isPending}` rather than hiding the control entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b90996655c23ceae28b88422feedfff9e16088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->