### PR TITLE
chore: bump `@metamask/solana-wallet-snap` to `^6.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -476,7 +476,7 @@
     "@metamask/snaps-rpc-methods": "^17.1.0",
     "@metamask/snaps-sdk": "^11.2.0",
     "@metamask/snaps-utils": "^12.4.0",
-    "@metamask/solana-wallet-snap": "^2.10.0",
+    "@metamask/solana-wallet-snap": "^6.0.0",
     "@metamask/solana-wallet-standard": "^1.0.0",
     "@metamask/storage-service": "^1.0.0",
     "@metamask/subscription-controller": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8654,10 +8654,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/solana-wallet-snap@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "@metamask/solana-wallet-snap@npm:2.10.0"
-  checksum: 10/cb62950bbba0bc23974f0f50597382fb35ff4c0778d863911b872913cb667e1ca11fcdc0a6b808ccfeb8185ce0a467ea85ff7298a086e68b11eb2e9edbab8c39
+"@metamask/solana-wallet-snap@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/solana-wallet-snap@npm:6.0.0"
+  checksum: 10/9f9e1484a85dc0aaba650fc721bbfaf295b93091469f9146a59b30bcd6eec874deb03c266f7c20a0a9a40e96071dc99cfe5edefd9d8d1b68734510615d6bad61
   languageName: node
   linkType: hard
 
@@ -33371,7 +33371,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:^11.2.0"
     "@metamask/snaps-utils": "npm:^12.4.0"
     "@metamask/solana-test-validator-up": "npm:^1.0.0"
-    "@metamask/solana-wallet-snap": "npm:^2.10.0"
+    "@metamask/solana-wallet-snap": "npm:^6.0.0"
     "@metamask/solana-wallet-standard": "npm:^1.0.0"
     "@metamask/storage-service": "npm:^1.0.0"
     "@metamask/subscription-controller": "npm:^6.2.0"


### PR DESCRIPTION
## Description

Bringing the following changes to the client:

    ## [6.0.0]

    ### Changed

    - Bump `@metamask/key-tree` from `9.1.2` to `^10.1.1` ([#133](https://github.com/MetaMask/internal-snaps/pull/133))

    ### Removed

    - **BREAKING:** Removed the legacy snap-hosted send dialog (`startSendTransactionFlow` RPC and `features/send` UI) ([#130](https://github.com/MetaMask/internal-snaps/pull/130))
    - **BREAKING:** Removed the deprecated `getFeeForTransaction` RPC ([#130](https://github.com/MetaMask/internal-snaps/pull/130))

## Changelog

CHANGELOG entry: null

## Related issues

n/a

## Manual testing steps

n/a

## Screenshots/Recordings

### Before

n/a

### After

n/a