### PR TITLE
feat: updated typography changes in search

### DIFF
--- a/ui/pages/discover-search/discover-no-results-state.tsx
+++ b/ui/pages/discover-search/discover-no-results-state.tsx
@@ -79,7 +79,7 @@ export const DiscoverNoResultsState = ({
       className="flex h-full flex-col items-center gap-4 px-4 pt-[60px] text-center"
       data-testid="discover-search-no-results"
     >
-      <Box className="flex flex-col items-center gap-[18px]">
+      <Box className="flex w-full min-w-0 flex-col items-center gap-[18px]">
         <img
           src={activityIcon}
           alt=""
@@ -88,11 +88,11 @@ export const DiscoverNoResultsState = ({
           aria-hidden="true"
           data-testid="discover-search-no-results-illustration"
         />
-        <Box className="flex w-full max-w-full flex-col items-center gap-1 overflow-hidden">
+        <Box className="flex w-full max-w-full flex-col items-center gap-1">
           <Text
             variant={TextVariant.BodyMd}
             textAlign={TextAlign.Center}
-            className="max-w-full truncate"
+            className="w-full max-w-[320px] whitespace-normal break-words"
           >
             {t('discoverSearchNoResultsFor', [query])}
           </Text>

--- a/ui/pages/discover-search/discover-search.tsx
+++ b/ui/pages/discover-search/discover-search.tsx
@@ -606,7 +606,7 @@ export const DiscoverSearchPage = () => {
         ) : null}
 
         <Tab
-          name={t('tokenStock')}
+          name={t('perpsFilterStocks')}
           tabKey="stocks"
           data-testid="discover-tab-stocks"
         >


### PR DESCRIPTION
This PR:
1. Fixes the stock title to "stocks"
2. Updates the styling for no search when input string is too long

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
3. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
4.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1636" height="1370" alt="Screenshot 2026-08-10 at 12 26 50 PM" src="https://github.com/user-attachments/assets/b7a59a5f-7af1-4988-94f1-c07be6f5b8ff" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and CSS-only tweaks on discover search UI with no logic or data-path changes.
> 
> **Overview**
> Improves discover search polish when a query returns nothing and aligns the Stocks tab label with the rest of discover.
> 
> The **no-results** empty state no longer **truncates** the “no results for …” line. That message now **wraps** within a **320px** max width (`whitespace-normal`, `break-words`), and the illustration block gets **`w-full min-w-0`** so long strings don’t blow out the flex layout. **`overflow-hidden`** was dropped from the inner text container.
> 
> The **Stocks** tab label switches from **`tokenStock`** to **`perpsFilterStocks`**, matching the “Stocks” wording used on the All tab section headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad06f39f9a421cbe6548154c44207838b242915e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->