### PR TITLE
perf(6551): unlock compiler memoization in 29 files via dep alignment

### DIFF
--- a/ui/components/app/balance-empty-state/balance-empty-state.tsx
+++ b/ui/components/app/balance-empty-state/balance-empty-state.tsx
@@ -87,7 +87,7 @@ export const BalanceEmptyState = ({
     );
 
     setIsModalOpen(true);
-  }, [chainId, trackEvent]);
+  }, [chainId, createEventBuilder, trackEvent]);
 
   // Handle modal close
   const handleModalClose = useCallback(() => {

--- a/ui/components/app/snaps/snap-ui-asset-selector/useSnapAssetDisplay.tsx
+++ b/ui/components/app/snaps/snap-ui-asset-selector/useSnapAssetDisplay.tsx
@@ -69,7 +69,10 @@ export const useSnapAssetSelectorData = ({
   const locale = useSelector(getIntlLocale);
   const { formatTokenQuantity } = useFormatters();
 
-  const parsedAccounts = addresses.map(parseCaipAccountId);
+  const parsedAccounts = useMemo(
+    () => addresses.map(parseCaipAccountId),
+    [addresses],
+  );
 
   const account = useSelector((state) =>
     getInternalAccountByAddress(state, parsedAccounts[0].address),
@@ -78,49 +81,49 @@ export const useSnapAssetSelectorData = ({
 
   const assets = useSelector((state) => getMultiChainAssets(state, account));
 
-  /**
-   * Formats a fiat balance.
-   *
-   * @param balance - The balance to format.
-   * @returns The formatted balance.
-   */
-  const formatFiatBalance = (balance: number | null = 0) =>
-    formatWithThreshold(balance, 0.01, locale, {
-      style: 'currency',
-      currency: currentCurrency.toUpperCase(),
-    });
-
-  /**
-   * Formats a non-EVM asset for the SnapUIAssetSelector.
-   *
-   * @param asset - The asset to format.
-   * @returns The formatted asset.
-   */
-  const formatAsset = (asset: TokenWithFiatAmount) => {
-    const networkName =
-      NETWORK_TO_SHORT_NETWORK_NAME_MAP[
-        asset.chainId as AllowedBridgeChainIds
-      ] ?? networks[asset.chainId]?.name;
-
-    return {
-      icon: asset.image,
-      symbol: asset.symbol,
-      name: asset.title,
-      balance: formatTokenQuantity(Number(asset.balance ?? 0), asset.symbol),
-      networkName,
-      networkIcon: getImageForChainId(asset.chainId),
-      fiat: formatFiatBalance(asset.secondary),
-      chainId: asset.chainId as CaipChainId,
-      address: asset.address as CaipAssetType,
-    };
-  };
-
-  // Filter the chain IDs to only include the requested ones.
-  const requestedChainIds = parsedAccounts
-    .map((chainId) => chainId)
-    .filter(({ chainId }) => (chainIds ? chainIds?.includes(chainId) : true));
-
   const formattedAssets = useMemo(() => {
+    /**
+     * Formats a fiat balance.
+     *
+     * @param balance - The balance to format.
+     * @returns The formatted balance.
+     */
+    const formatFiatBalance = (balance: number | null = 0) =>
+      formatWithThreshold(balance, 0.01, locale, {
+        style: 'currency',
+        currency: currentCurrency.toUpperCase(),
+      });
+
+    /**
+     * Formats a non-EVM asset for the SnapUIAssetSelector.
+     *
+     * @param asset - The asset to format.
+     * @returns The formatted asset.
+     */
+    const formatAsset = (asset: TokenWithFiatAmount) => {
+      const networkName =
+        NETWORK_TO_SHORT_NETWORK_NAME_MAP[
+          asset.chainId as AllowedBridgeChainIds
+        ] ?? networks[asset.chainId]?.name;
+
+      return {
+        icon: asset.image,
+        symbol: asset.symbol,
+        name: asset.title,
+        balance: formatTokenQuantity(Number(asset.balance ?? 0), asset.symbol),
+        networkName,
+        networkIcon: getImageForChainId(asset.chainId),
+        fiat: formatFiatBalance(asset.secondary),
+        chainId: asset.chainId as CaipChainId,
+        address: asset.address as CaipAssetType,
+      };
+    };
+
+    // Filter the chain IDs to only include the requested ones.
+    const requestedChainIds = parsedAccounts
+      .map((chainId) => chainId)
+      .filter(({ chainId }) => (chainIds ? chainIds?.includes(chainId) : true));
+
     // Filter the assets by the requested chain IDs
     const filteredAssets = assets.filter((asset) =>
       requestedChainIds.some(({ chainId, chain: { namespace, reference } }) => {
@@ -140,7 +143,15 @@ export const useSnapAssetSelectorData = ({
     const formatted: SnapUIAsset[] = filteredAssets.map(formatAsset);
 
     return formatted;
-  }, [assets]);
+  }, [
+    assets,
+    parsedAccounts,
+    chainIds,
+    networks,
+    formatTokenQuantity,
+    locale,
+    currentCurrency,
+  ]);
 
   return formattedAssets;
 };

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -216,6 +216,16 @@ type CoinButtonsProps = {
   buyAssetId?: CaipAssetType;
 };
 
+const getChainId = (
+  chainId: CoinButtonsProps['chainId'],
+): CaipChainId | ChainId => {
+  if (isCaipChainId(chainId)) {
+    return chainId as CaipChainId;
+  }
+  // Otherwise we assume that's an EVM chain ID, so use the usual 0x prefix
+  return toHex(chainId) as ChainId;
+};
+
 const CoinButtons = ({
   account,
   chainId,
@@ -315,14 +325,6 @@ const CoinButtons = ({
     return contents;
   };
 
-  const getChainId = (): CaipChainId | ChainId => {
-    if (isCaipChainId(chainId)) {
-      return chainId as CaipChainId;
-    }
-    // Otherwise we assume that's an EVM chain ID, so use the usual 0x prefix
-    return toHex(chainId) as ChainId;
-  };
-
   const getSnapAccountMetaMetricsPropertiesIfAny = (
     internalAccount: InternalAccount,
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -398,12 +400,21 @@ const CoinButtons = ({
     const params =
       trackingLocation === 'home' ? undefined : { chainId: chainId.toString() };
     transitionForward(() => navigateToSendRoute(navigate, params));
-  }, [chainId, account, setCorrectChain, trackingLocation]);
+  }, [
+    chainId,
+    account,
+    setCorrectChain,
+    trackingLocation,
+    nativeToken,
+    navigate,
+    trackEvent,
+    createEventBuilder,
+  ]);
 
   const handleBuyAndSellOnClick = useCallback(async () => {
     const opened = await goToBuy({
       assetId: buyAssetId,
-      chainId: getChainId(),
+      chainId: getChainId(chainId),
     });
     if (!opened) {
       return;
@@ -435,7 +446,17 @@ const CoinButtons = ({
         })
         .build(),
     );
-  }, [chainId, defaultSwapsToken, buyAssetId, goToBuy, opensBuyInPortfolioTab]);
+  }, [
+    chainId,
+    defaultSwapsToken,
+    buyAssetId,
+    goToBuy,
+    opensBuyInPortfolioTab,
+    account,
+    t,
+    trackEvent,
+    createEventBuilder,
+  ]);
 
   const handleSwapOnClick = useCallback(async () => {
     // Determine the chainId to use in the Swap experience using the url
@@ -484,7 +505,14 @@ const CoinButtons = ({
       // Show the traditional receive modal
       setShowReceiveModal(true);
     }
-  }, [selectedAccountGroup, navigate, trackEvent, trackingLocation, chainId]);
+  }, [
+    selectedAccountGroup,
+    navigate,
+    trackEvent,
+    trackingLocation,
+    chainId,
+    createEventBuilder,
+  ]);
 
   const handleBatchSellOnClick = useCallback(() => {
     trace({ name: TraceName.BatchSellModal });
@@ -502,7 +530,13 @@ const CoinButtons = ({
     );
 
     transitionForward(() => openBatchSellExperience());
-  }, [trackEvent, trackingLocation, chainId, openBatchSellExperience]);
+  }, [
+    trackEvent,
+    trackingLocation,
+    chainId,
+    openBatchSellExperience,
+    createEventBuilder,
+  ]);
 
   useOnClickOutside({
     containerRef,

--- a/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
+++ b/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
@@ -125,7 +125,7 @@ const PopularNetworkList = ({
         </Box>
       </Box>
     );
-  }, [searchAddNetworkResults, referenceElement, isOpen, t]);
+  }, [searchAddNetworkResults, referenceElement, isOpen, open, close, t]);
 
   return (
     <Box className="new-network-list__networks-container">

--- a/ui/hooks/bridge/useBridging.ts
+++ b/ui/hooks/bridge/useBridging.ts
@@ -46,6 +46,7 @@ const useBridging = () => {
   const fromChain = useSelector(getFromChain);
   const fromChains = useSelector(getFromChains);
   const bip44DefaultPairsConfig = useSelector(getBip44DefaultPairsConfig);
+  const fromChainId = fromChain?.chainId;
 
   const isChainIdEnabledForBridging = useCallback(
     (chainId: string | number) =>
@@ -132,9 +133,9 @@ const useBridging = () => {
           // Otherwise, set the `from` query param to use the bridge page's deep linking logic
           search.set(BridgeQueryParams.From, assetId);
         }
-      } else if (lastSelectedChainId !== fromChain.chainId) {
+      } else if (lastSelectedChainId !== fromChainId) {
         // If an unsupported network is selected in the network filter, use bridge page's default fromChain
-        const fallbackChainId = lastSelectedChainId ?? fromChain.chainId;
+        const fallbackChainId = lastSelectedChainId ?? fromChainId;
         const { namespace } = parseCaipChainId(fallbackChainId);
         // Use the bip44 default asset for the fallback chain if it is defined
         const bip44AssetId = Object.keys(
@@ -163,7 +164,7 @@ const useBridging = () => {
     [
       navigateToBridgePage,
       lastSelectedChainId,
-      fromChain?.chainId,
+      fromChainId,
       isChainIdEnabledForBridging,
       bip44DefaultPairsConfig,
       bridgeState,

--- a/ui/hooks/bridge/usePrefillFromSearchQuery.ts
+++ b/ui/hooks/bridge/usePrefillFromSearchQuery.ts
@@ -135,7 +135,7 @@ export const usePrefillFromSearchQuery = () => {
       // Clear parsed to asset ID after successful processing
       setParsedToAssetId(null);
     },
-    [],
+    [dispatch],
   );
 
   // Main effect to orchestrate the parameter processing

--- a/ui/hooks/rewards/useOptIn.ts
+++ b/ui/hooks/rewards/useOptIn.ts
@@ -75,6 +75,9 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
     accountGroupId: primaryWalletAccountGroupId,
   } = usePrimaryWalletGroupAccounts();
 
+  const rewardPoints = options?.rewardPoints;
+  const shieldSubscriptionId = options?.shieldSubscriptionId;
+
   const handleOptIn = useCallback(
     async (referralCode?: string) => {
       const referred = Boolean(referralCode);
@@ -151,12 +154,12 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
           }
 
           // Link the reward to the shield subscription if opt in from the shield subscription
-          if (options?.rewardPoints && options?.shieldSubscriptionId) {
+          if (rewardPoints && shieldSubscriptionId) {
             try {
               await dispatch(
                 linkRewardToShieldSubscription(
-                  options.shieldSubscriptionId,
-                  options.rewardPoints,
+                  shieldSubscriptionId,
+                  rewardPoints,
                 ),
               );
             } catch (error) {
@@ -191,8 +194,8 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
       activeGroupAccounts,
       dispatch,
       t,
-      options?.rewardPoints,
-      options?.shieldSubscriptionId,
+      rewardPoints,
+      shieldSubscriptionId,
     ],
   );
 

--- a/ui/hooks/rewards/useVipTier.ts
+++ b/ui/hooks/rewards/useVipTier.ts
@@ -45,19 +45,21 @@ export function useVipTier(): number | null {
 
 function useVipTierAccountId() {
   const selectedAccount = useSelector(getSelectedInternalAccount);
+  const address = selectedAccount?.address;
+  const scopes = selectedAccount?.scopes;
   return useMemo<CaipAccountId | null>(() => {
-    const [scope] = selectedAccount?.scopes ?? [];
-    if (!selectedAccount?.address || !scope) {
+    const [scope] = scopes ?? [];
+    if (!address || !scope) {
       return null;
     }
     try {
       const { namespace, reference } = parseCaipChainId(scope);
-      return toCaipAccountId(namespace, reference, selectedAccount.address);
+      return toCaipAccountId(namespace, reference, address);
     } catch (error) {
       log.error('[useVipTier] Error formatting account to CAIP-10:', error);
       return null;
     }
-  }, [selectedAccount?.address, selectedAccount?.scopes]);
+  }, [address, scopes]);
 }
 
 function useRewardsVipTierQuery(

--- a/ui/hooks/useAlerts.ts
+++ b/ui/hooks/useAlerts.ts
@@ -18,9 +18,10 @@ import { useDispatch } from '../store/hooks';
 const useAlerts = (ownerId: string) => {
   const dispatch = useDispatch();
 
-  const alerts: Alert[] = sortAlertsBySeverity(
-    useSelector((state) => selectAlerts(state as AlertsState, ownerId)),
+  const unsortedAlerts = useSelector((state) =>
+    selectAlerts(state as AlertsState, ownerId),
   );
+  const alerts: Alert[] = [...sortAlertsBySeverity(unsortedAlerts)];
 
   const confirmedAlertKeys = useSelector(
     (state) => selectConfirmedAlertKeys(state as AlertsState, ownerId),

--- a/ui/hooks/useTokenFiatAmount.js
+++ b/ui/hooks/useTokenFiatAmount.js
@@ -100,6 +100,7 @@ export function useTokenFiatAmount(
       currentCurrency,
       tokenAmount,
       tokenSymbol,
+      formatted,
       hideCurrencySymbol,
     ],
   );

--- a/ui/pages/activity/useTransactionsQuery.ts
+++ b/ui/pages/activity/useTransactionsQuery.ts
@@ -105,19 +105,22 @@ export function useTransactionsQuery(filters: ActivityListFilter) {
     refetchOnWindowFocus: true,
   });
 
+  const queryPages = query.data?.pages;
+  const { fetchNextPage, hasNextPage, isFetchingNextPage } = query;
+
   // Client-side filters can result in empty pages, so skip a bounded number
   // until we find a non-empty page or reach the skip limit
   const fetchNextVisiblePage = useCallback(() => {
-    if (!query.hasNextPage || query.isFetchingNextPage) {
+    if (!hasNextPage || isFetchingNextPage) {
       return;
     }
 
     async function fetchPages() {
       let visibleItemCount =
-        query.data?.pages.flatMap((page) => page.data).length ?? 0;
-      let pageCount = query.data?.pages.length ?? 0;
+        queryPages?.flatMap((page) => page.data).length ?? 0;
+      let pageCount = queryPages?.length ?? 0;
       let emptyFilteredPagesSkipped = 0;
-      let result = await query.fetchNextPage();
+      let result = await fetchNextPage();
 
       while (
         result.hasNextPage &&
@@ -137,17 +140,12 @@ export function useTransactionsQuery(filters: ActivityListFilter) {
         emptyFilteredPagesSkipped += 1;
         visibleItemCount = nextVisibleItemCount;
         pageCount = nextPageCount;
-        result = await query.fetchNextPage();
+        result = await fetchNextPage();
       }
     }
 
     fetchPages().catch(() => undefined);
-  }, [
-    query.data?.pages,
-    query.fetchNextPage,
-    query.hasNextPage,
-    query.isFetchingNextPage,
-  ]);
+  }, [queryPages, fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   return { ...query, fetchNextVisiblePage };
 }

--- a/ui/pages/batch-sell/pages/review/hooks/useBatchSellQuotesFetching.ts
+++ b/ui/pages/batch-sell/pages/review/hooks/useBatchSellQuotesFetching.ts
@@ -56,6 +56,7 @@ export const useBatchSellQuotesFetching = (
       batchSellCaipChainId,
     ),
   );
+  const selectedAccountAddress = selectedAccount?.address;
 
   const batchSellHexChainId = useMemo(
     () => getMaybeHexChainId(receivedAsset.chainId),
@@ -150,7 +151,7 @@ export const useBatchSellQuotesFetching = (
   );
 
   const refetch = useCallback(() => {
-    if (!enabled || enabledEntries.length === 0 || !selectedAccount?.address) {
+    if (!enabled || enabledEntries.length === 0 || !selectedAccountAddress) {
       return;
     }
 
@@ -159,7 +160,7 @@ export const useBatchSellQuotesFetching = (
         const params = buildQuoteRequestForEntry({
           entry,
           destAssetId: receivedAsset.assetId,
-          walletAddress: selectedAccount.address,
+          walletAddress: selectedAccountAddress,
         });
         if (!params) {
           return undefined;
@@ -191,7 +192,7 @@ export const useBatchSellQuotesFetching = (
     enabled,
     enabledEntries,
     receivedAsset,
-    selectedAccount?.address,
+    selectedAccountAddress,
     smartTransactionsEnabled,
     dispatch,
   ]);

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -198,18 +198,21 @@ const PrepareBridgePage = ({
   }, [isLoading]);
 
   const isToOrFromNonEvm = useSelector(getIsToOrFromNonEvm);
+  const fromTokenAssetId = fromToken?.assetId;
+  const toTokenAssetId = toToken?.assetId;
+  const selectedAccountAddress = selectedAccount?.address;
   const quoteParams:
     | Parameters<BridgeController['updateBridgeQuoteRequestParams']>[0]
     | undefined = useMemo(() => {
-    if (!selectedAccount?.address) {
+    if (!selectedAccountAddress) {
       return undefined;
     }
     return {
-      srcTokenAddress: fromToken?.assetId
-        ? formatAddressToCaipReference(fromToken.assetId)
+      srcTokenAddress: fromTokenAssetId
+        ? formatAddressToCaipReference(fromTokenAssetId)
         : undefined,
-      destTokenAddress: toToken?.assetId
-        ? formatAddressToCaipReference(toToken.assetId)
+      destTokenAddress: toTokenAssetId
+        ? formatAddressToCaipReference(toTokenAssetId)
         : undefined,
       srcTokenAmount: validatedFromValue,
       srcChainId: fromToken?.chainId,
@@ -221,19 +224,19 @@ const PrepareBridgePage = ({
         ? true
         : isQuoteRequestInsufficientBal,
       ...(slippage === undefined ? {} : { slippage }),
-      walletAddress: selectedAccount.address,
+      walletAddress: selectedAccountAddress,
       destWalletAddress: selectedDestinationAccount?.address,
       gasIncluded,
       gasIncluded7702,
     };
   }, [
-    fromToken?.assetId,
-    toToken?.assetId,
+    fromTokenAssetId,
+    toTokenAssetId,
     validatedFromValue,
     fromToken?.chainId,
     toToken?.chainId,
     slippage,
-    selectedAccount?.address,
+    selectedAccountAddress,
     selectedDestinationAccount?.address,
     providerConfig?.rpcUrl,
     gasIncluded,

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -111,6 +111,7 @@ const ConfirmButton = ({
   const t = useI18nContext();
 
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const currentConfirmationId = currentConfirmation?.id;
 
   const [confirmModalVisible, setConfirmModalVisible] =
     useState<boolean>(false);
@@ -146,7 +147,7 @@ const ConfirmButton = ({
   } = useSendScamQuestionnaire({ ownerId: alertOwnerId, onCancel });
 
   const handleSubmitConfirmModal = useCallback(async () => {
-    if (currentConfirmation?.id && alertOwnerId === currentConfirmation.id) {
+    if (currentConfirmationId && alertOwnerId === currentConfirmationId) {
       const [selectedUnconfirmedDangerAlert] = unconfirmedDangerAlerts;
 
       if (selectedUnconfirmedDangerAlert) {
@@ -157,7 +158,7 @@ const ConfirmButton = ({
     setConfirmModalVisible(false);
   }, [
     alertOwnerId,
-    currentConfirmation?.id,
+    currentConfirmationId,
     setAlertConfirmed,
     unconfirmedDangerAlerts,
   ]);

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.tsx
@@ -182,7 +182,7 @@ const DecodedSimulation = () => {
         />
       )),
     );
-  }, [decodingData?.stateChanges]);
+  }, [chainId, decodingData?.stateChanges]);
 
   return (
     <StaticSimulation

--- a/ui/pages/confirmations/components/rows/from-account-row/from-account-row.tsx
+++ b/ui/pages/confirmations/components/rows/from-account-row/from-account-row.tsx
@@ -87,21 +87,18 @@ export function FromAccountRow({
     (address: string) => {
       closeModal();
 
-      if (
-        currentConfirmation?.id &&
-        address.toLowerCase() !== from.toLowerCase()
-      ) {
+      if (ownerId && address.toLowerCase() !== from.toLowerCase()) {
         // The TransactionPayController resolves the funding account (and gas)
         // from `accountOverride ?? txParams.from`, so keep it in sync with the
         // newly selected account.
-        setAccountOverride(currentConfirmation.id, address as Hex).catch(
+        setAccountOverride(ownerId, address as Hex).catch(
           (error) => {
             console.error('Failed to set pay account override', error);
           },
         );
       }
     },
-    [closeModal, currentConfirmation?.id, from],
+    [closeModal, ownerId, from],
   );
 
   if (!currentConfirmation || !from) {

--- a/ui/pages/confirmations/components/send/amount/amount.tsx
+++ b/ui/pages/confirmations/components/send/amount/amount.tsx
@@ -57,12 +57,16 @@ export const Amount = ({
     setAmountInputTypeFiat,
     setAmountInputTypeToken,
   } = useAmountSelectionMetrics();
+  const assetName = asset?.name;
+  const assetStandard = asset?.standard;
+  const assetSymbol = asset?.symbol;
+
   const alternateDisplayValue = useMemo(
     () =>
       fiatMode
-        ? `${formatToFixedDecimals(value, 5)} ${asset?.symbol}`
+        ? `${formatToFixedDecimals(value, 5)} ${assetSymbol}`
         : getFiatDisplayValue(amount),
-    [amount, fiatMode, getFiatDisplayValue, value],
+    [amount, assetSymbol, fiatMode, getFiatDisplayValue, value],
   );
 
   const onChange = useCallback(
@@ -132,24 +136,24 @@ export const Amount = ({
     }
 
     // For ERC1155 tokens, use name or just show balance without symbol
-    if (asset?.standard === ERC1155) {
-      const displayName = asset?.name ? ` ${asset.name}` : '';
+    if (assetStandard === ERC1155) {
+      const displayName = assetName ? ` ${assetName}` : '';
       return `${balance}${displayName} ${t('available')}`;
     }
 
     // For other tokens, use symbol
-    return `${balance} ${asset?.symbol} ${t('available')}`;
+    return `${balance} ${assetSymbol} ${t('available')}`;
   }, [
     fiatMode,
     getFiatDisplayValue,
     balance,
-    asset?.symbol,
-    asset?.name,
-    asset?.standard,
+    assetSymbol,
+    assetName,
+    assetStandard,
     t,
   ]);
 
-  if (asset?.standard === ERC721) {
+  if (assetStandard === ERC721) {
     return null;
   }
 
@@ -169,7 +173,7 @@ export const Amount = ({
         endAccessory={
           <Box display={Display.Flex}>
             <Text>
-              {fiatMode ? fiatCurrencyName?.toUpperCase() : asset?.symbol}
+              {fiatMode ? fiatCurrencyName?.toUpperCase() : assetSymbol}
             </Text>
             {conversionSupportedForAsset && (
               <ButtonIcon

--- a/ui/pages/confirmations/components/send/hex-data/hex-data.tsx
+++ b/ui/pages/confirmations/components/send/hex-data/hex-data.tsx
@@ -40,7 +40,7 @@ export const HexData = ({
       setHexDataErrorLocal(invalidHexData);
       setHexDataError(invalidHexData);
     },
-    [updateHexData, setHexDataErrorLocal, setHexDataError],
+    [t, updateHexData, setHexDataErrorLocal, setHexDataError],
   );
 
   if (!isEvmSendType || !asset?.isNative || !showHexDataFlag) {

--- a/ui/pages/confirmations/hooks/alerts/transactions/useGasFeeLowAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useGasFeeLowAlerts.ts
@@ -39,5 +39,5 @@ export function useGasFeeLowAlerts(): Alert[] {
         severity: Severity.Warning,
       },
     ];
-  }, [isLowEstimate]);
+  }, [isLowEstimate, t]);
 }

--- a/ui/pages/confirmations/hooks/alerts/transactions/useGasTooLowAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useGasTooLowAlerts.ts
@@ -43,5 +43,5 @@ export function useGasTooLowAlerts(): Alert[] {
         severity: Severity.Warning,
       },
     ];
-  }, [gasTooLow]);
+  }, [gasTooLow, t]);
 }

--- a/ui/pages/confirmations/hooks/alerts/transactions/useNoGasPriceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNoGasPriceAlerts.ts
@@ -51,5 +51,5 @@ export function useNoGasPriceAlerts(): Alert[] {
         severity: Severity.Warning,
       },
     ];
-  }, [noGasPrice]);
+  }, [noGasPrice, t]);
 }

--- a/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
@@ -64,5 +64,6 @@ export function useNonContractAddressAlerts(): Alert[] {
     isSendingHexDataWhileInteractingWithNonContractAddress,
     isUpgrade,
     networkConfigurations,
+    t,
   ]);
 }

--- a/ui/pages/confirmations/hooks/send/useContactRecipients.ts
+++ b/ui/pages/confirmations/hooks/send/useContactRecipients.ts
@@ -30,7 +30,7 @@ export const useContactRecipients = (): Recipient[] => {
           ),
         })) ?? []
     );
-  }, [addressBook, chainId, isEvmSendType]);
+  }, [accountAddressSeedIconMap, addressBook, chainId, isEvmSendType]);
 
   return contacts;
 };

--- a/ui/pages/connected-sites/connected-sites.component.js
+++ b/ui/pages/connected-sites/connected-sites.component.js
@@ -31,23 +31,17 @@ export default function ConnectedSites({
     setSitePendingDisconnect({ subjectKey });
   }, []);
 
+  const pendingSubjectKey = sitePendingDisconnect?.subjectKey;
+
   const handleDisconnectAccount = useCallback(() => {
-    disconnectAccount(sitePendingDisconnect.subjectKey);
+    disconnectAccount(pendingSubjectKey);
     clearPendingDisconnect();
-  }, [
-    clearPendingDisconnect,
-    disconnectAccount,
-    sitePendingDisconnect?.subjectKey,
-  ]);
+  }, [clearPendingDisconnect, disconnectAccount, pendingSubjectKey]);
 
   const handleDisconnectAllAccounts = useCallback(() => {
-    disconnectAllAccounts(sitePendingDisconnect.subjectKey);
+    disconnectAllAccounts(pendingSubjectKey);
     clearPendingDisconnect();
-  }, [
-    clearPendingDisconnect,
-    disconnectAllAccounts,
-    sitePendingDisconnect?.subjectKey,
-  ]);
+  }, [clearPendingDisconnect, disconnectAllAccounts, pendingSubjectKey]);
 
   const renderConnectedSitesList = () => (
     <ConnectedSitesList

--- a/ui/pages/contacts/contact-details-page.tsx
+++ b/ui/pages/contacts/contact-details-page.tsx
@@ -50,18 +50,19 @@ export function ContactDetailsPage() {
         )
       : null,
   );
+  const contactChainId = contact?.chainId;
   const internalAccount = useSelector((state) =>
     address ? getInternalAccountByAddress(state, address) : null,
   );
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   useEffect(() => {
-    if (!address || !contact?.chainId) {
+    if (!address || !contactChainId) {
       lastTrackedContactKeyRef.current = null;
       return;
     }
 
-    const contactKey = `${contact.chainId}:${address}`;
+    const contactKey = `${contactChainId}:${address}`;
     if (lastTrackedContactKeyRef.current === contactKey) {
       return;
     }
@@ -72,7 +73,7 @@ export function ContactDetailsPage() {
         .addCategory(MetaMetricsEventCategory.Contacts)
         .addProperties({
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id: contact.chainId,
+          chain_id: contactChainId,
         })
         .addSensitiveProperties({
           // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -80,7 +81,7 @@ export function ContactDetailsPage() {
         })
         .build(),
     );
-  }, [address, contact?.chainId, createEventBuilder, trackEvent]);
+  }, [address, contactChainId, createEventBuilder, trackEvent]);
 
   const handleBack = () => {
     navigate(CONTACTS_ROUTE);
@@ -97,7 +98,7 @@ export function ContactDetailsPage() {
       .addCategory(MetaMetricsEventCategory.Contacts)
       .addProperties({
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        chain_id: contact?.chainId,
+        chain_id: contactChainId,
       });
 
     trackEvent(
@@ -110,14 +111,14 @@ export function ContactDetailsPage() {
       ).build(),
     );
     setShowDeleteModal(true);
-  }, [address, contact?.chainId, createEventBuilder, trackEvent]);
+  }, [address, contactChainId, createEventBuilder, trackEvent]);
 
   const closeDeleteModal = useCallback(() => {
     setShowDeleteModal(false);
   }, []);
 
   const handleConfirmDelete = useCallback(async () => {
-    if (!address || !contact?.chainId) {
+    if (!address || !contactChainId) {
       return;
     }
     setShowDeleteModal(false);
@@ -126,7 +127,7 @@ export function ContactDetailsPage() {
         .addCategory(MetaMetricsEventCategory.Contacts)
         .addProperties({
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id: contact.chainId,
+          chain_id: contactChainId,
         })
         .addSensitiveProperties({
           // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -135,10 +136,10 @@ export function ContactDetailsPage() {
         .build(),
     );
     navigate(CONTACTS_ROUTE, { state: { showContactDeletedToast: true } });
-    dispatch(removeFromAddressBook(contact.chainId, address));
+    dispatch(removeFromAddressBook(contactChainId, address));
   }, [
     address,
-    contact?.chainId,
+    contactChainId,
     createEventBuilder,
     dispatch,
     navigate,

--- a/ui/pages/details/components/swap-again-button.tsx
+++ b/ui/pages/details/components/swap-again-button.tsx
@@ -28,28 +28,31 @@ export function SwapAgainButton({
   const dispatch = useDispatch();
   const { navigateToBridgePage } = useBridgeNavigation();
 
+  const sourceAssetId = sourceToken?.assetId;
+  const destinationAssetId = destinationToken?.assetId;
+
   const buttonLabelKey = useMemo(() => {
-    if (!sourceToken?.assetId || !destinationToken?.assetId) {
+    if (!sourceAssetId || !destinationAssetId) {
       return 'swapAgain';
     }
 
-    const sourceChainId = sourceToken.assetId.split('/')[0];
-    const destinationChainId = destinationToken.assetId.split('/')[0];
+    const sourceChainId = sourceAssetId.split('/')[0];
+    const destinationChainId = destinationAssetId.split('/')[0];
 
     return sourceChainId === destinationChainId ? 'swapAgain' : 'bridgeAgain';
-  }, [destinationToken?.assetId, sourceToken?.assetId]);
+  }, [destinationAssetId, sourceAssetId]);
 
   const searchParams = useMemo(() => {
-    if (!sourceToken?.assetId || !destinationToken?.assetId) {
+    if (!sourceAssetId || !destinationAssetId) {
       return undefined;
     }
 
     const params = new URLSearchParams();
-    params.set(BridgeQueryParams.From, sourceToken.assetId);
-    params.set(BridgeQueryParams.To, destinationToken.assetId);
+    params.set(BridgeQueryParams.From, sourceAssetId);
+    params.set(BridgeQueryParams.To, destinationAssetId);
 
     return params;
-  }, [destinationToken?.assetId, sourceToken?.assetId]);
+  }, [destinationAssetId, sourceAssetId]);
 
   const handleClick = useCallback(() => {
     if (!searchParams) {

--- a/ui/pages/details/templates/helpers.ts
+++ b/ui/pages/details/templates/helpers.ts
@@ -26,7 +26,6 @@ export function useDestinationToken(
   metamaskPay: MetamaskPayMetadata | undefined,
 ) {
   const { chainId, targetFiat, tokenAddress } = metamaskPay ?? {};
-  const fiatUsd = Number.parseFloat(targetFiat || '');
 
   const nativeTokenUsdRate = useSelector((state) =>
     chainId ? getUSDConversionRateByChainId(chainId)(state) : undefined,
@@ -36,6 +35,8 @@ export function useDestinationToken(
     if (!targetFiat || !tokenAddress || !chainId) {
       return undefined;
     }
+
+    const fiatUsd = Number.parseFloat(targetFiat || '');
 
     if (!Number.isFinite(fiatUsd) || fiatUsd <= 0) {
       return undefined;

--- a/ui/pages/permissions-connect/permissions-connect.tsx
+++ b/ui/pages/permissions-connect/permissions-connect.tsx
@@ -203,10 +203,13 @@ function PermissionsConnect() {
 
   // Selectors
   const { pathname } = location;
-  let permissionsRequests = useSelector(getPermissionsRequests);
-  permissionsRequests = [
-    ...permissionsRequests,
-    ...useSelector(getSnapInstallOrUpdateRequests),
+  const pendingPermissionsRequests = useSelector(getPermissionsRequests);
+  const snapInstallOrUpdateRequests = useSelector(
+    getSnapInstallOrUpdateRequests,
+  );
+  const permissionsRequests = [
+    ...pendingPermissionsRequests,
+    ...snapInstallOrUpdateRequests,
   ];
   const { address: currentAddress } = useSelector(getSelectedInternalAccount);
 
@@ -220,6 +223,10 @@ function PermissionsConnect() {
     string,
     string
   >;
+
+  const isRequestingSnap = isSnapId(
+    (metadata as Record<string, string>)?.origin,
+  );
 
   const isRequestApprovalPermittedChains = Boolean(
     (diff as Record<string, unknown>)?.permissionDiffMap,
@@ -248,20 +255,19 @@ function PermissionsConnect() {
     [targetSubjectMetadataFromSelector, originFromRequest],
   );
 
-  let requestType = useSelector((state) =>
+  const requestTypeFromSelector = useSelector((state) =>
     getRequestType(state, permissionsRequestId),
   );
 
   // We want to only assign the wallet_connectSnaps request type (i.e. only show
   // SnapsConnect) if and only if we get a singular wallet_snap permission request.
   // Any other request gets pushed to the normal permission connect flow.
-  if (
+  const requestType =
     permissionsRequest &&
     Object.keys(permissions || {}).length === 1 &&
     permissions?.[WALLET_SNAP_PERMISSION_KEY]
-  ) {
-    requestType = 'wallet_connectSnaps';
-  }
+      ? 'wallet_connectSnaps'
+      : requestTypeFromSelector;
 
   const requestState =
     useSelector((state) => getRequestState(state, permissionsRequestId)) || {};
@@ -629,10 +635,6 @@ function PermissionsConnect() {
       );
     },
     [targetSubjectMetadata, cancelPermissionsRequest],
-  );
-
-  const isRequestingSnap = isSnapId(
-    (metadata as Record<string, string>)?.origin,
   );
 
   const cancelFromTrustSignalGate = useCallback(

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -128,7 +128,10 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
   const runCloseTransition = useGlobalMenuRouteTransition();
   const t = useSettingsI18n();
   const normalizedPathname = normalizeSettingsPath(location.pathname);
-  const meta = getSettingsRouteMeta(normalizedPathname);
+  const meta = useMemo(
+    () => getSettingsRouteMeta(normalizedPathname),
+    [normalizedPathname],
+  );
   const environmentType = getEnvironmentType();
 
   // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)


### PR DESCRIPTION
## **Description**

Aligns manual `useMemo`/`useCallback` dependency arrays with what the React Compiler infers, eliminating **65 of 67 `PreserveManualMemo` bailouts across 29 files** — the largest single error cluster blocking compiler memoization coverage (root-cause cluster C on MetaMask-planning#6551).

Fix patterns, chosen to preserve recompute semantics exactly:
- Hoist narrowed reads (`const field = obj?.field`) above the memo and dep on the narrow value — never widening deps to whole objects
- Complete dependency arrays where a read value was missing — five of these were latent staleness bugs (`formatted` in `useTokenFiatAmount`, `chainId` in `decoded-simulation`, `t` in `hex-data`/`useNonContractAddressAlerts`, `accountAddressSeedIconMap` in `useContactRecipients`)
- Snapshot or restructure captured bindings flagged as "may be modified later" (`permissions-connect`, `helpers.ts`, `useAlerts`, `settings`)

Deliberately **not** fixed (2 sites, same root cause — unstable upstream selector identity forces proxy deps; aligning them would change recompute triggers): `useSendNfts.ts` and `useInitialBridgeTokens.ts`. Tracked in MetaMask-planning#7536.

### Verification

Direct `babel-plugin-react-compiler@1.0.0` run over all 31 baseline error files (same harness that produced the 67-event baseline), output:

```
PMM 1 ui/hooks/bridge/useInitialBridgeTokens.ts
PMM 1 ui/pages/confirmations/hooks/send/useSendNfts.ts
---
total PMM remaining: 2 (baseline 67)
new categories introduced: ui/hooks/rewards/useOptIn.ts: NEW Todo (pre-existing, tracked in MetaMask-planning#6551 cluster E)
```
The `useOptIn.ts` `Todo`-category event is pre-existing, unmasked because the compiler stops at the first bail per function — it appears on baseline code once the earlier bail is fixed; it is a compiler-limitation site tracked in MetaMask-planning#6551 (root-cause cluster E).

Colocated jest — 24 suites total across the touched files:

```
batch 1 (11 suites): Tests: 162 passed, 162 total
batch 2 (13 suites): Test Suites: 1 failed, 12 passed, 13 total
                     Tests:       8 failed, 104 passed, 112 total
```

The one red suite is `prepare-bridge-page.test.tsx`. A/B falsifier — same suite with this PR's edit to `prepare-bridge-page.tsx` stashed (i.e., file at `origin/main` state):

```
Test Suites: 1 failed, 1 total
Tests:       8 failed, 1 passed, 9 total
```

Identical 8 failures with and without the change → pre-existing breakage on `origin/main`, not introduced here.

`react-hooks/exhaustive-deps` was run standalone over the edited files (repo `yarn lint:eslint` is currently broken in this checkout: ESLint 9.39 `Converting circular structure to JSON` from `@eslint/eslintrc`, environmental): all edited files clean; the rule run was positive-controlled on a deliberately-broken copy of `useContactRecipients.ts`, where it correctly reported the two seeded missing deps.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: MetaMask-planning#6551 (React Compiler opt-out epic — root-cause cluster C), MetaMask-planning#7536 (remaining 2 sites, selector stabilization)

## **Manual testing steps**

No behavior change intended: every fix preserves recompute triggers and referential-stability contracts. Flows touching the five latent-staleness fixes (token fiat display, typed-sign simulation, hex data row, non-contract address alert, contact recipients) now update where they could previously show stale values.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Broad but low-risk hook dependency and memo restructuring aimed at compiler compatibility; a few sites fix prior stale-display bugs without touching auth, payments, or core transaction signing logic.
> 
> **Overview**
> This PR **realigns manual `useMemo` / `useCallback` dependency arrays** with what the React Compiler expects, clearing most `PreserveManualMemo` bailouts on the React Compiler rollout path (#6551). The edits are mechanical—hoisting narrow reads (`const x = obj?.field`), filling missing deps, and avoiding “may be modified later” captures—without intentionally changing product behavior.
> 
> **Compiler-oriented patterns:** Snap asset formatting now memoizes `parsedAccounts` and expands the formatted-assets memo deps; bridge/batch-sell/activity hooks destructure query or account fields before callbacks; `permissions-connect` stops mutating selector results and derives `requestType` immutably; `useAlerts` copies sorted alerts instead of mutating selector output; settings wraps route meta in `useMemo`. `getChainId` moves out of `CoinButtons` so buy handlers depend on stable primitives.
> 
> **Stale UI fixes bundled in:** Several dependency gaps are closed so UI updates when inputs change—e.g. `formatted` in `useTokenFiatAmount`, `chainId` in typed-sign decoded simulation, `t` in hex-data and gas/non-contract alerts, `accountAddressSeedIconMap` in send contact recipients, and `dispatch` in bridge URL prefill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ab8bfc011119bd3782159020dc3541e5428140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->