### PR TITLE
feat: convert individual list to use virtualised list

### DIFF
--- a/ui/hooks/discover-search/constants.ts
+++ b/ui/hooks/discover-search/constants.ts
@@ -29,7 +29,7 @@ export const DISCOVER_STOCKS_CHAIN_IDS: CaipChainId[] = [
   toEvmCaipChainId(CHAIN_IDS.BSC),
 ];
 
-export const DISCOVER_SEARCH_DEBOUNCE_MS = 200;
+export const DISCOVER_SEARCH_DEBOUNCE_MS = 500;
 export const DISCOVER_SEARCH_PREVIEW_COUNT = 3;
 export const DISCOVER_SEARCH_PAGE_SIZE = 20;
 export const DISCOVER_SEARCH_STALE_TIME_MS = 30_000;

--- a/ui/pages/discover-search/discover-search.tsx
+++ b/ui/pages/discover-search/discover-search.tsx
@@ -22,6 +22,8 @@ import { isCaipAssetType } from '@metamask/utils';
 
 import { MarketRow } from '../../components/app/perps/market-row';
 import { Tab, Tabs } from '../../components/ui/tabs';
+import { VirtualizedList } from '../../components/ui/virtualized-list/virtualized-list';
+import { ScrollContainer } from '../../contexts/scroll-container';
 import {
   DEFAULT_ROUTE,
   PERPS_MARKET_DETAIL_ROUTE,
@@ -102,6 +104,7 @@ const DiscoverSearchSectionDivider = () => (
 const SEARCH_QUERY_PARAM = 'q';
 const SEARCH_TAB_PARAM = 'tab';
 const DEFAULT_DISCOVER_SEARCH_TAB: DiscoverSearchTab = 'all';
+const DISCOVER_SEARCH_ROW_HEIGHT = 72;
 
 const isDiscoverSearchTab = (
   value: string | null,
@@ -386,6 +389,7 @@ export const DiscoverSearchPage = () => {
     isLoading: boolean,
     error: Error | null | undefined,
     testIdPrefix: string,
+    shouldVirtualize = false,
   ) => {
     if (isLoading && items.length === 0) {
       return <DiscoverSearchSectionSkeleton testIdPrefix={testIdPrefix} />;
@@ -401,6 +405,24 @@ export const DiscoverSearchPage = () => {
         />
       );
     }
+    if (shouldVirtualize) {
+      return (
+        <VirtualizedList
+          data={items}
+          estimatedItemSize={DISCOVER_SEARCH_ROW_HEIGHT}
+          overscan={10}
+          keyExtractor={(asset) => asset.assetId}
+          renderItem={({ item: asset }) => (
+            <DiscoverAssetRow
+              asset={asset}
+              onPress={handleAssetPress}
+              data-testid={`${testIdPrefix}-${asset.assetId}`}
+            />
+          )}
+        />
+      );
+    }
+
     return items.map((asset) => (
       <DiscoverAssetRow
         key={asset.assetId}
@@ -415,6 +437,7 @@ export const DiscoverSearchPage = () => {
     items: PerpsMarketData[],
     isLoading: boolean,
     error: Error | null | undefined,
+    shouldVirtualize = false,
   ) => {
     if (isLoading && items.length === 0) {
       return <DiscoverSearchSectionSkeleton testIdPrefix="discover-perps" />;
@@ -430,6 +453,25 @@ export const DiscoverSearchPage = () => {
         />
       );
     }
+    if (shouldVirtualize) {
+      return (
+        <VirtualizedList
+          data={items}
+          estimatedItemSize={DISCOVER_SEARCH_ROW_HEIGHT}
+          overscan={10}
+          keyExtractor={(market) => market.symbol}
+          renderItem={({ item: market }) => (
+            <MarketRow
+              market={market}
+              onPress={handlePerpsPress}
+              displayMetric="volume"
+              data-testid={`discover-perps-row-${market.symbol.replaceAll(':', '-')}`}
+            />
+          )}
+        />
+      );
+    }
+
     return items.map((market) => (
       <MarketRow
         key={market.symbol}
@@ -440,6 +482,15 @@ export const DiscoverSearchPage = () => {
       />
     ));
   };
+
+  const renderScrollableTabContent = (content: React.ReactNode) => (
+    <ScrollContainer
+      className="h-full min-h-0 overflow-y-auto overscroll-contain pb-6"
+      onScroll={handleTabContentScroll}
+    >
+      {content}
+    </ScrollContainer>
+  );
 
   const allTabContent = (() => {
     if (showAllLoading) {
@@ -574,12 +625,11 @@ export const DiscoverSearchPage = () => {
         flexDirection={BoxFlexDirection.Column}
         tabListProps={{ className: 'px-4 pb-4 shrink-0' }}
         tabContentProps={{
-          className: 'min-h-0 flex-1 overflow-y-auto overscroll-contain pb-6',
-          onScroll: handleTabContentScroll,
+          className: 'min-h-0 flex-1',
         }}
       >
         <Tab name={t('all')} tabKey="all" data-testid="discover-tab-all">
-          {allTabContent}
+          {renderScrollableTabContent(allTabContent)}
         </Tab>
 
         <Tab
@@ -587,11 +637,14 @@ export const DiscoverSearchPage = () => {
           tabKey="crypto"
           data-testid="discover-tab-crypto"
         >
-          {renderAssetList(
-            cryptoSection.items,
-            cryptoSection.isLoading,
-            cryptoSection.error,
-            'discover-crypto',
+          {renderScrollableTabContent(
+            renderAssetList(
+              cryptoSection.items,
+              cryptoSection.isLoading,
+              cryptoSection.error,
+              'discover-crypto',
+              true,
+            ),
           )}
         </Tab>
 
@@ -601,7 +654,9 @@ export const DiscoverSearchPage = () => {
             tabKey="perps"
             data-testid="discover-tab-perps"
           >
-            {renderPerpsList(perps.items, perps.isLoading, perps.error)}
+            {renderScrollableTabContent(
+              renderPerpsList(perps.items, perps.isLoading, perps.error, true),
+            )}
           </Tab>
         ) : null}
 
@@ -610,11 +665,14 @@ export const DiscoverSearchPage = () => {
           tabKey="stocks"
           data-testid="discover-tab-stocks"
         >
-          {renderAssetList(
-            stocks.items,
-            stocks.isLoading,
-            stocks.error,
-            'discover-stocks',
+          {renderScrollableTabContent(
+            renderAssetList(
+              stocks.items,
+              stocks.isLoading,
+              stocks.error,
+              'discover-stocks',
+              true,
+            ),
           )}
         </Tab>
       </Tabs>


### PR DESCRIPTION
This PR is to update individual search list to use Virtualised list

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only discover search rendering and debounce tuning; no auth, data, or payment paths touched.
> 
> **Overview**
> Discover Search **crypto**, **stocks**, and **perps** tab lists now render through **`VirtualizedList`** (72px row estimate, overscan 10) instead of mapping every row into the DOM, so long result sets should scroll more smoothly.
> 
> Tab panels no longer own scrolling themselves: each tab’s body is wrapped in **`ScrollContainer`** with the existing **`handleResultsContainerScroll`** handler (analytics + crypto/stocks infinite scroll), which lines up with **`VirtualizedList`**’s scroll-parent context and **`enableScrollMargin`**.
> 
> Search input debounce is raised from **200ms** to **500ms** in discover-search constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52d1d149942faeac3b61308d07d03253c46205b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->