### PR TITLE
chore: bump `@metamask/bitcoin-wallet-snap` to `^2.0.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -374,7 +374,7 @@
     "@metamask/assets-controllers": "^111.0.0",
     "@metamask/authenticated-user-storage": "^3.0.0",
     "@metamask/base-controller": "^9.0.1",
-    "@metamask/bitcoin-wallet-snap": "^1.14.2",
+    "@metamask/bitcoin-wallet-snap": "^2.0.1",
     "@metamask/bitcoin-wallet-standard": "^1.1.0",
     "@metamask/bridge-controller": "^79.0.1",
     "@metamask/bridge-status-controller": "^75.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6088,10 +6088,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bitcoin-wallet-snap@npm:^1.14.2":
-  version: 1.14.2
-  resolution: "@metamask/bitcoin-wallet-snap@npm:1.14.2"
-  checksum: 10/1d109536bdbf2e840eb0ce7867c5c1c2416946b8e5d003b05d1b23a579eaa8c8ee023703e7c87f4096833806e8309ca1eb846cde5a450c28b0ae9f81c6abf561
+"@metamask/bitcoin-wallet-snap@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@metamask/bitcoin-wallet-snap@npm:2.0.1"
+  checksum: 10/ed8c92f6959f2e9a51a3496373217cff8d6a3ca248211aad6f2fe87739d6d9f389f7f526f7e5166acac657bf81d6dd169487288d686067a9b91eed30f79222e5
   languageName: node
   linkType: hard
 
@@ -33248,7 +33248,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^5.3.1"
     "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bitcoin-regtest-up": "npm:^1.0.0"
-    "@metamask/bitcoin-wallet-snap": "npm:^1.14.2"
+    "@metamask/bitcoin-wallet-snap": "npm:^2.0.1"
     "@metamask/bitcoin-wallet-standard": "npm:^1.1.0"
     "@metamask/bridge-controller": "npm:^79.0.1"
     "@metamask/bridge-status-controller": "npm:^75.0.0"


### PR DESCRIPTION
## Description

Bringing the following changes to the client:

    ## [2.0.1]

    ### Fixed

    - Fix `onKeyringRequest` responses to correctly return `Json` directly (v2 protocol) instead of v1's `{ pending: false, result }` envelope ([#100](https://github.com/MetaMask/internal-snaps/pull/100))

## Changelog

CHANGELOG entry: null

## Related issues

n/a

## Manual testing steps

n/a

## Screenshots/Recordings

### Before

n/a

### After

n/a