### PR TITLE
fix(ci): avoid unnecessary rebuilds when the run listing comes back stale

### DIFF
--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -651,6 +651,15 @@ jobs:
       # Benchmarks measure build output performance — reused builds produce
       # identical results, so running them is pointless. This absorbs the
       # inline builds-from-run == github.run_id gate from main.yml.
+      #
+      # The decision is pinned to the head SHA as a commit status, because the
+      # inputs to it drift with the clock: `find-reusable-builds` scans only the
+      # 10 most recent runs on a branch and additionally requires that run's
+      # artifacts to still exist. The same commit can therefore resolve to
+      # "reusable" on one attempt and "not reusable" on the next. Left unpinned
+      # that is a gate bypass, since a skipped job counts as passing in
+      # ci-status-gate.yml — a failing benchmark gate could be cleared by
+      # re-running until the lookup happened to find a base build.
       - name: Compute needs-benchmarks flag
         id: set-needs-benchmarks
         # Skip on cross-repo PRs — benchmarks need secrets not available to external contributors.
@@ -661,18 +670,65 @@ jobs:
             env.EVENT_NAME != 'merge_group' &&
             steps.set-skip-everything.outputs.skip-everything != 'true'
           }}
+        uses: actions/github-script@v8
         env:
           BUILDS_FROM_BASE_BRANCH: ${{ steps.find-reusable-builds.outputs.builds-from-base-branch }}
-        run: |
-          echo "=== Benchmarks skip decision ==="
-          echo "  Builds from base branch: $BUILDS_FROM_BASE_BRANCH"
+          HEAD_COMMIT_HASH: ${{ env.HEAD_COMMIT_HASH }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = process.env.HEAD_COMMIT_HASH;
+            const statusContext = 'benchmarks-required';
 
-          if [[ "$BUILDS_FROM_BASE_BRANCH" == "true" ]]; then
-            echo "-> needs-benchmarks=false (builds from base branch — identical output)"
-          else
-            echo "needs-benchmarks=true" >> "$GITHUB_OUTPUT"
-            echo "-> needs-benchmarks=true (fresh builds)"
-          fi
+            core.info('=== Benchmarks skip decision ===');
+            core.info(`  Builds from base branch: ${process.env.BUILDS_FROM_BASE_BRANCH}`);
+
+            // Honour a decision already recorded for this commit, so a re-run
+            // cannot turn a gated commit into an ungated one.
+            let pinned;
+            try {
+              const { data: { statuses } } = await github.rest.repos.getCombinedStatusForRef({
+                owner,
+                repo,
+                ref: sha,
+                per_page: 100,
+              });
+              pinned = statuses.find((s) => s.context === statusContext)?.description;
+            } catch (err) {
+              core.warning(`Could not read ${statusContext} status: ${err.message}`);
+            }
+
+            if (pinned === 'true' || pinned === 'false') {
+              if (pinned === 'true') {
+                core.setOutput('needs-benchmarks', 'true');
+              }
+              core.info(`-> needs-benchmarks=${pinned} (pinned to ${sha.slice(0, 9)} by an earlier attempt)`);
+              return;
+            }
+
+            const required = process.env.BUILDS_FROM_BASE_BRANCH !== 'true';
+            if (required) {
+              core.setOutput('needs-benchmarks', 'true');
+              core.info('-> needs-benchmarks=true (fresh builds)');
+            } else {
+              core.info('-> needs-benchmarks=false (builds from base branch — identical output)');
+            }
+
+            // Best-effort, like the other commit statuses in this job: if the
+            // write fails, the next attempt simply recomputes as before.
+            try {
+              await github.rest.repos.createCommitStatus({
+                owner,
+                repo,
+                sha,
+                state: 'success',
+                context: statusContext,
+                description: String(required),
+              });
+              core.info(`Posted ${statusContext}: ${required}`);
+            } catch (err) {
+              core.warning(`Could not post ${statusContext} status: ${err.message}`);
+            }
 
       - name: Compute needs-e2e flag
         id: set-needs-e2e

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -335,8 +335,15 @@ jobs:
             async function findMatchingRun(searchBranch) {
               core.info(`Searching branch '${searchBranch}' for matching build hash...`);
 
-              let runs;
-              try {
+              // This listing intermittently serves a stale page: observed returning
+              // ten contiguous runs from four weeks earlier, and on another
+              // occasion from four months earlier, while hundreds of newer runs
+              // existed. A stale page contains no recent build, so the lookup
+              // concludes "nothing reusable" and rebuilds work that was already
+              // done. Re-request once when the newest run returned predates the
+              // last push; the staleness is transient and a second call usually
+              // gets current data.
+              async function listRuns() {
                 const resp = await github.rest.actions.listWorkflowRuns({
                   owner,
                   repo,
@@ -344,7 +351,22 @@ jobs:
                   branch: searchBranch,
                   per_page: 10,
                 });
-                runs = resp.data.workflow_runs ?? [];
+                return resp.data.workflow_runs ?? [];
+              }
+
+              let runs;
+              try {
+                runs = await listRuns();
+                const newest = runs[0]?.created_at;
+                const lastPush = context.payload.repository?.pushed_at;
+                if (newest && lastPush && new Date(newest) < new Date(lastPush)) {
+                  core.info(`Newest '${searchBranch}' run is ${newest}, older than the last push — re-requesting.`);
+                  const retry = await listRuns();
+                  if ((retry[0]?.created_at ?? '') > newest) {
+                    core.info(`-> retry returned fresher data (${retry[0].created_at})`);
+                    runs = retry;
+                  }
+                }
               } catch (err) {
                 core.warning(`API error listing runs for '${searchBranch}': ${err.message}`);
                 return false;
@@ -651,13 +673,6 @@ jobs:
       # Benchmarks measure build output performance — reused builds produce
       # identical results, so running them is pointless. This absorbs the
       # inline builds-from-run == github.run_id gate from main.yml.
-      #
-      # The decision is pinned to the head SHA as a commit status, because the
-      # lookup behind it is not deterministic: the workflow-run listing it
-      # depends on intermittently returns a stale page, so an unchanged commit
-      # can require benchmarks on one attempt and skip them on the next. Left
-      # unpinned that is a gate bypass, since a skipped job counts as passing
-      # in ci-status-gate.yml.
       - name: Compute needs-benchmarks flag
         id: set-needs-benchmarks
         # Skip on cross-repo PRs — benchmarks need secrets not available to external contributors.
@@ -668,82 +683,18 @@ jobs:
             env.EVENT_NAME != 'merge_group' &&
             steps.set-skip-everything.outputs.skip-everything != 'true'
           }}
-        uses: actions/github-script@v8
         env:
           BUILDS_FROM_BASE_BRANCH: ${{ steps.find-reusable-builds.outputs.builds-from-base-branch }}
-          HEAD_COMMIT_HASH: ${{ env.HEAD_COMMIT_HASH }}
-          SKIP_BUILDS: ${{ steps.build-overrides.outputs.skip }}
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const sha = process.env.HEAD_COMMIT_HASH;
-            const statusContext = 'benchmarks-required';
+        run: |
+          echo "=== Benchmarks skip decision ==="
+          echo "  Builds from base branch: $BUILDS_FROM_BASE_BRANCH"
 
-            core.info('=== Benchmarks skip decision ===');
-            core.info(`  Builds from base branch: ${process.env.BUILDS_FROM_BASE_BRANCH}`);
-
-            // Honour a decision already recorded for this commit, so a re-run
-            // cannot turn a gated commit into an ungated one.
-            let pinned;
-            try {
-              const { data: { statuses } } = await github.rest.repos.getCombinedStatusForRef({
-                owner,
-                repo,
-                ref: sha,
-                per_page: 100,
-              });
-              pinned = statuses.find((s) => s.context === statusContext)?.description;
-            } catch (err) {
-              core.warning(`Could not read ${statusContext} status: ${err.message}`);
-            }
-
-            if (pinned === 'true' || pinned === 'false') {
-              if (pinned === 'true') {
-                core.setOutput('needs-benchmarks', 'true');
-              }
-              core.info(`-> needs-benchmarks=${pinned} (pinned to ${sha.slice(0, 9)} by an earlier attempt)`);
-              return;
-            }
-
-            const required = process.env.BUILDS_FROM_BASE_BRANCH !== 'true';
-            if (required) {
-              core.setOutput('needs-benchmarks', 'true');
-              core.info('-> needs-benchmarks=true (fresh builds)');
-            } else {
-              core.info('-> needs-benchmarks=false (builds from base branch — identical output)');
-            }
-
-            // Never pin a decision reached under [skip-builds]. That path skips the
-            // build-hash check when matching a donor run, so `builds-from-base-branch`
-            // can be true without the build output being equivalent, and the resulting
-            // `false` says nothing about this commit. ci-status-gate blocks the merge
-            // while the label is present, but that block lifts when the label is
-            // removed — so a pin written here would outlive the only thing making it
-            // safe, and a same-SHA re-run would skip benchmarks with nothing blocking.
-            // Reading an existing pin stays unconditional: one written by a normal,
-            // hash-checked evaluation is still valid.
-            if (process.env.SKIP_BUILDS === 'true') {
-              core.info(
-                `Not pinning ${statusContext} under [skip-builds] — the decision was made without a build-hash check`,
-              );
-              return;
-            }
-
-            // Best-effort, like the other commit statuses in this job: if the
-            // write fails, the next attempt simply recomputes as before.
-            try {
-              await github.rest.repos.createCommitStatus({
-                owner,
-                repo,
-                sha,
-                state: 'success',
-                context: statusContext,
-                description: String(required),
-              });
-              core.info(`Posted ${statusContext}: ${required}`);
-            } catch (err) {
-              core.warning(`Could not post ${statusContext} status: ${err.message}`);
-            }
+          if [[ "$BUILDS_FROM_BASE_BRANCH" == "true" ]]; then
+            echo "-> needs-benchmarks=false (builds from base branch — identical output)"
+          else
+            echo "needs-benchmarks=true" >> "$GITHUB_OUTPUT"
+            echo "-> needs-benchmarks=true (fresh builds)"
+          fi
 
       - name: Compute needs-e2e flag
         id: set-needs-e2e

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -652,11 +652,12 @@ jobs:
       # identical results, so running them is pointless. This absorbs the
       # inline builds-from-run == github.run_id gate from main.yml.
       #
-      # Pinned to the head SHA because the lookup is not deterministic: the
-      # workflow-run listing behind it intermittently returns a stale page, so
-      # an unchanged commit can require benchmarks on one attempt and skip them
-      # on the next. Left unpinned that is a gate bypass, since a skipped job
-      # counts as passing in ci-status-gate.yml.
+      # The decision is pinned to the head SHA as a commit status, because the
+      # lookup behind it is not deterministic: the workflow-run listing it
+      # depends on intermittently returns a stale page, so an unchanged commit
+      # can require benchmarks on one attempt and skip them on the next. Left
+      # unpinned that is a gate bypass, since a skipped job counts as passing
+      # in ci-status-gate.yml.
       - name: Compute needs-benchmarks flag
         id: set-needs-benchmarks
         # Skip on cross-repo PRs — benchmarks need secrets not available to external contributors.

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -335,49 +335,42 @@ jobs:
             async function findMatchingRun(searchBranch) {
               core.info(`Searching branch '${searchBranch}' for matching build hash...`);
 
-              // This listing intermittently serves a stale page: observed returning
-              // ten contiguous runs from four weeks earlier, and on another
-              // occasion from four months earlier, while hundreds of newer runs
-              // existed. A stale page contains no recent build, so the lookup
-              // concludes "nothing reusable" and rebuilds work that was already
-              // done. Re-request once when the newest run returned predates the
-              // last push; the staleness is transient and a second call usually
-              // gets current data.
+              // Stops CI rebuilding work that already exists. This listing
+              // intermittently serves a stale page — observed returning ten
+              // contiguous runs four weeks old, and once four months old, while
+              // hundreds of newer ones existed — so the scan below finds no
+              // reusable build and everything gets built again.
+              //
+              // The retry hangs off the miss rather than off a guess about
+              // freshness, so it only costs a call on the path that had already
+              // decided to rebuild. Its own try/catch keeps a failed retry from
+              // discarding a first listing that succeeded.
               async function listRuns() {
-                const resp = await github.rest.actions.listWorkflowRuns({
-                  owner,
-                  repo,
-                  workflow_id: 'main.yml',
-                  branch: searchBranch,
-                  per_page: 10,
-                });
-                return resp.data.workflow_runs ?? [];
+                try {
+                  const resp = await github.rest.actions.listWorkflowRuns({
+                    owner,
+                    repo,
+                    workflow_id: 'main.yml',
+                    branch: searchBranch,
+                    per_page: 10,
+                  });
+                  return resp.data.workflow_runs ?? [];
+                } catch (err) {
+                  core.warning(`API error listing runs for '${searchBranch}': ${err.message}`);
+                  return null;
+                }
               }
 
-              let runs;
-              try {
-                runs = await listRuns();
-                const newest = runs[0]?.created_at;
-                const lastPush = context.payload.repository?.pushed_at;
-                if (newest && lastPush && new Date(newest) < new Date(lastPush)) {
-                  core.info(`Newest '${searchBranch}' run is ${newest}, older than the last push — re-requesting.`);
-                  const retry = await listRuns();
-                  if ((retry[0]?.created_at ?? '') > newest) {
-                    core.info(`-> retry returned fresher data (${retry[0].created_at})`);
-                    runs = retry;
-                  }
-                }
-              } catch (err) {
-                core.warning(`API error listing runs for '${searchBranch}': ${err.message}`);
-                return false;
-              }
+              const runs = await listRuns();
+              if (runs === null) return false;
 
               // 'in_progress' is included intentionally: a concurrent run that
               // already uploaded all build artifacts can be reused even before it
               // finishes its E2E/lint jobs. The artifact completeness check below
               // ensures we never use a run with missing uploads.
               const allowedStatuses = new Set(['completed', 'in_progress']);
-              for (const run of runs) {
+              async function scan(candidates) {
+              for (const run of candidates) {
                 if (!allowedStatuses.has(run.status)) continue;
                 if (run.id === currentRunId) continue;
 
@@ -421,6 +414,17 @@ jobs:
                 }
               }
               return false;
+              }
+
+              if (await scan(runs)) return true;
+
+              // Nothing matched. Re-request once in case the page was stale, and
+              // rescan only if it actually came back different.
+              const retry = await listRuns();
+              if (retry === null) return false;
+              if ((retry[0]?.id ?? null) === (runs[0]?.id ?? null)) return false;
+              core.info(`-> re-requested '${searchBranch}': listing changed, rescanning`);
+              return await scan(retry);
             }
 
             try {

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -674,6 +674,7 @@ jobs:
         env:
           BUILDS_FROM_BASE_BRANCH: ${{ steps.find-reusable-builds.outputs.builds-from-base-branch }}
           HEAD_COMMIT_HASH: ${{ env.HEAD_COMMIT_HASH }}
+          SKIP_BUILDS: ${{ steps.build-overrides.outputs.skip }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -712,6 +713,22 @@ jobs:
               core.info('-> needs-benchmarks=true (fresh builds)');
             } else {
               core.info('-> needs-benchmarks=false (builds from base branch — identical output)');
+            }
+
+            // Never pin a decision reached under [skip-builds]. That path skips the
+            // build-hash check when matching a donor run, so `builds-from-base-branch`
+            // can be true without the build output being equivalent, and the resulting
+            // `false` says nothing about this commit. ci-status-gate blocks the merge
+            // while the label is present, but that block lifts when the label is
+            // removed — so a pin written here would outlive the only thing making it
+            // safe, and a same-SHA re-run would skip benchmarks with nothing blocking.
+            // Reading an existing pin stays unconditional: one written by a normal,
+            // hash-checked evaluation is still valid.
+            if (process.env.SKIP_BUILDS === 'true') {
+              core.info(
+                `Not pinning ${statusContext} under [skip-builds] — the decision was made without a build-hash check`,
+              );
+              return;
             }
 
             // Best-effort, like the other commit statuses in this job: if the

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -652,14 +652,11 @@ jobs:
       # identical results, so running them is pointless. This absorbs the
       # inline builds-from-run == github.run_id gate from main.yml.
       #
-      # The decision is pinned to the head SHA as a commit status, because the
-      # inputs to it drift with the clock: `find-reusable-builds` scans only the
-      # 10 most recent runs on a branch and additionally requires that run's
-      # artifacts to still exist. The same commit can therefore resolve to
-      # "reusable" on one attempt and "not reusable" on the next. Left unpinned
-      # that is a gate bypass, since a skipped job counts as passing in
-      # ci-status-gate.yml — a failing benchmark gate could be cleared by
-      # re-running until the lookup happened to find a base build.
+      # Pinned to the head SHA because the lookup is not deterministic: the
+      # workflow-run listing behind it intermittently returns a stale page, so
+      # an unchanged commit can require benchmarks on one attempt and skip them
+      # on the next. Left unpinned that is a gate bypass, since a skipped job
+      # counts as passing in ci-status-gate.yml.
       - name: Compute needs-benchmarks flag
         id: set-needs-benchmarks
         # Skip on cross-repo PRs — benchmarks need secrets not available to external contributors.


### PR DESCRIPTION
## **Changelog**

CHANGELOG entry: null

## **Description**

CI sometimes rebuilds work that already exists and runs a full benchmark suite against it, because a reusable build was there and the lookup didn't see it.

`find-reusable-builds` takes the 10 most recent `main.yml` runs and uses whatever the API returns, and that listing intermittently serves a stale page.

Two cases in the 250 most recent PRs, both from the `get-requirements` job logs:

These are CI runs on https://github.com/MetaMask/metamask-extension/pull/45412:
- [Attempt 1](https://github.com/MetaMask/metamask-extension/actions/runs/31507480239/job/93832657904#step:9:1) got ten `main` runs, all created 2026-07-15, and [ran the benchmarks](https://github.com/MetaMask/metamask-extension/actions/runs/31507480239/job/93834301133) across 19 jobs. Those ten are exactly the ten `main.yml` runs in that window, with several hundred newer ones already in existence, so it was page 1 of a frozen listing rather than a filter.
- It didn't include [an earlier run from the same day](https://github.com/MetaMask/metamask-extension/actions/runs/31494719122/job/93823486364#step:6:1) carrying the same build hash.
- [Attempt 3](https://github.com/MetaMask/metamask-extension/actions/runs/31507480239/job/93856676795#step:9:1) found that build hash, and [`run-benchmarks` was skipped](https://github.com/MetaMask/metamask-extension/actions/runs/31507480239/job/93856848116) down to a single job.

And on https://github.com/MetaMask/metamask-extension/pull/45172:
- [Attempt 1](https://github.com/MetaMask/metamask-extension/actions/runs/31365356027/job/93382451828#step:9:1) got ten runs from 2026-03-24/25, every one recording `hash not found` because they predate the `build-source-hash` status, and [ran benchmarks](https://github.com/MetaMask/metamask-extension/actions/runs/31365356027/job/93383446960) across 17 jobs.
- [Attempt 4](https://github.com/MetaMask/metamask-extension/actions/runs/31365356027/job/93413164147#step:9:1) got current runs and [skipped them](https://github.com/MetaMask/metamask-extension/actions/runs/31365356027/job/93413322640).

`build-source-hash` was identical across attempts in both, so the input never changed — only what the listing returned.

### What this changes

When the scan finds no reusable build, the listing is re-requested once and rescanned only if it came back different. Hanging the retry off the miss means it costs an extra call only where CI had already decided to rebuild, and `listRuns` owns its own `try/catch` so a failed retry cannot discard a first listing that succeeded.

An earlier revision triggered the retry on a freshness comparison against `repository.pushed_at` instead. That is repo-wide, so a PR's own push made it newer than `main`'s latest run and the retry fired on nearly every base-branch lookup.

### What this does not claim

An earlier version of this PR pinned the decision to the head SHA, on the theory that re-running could clear a failed benchmark gate. That framing was wrong. When `build-source-hash` matches a base build the build output is identical, so skipping is the intended outcome — the later attempt had the right answer, and pinning would have frozen the earlier wrong one.

Staleness also only ever causes a miss, never a spurious match, since a match still requires hash equality and every required artifact present. The remaining cost is a wasted build-and-benchmark cycle, not a gating hole.

The skip that would genuinely be wrong is a PR touching only benchmark-owned files, where the build hash matches and the change goes unmeasured. That is https://github.com/MetaMask/metamask-extension/pull/45460.
