### PR TITLE
feat: MUSD-1262 Add address derivation and balance service

### DIFF
--- a/.github/scripts/known-feature-flag-constants.mts
+++ b/.github/scripts/known-feature-flag-constants.mts
@@ -75,6 +75,11 @@ const FILE_SOURCES: Array<{
     file: 'shared/lib/assets/security-trust-feature-flags.ts',
     exportName: 'EXTENSION_TRUST_AND_SECURITY_TDP_FLAG',
   },
+  {
+    key: 'MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME',
+    file: 'shared/lib/money/feature-flags.ts',
+    exportName: 'MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME',
+  },
 ];
 
 /**

--- a/app/scripts/lib/money/get-money-account-address.test.ts
+++ b/app/scripts/lib/money/get-money-account-address.test.ts
@@ -1,0 +1,119 @@
+import type { HdKeyring } from '@metamask/eth-hd-keyring';
+import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
+import {
+  deriveMoneyAccountAddress,
+  type MoneyAccountAddressMessenger,
+} from './get-money-account-address';
+
+const TEST_MNEMONIC =
+  'spread raise short crane omit tent fringe mandate neglect detail suspect cradle';
+
+/**
+ * The money account address for `TEST_MNEMONIC`, derived at
+ * `m/44'/4392018'/0'/0`. Hard-coded so that any change to the derivation path,
+ * the mnemonic encoding, or the keyring version shows up as a failure here.
+ */
+const EXPECTED_MONEY_ADDRESS = '0xd5fe9b0579443e7025cf3309ba420977710e7183';
+
+const PRIMARY_KEYRING_ID = 'primary-hd-keyring-id';
+
+/**
+ * Encode a mnemonic the way `HdKeyring` holds it internally: a byte view over
+ * the 16-bit indices of its words in the English wordlist.
+ *
+ * @param mnemonic - The mnemonic phrase.
+ * @returns The wordlist indices as a byte array.
+ */
+function toMnemonicIndicesBytes(mnemonic: string): Uint8Array {
+  const indices = mnemonic.split(' ').map((word) => wordlist.indexOf(word));
+
+  return new Uint8Array(new Uint16Array(indices).buffer);
+}
+
+/**
+ * Build a messenger whose `withKeyringUnsafe` runs the given operation against
+ * a stub primary HD keyring.
+ *
+ * @param options - Options.
+ * @param options.mnemonic - The mnemonic the stub keyring holds, if any.
+ * @returns The messenger and its `call` mock.
+ */
+function createMockMessenger({
+  mnemonic = TEST_MNEMONIC,
+}: { mnemonic?: string | null } = {}) {
+  const keyring = {
+    type: 'HD Key Tree',
+    mnemonic: mnemonic === null ? null : toMnemonicIndicesBytes(mnemonic),
+  } as unknown as HdKeyring;
+
+  const call = jest.fn(
+    async (
+      _action: string,
+      _selector: unknown,
+      operation: (args: {
+        keyring: HdKeyring;
+        metadata: { id: string; name: string };
+      }) => Promise<unknown>,
+    ) =>
+      operation({
+        keyring,
+        metadata: { id: PRIMARY_KEYRING_ID, name: '' },
+      }),
+  );
+
+  return {
+    messenger: { call } as unknown as MoneyAccountAddressMessenger,
+    call,
+  };
+}
+
+describe('deriveMoneyAccountAddress', () => {
+  it('derives the money account address from the primary HD seed', async () => {
+    const { messenger } = createMockMessenger();
+
+    const address = await deriveMoneyAccountAddress(messenger);
+
+    expect(address.toLowerCase()).toBe(EXPECTED_MONEY_ADDRESS);
+  });
+
+  it('derives the same address on every call', async () => {
+    const { messenger } = createMockMessenger();
+
+    const first = await deriveMoneyAccountAddress(messenger);
+    const second = await deriveMoneyAccountAddress(messenger);
+
+    expect(second).toBe(first);
+  });
+
+  it('derives a different address for a different seed', async () => {
+    const { messenger } = createMockMessenger({
+      mnemonic:
+        'phrase upgrade clock rough situate wedding elder clever doctor stamp excess tent',
+    });
+
+    const address = await deriveMoneyAccountAddress(messenger);
+
+    expect(address.toLowerCase()).not.toBe(EXPECTED_MONEY_ADDRESS);
+  });
+
+  it('selects the primary HD keyring without requiring the password', async () => {
+    const { messenger, call } = createMockMessenger();
+
+    await deriveMoneyAccountAddress(messenger);
+
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(call).toHaveBeenCalledWith(
+      'KeyringController:withKeyringUnsafe',
+      { type: 'HD Key Tree' },
+      expect.any(Function),
+    );
+  });
+
+  it('throws if the primary keyring has no mnemonic', async () => {
+    const { messenger } = createMockMessenger({ mnemonic: null });
+
+    await expect(deriveMoneyAccountAddress(messenger)).rejects.toThrow(
+      'Unable to get mnemonic to derive the money account address',
+    );
+  });
+});

--- a/app/scripts/lib/money/get-money-account-address.test.ts
+++ b/app/scripts/lib/money/get-money-account-address.test.ts
@@ -18,11 +18,7 @@ const EXPECTED_MONEY_ADDRESS = '0xd5fe9b0579443e7025cf3309ba420977710e7183';
 const PRIMARY_KEYRING_ID = 'primary-hd-keyring-id';
 
 /**
- * Encode a mnemonic the way `HdKeyring` holds it internally: a byte view over
- * the 16-bit indices of its words in the English wordlist.
- *
- * @param mnemonic - The mnemonic phrase.
- * @returns The wordlist indices as a byte array.
+ * Encode a mnemonic the way `HdKeyring` holds it internally
  */
 function toMnemonicIndicesBytes(mnemonic: string): Uint8Array {
   const indices = mnemonic.split(' ').map((word) => wordlist.indexOf(word));
@@ -30,14 +26,6 @@ function toMnemonicIndicesBytes(mnemonic: string): Uint8Array {
   return new Uint8Array(new Uint16Array(indices).buffer);
 }
 
-/**
- * Build a messenger whose `withKeyringUnsafe` runs the given operation against
- * a stub primary HD keyring.
- *
- * @param options - Options.
- * @param options.mnemonic - The mnemonic the stub keyring holds, if any.
- * @returns The messenger and its `call` mock.
- */
 function createMockMessenger({
   mnemonic = TEST_MNEMONIC,
 }: { mnemonic?: string | null } = {}) {

--- a/app/scripts/lib/money/get-money-account-address.test.ts
+++ b/app/scripts/lib/money/get-money-account-address.test.ts
@@ -19,6 +19,8 @@ const PRIMARY_KEYRING_ID = 'primary-hd-keyring-id';
 
 /**
  * Encode a mnemonic the way `HdKeyring` holds it internally
+ *
+ * @param mnemonic - The mnemonic to encode.
  */
 function toMnemonicIndicesBytes(mnemonic: string): Uint8Array {
   const indices = mnemonic.split(' ').map((word) => wordlist.indexOf(word));

--- a/app/scripts/lib/money/get-money-account-address.ts
+++ b/app/scripts/lib/money/get-money-account-address.ts
@@ -1,0 +1,95 @@
+import type { HdKeyring } from '@metamask/eth-hd-keyring';
+import { MoneyKeyring } from '@metamask/eth-money-keyring';
+import {
+  KeyringTypes,
+  type KeyringControllerWithKeyringUnsafeAction,
+} from '@metamask/keyring-controller';
+import { encodeMnemonic } from '@metamask/keyring-sdk';
+import type { Messenger } from '@metamask/messenger';
+import type { Hex } from '@metamask/utils';
+
+export type MoneyAccountAddressMessenger = Messenger<
+  string,
+  KeyringControllerWithKeyringUnsafeAction,
+  never
+>;
+
+/**
+ * The primary HD seed, in the shape `MoneyKeyring` needs it: the id of the
+ * entropy source it came from, plus the mnemonic as UTF-8 byte values.
+ */
+type PrimarySeed = {
+  entropySource: string;
+  mnemonic: number[];
+};
+
+/**
+ * Read the primary HD keyring's mnemonic.
+ *
+ * Uses `withKeyringUnsafe`, which asserts the wallet is unlocked but does not
+ * require the password. The `{ type }` selector picks the first keyring of that
+ * type, which is the primary HD keyring.
+ *
+ * @param messenger - The messenger used to reach the `KeyringController`.
+ * @returns The primary entropy source id and its mnemonic as UTF-8 byte values.
+ */
+async function getPrimarySeed(
+  messenger: MoneyAccountAddressMessenger,
+): Promise<PrimarySeed> {
+  return (await messenger.call(
+    'KeyringController:withKeyringUnsafe',
+    { type: KeyringTypes.hd },
+    async ({ keyring, metadata }) => {
+      // `mnemonic` holds wordlist indices as a byte view, not the phrase
+      // itself; `encodeMnemonic` turns it into the UTF-8 bytes of the phrase.
+      const { mnemonic } = keyring as HdKeyring;
+
+      if (!mnemonic) {
+        throw new Error(
+          'Unable to get mnemonic to derive the money account address',
+        );
+      }
+
+      return {
+        entropySource: metadata.id,
+        mnemonic: encodeMnemonic(mnemonic),
+      };
+      // The action type erases `withKeyringUnsafe`'s `CallbackResult` generic
+      // to its `void` default, so the callback's return type is lost here.
+    },
+  )) as unknown as PrimarySeed;
+}
+
+/**
+ * Derive the money account address.
+ *
+ * The address is a deterministic BIP-44 derivation of the user's existing
+ * primary HD seed at `MONEY_DERIVATION_PATH`, so it can be recomputed at any
+ * time from an unlocked wallet. `MoneyKeyring` is used purely as a deriver
+ * here: the instance is discarded once the address has been read, and is never
+ * registered with the `KeyringController`.
+ *
+ * @param messenger - The messenger used to reach the `KeyringController`.
+ * @returns The money account address.
+ */
+export async function deriveMoneyAccountAddress(
+  messenger: MoneyAccountAddressMessenger,
+): Promise<Hex> {
+  const { entropySource, mnemonic } = await getPrimarySeed(messenger);
+
+  const keyring = new MoneyKeyring({
+    getMnemonic: async () => mnemonic,
+  });
+
+  // `MoneyKeyring` derives lazily and needs an entropy source before it will
+  // do anything, so it has to be deserialized before adding the account.
+  await keyring.deserialize({ entropySource });
+
+  const [address] = await keyring.addAccounts(1);
+
+  if (!address) {
+    throw new Error('Failed to derive the money account address');
+  }
+
+  return address;
+}

--- a/app/scripts/lib/money/get-money-account-address.ts
+++ b/app/scripts/lib/money/get-money-account-address.ts
@@ -28,7 +28,8 @@ type PrimarySeed = {
  *
  * Uses `withKeyringUnsafe`, which asserts the wallet is unlocked but does not
  * require the password. The `{ type }` selector picks the first keyring of that
- * type, which is the primary HD keyring.
+ * type, which is the primary HD keyring. This is because the money account is always
+ * derived from the primary SRP
  *
  * @param messenger - The messenger used to reach the `KeyringController`.
  * @returns The primary entropy source id and its mnemonic as UTF-8 byte values.
@@ -54,8 +55,6 @@ async function getPrimarySeed(
         entropySource: metadata.id,
         mnemonic: encodeMnemonic(mnemonic),
       };
-      // The action type erases `withKeyringUnsafe`'s `CallbackResult` generic
-      // to its `void` default, so the callback's return type is lost here.
     },
   )) as unknown as PrimarySeed;
 }
@@ -65,9 +64,7 @@ async function getPrimarySeed(
  *
  * The address is a deterministic BIP-44 derivation of the user's existing
  * primary HD seed at `MONEY_DERIVATION_PATH`, so it can be recomputed at any
- * time from an unlocked wallet. `MoneyKeyring` is used purely as a deriver
- * here: the instance is discarded once the address has been read, and is never
- * registered with the `KeyringController`.
+ * time from an unlocked wallet.
  *
  * @param messenger - The messenger used to reach the `KeyringController`.
  * @returns The money account address.

--- a/app/scripts/lib/money/money-account-availability.test.ts
+++ b/app/scripts/lib/money/money-account-availability.test.ts
@@ -15,14 +15,6 @@ const DISABLED_FLAG = { enabled: false, minimumVersion: '0.0.1' };
 
 const deriveMoneyAccountAddressMock = jest.mocked(deriveMoneyAccountAddress);
 
-/**
- * Build a messenger that answers the actions the service calls, and records
- * the `KeyringController:unlock` subscriber so a test can fire it.
- *
- * @param options - Options.
- * @param options.moneyFlag - The raw `moneyEnableMoneyAccount` flag value.
- * @returns The messenger, its mocks, and a way to publish an unlock.
- */
 function createMockMessenger({
   moneyFlag = ENABLED_FLAG as unknown,
 }: {

--- a/app/scripts/lib/money/money-account-availability.test.ts
+++ b/app/scripts/lib/money/money-account-availability.test.ts
@@ -1,0 +1,175 @@
+import type { Hex } from '@metamask/utils';
+import { MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME } from '../../../../shared/lib/money/feature-flags';
+import { deriveMoneyAccountAddress } from './get-money-account-address';
+import {
+  MoneyAccountAvailabilityService,
+  type MoneyAccountAvailabilityMessenger,
+} from './money-account-availability';
+
+jest.mock('./get-money-account-address');
+
+const MONEY_ADDRESS = '0xd5fe9b0579443e7025cf3309ba420977710e7183' as Hex;
+
+const ENABLED_FLAG = { enabled: true, minimumVersion: '0.0.1' };
+const DISABLED_FLAG = { enabled: false, minimumVersion: '0.0.1' };
+
+const deriveMoneyAccountAddressMock = jest.mocked(deriveMoneyAccountAddress);
+
+/**
+ * Build a messenger that answers the actions the service calls, and records
+ * the `KeyringController:unlock` subscriber so a test can fire it.
+ *
+ * @param options - Options.
+ * @param options.moneyFlag - The raw `moneyEnableMoneyAccount` flag value.
+ * @returns The messenger, its mocks, and a way to publish an unlock.
+ */
+function createMockMessenger({
+  moneyFlag = ENABLED_FLAG as unknown,
+}: {
+  moneyFlag?: unknown;
+} = {}) {
+  const call = jest.fn((action: string) => {
+    if (action === 'RemoteFeatureFlagController:getState') {
+      return {
+        remoteFeatureFlags: {
+          [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: moneyFlag,
+        },
+      };
+    }
+    throw new Error(`Unexpected action: ${action}`);
+  });
+
+  const subscribers: (() => void)[] = [];
+  const subscribe = jest.fn((event: string, handler: () => void) => {
+    expect(event).toBe('KeyringController:unlock');
+    subscribers.push(handler);
+  });
+
+  const messenger = {
+    call,
+    subscribe,
+  } as unknown as MoneyAccountAvailabilityMessenger;
+
+  return {
+    messenger,
+    call,
+    publishUnlock: () => subscribers.forEach((handler) => handler()),
+  };
+}
+
+function createService(
+  options: Parameters<typeof createMockMessenger>[0] = {},
+) {
+  const mock = createMockMessenger(options);
+  const service = new MoneyAccountAvailabilityService({
+    messenger: mock.messenger,
+  });
+  return { service, ...mock };
+}
+
+describe('MoneyAccountAvailabilityService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    deriveMoneyAccountAddressMock.mockResolvedValue(MONEY_ADDRESS);
+  });
+
+  it('answers available with the derived address when the flag is on', async () => {
+    const { service } = createService();
+
+    expect(await service.getAvailability()).toStrictEqual({
+      isAvailable: true,
+      address: MONEY_ADDRESS,
+    });
+  });
+
+  it('answers unavailable when the flag is off, without touching the seed', async () => {
+    const { service } = createService({ moneyFlag: DISABLED_FLAG });
+
+    expect(await service.getAvailability()).toStrictEqual({
+      isAvailable: false,
+    });
+    expect(deriveMoneyAccountAddressMock).not.toHaveBeenCalled();
+  });
+
+  it('answers unavailable when the flag is absent or malformed', async () => {
+    for (const moneyFlag of [null, 'yes', { enabled: true }]) {
+      const { service } = createService({ moneyFlag });
+
+      expect(await service.getAvailability()).toStrictEqual({
+        isAvailable: false,
+      });
+    }
+  });
+
+  it('re-reads the flag on every call so a remote-flag refresh takes effect', async () => {
+    let flag: unknown = DISABLED_FLAG;
+    const call = jest.fn(() => ({
+      remoteFeatureFlags: { [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: flag },
+    }));
+    const messenger = {
+      call,
+      subscribe: jest.fn(),
+    } as unknown as MoneyAccountAvailabilityMessenger;
+    const service = new MoneyAccountAvailabilityService({ messenger });
+
+    expect((await service.getAvailability()).isAvailable).toBe(false);
+
+    flag = ENABLED_FLAG;
+    expect((await service.getAvailability()).isAvailable).toBe(true);
+  });
+
+  it('answers unavailable when the address cannot be derived, and retries next call', async () => {
+    deriveMoneyAccountAddressMock.mockRejectedValueOnce(
+      new Error('wallet is locked'),
+    );
+    const { service } = createService();
+
+    expect(await service.getAvailability()).toStrictEqual({
+      isAvailable: false,
+    });
+
+    // The failure was not cached: the next call derives again and succeeds.
+    expect(await service.getAvailability()).toStrictEqual({
+      isAvailable: true,
+      address: MONEY_ADDRESS,
+    });
+    expect(deriveMoneyAccountAddressMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches the derived address across calls', async () => {
+    const { service } = createService();
+
+    await service.getAvailability();
+    await service.getAvailability();
+
+    expect(deriveMoneyAccountAddressMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one in-flight derivation between concurrent callers', async () => {
+    const { service } = createService();
+
+    const [first, second] = await Promise.all([
+      service.getAvailability(),
+      service.getAvailability(),
+    ]);
+
+    expect(first).toStrictEqual(second);
+    expect(deriveMoneyAccountAddressMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the cached address on unlock so a vault restore re-derives', async () => {
+    const { service, publishUnlock } = createService();
+
+    await service.getAvailability();
+
+    const restoredAddress = '0x1111111111111111111111111111111111111111';
+    deriveMoneyAccountAddressMock.mockResolvedValue(restoredAddress as Hex);
+    publishUnlock();
+
+    expect(await service.getAvailability()).toStrictEqual({
+      isAvailable: true,
+      address: restoredAddress,
+    });
+    expect(deriveMoneyAccountAddressMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/scripts/lib/money/money-account-availability.test.ts
+++ b/app/scripts/lib/money/money-account-availability.test.ts
@@ -43,9 +43,11 @@ function createMockMessenger({
     }
   });
 
+  const registerMethodActionHandlers = jest.fn();
   const messenger = {
     call,
     subscribe,
+    registerMethodActionHandlers,
   } as unknown as MoneyAccountAvailabilityMessenger;
 
   return {
@@ -108,6 +110,7 @@ describe('MoneyAccountAvailabilityService', () => {
     const messenger = {
       call,
       subscribe: jest.fn(),
+      registerMethodActionHandlers: jest.fn(),
     } as unknown as MoneyAccountAvailabilityMessenger;
     const service = new MoneyAccountAvailabilityService({ messenger });
 

--- a/app/scripts/lib/money/money-account-availability.test.ts
+++ b/app/scripts/lib/money/money-account-availability.test.ts
@@ -31,10 +31,16 @@ function createMockMessenger({
     throw new Error(`Unexpected action: ${action}`);
   });
 
-  const subscribers: (() => void)[] = [];
+  const unlockSubscribers: (() => void)[] = [];
+  const lockSubscribers: (() => void)[] = [];
   const subscribe = jest.fn((event: string, handler: () => void) => {
-    expect(event).toBe('KeyringController:unlock');
-    subscribers.push(handler);
+    if (event === 'KeyringController:unlock') {
+      unlockSubscribers.push(handler);
+    } else if (event === 'KeyringController:lock') {
+      lockSubscribers.push(handler);
+    } else {
+      throw new Error(`Unexpected event: ${event}`);
+    }
   });
 
   const messenger = {
@@ -45,7 +51,8 @@ function createMockMessenger({
   return {
     messenger,
     call,
-    publishUnlock: () => subscribers.forEach((handler) => handler()),
+    publishUnlock: () => unlockSubscribers.forEach((handler) => handler()),
+    publishLock: () => lockSubscribers.forEach((handler) => handler()),
   };
 }
 
@@ -161,6 +168,46 @@ describe('MoneyAccountAvailabilityService', () => {
     expect(await service.getAvailability()).toStrictEqual({
       isAvailable: true,
       address: restoredAddress,
+    });
+    expect(deriveMoneyAccountAddressMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops the cached address on lock so a locked wallet is not served a stale address', async () => {
+    const { service, publishLock } = createService();
+
+    await service.getAvailability();
+    publishLock();
+
+    await service.getAvailability();
+
+    expect(deriveMoneyAccountAddressMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not clear a newer cached derivation when an older, superseded one rejects', async () => {
+    const { service, publishUnlock } = createService();
+
+    let rejectFirst: (error: Error) => void = () => undefined;
+    deriveMoneyAccountAddressMock.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectFirst = reject;
+      }),
+    );
+
+    const firstCall = service.getAvailability();
+
+    // Unlock clears the cache and starts a second, successful derivation.
+    publishUnlock();
+    deriveMoneyAccountAddressMock.mockResolvedValueOnce(MONEY_ADDRESS);
+    const secondCall = service.getAvailability();
+
+    // The first (now superseded) derivation finally rejects.
+    rejectFirst(new Error('wallet was locked'));
+
+    await Promise.all([firstCall, secondCall]);
+
+    expect(await service.getAvailability()).toStrictEqual({
+      isAvailable: true,
+      address: MONEY_ADDRESS,
     });
     expect(deriveMoneyAccountAddressMock).toHaveBeenCalledTimes(2);
   });

--- a/app/scripts/lib/money/money-account-availability.ts
+++ b/app/scripts/lib/money/money-account-availability.ts
@@ -22,11 +22,6 @@ export type MoneyAccountAvailabilityMessenger = Messenger<
 
 /**
  * Whether this user has a usable Money Account, and its address when they do.
- *
- * The address is only present in the available case: when the account is
- * unavailable the entire Money surface is hidden, so there is nothing for a
- * caller to render it against. Callers get one answer rather than a flag per
- * input to recombine.
  */
 export type MoneyAccountAvailability =
   | { isAvailable: true; address: Hex }
@@ -37,25 +32,16 @@ const UNAVAILABLE: MoneyAccountAvailability = { isAvailable: false };
 /**
  * Resolves whether the Money Account surface should be shown at all.
  *
- * Two things have to hold: the `moneyEnableMoneyAccount` flag is on, and the
- * money address can be derived (which requires an unlocked wallet).
- * Visibility is deliberately controlled by the flag alone — it is **not**
- * gated on the account having an EIP-7702 delegation, because an upgrade flow
- * is planned for the extension: a user whose account is not yet upgraded
- * should still see the surface that leads them there.
+ * We look at the state of the `moneyEnableMoneyAccount` flag, and whether
+ * a money address can be derived from an unlocked wallet.
  *
- * ## Not a deposit pre-flight
+ * A money account being available doesn’t mean that the account has been
+ * upgraded yet.
  *
- * A `true` answer means "the feature is on and this wallet derives a money
- * address", nothing more. A visible account may not be upgraded yet, and even
- * an upgraded one can fail a deposit (insufficient gas, an unavailable
- * network client). A deposit path must handle its own failures.
+ * The flag is checked first and never cached because it can
+ * change when remote feature flags update.
  *
- * ## Caching
- *
- * The flag is checked first and never cached: it is a synchronous state read,
- * and it can flip while the wallet stays unlocked when the remote flags
- * refresh. The derived address is cached as a promise until the next unlock,
+ * The derived address is cached as a promise until the next unlock,
  * so concurrent callers share one in-flight derivation; failures are not
  * cached, so a locked wallet is retried on the next call.
  */

--- a/app/scripts/lib/money/money-account-availability.ts
+++ b/app/scripts/lib/money/money-account-availability.ts
@@ -1,0 +1,130 @@
+import type {
+  KeyringControllerUnlockEvent,
+  KeyringControllerWithKeyringUnsafeAction,
+} from '@metamask/keyring-controller';
+import type { Messenger } from '@metamask/messenger';
+import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import { createProjectLogger, type Hex } from '@metamask/utils';
+import { isMoneyAccountEnabled } from '../../../../shared/lib/money/feature-flags';
+import { deriveMoneyAccountAddress } from './get-money-account-address';
+
+const log = createProjectLogger('money-account-availability');
+
+type MoneyAccountAvailabilityActions =
+  | KeyringControllerWithKeyringUnsafeAction
+  | RemoteFeatureFlagControllerGetStateAction;
+
+export type MoneyAccountAvailabilityMessenger = Messenger<
+  string,
+  MoneyAccountAvailabilityActions,
+  KeyringControllerUnlockEvent
+>;
+
+/**
+ * Whether this user has a usable Money Account, and its address when they do.
+ *
+ * The address is only present in the available case: when the account is
+ * unavailable the entire Money surface is hidden, so there is nothing for a
+ * caller to render it against. Callers get one answer rather than a flag per
+ * input to recombine.
+ */
+export type MoneyAccountAvailability =
+  | { isAvailable: true; address: Hex }
+  | { isAvailable: false };
+
+const UNAVAILABLE: MoneyAccountAvailability = { isAvailable: false };
+
+/**
+ * Resolves whether the Money Account surface should be shown at all.
+ *
+ * Two things have to hold: the `moneyEnableMoneyAccount` flag is on, and the
+ * money address can be derived (which requires an unlocked wallet).
+ * Visibility is deliberately controlled by the flag alone — it is **not**
+ * gated on the account having an EIP-7702 delegation, because an upgrade flow
+ * is planned for the extension: a user whose account is not yet upgraded
+ * should still see the surface that leads them there.
+ *
+ * ## Not a deposit pre-flight
+ *
+ * A `true` answer means "the feature is on and this wallet derives a money
+ * address", nothing more. A visible account may not be upgraded yet, and even
+ * an upgraded one can fail a deposit (insufficient gas, an unavailable
+ * network client). A deposit path must handle its own failures.
+ *
+ * ## Caching
+ *
+ * The flag is checked first and never cached: it is a synchronous state read,
+ * and it can flip while the wallet stays unlocked when the remote flags
+ * refresh. The derived address is cached as a promise until the next unlock,
+ * so concurrent callers share one in-flight derivation; failures are not
+ * cached, so a locked wallet is retried on the next call.
+ */
+export class MoneyAccountAvailabilityService {
+  readonly #messenger: MoneyAccountAvailabilityMessenger;
+
+  #address?: Promise<Hex>;
+
+  constructor({ messenger }: { messenger: MoneyAccountAvailabilityMessenger }) {
+    this.#messenger = messenger;
+
+    // An unlock can follow a vault restore, which changes the primary seed and
+    // therefore the derived address, so the cached value is dropped.
+    this.#messenger.subscribe('KeyringController:unlock', () => {
+      this.#address = undefined;
+    });
+  }
+
+  /**
+   * Resolve whether the Money Account is available.
+   *
+   * @returns The availability, with the money address when available.
+   */
+  async getAvailability(): Promise<MoneyAccountAvailability> {
+    if (!this.#isEnabled()) {
+      return UNAVAILABLE;
+    }
+
+    try {
+      const address = await this.#getAddress();
+
+      return { isAvailable: true, address };
+    } catch (error) {
+      // A locked wallet lands here. It is not evidence that the user has no
+      // money account, so the surface is hidden without the answer being
+      // cached.
+      log('Failed to resolve money account availability', error);
+      return UNAVAILABLE;
+    }
+  }
+
+  /**
+   * Read the `moneyEnableMoneyAccount` flag.
+   *
+   * @returns Whether the Money Account feature is enabled.
+   */
+  #isEnabled(): boolean {
+    const { remoteFeatureFlags } = this.#messenger.call(
+      'RemoteFeatureFlagController:getState',
+    );
+
+    return isMoneyAccountEnabled(remoteFeatureFlags);
+  }
+
+  /**
+   * The derived money address, from cache when already resolved.
+   *
+   * @returns The money account address.
+   */
+  async #getAddress(): Promise<Hex> {
+    if (!this.#address) {
+      const address = deriveMoneyAccountAddress(this.#messenger);
+
+      this.#address = address;
+      address.catch(() => {
+        this.#address = undefined;
+      });
+    }
+
+    return await this.#address;
+  }
+}

--- a/app/scripts/lib/money/money-account-availability.ts
+++ b/app/scripts/lib/money/money-account-availability.ts
@@ -1,4 +1,5 @@
 import type {
+  KeyringControllerLockEvent,
   KeyringControllerUnlockEvent,
   KeyringControllerWithKeyringUnsafeAction,
 } from '@metamask/keyring-controller';
@@ -14,10 +15,14 @@ type MoneyAccountAvailabilityActions =
   | KeyringControllerWithKeyringUnsafeAction
   | RemoteFeatureFlagControllerGetStateAction;
 
+type MoneyAccountAvailabilityEvents =
+  | KeyringControllerUnlockEvent
+  | KeyringControllerLockEvent;
+
 export type MoneyAccountAvailabilityMessenger = Messenger<
   string,
   MoneyAccountAvailabilityActions,
-  KeyringControllerUnlockEvent
+  MoneyAccountAvailabilityEvents
 >;
 
 /**
@@ -54,8 +59,13 @@ export class MoneyAccountAvailabilityService {
     this.#messenger = messenger;
 
     // An unlock can follow a vault restore, which changes the primary seed and
-    // therefore the derived address, so the cached value is dropped.
+    // therefore the derived address, so the cached value is dropped. A lock
+    // also drops it, so a re-derivation re-checks that the wallet is unlocked
+    // rather than serving a stale address from before the lock.
     this.#messenger.subscribe('KeyringController:unlock', () => {
+      this.#address = undefined;
+    });
+    this.#messenger.subscribe('KeyringController:lock', () => {
       this.#address = undefined;
     });
   }
@@ -66,18 +76,19 @@ export class MoneyAccountAvailabilityService {
    * @returns The availability, with the money address when available.
    */
   async getAvailability(): Promise<MoneyAccountAvailability> {
-    if (!this.#isEnabled()) {
-      return UNAVAILABLE;
-    }
-
     try {
+      if (!this.#isEnabled()) {
+        return UNAVAILABLE;
+      }
+
       const address = await this.#getAddress();
 
       return { isAvailable: true, address };
     } catch (error) {
-      // A locked wallet lands here. It is not evidence that the user has no
-      // money account, so the surface is hidden without the answer being
-      // cached.
+      // A locked wallet, or a transient failure reading the feature flag or
+      // deriving the address, lands here. None of these are evidence that
+      // the user has no money account, so the surface is hidden without the
+      // answer being cached.
       log('Failed to resolve money account availability', error);
       return UNAVAILABLE;
     }
@@ -107,7 +118,12 @@ export class MoneyAccountAvailabilityService {
 
       this.#address = address;
       address.catch(() => {
-        this.#address = undefined;
+        // Only clear the cache if it still points at this derivation. A lock
+        // or unlock in between may have already replaced it with a newer,
+        // possibly successful, one.
+        if (this.#address === address) {
+          this.#address = undefined;
+        }
       });
     }
 

--- a/app/scripts/lib/money/money-account-availability.ts
+++ b/app/scripts/lib/money/money-account-availability.ts
@@ -11,7 +11,9 @@ import { deriveMoneyAccountAddress } from './get-money-account-address';
 
 const log = createProjectLogger('money-account-availability');
 
-type MoneyAccountAvailabilityActions =
+const serviceName = 'MoneyAccountAvailabilityService';
+
+type MoneyAccountAvailabilityAllowedActions =
   | KeyringControllerWithKeyringUnsafeAction
   | RemoteFeatureFlagControllerGetStateAction;
 
@@ -19,9 +21,31 @@ type MoneyAccountAvailabilityEvents =
   | KeyringControllerUnlockEvent
   | KeyringControllerLockEvent;
 
+/**
+ * The action other clients use to call {@link MoneyAccountAvailabilityService.getAvailability}
+ * directly through the messenger, instead of via a controller wrapper method.
+ */
+export type MoneyAccountAvailabilityServiceGetAvailabilityAction = {
+  type: `${typeof serviceName}:getAvailability`;
+  handler: MoneyAccountAvailabilityService['getAvailability'];
+};
+
+/**
+ * The action other clients use to call {@link MoneyAccountAvailabilityService.getAddress}
+ * directly through the messenger, instead of via a controller wrapper method.
+ */
+export type MoneyAccountAvailabilityServiceGetAddressAction = {
+  type: `${typeof serviceName}:getAddress`;
+  handler: MoneyAccountAvailabilityService['getAddress'];
+};
+
+type MoneyAccountAvailabilityActions =
+  | MoneyAccountAvailabilityServiceGetAvailabilityAction
+  | MoneyAccountAvailabilityServiceGetAddressAction;
+
 export type MoneyAccountAvailabilityMessenger = Messenger<
-  string,
-  MoneyAccountAvailabilityActions,
+  typeof serviceName,
+  MoneyAccountAvailabilityActions | MoneyAccountAvailabilityAllowedActions,
   MoneyAccountAvailabilityEvents
 >;
 
@@ -51,6 +75,8 @@ const UNAVAILABLE: MoneyAccountAvailability = { isAvailable: false };
  * cached, so a locked wallet is retried on the next call.
  */
 export class MoneyAccountAvailabilityService {
+  readonly name: typeof serviceName = serviceName;
+
   readonly #messenger: MoneyAccountAvailabilityMessenger;
 
   #address?: Promise<Hex>;
@@ -68,6 +94,11 @@ export class MoneyAccountAvailabilityService {
     this.#messenger.subscribe('KeyringController:lock', () => {
       this.#address = undefined;
     });
+
+    this.#messenger.registerMethodActionHandlers(this, [
+      'getAvailability',
+      'getAddress',
+    ]);
   }
 
   /**
@@ -81,7 +112,7 @@ export class MoneyAccountAvailabilityService {
         return UNAVAILABLE;
       }
 
-      const address = await this.#getAddress();
+      const address = await this.getAddress();
 
       return { isAvailable: true, address };
     } catch (error) {
@@ -95,24 +126,16 @@ export class MoneyAccountAvailabilityService {
   }
 
   /**
-   * Read the `moneyEnableMoneyAccount` flag.
+   * The money account address, derived from the primary HD seed. Requires an
+   * unlocked wallet, but not the password.
    *
-   * @returns Whether the Money Account feature is enabled.
-   */
-  #isEnabled(): boolean {
-    const { remoteFeatureFlags } = this.#messenger.call(
-      'RemoteFeatureFlagController:getState',
-    );
-
-    return isMoneyAccountEnabled(remoteFeatureFlags);
-  }
-
-  /**
-   * The derived money address, from cache when already resolved.
+   * Cached as a promise until the next unlock, so concurrent callers share
+   * one in-flight derivation; failures are not cached, so a locked wallet is
+   * retried on the next call.
    *
    * @returns The money account address.
    */
-  async #getAddress(): Promise<Hex> {
+  async getAddress(): Promise<Hex> {
     if (!this.#address) {
       const address = deriveMoneyAccountAddress(this.#messenger);
 
@@ -128,5 +151,18 @@ export class MoneyAccountAvailabilityService {
     }
 
     return await this.#address;
+  }
+
+  /**
+   * Read the `moneyEnableMoneyAccount` flag.
+   *
+   * @returns Whether the Money Account feature is enabled.
+   */
+  #isEnabled(): boolean {
+    const { remoteFeatureFlags } = this.#messenger.call(
+      'RemoteFeatureFlagController:getState',
+    );
+
+    return isMoneyAccountEnabled(remoteFeatureFlags);
   }
 }

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -111,6 +111,7 @@ import { RampsController, RampsService } from '@metamask/ramps-controller';
 import { PasskeyController } from '@metamask/passkey-controller';
 import { AnalyticsController } from '@metamask/analytics-controller';
 import { SentinelApiService } from '@metamask/sentinel-api-service';
+import { MoneyAccountApiDataService } from '@metamask/money-account-api-data-service';
 import { MoneyAccountBalanceService } from '@metamask/money-account-balance-service';
 import { OnboardingController } from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
@@ -177,6 +178,7 @@ export type MessengerClient =
   | LoggingController
   | MetaMetricsController
   | MetaMetricsDataDeletionController
+  | MoneyAccountApiDataService
   | MoneyAccountBalanceService
   | MultichainAssetsController
   | MultichainAssetsRatesController

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -111,6 +111,7 @@ import { RampsController, RampsService } from '@metamask/ramps-controller';
 import { PasskeyController } from '@metamask/passkey-controller';
 import { AnalyticsController } from '@metamask/analytics-controller';
 import { SentinelApiService } from '@metamask/sentinel-api-service';
+import { MoneyAccountBalanceService } from '@metamask/money-account-balance-service';
 import { OnboardingController } from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import { InstitutionalSnapController } from '../controllers/institutional-snap/InstitutionalSnapController';
@@ -176,6 +177,7 @@ export type MessengerClient =
   | LoggingController
   | MetaMetricsController
   | MetaMetricsDataDeletionController
+  | MoneyAccountBalanceService
   | MultichainAssetsController
   | MultichainAssetsRatesController
   | MultichainBalancesController

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -113,6 +113,7 @@ import { AnalyticsController } from '@metamask/analytics-controller';
 import { SentinelApiService } from '@metamask/sentinel-api-service';
 import { MoneyAccountApiDataService } from '@metamask/money-account-api-data-service';
 import { MoneyAccountBalanceService } from '@metamask/money-account-balance-service';
+import { MoneyAccountAvailabilityService } from '../lib/money/money-account-availability';
 import { OnboardingController } from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import { InstitutionalSnapController } from '../controllers/institutional-snap/InstitutionalSnapController';
@@ -179,6 +180,7 @@ export type MessengerClient =
   | MetaMetricsController
   | MetaMetricsDataDeletionController
   | MoneyAccountApiDataService
+  | MoneyAccountAvailabilityService
   | MoneyAccountBalanceService
   | MultichainAssetsController
   | MultichainAssetsRatesController

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -205,6 +205,7 @@ import { getDataDeletionServiceMessenger } from './data-deletion-service-messeng
 import { getLegacyBackgroundApiServiceMessenger } from './legacy-background-api-service-messenger';
 import { getConfigRegistryApiServiceMessenger } from './config-registry-api-service-messenger';
 import { getSentinelApiServiceMessenger } from './sentinel-api-service-messenger';
+import { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-service-messenger';
 
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
 export type { AccountTrackerControllerInitMessenger } from './account-tracker-controller-messenger';
@@ -278,6 +279,7 @@ export { getPermissionLogControllerMessenger } from './permission-log-controller
 export { getGeolocationApiServiceMessenger } from './geolocation-api-service-messenger';
 export { getGeolocationControllerMessenger } from './geolocation-controller-messenger';
 export { getSentinelApiServiceMessenger } from './sentinel-api-service-messenger';
+export { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-service-messenger';
 export type { ComplianceControllerMessenger } from './compliance-controller-messenger';
 export { getComplianceControllerMessenger } from './compliance-controller-messenger';
 export type { ComplianceServiceMessenger } from './compliance-service-messenger';
@@ -487,6 +489,10 @@ export const MESSENGER_FACTORIES = {
   },
   MetaMetricsDataDeletionController: {
     getMessenger: getMetaMetricsDataDeletionControllerMessenger,
+    getInitMessenger: noop,
+  },
+  MoneyAccountBalanceService: {
+    getMessenger: getMoneyAccountBalanceServiceMessenger,
     getInitMessenger: noop,
   },
   MultichainAssetsController: {

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -205,6 +205,7 @@ import { getDataDeletionServiceMessenger } from './data-deletion-service-messeng
 import { getLegacyBackgroundApiServiceMessenger } from './legacy-background-api-service-messenger';
 import { getConfigRegistryApiServiceMessenger } from './config-registry-api-service-messenger';
 import { getSentinelApiServiceMessenger } from './sentinel-api-service-messenger';
+import { getMoneyAccountApiDataServiceMessenger } from './money-account-api-data-service-messenger';
 import { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-service-messenger';
 
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -279,6 +280,7 @@ export { getPermissionLogControllerMessenger } from './permission-log-controller
 export { getGeolocationApiServiceMessenger } from './geolocation-api-service-messenger';
 export { getGeolocationControllerMessenger } from './geolocation-controller-messenger';
 export { getSentinelApiServiceMessenger } from './sentinel-api-service-messenger';
+export { getMoneyAccountApiDataServiceMessenger } from './money-account-api-data-service-messenger';
 export { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-service-messenger';
 export type { ComplianceControllerMessenger } from './compliance-controller-messenger';
 export { getComplianceControllerMessenger } from './compliance-controller-messenger';
@@ -489,6 +491,10 @@ export const MESSENGER_FACTORIES = {
   },
   MetaMetricsDataDeletionController: {
     getMessenger: getMetaMetricsDataDeletionControllerMessenger,
+    getInitMessenger: noop,
+  },
+  MoneyAccountApiDataService: {
+    getMessenger: getMoneyAccountApiDataServiceMessenger,
     getInitMessenger: noop,
   },
   MoneyAccountBalanceService: {

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -207,6 +207,7 @@ import { getConfigRegistryApiServiceMessenger } from './config-registry-api-serv
 import { getSentinelApiServiceMessenger } from './sentinel-api-service-messenger';
 import { getMoneyAccountApiDataServiceMessenger } from './money-account-api-data-service-messenger';
 import { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-service-messenger';
+import { getMoneyAccountAvailabilityServiceMessenger } from './money-account-availability-service-messenger';
 
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
 export type { AccountTrackerControllerInitMessenger } from './account-tracker-controller-messenger';
@@ -282,6 +283,7 @@ export { getGeolocationControllerMessenger } from './geolocation-controller-mess
 export { getSentinelApiServiceMessenger } from './sentinel-api-service-messenger';
 export { getMoneyAccountApiDataServiceMessenger } from './money-account-api-data-service-messenger';
 export { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-service-messenger';
+export { getMoneyAccountAvailabilityServiceMessenger } from './money-account-availability-service-messenger';
 export type { ComplianceControllerMessenger } from './compliance-controller-messenger';
 export { getComplianceControllerMessenger } from './compliance-controller-messenger';
 export type { ComplianceServiceMessenger } from './compliance-service-messenger';

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -499,6 +499,10 @@ export const MESSENGER_FACTORIES = {
     getMessenger: getMoneyAccountApiDataServiceMessenger,
     getInitMessenger: noop,
   },
+  MoneyAccountAvailabilityService: {
+    getMessenger: getMoneyAccountAvailabilityServiceMessenger,
+    getInitMessenger: noop,
+  },
   MoneyAccountBalanceService: {
     getMessenger: getMoneyAccountBalanceServiceMessenger,
     getInitMessenger: noop,

--- a/app/scripts/messenger-client-init/messengers/money-account-api-data-service-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-api-data-service-messenger.test.ts
@@ -1,0 +1,25 @@
+import { Messenger } from '@metamask/messenger';
+import { getRootMessenger } from '../../lib/messenger';
+import { getMoneyAccountApiDataServiceMessenger } from './money-account-api-data-service-messenger';
+
+describe('getMoneyAccountApiDataServiceMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = getRootMessenger<never, never>();
+    const serviceMessenger = getMoneyAccountApiDataServiceMessenger(messenger);
+
+    expect(serviceMessenger).toBeInstanceOf(Messenger);
+  });
+
+  it('delegates AuthenticationController:getBearerToken', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getMoneyAccountApiDataServiceMessenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: ['AuthenticationController:getBearerToken'],
+      }),
+    );
+  });
+});

--- a/app/scripts/messenger-client-init/messengers/money-account-api-data-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-api-data-service-messenger.ts
@@ -1,0 +1,36 @@
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import type { MoneyAccountApiDataServiceMessenger } from '@metamask/money-account-api-data-service';
+import type { RootMessenger } from '../../lib/messenger';
+
+/**
+ * Create a messenger for the MoneyAccountApiDataService, scoped to the actions
+ * and events the service is allowed to use.
+ *
+ * The bearer token is best-effort: the service swallows a rejection and issues
+ * the request unauthenticated, falling back to IP-based rate limiting.
+ *
+ * @param messenger - The root messenger.
+ * @returns The MoneyAccountApiDataService messenger.
+ */
+export function getMoneyAccountApiDataServiceMessenger(
+  messenger: RootMessenger<
+    MessengerActions<MoneyAccountApiDataServiceMessenger>,
+    MessengerEvents<MoneyAccountApiDataServiceMessenger>
+  >,
+): MoneyAccountApiDataServiceMessenger {
+  const serviceMessenger: MoneyAccountApiDataServiceMessenger = new Messenger({
+    namespace: 'MoneyAccountApiDataService',
+    parent: messenger,
+  });
+
+  messenger.delegate({
+    messenger: serviceMessenger,
+    actions: ['AuthenticationController:getBearerToken'],
+  });
+
+  return serviceMessenger;
+}

--- a/app/scripts/messenger-client-init/messengers/money-account-api-data-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-api-data-service-messenger.ts
@@ -10,9 +10,6 @@ import type { RootMessenger } from '../../lib/messenger';
  * Create a messenger for the MoneyAccountApiDataService, scoped to the actions
  * and events the service is allowed to use.
  *
- * The bearer token is best-effort: the service swallows a rejection and issues
- * the request unauthenticated, falling back to IP-based rate limiting.
- *
  * @param messenger - The root messenger.
  * @returns The MoneyAccountApiDataService messenger.
  */

--- a/app/scripts/messenger-client-init/messengers/money-account-availability-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-availability-service-messenger.ts
@@ -1,0 +1,37 @@
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import type { MoneyAccountAvailabilityMessenger } from '../../lib/money/money-account-availability';
+import type { RootMessenger } from '../../lib/messenger';
+
+/**
+ * Create a messenger for the MoneyAccountAvailabilityService, scoped to the
+ * actions and events the service is allowed to use.
+ *
+ * @param messenger - The root messenger.
+ * @returns The MoneyAccountAvailabilityService messenger.
+ */
+export function getMoneyAccountAvailabilityServiceMessenger(
+  messenger: RootMessenger<
+    MessengerActions<MoneyAccountAvailabilityMessenger>,
+    MessengerEvents<MoneyAccountAvailabilityMessenger>
+  >,
+): MoneyAccountAvailabilityMessenger {
+  const serviceMessenger: MoneyAccountAvailabilityMessenger = new Messenger({
+    namespace: 'MoneyAccountAvailabilityService',
+    parent: messenger,
+  });
+
+  messenger.delegate({
+    messenger: serviceMessenger,
+    actions: [
+      'KeyringController:withKeyringUnsafe',
+      'RemoteFeatureFlagController:getState',
+    ],
+    events: ['KeyringController:unlock', 'KeyringController:lock'],
+  });
+
+  return serviceMessenger;
+}

--- a/app/scripts/messenger-client-init/messengers/money-account-balance-service-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-balance-service-messenger.test.ts
@@ -1,6 +1,13 @@
 import { Messenger } from '@metamask/messenger';
+import {
+  MoneyAccountApiDataService,
+  type PositionResponse,
+} from '@metamask/money-account-api-data-service';
 import { getRootMessenger } from '../../lib/messenger';
+import { getMoneyAccountApiDataServiceMessenger } from './money-account-api-data-service-messenger';
 import { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-service-messenger';
+
+const MOCK_ADDRESS = '0x1234567890123456789012345678901234567890';
 
 describe('getMoneyAccountBalanceServiceMessenger', () => {
   it('returns a restricted messenger', () => {
@@ -10,7 +17,7 @@ describe('getMoneyAccountBalanceServiceMessenger', () => {
     expect(serviceMessenger).toBeInstanceOf(Messenger);
   });
 
-  it('delegates the network and remote feature flag actions', () => {
+  it('delegates the network, remote feature flag and money API actions', () => {
     const messenger = getRootMessenger<never, never>();
     const delegateSpy = jest.spyOn(messenger, 'delegate');
 
@@ -22,9 +29,44 @@ describe('getMoneyAccountBalanceServiceMessenger', () => {
           'NetworkController:getNetworkConfigurationByChainId',
           'NetworkController:getNetworkClientById',
           'RemoteFeatureFlagController:getState',
+          'MoneyAccountApiDataService:fetchPositions',
         ],
       }),
     );
+  });
+
+  it('can call fetchPositions once MoneyAccountApiDataService is registered', async () => {
+    const messenger = getRootMessenger<never, never>();
+    const positions: PositionResponse = {
+      address: MOCK_ADDRESS,
+      // The Money API responds in snake_case.
+      /* eslint-disable @typescript-eslint/naming-convention */
+      as_of_block: 1,
+      as_of_timestamp: '2026-01-01T00:00:00Z',
+      data_freshness: 'live',
+      indexer_lag_seconds: 0,
+      /* eslint-enable @typescript-eslint/naming-convention */
+      positions: [],
+      balance: null,
+    };
+    const fetchPositions = jest
+      .spyOn(MoneyAccountApiDataService.prototype, 'fetchPositions')
+      .mockResolvedValue(positions);
+
+    // The API data service registers its action handlers in its constructor.
+    const apiService = new MoneyAccountApiDataService({
+      messenger: getMoneyAccountApiDataServiceMessenger(messenger),
+    });
+    const serviceMessenger = getMoneyAccountBalanceServiceMessenger(messenger);
+
+    expect(
+      await serviceMessenger.call(
+        'MoneyAccountApiDataService:fetchPositions',
+        MOCK_ADDRESS,
+      ),
+    ).toBe(positions);
+    expect(fetchPositions).toHaveBeenCalledWith(MOCK_ADDRESS);
+    expect(fetchPositions.mock.instances[0]).toBe(apiService);
   });
 
   it('delegates the remote feature flag state change event', () => {

--- a/app/scripts/messenger-client-init/messengers/money-account-balance-service-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-balance-service-messenger.test.ts
@@ -1,0 +1,42 @@
+import { Messenger } from '@metamask/messenger';
+import { getRootMessenger } from '../../lib/messenger';
+import { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-service-messenger';
+
+describe('getMoneyAccountBalanceServiceMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = getRootMessenger<never, never>();
+    const serviceMessenger = getMoneyAccountBalanceServiceMessenger(messenger);
+
+    expect(serviceMessenger).toBeInstanceOf(Messenger);
+  });
+
+  it('delegates the network and remote feature flag actions', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getMoneyAccountBalanceServiceMessenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: [
+          'NetworkController:getNetworkConfigurationByChainId',
+          'NetworkController:getNetworkClientById',
+          'RemoteFeatureFlagController:getState',
+        ],
+      }),
+    );
+  });
+
+  it('delegates the remote feature flag state change event', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getMoneyAccountBalanceServiceMessenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: ['RemoteFeatureFlagController:stateChange'],
+      }),
+    );
+  });
+});

--- a/app/scripts/messenger-client-init/messengers/money-account-balance-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-balance-service-messenger.ts
@@ -1,0 +1,38 @@
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import type { MoneyAccountBalanceServiceMessenger } from '@metamask/money-account-balance-service';
+import type { RootMessenger } from '../../lib/messenger';
+
+/**
+ * Create a messenger for the MoneyAccountBalanceService, scoped to the actions
+ * and events the service is allowed to use.
+ *
+ * @param messenger - The root messenger.
+ * @returns The MoneyAccountBalanceService messenger.
+ */
+export function getMoneyAccountBalanceServiceMessenger(
+  messenger: RootMessenger<
+    MessengerActions<MoneyAccountBalanceServiceMessenger>,
+    MessengerEvents<MoneyAccountBalanceServiceMessenger>
+  >,
+): MoneyAccountBalanceServiceMessenger {
+  const serviceMessenger: MoneyAccountBalanceServiceMessenger = new Messenger({
+    namespace: 'MoneyAccountBalanceService',
+    parent: messenger,
+  });
+
+  messenger.delegate({
+    messenger: serviceMessenger,
+    actions: [
+      'NetworkController:getNetworkConfigurationByChainId',
+      'NetworkController:getNetworkClientById',
+      'RemoteFeatureFlagController:getState',
+    ],
+    events: ['RemoteFeatureFlagController:stateChange'],
+  });
+
+  return serviceMessenger;
+}

--- a/app/scripts/messenger-client-init/messengers/money-account-balance-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-balance-service-messenger.ts
@@ -30,6 +30,9 @@ export function getMoneyAccountBalanceServiceMessenger(
       'NetworkController:getNetworkConfigurationByChainId',
       'NetworkController:getNetworkClientById',
       'RemoteFeatureFlagController:getState',
+      // Required by MoneyAccountBalanceService:fetchBalanceWithFallback when
+      // the Money API is the preferred or fallback balance source.
+      'MoneyAccountApiDataService:fetchPositions',
     ],
     events: ['RemoteFeatureFlagController:stateChange'],
   });

--- a/app/scripts/messenger-client-init/messengers/money-account-balance-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-balance-service-messenger.ts
@@ -30,8 +30,6 @@ export function getMoneyAccountBalanceServiceMessenger(
       'NetworkController:getNetworkConfigurationByChainId',
       'NetworkController:getNetworkClientById',
       'RemoteFeatureFlagController:getState',
-      // Required by MoneyAccountBalanceService:fetchBalanceWithFallback when
-      // the Money API is the preferred or fallback balance source.
       'MoneyAccountApiDataService:fetchPositions',
     ],
     events: ['RemoteFeatureFlagController:stateChange'],

--- a/app/scripts/messenger-client-init/money-account-api-data-service-init.test.ts
+++ b/app/scripts/messenger-client-init/money-account-api-data-service-init.test.ts
@@ -1,0 +1,58 @@
+import {
+  Env,
+  MoneyAccountApiDataService,
+  type MoneyAccountApiDataServiceMessenger,
+} from '@metamask/money-account-api-data-service';
+import { getRootMessenger } from '../lib/messenger';
+import type { MessengerClientInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import { getMoneyAccountApiDataServiceMessenger } from './messengers';
+import { MoneyAccountApiDataServiceInit } from './money-account-api-data-service-init';
+
+jest.mock('@metamask/money-account-api-data-service');
+
+function getInitRequestMock(): jest.Mocked<
+  MessengerClientInitRequest<MoneyAccountApiDataServiceMessenger>
+> {
+  const baseMessenger = getRootMessenger<never, never>();
+
+  return {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getMoneyAccountApiDataServiceMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+}
+
+describe('MoneyAccountApiDataServiceInit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes the service', () => {
+    const { messengerClient } =
+      MoneyAccountApiDataServiceInit(getInitRequestMock());
+
+    expect(messengerClient).toBeInstanceOf(MoneyAccountApiDataService);
+  });
+
+  it('passes the service messenger and the production environment', () => {
+    MoneyAccountApiDataServiceInit(getInitRequestMock());
+
+    expect(jest.mocked(MoneyAccountApiDataService)).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      env: Env.PRD,
+    });
+  });
+
+  it('returns null for persistedStateKey', () => {
+    const result = MoneyAccountApiDataServiceInit(getInitRequestMock());
+
+    expect(result.persistedStateKey).toBeNull();
+  });
+
+  it('returns null for memStateKey', () => {
+    const result = MoneyAccountApiDataServiceInit(getInitRequestMock());
+
+    expect(result.memStateKey).toBeNull();
+  });
+});

--- a/app/scripts/messenger-client-init/money-account-api-data-service-init.ts
+++ b/app/scripts/messenger-client-init/money-account-api-data-service-init.ts
@@ -1,0 +1,33 @@
+import {
+  Env,
+  MoneyAccountApiDataService,
+  type MoneyAccountApiDataServiceMessenger,
+} from '@metamask/money-account-api-data-service';
+import type { MessengerClientInitFunction } from './types';
+
+/**
+ * Initialize the MoneyAccountApiDataService.
+ *
+ * This is the Money API source behind
+ * `MoneyAccountBalanceService:fetchBalanceWithFallback`. Without it registered,
+ * the balance service's fallback calls an unregistered action and throws
+ * instead of falling back.
+ *
+ * The service registers its own action handlers in its constructor and holds no
+ * persisted or in-memory client state, so there is nothing to init.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the service.
+ * @returns The initialized service.
+ */
+export const MoneyAccountApiDataServiceInit: MessengerClientInitFunction<
+  MoneyAccountApiDataService,
+  MoneyAccountApiDataServiceMessenger
+> = ({ controllerMessenger }) => {
+  const messengerClient = new MoneyAccountApiDataService({
+    messenger: controllerMessenger,
+    env: Env.PRD,
+  });
+
+  return { messengerClient, persistedStateKey: null, memStateKey: null };
+};

--- a/app/scripts/messenger-client-init/money-account-api-data-service-init.ts
+++ b/app/scripts/messenger-client-init/money-account-api-data-service-init.ts
@@ -8,14 +8,6 @@ import type { MessengerClientInitFunction } from './types';
 /**
  * Initialize the MoneyAccountApiDataService.
  *
- * This is the Money API source behind
- * `MoneyAccountBalanceService:fetchBalanceWithFallback`. Without it registered,
- * the balance service's fallback calls an unregistered action and throws
- * instead of falling back.
- *
- * The service registers its own action handlers in its constructor and holds no
- * persisted or in-memory client state, so there is nothing to init.
- *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized service.

--- a/app/scripts/messenger-client-init/money-account-availability-service-init.test.ts
+++ b/app/scripts/messenger-client-init/money-account-availability-service-init.test.ts
@@ -1,0 +1,33 @@
+import { getRootMessenger } from '../lib/messenger';
+import {
+  MoneyAccountAvailabilityService,
+  MoneyAccountAvailabilityMessenger,
+} from '../lib/money/money-account-availability';
+import { MessengerClientInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import { MoneyAccountAvailabilityServiceInit } from './money-account-availability-service-init';
+import { getMoneyAccountAvailabilityServiceMessenger } from './messengers/money-account-availability-service-messenger';
+
+function buildInitRequestMock(): jest.Mocked<
+  MessengerClientInitRequest<MoneyAccountAvailabilityMessenger>
+> {
+  const baseControllerMessenger = getRootMessenger<never, never>();
+
+  return {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getMoneyAccountAvailabilityServiceMessenger(
+      baseControllerMessenger,
+    ),
+    initMessenger: undefined,
+  };
+}
+
+describe('MoneyAccountAvailabilityServiceInit', () => {
+  it('returns the service instance', () => {
+    const requestMock = buildInitRequestMock();
+
+    expect(
+      MoneyAccountAvailabilityServiceInit(requestMock).messengerClient,
+    ).toBeInstanceOf(MoneyAccountAvailabilityService);
+  });
+});

--- a/app/scripts/messenger-client-init/money-account-availability-service-init.ts
+++ b/app/scripts/messenger-client-init/money-account-availability-service-init.ts
@@ -1,0 +1,27 @@
+import {
+  MoneyAccountAvailabilityService,
+  MoneyAccountAvailabilityMessenger,
+} from '../lib/money/money-account-availability';
+import { MessengerClientInitFunction } from './types';
+
+/**
+ * Initialize the MoneyAccountAvailabilityService.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the service.
+ * @returns The initialized service.
+ */
+export const MoneyAccountAvailabilityServiceInit: MessengerClientInitFunction<
+  MoneyAccountAvailabilityService,
+  MoneyAccountAvailabilityMessenger
+> = ({ controllerMessenger }) => {
+  const messengerClient = new MoneyAccountAvailabilityService({
+    messenger: controllerMessenger,
+  });
+
+  return {
+    messengerClient,
+    memStateKey: null,
+    persistedStateKey: null,
+  };
+};

--- a/app/scripts/messenger-client-init/money-account-balance-service-init.test.ts
+++ b/app/scripts/messenger-client-init/money-account-balance-service-init.test.ts
@@ -1,0 +1,65 @@
+import {
+  MoneyAccountBalanceService,
+  type MoneyAccountBalanceServiceMessenger,
+} from '@metamask/money-account-balance-service';
+import { getRootMessenger } from '../lib/messenger';
+import type { MessengerClientInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import { getMoneyAccountBalanceServiceMessenger } from './messengers';
+import { MoneyAccountBalanceServiceInit } from './money-account-balance-service-init';
+
+jest.mock('@metamask/money-account-balance-service');
+
+function getInitRequestMock(): jest.Mocked<
+  MessengerClientInitRequest<MoneyAccountBalanceServiceMessenger>
+> {
+  const baseMessenger = getRootMessenger<never, never>();
+
+  return {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getMoneyAccountBalanceServiceMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+}
+
+describe('MoneyAccountBalanceServiceInit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes the service', () => {
+    const { messengerClient } = MoneyAccountBalanceServiceInit(
+      getInitRequestMock(),
+    );
+
+    expect(messengerClient).toBeInstanceOf(MoneyAccountBalanceService);
+  });
+
+  it('passes the service messenger', () => {
+    MoneyAccountBalanceServiceInit(getInitRequestMock());
+
+    expect(jest.mocked(MoneyAccountBalanceService)).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+    });
+  });
+
+  it('calls init on the service', () => {
+    const { messengerClient } = MoneyAccountBalanceServiceInit(
+      getInitRequestMock(),
+    );
+
+    expect(jest.mocked(messengerClient).init).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null for persistedStateKey', () => {
+    const result = MoneyAccountBalanceServiceInit(getInitRequestMock());
+
+    expect(result.persistedStateKey).toBeNull();
+  });
+
+  it('returns null for memStateKey', () => {
+    const result = MoneyAccountBalanceServiceInit(getInitRequestMock());
+
+    expect(result.memStateKey).toBeNull();
+  });
+});

--- a/app/scripts/messenger-client-init/money-account-balance-service-init.test.ts
+++ b/app/scripts/messenger-client-init/money-account-balance-service-init.test.ts
@@ -28,9 +28,8 @@ describe('MoneyAccountBalanceServiceInit', () => {
   });
 
   it('initializes the service', () => {
-    const { messengerClient } = MoneyAccountBalanceServiceInit(
-      getInitRequestMock(),
-    );
+    const { messengerClient } =
+      MoneyAccountBalanceServiceInit(getInitRequestMock());
 
     expect(messengerClient).toBeInstanceOf(MoneyAccountBalanceService);
   });
@@ -44,9 +43,8 @@ describe('MoneyAccountBalanceServiceInit', () => {
   });
 
   it('calls init on the service', () => {
-    const { messengerClient } = MoneyAccountBalanceServiceInit(
-      getInitRequestMock(),
-    );
+    const { messengerClient } =
+      MoneyAccountBalanceServiceInit(getInitRequestMock());
 
     expect(jest.mocked(messengerClient).init).toHaveBeenCalledTimes(1);
   });

--- a/app/scripts/messenger-client-init/money-account-balance-service-init.ts
+++ b/app/scripts/messenger-client-init/money-account-balance-service-init.ts
@@ -1,0 +1,30 @@
+import {
+  MoneyAccountBalanceService,
+  type MoneyAccountBalanceServiceMessenger,
+} from '@metamask/money-account-balance-service';
+import type { MessengerClientInitFunction } from './types';
+
+/**
+ * Initialize the MoneyAccountBalanceService.
+ *
+ * The service is not persisted, and `init` must be called once the
+ * `RemoteFeatureFlagController:getState` action is registered so the vault
+ * config can be read. Until the `moneyAccountVaultConfig` flag is served, the
+ * service methods reject with `VaultConfigNotAvailableError`.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the service.
+ * @returns The initialized service.
+ */
+export const MoneyAccountBalanceServiceInit: MessengerClientInitFunction<
+  MoneyAccountBalanceService,
+  MoneyAccountBalanceServiceMessenger
+> = ({ controllerMessenger }) => {
+  const messengerClient = new MoneyAccountBalanceService({
+    messenger: controllerMessenger,
+  });
+
+  messengerClient.init();
+
+  return { messengerClient, persistedStateKey: null, memStateKey: null };
+};

--- a/app/scripts/messenger-client-init/money-account-balance-service-init.ts
+++ b/app/scripts/messenger-client-init/money-account-balance-service-init.ts
@@ -7,11 +7,6 @@ import type { MessengerClientInitFunction } from './types';
 /**
  * Initialize the MoneyAccountBalanceService.
  *
- * The service is not persisted, and `init` must be called once the
- * `RemoteFeatureFlagController:getState` action is registered so the vault
- * config can be read. Until the `moneyAccountVaultConfig` flag is served, the
- * service methods reject with `VaultConfigNotAvailableError`.
- *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized service.

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -389,6 +389,7 @@ import { DataDeletionServiceInit } from './messenger-client-init/data-deletion-s
 import { LegacyBackgroundApiServiceInit } from './messenger-client-init/legacy-background-api-service-init';
 import { ConfigRegistryApiServiceInit } from './messenger-client-init/config-registry-api-service-init';
 import { SentinelApiServiceInit } from './messenger-client-init/sentinel-api-service-init';
+import { MoneyAccountBalanceServiceInit } from './messenger-client-init/money-account-balance-service-init';
 import { initializeWallet } from './wallet-init/initialization';
 import { ExtensionConnectivityAdapter } from './controllers/connectivity';
 import { getTransactionControllerApi } from './wallet-init/instance-options/transaction-controller';
@@ -678,6 +679,10 @@ export default class MetamaskController extends EventEmitter {
       ClientController: ClientControllerInit,
       ConfigRegistryController: ConfigRegistryControllerInit,
       ConfigRegistryApiService: ConfigRegistryApiServiceInit,
+      // MoneyAccountBalanceService reads the vault config during its own init
+      // via RemoteFeatureFlagController:getState, which the wallet registers
+      // before these init functions run.
+      MoneyAccountBalanceService: MoneyAccountBalanceServiceInit,
       ...(getIsAssetsUnifiedStateIncludedInBuild()
         ? { AssetsController: AssetsControllerInit }
         : {}),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -390,6 +390,7 @@ import { DataDeletionServiceInit } from './messenger-client-init/data-deletion-s
 import { LegacyBackgroundApiServiceInit } from './messenger-client-init/legacy-background-api-service-init';
 import { ConfigRegistryApiServiceInit } from './messenger-client-init/config-registry-api-service-init';
 import { SentinelApiServiceInit } from './messenger-client-init/sentinel-api-service-init';
+import { MoneyAccountApiDataServiceInit } from './messenger-client-init/money-account-api-data-service-init';
 import { MoneyAccountBalanceServiceInit } from './messenger-client-init/money-account-balance-service-init';
 import { initializeWallet } from './wallet-init/initialization';
 import { ExtensionConnectivityAdapter } from './controllers/connectivity';
@@ -680,6 +681,10 @@ export default class MetamaskController extends EventEmitter {
       ClientController: ClientControllerInit,
       ConfigRegistryController: ConfigRegistryControllerInit,
       ConfigRegistryApiService: ConfigRegistryApiServiceInit,
+      // MoneyAccountApiDataService is the Money API source behind
+      // MoneyAccountBalanceService:fetchBalanceWithFallback, so it registers
+      // MoneyAccountApiDataService:fetchPositions first.
+      MoneyAccountApiDataService: MoneyAccountApiDataServiceInit,
       // MoneyAccountBalanceService reads the vault config during its own init
       // via RemoteFeatureFlagController:getState, which the wallet registers
       // before these init functions run.

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -681,13 +681,8 @@ export default class MetamaskController extends EventEmitter {
       ClientController: ClientControllerInit,
       ConfigRegistryController: ConfigRegistryControllerInit,
       ConfigRegistryApiService: ConfigRegistryApiServiceInit,
-      // MoneyAccountApiDataService is the Money API source behind
-      // MoneyAccountBalanceService:fetchBalanceWithFallback, so it registers
-      // MoneyAccountApiDataService:fetchPositions first.
+      // MoneyAccountApiDataService must be intialized before MoneyAccountBalanceService
       MoneyAccountApiDataService: MoneyAccountApiDataServiceInit,
-      // MoneyAccountBalanceService reads the vault config during its own init
-      // via RemoteFeatureFlagController:getState, which the wallet registers
-      // before these init functions run.
       MoneyAccountBalanceService: MoneyAccountBalanceServiceInit,
       ...(getIsAssetsUnifiedStateIncludedInBuild()
         ? { AssetsController: AssetsControllerInit }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -680,7 +680,6 @@ export default class MetamaskController extends EventEmitter {
       ClientController: ClientControllerInit,
       ConfigRegistryController: ConfigRegistryControllerInit,
       ConfigRegistryApiService: ConfigRegistryApiServiceInit,
-      // MoneyAccountApiDataService must be intialized before MoneyAccountBalanceService
       MoneyAccountApiDataService: MoneyAccountApiDataServiceInit,
       MoneyAccountAvailabilityService: MoneyAccountAvailabilityServiceInit,
       MoneyAccountBalanceService: MoneyAccountBalanceServiceInit,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -244,9 +244,6 @@ import {
 import createRPCMethodTrackingMiddleware from './lib/createRPCMethodTrackingMiddleware';
 import { addDappTransaction } from './lib/transaction/util';
 import { addTypedMessage, addPersonalMessage } from './lib/signature/util';
-import { deriveMoneyAccountAddress } from './lib/money/get-money-account-address';
-import { MoneyAccountAvailabilityService } from './lib/money/money-account-availability';
-import { getMoneyAccountAvailabilityServiceMessenger } from './messenger-client-init/messengers/money-account-availability-service-messenger';
 import {
   METAMASK_CAIP_MULTICHAIN_PROVIDER,
   METAMASK_COOKIE_HANDLER,
@@ -392,6 +389,7 @@ import { LegacyBackgroundApiServiceInit } from './messenger-client-init/legacy-b
 import { ConfigRegistryApiServiceInit } from './messenger-client-init/config-registry-api-service-init';
 import { SentinelApiServiceInit } from './messenger-client-init/sentinel-api-service-init';
 import { MoneyAccountApiDataServiceInit } from './messenger-client-init/money-account-api-data-service-init';
+import { MoneyAccountAvailabilityServiceInit } from './messenger-client-init/money-account-availability-service-init';
 import { MoneyAccountBalanceServiceInit } from './messenger-client-init/money-account-balance-service-init';
 import { initializeWallet } from './wallet-init/initialization';
 import { ExtensionConnectivityAdapter } from './controllers/connectivity';
@@ -684,6 +682,7 @@ export default class MetamaskController extends EventEmitter {
       ConfigRegistryApiService: ConfigRegistryApiServiceInit,
       // MoneyAccountApiDataService must be intialized before MoneyAccountBalanceService
       MoneyAccountApiDataService: MoneyAccountApiDataServiceInit,
+      MoneyAccountAvailabilityService: MoneyAccountAvailabilityServiceInit,
       MoneyAccountBalanceService: MoneyAccountBalanceServiceInit,
       ...(getIsAssetsUnifiedStateIncludedInBuild()
         ? { AssetsController: AssetsControllerInit }
@@ -845,12 +844,6 @@ export default class MetamaskController extends EventEmitter {
       networkController: this.networkController,
     });
     this.geolocationController = messengerClientsByName.GeolocationController;
-
-    this.moneyAccountAvailabilityService = new MoneyAccountAvailabilityService({
-      messenger: getMoneyAccountAvailabilityServiceMessenger(
-        this.controllerMessenger,
-      ),
-    });
 
     // Record installation info if this is the first time the extension is running.
     // This captures the version and date when MetaMask was first installed.
@@ -3399,8 +3392,14 @@ export default class MetamaskController extends EventEmitter {
         'PasskeyController:exportAccountsWithPasskey',
       ),
       exportSeedPhraseWithPasskey: this.exportSeedPhraseWithPasskey.bind(this),
-      getMoneyAccountAddress: this.getMoneyAccountAddress.bind(this),
-      getMoneyAccountAvailability: this.getMoneyAccountAvailability.bind(this),
+      getMoneyAccountAddress: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'MoneyAccountAvailabilityService:getAddress',
+      ),
+      getMoneyAccountAvailability: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'MoneyAccountAvailabilityService:getAvailability',
+      ),
 
       // txController
       updateTransaction: txController.updateTransaction.bind(txController),
@@ -4045,27 +4044,6 @@ export default class MetamaskController extends EventEmitter {
     return convertEnglishWordlistIndicesToCodepoints(mnemonic);
   }
 
-  /**
-   * Derives the money account address from the primary HD seed. Requires an
-   * unlocked wallet, but not the password.
-   *
-   * @returns {Promise<string>} The money account address.
-   */
-  async getMoneyAccountAddress() {
-    return deriveMoneyAccountAddress(this.controllerMessenger);
-  }
-
-  /**
-   * Resolves whether this user has a usable Money Account: the feature flag
-   * is on and the address can be derived. The whole Money surface is hidden
-   * when it is not available, so this is the one answer callers need — see
-   * {@link MoneyAccountAvailabilityService}.
-   *
-   * @returns {Promise<import('./lib/money/money-account-availability').MoneyAccountAvailability>} The availability, with the money address when available.
-   */
-  async getMoneyAccountAvailability() {
-    return this.moneyAccountAvailabilityService.getAvailability();
-  }
   //=============================================================================
   // VAULT / KEYRING RELATED METHODS
   //=============================================================================

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -246,6 +246,7 @@ import { addDappTransaction } from './lib/transaction/util';
 import { addTypedMessage, addPersonalMessage } from './lib/signature/util';
 import { deriveMoneyAccountAddress } from './lib/money/get-money-account-address';
 import { MoneyAccountAvailabilityService } from './lib/money/money-account-availability';
+import { getMoneyAccountAvailabilityServiceMessenger } from './messenger-client-init/messengers/money-account-availability-service-messenger';
 import {
   METAMASK_CAIP_MULTICHAIN_PROVIDER,
   METAMASK_COOKIE_HANDLER,
@@ -846,7 +847,9 @@ export default class MetamaskController extends EventEmitter {
     this.geolocationController = messengerClientsByName.GeolocationController;
 
     this.moneyAccountAvailabilityService = new MoneyAccountAvailabilityService({
-      messenger: this.controllerMessenger,
+      messenger: getMoneyAccountAvailabilityServiceMessenger(
+        this.controllerMessenger,
+      ),
     });
 
     // Record installation info if this is the first time the extension is running.

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -245,6 +245,7 @@ import createRPCMethodTrackingMiddleware from './lib/createRPCMethodTrackingMidd
 import { addDappTransaction } from './lib/transaction/util';
 import { addTypedMessage, addPersonalMessage } from './lib/signature/util';
 import { deriveMoneyAccountAddress } from './lib/money/get-money-account-address';
+import { MoneyAccountAvailabilityService } from './lib/money/money-account-availability';
 import {
   METAMASK_CAIP_MULTICHAIN_PROVIDER,
   METAMASK_COOKIE_HANDLER,
@@ -843,6 +844,10 @@ export default class MetamaskController extends EventEmitter {
       networkController: this.networkController,
     });
     this.geolocationController = messengerClientsByName.GeolocationController;
+
+    this.moneyAccountAvailabilityService = new MoneyAccountAvailabilityService({
+      messenger: this.controllerMessenger,
+    });
 
     // Record installation info if this is the first time the extension is running.
     // This captures the version and date when MetaMask was first installed.
@@ -3392,6 +3397,7 @@ export default class MetamaskController extends EventEmitter {
       ),
       exportSeedPhraseWithPasskey: this.exportSeedPhraseWithPasskey.bind(this),
       getMoneyAccountAddress: this.getMoneyAccountAddress.bind(this),
+      getMoneyAccountAvailability: this.getMoneyAccountAvailability.bind(this),
 
       // txController
       updateTransaction: txController.updateTransaction.bind(txController),
@@ -4044,6 +4050,18 @@ export default class MetamaskController extends EventEmitter {
    */
   async getMoneyAccountAddress() {
     return deriveMoneyAccountAddress(this.controllerMessenger);
+  }
+
+  /**
+   * Resolves whether this user has a usable Money Account: the feature flag
+   * is on and the address can be derived. The whole Money surface is hidden
+   * when it is not available, so this is the one answer callers need — see
+   * {@link MoneyAccountAvailabilityService}.
+   *
+   * @returns {Promise<import('./lib/money/money-account-availability').MoneyAccountAvailability>} The availability, with the money address when available.
+   */
+  async getMoneyAccountAvailability() {
+    return this.moneyAccountAvailabilityService.getAvailability();
   }
   //=============================================================================
   // VAULT / KEYRING RELATED METHODS

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -244,6 +244,7 @@ import {
 import createRPCMethodTrackingMiddleware from './lib/createRPCMethodTrackingMiddleware';
 import { addDappTransaction } from './lib/transaction/util';
 import { addTypedMessage, addPersonalMessage } from './lib/signature/util';
+import { deriveMoneyAccountAddress } from './lib/money/get-money-account-address';
 import {
   METAMASK_CAIP_MULTICHAIN_PROVIDER,
   METAMASK_COOKIE_HANDLER,
@@ -3385,6 +3386,7 @@ export default class MetamaskController extends EventEmitter {
         'PasskeyController:exportAccountsWithPasskey',
       ),
       exportSeedPhraseWithPasskey: this.exportSeedPhraseWithPasskey.bind(this),
+      getMoneyAccountAddress: this.getMoneyAccountAddress.bind(this),
 
       // txController
       updateTransaction: txController.updateTransaction.bind(txController),
@@ -4029,6 +4031,15 @@ export default class MetamaskController extends EventEmitter {
     return convertEnglishWordlistIndicesToCodepoints(mnemonic);
   }
 
+  /**
+   * Derives the money account address from the primary HD seed. Requires an
+   * unlocked wallet, but not the password.
+   *
+   * @returns {Promise<string>} The money account address.
+   */
+  async getMoneyAccountAddress() {
+    return deriveMoneyAccountAddress(this.controllerMessenger);
+  }
   //=============================================================================
   // VAULT / KEYRING RELATED METHODS
   //=============================================================================

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3392,14 +3392,6 @@ export default class MetamaskController extends EventEmitter {
         'PasskeyController:exportAccountsWithPasskey',
       ),
       exportSeedPhraseWithPasskey: this.exportSeedPhraseWithPasskey.bind(this),
-      getMoneyAccountAddress: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'MoneyAccountAvailabilityService:getAddress',
-      ),
-      getMoneyAccountAvailability: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'MoneyAccountAvailabilityService:getAvailability',
-      ),
 
       // txController
       updateTransaction: txController.updateTransaction.bind(txController),

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -889,7 +889,7 @@
         "@metamask/rpc-errors": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/core-backend>@tanstack/query-core": true,
+        "@metamask/assets-controllers>@tanstack/query-core": true,
         "async-mutex": true,
         "ethereumjs-util>bn.js": true,
         "immer": true,
@@ -952,7 +952,7 @@
         "@metamask/controller-utils": true,
         "@metamask/messenger": true,
         "@metamask/utils": true,
-        "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
         "eslint>fast-deep-equal": true
       }
     },
@@ -1301,6 +1301,29 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography' reexports from '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1374,6 +1397,14 @@
         "@metamask/utils": true,
         "buffer": true,
         "@metamask/eth-qr-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "async-mutex": true
       }
     },
     "@metamask/eth-qr-keyring": {
@@ -1675,6 +1706,7 @@
     },
     "@metamask/keyring-sdk": {
       "globals": {
+        "TextDecoder": true,
         "TextEncoder": true
       },
       "packages": {
@@ -1682,6 +1714,7 @@
         "@metamask/eth-sig-util": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-utils": true,
+        "@metamask/scure-bip39": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@noble/hashes": true,
@@ -1776,6 +1809,45 @@
         "@metamask/mobile-wallet-protocol-core": true,
         "@metamask/mobile-wallet-protocol-dapp-client>@metamask/utils": true,
         "@metamask/mobile-wallet-protocol-dapp-client>uuid": true
+      }
+    },
+    "@metamask/money-account-api-data-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
+      }
+    },
+    "@metamask/money-account-balance-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
       }
     },
     "@metamask/money-account-utils": {
@@ -2171,7 +2243,7 @@
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,
-        "@metamask/react-data-query>@tanstack/query-core": true
+        "@tanstack/react-query>@tanstack/query-core": true
       }
     },
     "@metamask/remote-feature-flag-controller": {
@@ -2915,6 +2987,14 @@
         "@metamask/eth-sig-util>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@noble/hashes": {
       "globals": {
         "TextDecoder": true,
@@ -2982,6 +3062,12 @@
     "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography>@noble/hashes": {
@@ -3156,11 +3242,24 @@
         "TextEncoder": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@segment/analytics-node>@segment/analytics-core": {
@@ -3456,15 +3555,16 @@
         "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true
       }
     },
-    "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": {
+    "@metamask/assets-controllers>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
+        "clearInterval": true,
         "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
+        "console.error": true,
+        "document.visibilityState": true,
         "removeEventListener": true,
+        "setInterval": true,
         "setTimeout": true
       }
     },
@@ -3481,24 +3581,13 @@
         "setTimeout": true
       }
     },
-    "@metamask/react-data-query>@tanstack/query-core": {
-      "globals": {
-        "AbortController": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
     "@tanstack/react-query>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
         "clearInterval": true,
         "clearTimeout": true,
+        "console": true,
         "document": true,
         "navigator": true,
         "removeEventListener": true,
@@ -4649,6 +4738,16 @@
       },
       "packages": {
         "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography": {

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -889,7 +889,7 @@
         "@metamask/rpc-errors": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/core-backend>@tanstack/query-core": true,
+        "@metamask/assets-controllers>@tanstack/query-core": true,
         "async-mutex": true,
         "ethereumjs-util>bn.js": true,
         "immer": true,
@@ -952,7 +952,7 @@
         "@metamask/controller-utils": true,
         "@metamask/messenger": true,
         "@metamask/utils": true,
-        "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
         "eslint>fast-deep-equal": true
       }
     },
@@ -1301,6 +1301,29 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography' reexports from '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1374,6 +1397,14 @@
         "@metamask/utils": true,
         "buffer": true,
         "@metamask/eth-qr-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "async-mutex": true
       }
     },
     "@metamask/eth-qr-keyring": {
@@ -1675,6 +1706,7 @@
     },
     "@metamask/keyring-sdk": {
       "globals": {
+        "TextDecoder": true,
         "TextEncoder": true
       },
       "packages": {
@@ -1682,6 +1714,7 @@
         "@metamask/eth-sig-util": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-utils": true,
+        "@metamask/scure-bip39": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@noble/hashes": true,
@@ -1776,6 +1809,45 @@
         "@metamask/mobile-wallet-protocol-core": true,
         "@metamask/mobile-wallet-protocol-dapp-client>@metamask/utils": true,
         "@metamask/mobile-wallet-protocol-dapp-client>uuid": true
+      }
+    },
+    "@metamask/money-account-api-data-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
+      }
+    },
+    "@metamask/money-account-balance-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
       }
     },
     "@metamask/money-account-utils": {
@@ -2171,7 +2243,7 @@
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,
-        "@metamask/react-data-query>@tanstack/query-core": true
+        "@tanstack/react-query>@tanstack/query-core": true
       }
     },
     "@metamask/remote-feature-flag-controller": {
@@ -2915,6 +2987,14 @@
         "@metamask/eth-sig-util>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@noble/hashes": {
       "globals": {
         "TextDecoder": true,
@@ -2982,6 +3062,12 @@
     "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography>@noble/hashes": {
@@ -3156,11 +3242,24 @@
         "TextEncoder": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@segment/analytics-node>@segment/analytics-core": {
@@ -3456,15 +3555,16 @@
         "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true
       }
     },
-    "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": {
+    "@metamask/assets-controllers>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
+        "clearInterval": true,
         "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
+        "console.error": true,
+        "document.visibilityState": true,
         "removeEventListener": true,
+        "setInterval": true,
         "setTimeout": true
       }
     },
@@ -3481,24 +3581,13 @@
         "setTimeout": true
       }
     },
-    "@metamask/react-data-query>@tanstack/query-core": {
-      "globals": {
-        "AbortController": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
     "@tanstack/react-query>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
         "clearInterval": true,
         "clearTimeout": true,
+        "console": true,
         "document": true,
         "navigator": true,
         "removeEventListener": true,
@@ -4649,6 +4738,16 @@
       },
       "packages": {
         "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography": {

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -889,7 +889,7 @@
         "@metamask/rpc-errors": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/core-backend>@tanstack/query-core": true,
+        "@metamask/assets-controllers>@tanstack/query-core": true,
         "async-mutex": true,
         "ethereumjs-util>bn.js": true,
         "immer": true,
@@ -952,7 +952,7 @@
         "@metamask/controller-utils": true,
         "@metamask/messenger": true,
         "@metamask/utils": true,
-        "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
         "eslint>fast-deep-equal": true
       }
     },
@@ -1301,6 +1301,29 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography' reexports from '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1374,6 +1397,14 @@
         "@metamask/utils": true,
         "buffer": true,
         "@metamask/eth-qr-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "async-mutex": true
       }
     },
     "@metamask/eth-qr-keyring": {
@@ -1675,6 +1706,7 @@
     },
     "@metamask/keyring-sdk": {
       "globals": {
+        "TextDecoder": true,
         "TextEncoder": true
       },
       "packages": {
@@ -1682,6 +1714,7 @@
         "@metamask/eth-sig-util": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-utils": true,
+        "@metamask/scure-bip39": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@noble/hashes": true,
@@ -1776,6 +1809,45 @@
         "@metamask/mobile-wallet-protocol-core": true,
         "@metamask/mobile-wallet-protocol-dapp-client>@metamask/utils": true,
         "@metamask/mobile-wallet-protocol-dapp-client>uuid": true
+      }
+    },
+    "@metamask/money-account-api-data-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
+      }
+    },
+    "@metamask/money-account-balance-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
       }
     },
     "@metamask/money-account-utils": {
@@ -2171,7 +2243,7 @@
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,
-        "@metamask/react-data-query>@tanstack/query-core": true
+        "@tanstack/react-query>@tanstack/query-core": true
       }
     },
     "@metamask/remote-feature-flag-controller": {
@@ -2915,6 +2987,14 @@
         "@metamask/eth-sig-util>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@noble/hashes": {
       "globals": {
         "TextDecoder": true,
@@ -2982,6 +3062,12 @@
     "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography>@noble/hashes": {
@@ -3156,11 +3242,24 @@
         "TextEncoder": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@segment/analytics-node>@segment/analytics-core": {
@@ -3456,15 +3555,16 @@
         "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true
       }
     },
-    "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": {
+    "@metamask/assets-controllers>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
+        "clearInterval": true,
         "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
+        "console.error": true,
+        "document.visibilityState": true,
         "removeEventListener": true,
+        "setInterval": true,
         "setTimeout": true
       }
     },
@@ -3481,24 +3581,13 @@
         "setTimeout": true
       }
     },
-    "@metamask/react-data-query>@tanstack/query-core": {
-      "globals": {
-        "AbortController": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
     "@tanstack/react-query>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
         "clearInterval": true,
         "clearTimeout": true,
+        "console": true,
         "document": true,
         "navigator": true,
         "removeEventListener": true,
@@ -4649,6 +4738,16 @@
       },
       "packages": {
         "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography": {

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -889,7 +889,7 @@
         "@metamask/rpc-errors": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/core-backend>@tanstack/query-core": true,
+        "@metamask/assets-controllers>@tanstack/query-core": true,
         "async-mutex": true,
         "ethereumjs-util>bn.js": true,
         "immer": true,
@@ -952,7 +952,7 @@
         "@metamask/controller-utils": true,
         "@metamask/messenger": true,
         "@metamask/utils": true,
-        "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
         "eslint>fast-deep-equal": true
       }
     },
@@ -1301,6 +1301,29 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography' reexports from '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1374,6 +1397,14 @@
         "@metamask/utils": true,
         "buffer": true,
         "@metamask/eth-qr-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "async-mutex": true
       }
     },
     "@metamask/eth-qr-keyring": {
@@ -1675,6 +1706,7 @@
     },
     "@metamask/keyring-sdk": {
       "globals": {
+        "TextDecoder": true,
         "TextEncoder": true
       },
       "packages": {
@@ -1682,6 +1714,7 @@
         "@metamask/eth-sig-util": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-utils": true,
+        "@metamask/scure-bip39": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@noble/hashes": true,
@@ -1776,6 +1809,45 @@
         "@metamask/mobile-wallet-protocol-core": true,
         "@metamask/mobile-wallet-protocol-dapp-client>@metamask/utils": true,
         "@metamask/mobile-wallet-protocol-dapp-client>uuid": true
+      }
+    },
+    "@metamask/money-account-api-data-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
+      }
+    },
+    "@metamask/money-account-balance-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
       }
     },
     "@metamask/money-account-utils": {
@@ -2171,7 +2243,7 @@
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,
-        "@metamask/react-data-query>@tanstack/query-core": true
+        "@tanstack/react-query>@tanstack/query-core": true
       }
     },
     "@metamask/remote-feature-flag-controller": {
@@ -2915,6 +2987,14 @@
         "@metamask/eth-sig-util>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@noble/hashes": {
       "globals": {
         "TextDecoder": true,
@@ -2982,6 +3062,12 @@
     "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography>@noble/hashes": {
@@ -3156,11 +3242,24 @@
         "TextEncoder": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@segment/analytics-node>@segment/analytics-core": {
@@ -3456,15 +3555,16 @@
         "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true
       }
     },
-    "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": {
+    "@metamask/assets-controllers>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
+        "clearInterval": true,
         "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
+        "console.error": true,
+        "document.visibilityState": true,
         "removeEventListener": true,
+        "setInterval": true,
         "setTimeout": true
       }
     },
@@ -3481,24 +3581,13 @@
         "setTimeout": true
       }
     },
-    "@metamask/react-data-query>@tanstack/query-core": {
-      "globals": {
-        "AbortController": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
     "@tanstack/react-query>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
         "clearInterval": true,
         "clearTimeout": true,
+        "console": true,
         "document": true,
         "navigator": true,
         "removeEventListener": true,
@@ -4649,6 +4738,16 @@
       },
       "packages": {
         "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography": {

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -975,7 +975,7 @@
         "@metamask/rpc-errors": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/core-backend>@tanstack/query-core": true,
+        "@metamask/assets-controllers>@tanstack/query-core": true,
         "async-mutex": true,
         "ethereumjs-util>bn.js": true,
         "immer": true,
@@ -1038,7 +1038,7 @@
         "@metamask/controller-utils": true,
         "@metamask/messenger": true,
         "@metamask/utils": true,
-        "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
         "eslint>fast-deep-equal": true
       }
     },
@@ -1387,6 +1387,29 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography' reexports from '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1460,6 +1483,14 @@
         "@metamask/utils": true,
         "buffer": true,
         "@metamask/eth-qr-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "async-mutex": true
       }
     },
     "@metamask/eth-qr-keyring": {
@@ -1761,6 +1792,7 @@
     },
     "@metamask/keyring-sdk": {
       "globals": {
+        "TextDecoder": true,
         "TextEncoder": true
       },
       "packages": {
@@ -1768,6 +1800,7 @@
         "@metamask/eth-sig-util": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-utils": true,
+        "@metamask/scure-bip39": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@noble/hashes": true,
@@ -1862,6 +1895,45 @@
         "@metamask/mobile-wallet-protocol-core": true,
         "@metamask/mobile-wallet-protocol-dapp-client>@metamask/utils": true,
         "@metamask/mobile-wallet-protocol-dapp-client>uuid": true
+      }
+    },
+    "@metamask/money-account-api-data-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
+      }
+    },
+    "@metamask/money-account-balance-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
       }
     },
     "@metamask/money-account-utils": {
@@ -2257,7 +2329,7 @@
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,
-        "@metamask/react-data-query>@tanstack/query-core": true
+        "@tanstack/react-query>@tanstack/query-core": true
       }
     },
     "@metamask/remote-feature-flag-controller": {
@@ -3011,6 +3083,14 @@
         "@metamask/eth-sig-util>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@noble/hashes": {
       "globals": {
         "TextDecoder": true,
@@ -3078,6 +3158,12 @@
     "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography>@noble/hashes": {
@@ -3252,11 +3338,24 @@
         "TextEncoder": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@segment/analytics-node>@segment/analytics-core": {
@@ -3552,15 +3651,16 @@
         "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true
       }
     },
-    "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": {
+    "@metamask/assets-controllers>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
+        "clearInterval": true,
         "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
+        "console.error": true,
+        "document.visibilityState": true,
         "removeEventListener": true,
+        "setInterval": true,
         "setTimeout": true
       }
     },
@@ -3577,24 +3677,13 @@
         "setTimeout": true
       }
     },
-    "@metamask/react-data-query>@tanstack/query-core": {
-      "globals": {
-        "AbortController": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
     "@tanstack/react-query>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
         "clearInterval": true,
         "clearTimeout": true,
+        "console": true,
         "document": true,
         "navigator": true,
         "removeEventListener": true,
@@ -4780,6 +4869,16 @@
       },
       "packages": {
         "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography": {

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -975,7 +975,7 @@
         "@metamask/rpc-errors": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/core-backend>@tanstack/query-core": true,
+        "@metamask/assets-controllers>@tanstack/query-core": true,
         "async-mutex": true,
         "ethereumjs-util>bn.js": true,
         "immer": true,
@@ -1038,7 +1038,7 @@
         "@metamask/controller-utils": true,
         "@metamask/messenger": true,
         "@metamask/utils": true,
-        "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
         "eslint>fast-deep-equal": true
       }
     },
@@ -1387,6 +1387,29 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography' reexports from '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1460,6 +1483,14 @@
         "@metamask/utils": true,
         "buffer": true,
         "@metamask/eth-qr-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "async-mutex": true
       }
     },
     "@metamask/eth-qr-keyring": {
@@ -1761,6 +1792,7 @@
     },
     "@metamask/keyring-sdk": {
       "globals": {
+        "TextDecoder": true,
         "TextEncoder": true
       },
       "packages": {
@@ -1768,6 +1800,7 @@
         "@metamask/eth-sig-util": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-utils": true,
+        "@metamask/scure-bip39": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@noble/hashes": true,
@@ -1862,6 +1895,45 @@
         "@metamask/mobile-wallet-protocol-core": true,
         "@metamask/mobile-wallet-protocol-dapp-client>@metamask/utils": true,
         "@metamask/mobile-wallet-protocol-dapp-client>uuid": true
+      }
+    },
+    "@metamask/money-account-api-data-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
+      }
+    },
+    "@metamask/money-account-balance-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
       }
     },
     "@metamask/money-account-utils": {
@@ -2257,7 +2329,7 @@
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,
-        "@metamask/react-data-query>@tanstack/query-core": true
+        "@tanstack/react-query>@tanstack/query-core": true
       }
     },
     "@metamask/remote-feature-flag-controller": {
@@ -3011,6 +3083,14 @@
         "@metamask/eth-sig-util>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@noble/hashes": {
       "globals": {
         "TextDecoder": true,
@@ -3078,6 +3158,12 @@
     "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography>@noble/hashes": {
@@ -3252,11 +3338,24 @@
         "TextEncoder": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@segment/analytics-node>@segment/analytics-core": {
@@ -3552,15 +3651,16 @@
         "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true
       }
     },
-    "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": {
+    "@metamask/assets-controllers>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
+        "clearInterval": true,
         "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
+        "console.error": true,
+        "document.visibilityState": true,
         "removeEventListener": true,
+        "setInterval": true,
         "setTimeout": true
       }
     },
@@ -3577,24 +3677,13 @@
         "setTimeout": true
       }
     },
-    "@metamask/react-data-query>@tanstack/query-core": {
-      "globals": {
-        "AbortController": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
     "@tanstack/react-query>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
         "clearInterval": true,
         "clearTimeout": true,
+        "console": true,
         "document": true,
         "navigator": true,
         "removeEventListener": true,
@@ -4780,6 +4869,16 @@
       },
       "packages": {
         "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography": {

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -975,7 +975,7 @@
         "@metamask/rpc-errors": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/core-backend>@tanstack/query-core": true,
+        "@metamask/assets-controllers>@tanstack/query-core": true,
         "async-mutex": true,
         "ethereumjs-util>bn.js": true,
         "immer": true,
@@ -1038,7 +1038,7 @@
         "@metamask/controller-utils": true,
         "@metamask/messenger": true,
         "@metamask/utils": true,
-        "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
         "eslint>fast-deep-equal": true
       }
     },
@@ -1387,6 +1387,29 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography' reexports from '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1460,6 +1483,14 @@
         "@metamask/utils": true,
         "buffer": true,
         "@metamask/eth-qr-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "async-mutex": true
       }
     },
     "@metamask/eth-qr-keyring": {
@@ -1761,6 +1792,7 @@
     },
     "@metamask/keyring-sdk": {
       "globals": {
+        "TextDecoder": true,
         "TextEncoder": true
       },
       "packages": {
@@ -1768,6 +1800,7 @@
         "@metamask/eth-sig-util": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-utils": true,
+        "@metamask/scure-bip39": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@noble/hashes": true,
@@ -1862,6 +1895,45 @@
         "@metamask/mobile-wallet-protocol-core": true,
         "@metamask/mobile-wallet-protocol-dapp-client>@metamask/utils": true,
         "@metamask/mobile-wallet-protocol-dapp-client>uuid": true
+      }
+    },
+    "@metamask/money-account-api-data-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
+      }
+    },
+    "@metamask/money-account-balance-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
       }
     },
     "@metamask/money-account-utils": {
@@ -2257,7 +2329,7 @@
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,
-        "@metamask/react-data-query>@tanstack/query-core": true
+        "@tanstack/react-query>@tanstack/query-core": true
       }
     },
     "@metamask/remote-feature-flag-controller": {
@@ -3011,6 +3083,14 @@
         "@metamask/eth-sig-util>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@noble/hashes": {
       "globals": {
         "TextDecoder": true,
@@ -3078,6 +3158,12 @@
     "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography>@noble/hashes": {
@@ -3252,11 +3338,24 @@
         "TextEncoder": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@segment/analytics-node>@segment/analytics-core": {
@@ -3552,15 +3651,16 @@
         "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true
       }
     },
-    "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": {
+    "@metamask/assets-controllers>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
+        "clearInterval": true,
         "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
+        "console.error": true,
+        "document.visibilityState": true,
         "removeEventListener": true,
+        "setInterval": true,
         "setTimeout": true
       }
     },
@@ -3577,24 +3677,13 @@
         "setTimeout": true
       }
     },
-    "@metamask/react-data-query>@tanstack/query-core": {
-      "globals": {
-        "AbortController": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
     "@tanstack/react-query>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
         "clearInterval": true,
         "clearTimeout": true,
+        "console": true,
         "document": true,
         "navigator": true,
         "removeEventListener": true,
@@ -4780,6 +4869,16 @@
       },
       "packages": {
         "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography": {

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -975,7 +975,7 @@
         "@metamask/rpc-errors": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/core-backend>@tanstack/query-core": true,
+        "@metamask/assets-controllers>@tanstack/query-core": true,
         "async-mutex": true,
         "ethereumjs-util>bn.js": true,
         "immer": true,
@@ -1038,7 +1038,7 @@
         "@metamask/controller-utils": true,
         "@metamask/messenger": true,
         "@metamask/utils": true,
-        "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
         "eslint>fast-deep-equal": true
       }
     },
@@ -1387,6 +1387,29 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography' reexports from '@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1460,6 +1483,14 @@
         "@metamask/utils": true,
         "buffer": true,
         "@metamask/eth-qr-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "async-mutex": true
       }
     },
     "@metamask/eth-qr-keyring": {
@@ -1761,6 +1792,7 @@
     },
     "@metamask/keyring-sdk": {
       "globals": {
+        "TextDecoder": true,
         "TextEncoder": true
       },
       "packages": {
@@ -1768,6 +1800,7 @@
         "@metamask/eth-sig-util": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-utils": true,
+        "@metamask/scure-bip39": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@noble/hashes": true,
@@ -1862,6 +1895,45 @@
         "@metamask/mobile-wallet-protocol-core": true,
         "@metamask/mobile-wallet-protocol-dapp-client>@metamask/utils": true,
         "@metamask/mobile-wallet-protocol-dapp-client>uuid": true
+      }
+    },
+    "@metamask/money-account-api-data-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
+      }
+    },
+    "@metamask/money-account-balance-service": {
+      "globals": {
+        "URL": true,
+        "fetch": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/react-data-query>@metamask/base-data-service": true,
+        "@metamask/controller-utils": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "cockatiel": true
       }
     },
     "@metamask/money-account-utils": {
@@ -2257,7 +2329,7 @@
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,
-        "@metamask/react-data-query>@tanstack/query-core": true
+        "@tanstack/react-query>@tanstack/query-core": true
       }
     },
     "@metamask/remote-feature-flag-controller": {
@@ -3011,6 +3083,14 @@
         "@metamask/eth-sig-util>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@noble/hashes": {
       "globals": {
         "TextDecoder": true,
@@ -3078,6 +3158,12 @@
     "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography>@noble/hashes": {
@@ -3252,11 +3338,24 @@
         "TextEncoder": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/curves": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@segment/analytics-node>@segment/analytics-core": {
@@ -3552,15 +3651,16 @@
         "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true
       }
     },
-    "@metamask/react-data-query>@metamask/base-data-service>@tanstack/query-core": {
+    "@metamask/assets-controllers>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
+        "clearInterval": true,
         "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
+        "console.error": true,
+        "document.visibilityState": true,
         "removeEventListener": true,
+        "setInterval": true,
         "setTimeout": true
       }
     },
@@ -3577,24 +3677,13 @@
         "setTimeout": true
       }
     },
-    "@metamask/react-data-query>@tanstack/query-core": {
-      "globals": {
-        "AbortController": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "console": true,
-        "document": true,
-        "navigator": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
     "@tanstack/react-query>@tanstack/query-core": {
       "globals": {
         "AbortController": true,
         "addEventListener": true,
         "clearInterval": true,
         "clearTimeout": true,
+        "console": true,
         "document": true,
         "navigator": true,
         "removeEventListener": true,
@@ -4780,6 +4869,16 @@
       },
       "packages": {
         "@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/phishing-controller>ethereum-cryptography": {

--- a/package.json
+++ b/package.json
@@ -405,6 +405,7 @@
     "@metamask/eth-json-rpc-filters": "^9.0.0",
     "@metamask/eth-json-rpc-middleware": "^23.1.3",
     "@metamask/eth-ledger-bridge-keyring": "^13.0.1",
+    "@metamask/eth-money-keyring": "3.0.0",
     "@metamask/eth-qr-keyring": "^3.0.0",
     "@metamask/eth-sig-util": "^8.2.0",
     "@metamask/eth-snap-keyring": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -435,6 +435,7 @@
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-dapp-client": "^0.3.0",
+    "@metamask/money-account-balance-service": "2.4.0",
     "@metamask/money-account-utils": "^1.1.0",
     "@metamask/multichain-account-service": "^13.0.1",
     "@metamask/multichain-api-client": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -435,6 +435,7 @@
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-dapp-client": "^0.3.0",
+    "@metamask/money-account-api-data-service": "^0.4.0",
     "@metamask/money-account-balance-service": "2.4.0",
     "@metamask/money-account-utils": "^1.1.0",
     "@metamask/multichain-account-service": "^13.0.1",

--- a/shared/constants/data-services.ts
+++ b/shared/constants/data-services.ts
@@ -1,2 +1,11 @@
 // A list of all names of data services available in the client.
-export const DATA_SERVICES: string[] = [];
+//
+// `createUIQueryClient` asserts that the namespace of every `useQuery` key is
+// in this list, so a data service whose name is missing here throws
+// "Queries must call actions on the messenger provided to createUIQueryClient"
+// rather than fetching. Cross-context `cacheUpdated` subscriptions are wired up
+// from this list too.
+export const DATA_SERVICES: string[] = [
+  'MoneyAccountBalanceService',
+  'MoneyAccountApiDataService',
+];

--- a/shared/lib/money/feature-flags.test.ts
+++ b/shared/lib/money/feature-flags.test.ts
@@ -1,0 +1,72 @@
+import packageJson from '../../../package.json';
+import {
+  MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME,
+  isMoneyAccountEnabled,
+} from './feature-flags';
+
+const CURRENT_VERSION = packageJson.version;
+
+describe('isMoneyAccountEnabled', () => {
+  it('returns true for an enabled flag the current version satisfies', () => {
+    expect(
+      isMoneyAccountEnabled({
+        [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: {
+          enabled: true,
+          minimumVersion: '0.0.1',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for an enabled flag inside a progressive rollout wrapper', () => {
+    expect(
+      isMoneyAccountEnabled({
+        [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: {
+          name: 'money-rollout',
+          value: { enabled: true, minimumVersion: CURRENT_VERSION },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for a disabled flag', () => {
+    expect(
+      isMoneyAccountEnabled({
+        [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: {
+          enabled: false,
+          minimumVersion: '0.0.1',
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when the current version is below the minimum', () => {
+    expect(
+      isMoneyAccountEnabled({
+        [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: {
+          enabled: true,
+          minimumVersion: '9999.0.0',
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when the flag is absent, malformed, or the flags are unserved', () => {
+    const cases: [string, Record<string, unknown> | undefined][] = [
+      ['unserved flags', undefined],
+      ['no money flag', { someOtherFlag: true }],
+      ['malformed flag', { [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: 'yes' }],
+      [
+        'missing minimumVersion',
+        { [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: { enabled: true } },
+      ],
+    ];
+
+    for (const [name, flags] of cases) {
+      expect({ name, enabled: isMoneyAccountEnabled(flags) }).toStrictEqual({
+        name,
+        enabled: false,
+      });
+    }
+  });
+});

--- a/shared/lib/money/feature-flags.ts
+++ b/shared/lib/money/feature-flags.ts
@@ -1,0 +1,27 @@
+import { validatedVersionGatedFeatureFlag } from '../remote-feature-flag-utils';
+
+/**
+ * The LaunchDarkly flag that gates the Money Account surface. The same flag
+ * name and shape mobile reads in `app/lib/Money/feature-flags.ts`, so the two
+ * clients turn on and off together.
+ */
+export const MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME = 'moneyEnableMoneyAccount';
+
+/**
+ * Whether the Money Account feature is enabled.
+ *
+ * The flag is version-gated, so an absent, malformed, or below-minimum-version
+ * value means "off" — the surface stays hidden rather than defaulting on.
+ *
+ * @param remoteFeatureFlags - The remote feature flags.
+ * @returns Whether the Money Account feature is enabled.
+ */
+export function isMoneyAccountEnabled(
+  remoteFeatureFlags: Record<string, unknown> | undefined,
+): boolean {
+  return (
+    validatedVersionGatedFeatureFlag(
+      remoteFeatureFlags?.[MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME],
+    ) ?? false
+  );
+}

--- a/test/e2e/feature-flags/feature-flag-registry.ts
+++ b/test/e2e/feature-flags/feature-flag-registry.ts
@@ -20,6 +20,7 @@ import type { Json } from '@metamask/utils';
 import { ENABLED_ADVANCED_PERMISSIONS_FEATURE_FLAG } from '../../../shared/lib/gator-permissions/feature-flags';
 import { getBooleanFeatureFlag } from '../../../shared/lib/remote-feature-flag-utils';
 import { ACTIVE_TAB_DOMAIN_METRICS_FLAG } from '../../../shared/lib/active-tab-domain-metrics';
+import { MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME } from '../../../shared/lib/money/feature-flags';
 
 // ============================================================================
 // Types
@@ -2537,6 +2538,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
         'erc20-token-allowance',
         'token-approval-revocation',
       ],
+    },
+    status: FeatureFlagStatus.Active,
+    type: FeatureFlagType.Remote,
+  },
+
+  [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: {
+    inProd: false,
+    name: MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
     },
     status: FeatureFlagStatus.Active,
     type: FeatureFlagType.Remote,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7464,6 +7464,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/money-account-api-data-service@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@metamask/money-account-api-data-service@npm:0.4.0"
+  dependencies:
+    "@metamask/base-data-service": "npm:^0.1.3"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    "@tanstack/query-core": "npm:^4.43.0"
+  checksum: 10/cb3106f2c40e776a9876844aaa5778f79308b23a7f0ff9eaee8cc2c7fbdf0489532b7bd2463e740051c1b7da0fb980aa59ad3f5272a3c19898744294d89a002a
+  languageName: node
+  linkType: hard
+
+"@metamask/money-account-balance-service@npm:2.4.0":
+  version: 2.4.0
+  resolution: "@metamask/money-account-balance-service@npm:2.4.0"
+  dependencies:
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/base-data-service": "npm:^0.1.3"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/money-account-api-data-service": "npm:^0.4.0"
+    "@metamask/network-controller": "npm:^34.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+  checksum: 10/064ebd057c871b3ee861d901efdca9eaea7e52aa5681c8d539913cfbb2e474651f85ece5c7afcc873f4c681e02152eba8e29e1eba1a7356e4cc99c2b47781bac
+  languageName: node
+  linkType: hard
+
 "@metamask/money-account-utils@npm:^1.1.0":
   version: 1.1.0
   resolution: "@metamask/money-account-utils@npm:1.1.0"
@@ -33212,6 +33245,7 @@ __metadata:
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"
     "@metamask/mobile-wallet-protocol-dapp-client": "npm:^0.3.0"
+    "@metamask/money-account-balance-service": "npm:2.4.0"
     "@metamask/money-account-utils": "npm:^1.1.0"
     "@metamask/multichain-account-service": "npm:^13.0.1"
     "@metamask/multichain-api-client": "npm:^0.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6579,6 +6579,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-hd-keyring@npm:^14.1.1":
+  version: 14.1.1
+  resolution: "@metamask/eth-hd-keyring@npm:14.1.1"
+  dependencies:
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/key-tree": "npm:^10.0.2"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-sdk": "npm:^2.0.2"
+    "@metamask/keyring-utils": "npm:^3.2.0"
+    "@metamask/scure-bip39": "npm:^2.1.1"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    ethereum-cryptography: "npm:^2.2.1"
+  checksum: 10/f711742682a77990310272013523595822e29bfb61980828d1460ab8af888d7c344bb50f04d2611d801d63438e31532d3d66698c595b4fd3ad512b02056b7234
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-hd-keyring@npm:^15.0.0":
   version: 15.0.0
   resolution: "@metamask/eth-hd-keyring@npm:15.0.0"
@@ -6699,6 +6718,20 @@ __metadata:
     hdkey: "npm:^2.1.0"
     rxjs: "npm:^7.8.2"
   checksum: 10/b4c06bead6c998601ac4bd06fecf8d09216f0d60e6a07e6e41e00ab58a965cb516405316c828b2970aac51c2534ae7b2456b3bc5067ff7cf544e3d70d223c25a
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-money-keyring@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/eth-money-keyring@npm:3.0.0"
+  dependencies:
+    "@metamask/eth-hd-keyring": "npm:^14.1.1"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-sdk": "npm:^2.1.1"
+    "@metamask/keyring-utils": "npm:^3.3.1"
+    "@metamask/superstruct": "npm:^3.1.0"
+    async-mutex: "npm:^0.5.0"
+  checksum: 10/2d14c0581ea0df3b19372fc292ccfffbc25119057317f813335bb581c49e8cb34f46389c5013be25e8cf039d4a230dbdc72949766bb474941d5da0d8611172df
   languageName: node
   linkType: hard
 
@@ -7167,6 +7200,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/keyring-sdk@npm:^2.0.2, @metamask/keyring-sdk@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "@metamask/keyring-sdk@npm:2.2.0"
+  dependencies:
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/keyring-api": "npm:^23.2.0"
+    "@metamask/keyring-utils": "npm:^3.3.1"
+    "@metamask/scure-bip39": "npm:^2.1.1"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    async-mutex: "npm:^0.5.0"
+    ethereum-cryptography: "npm:^2.2.1"
+    uuid: "npm:^9.0.1"
+  checksum: 10/5cb7f2496f0fc95e85eb97932b69da9c02c232e2310b5f390bfc7c56996bf8516d15db54260e68288f6d6f5604bfacc19b4b82b9b28b7f794a3ab5ee9a1f10d1
+  languageName: node
+  linkType: hard
+
 "@metamask/keyring-sdk@npm:^3.0.0, @metamask/keyring-sdk@npm:^3.1.0":
   version: 3.1.0
   resolution: "@metamask/keyring-sdk@npm:3.1.0"
@@ -7258,6 +7309,18 @@ __metadata:
     "@metamask/utils": "npm:^11.1.0"
     bitcoin-address-validation: "npm:^2.2.3"
   checksum: 10/9072791320108218875bdbcc7823a4ab4d8c29675deab3163373d31a997ae6fc23995a74ffa085e06534d14b72c2edb5e7192d371cd1ef69ac7fae70fa50d8d0
+  languageName: node
+  linkType: hard
+
+"@metamask/keyring-utils@npm:^3.2.0, @metamask/keyring-utils@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@metamask/keyring-utils@npm:3.3.1"
+  dependencies:
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    bitcoin-address-validation: "npm:^2.2.3"
+  checksum: 10/d0917b2f634d9eb2f563827739fca00c1675ee90674ec49b2b68afcb604aee843d6c5be5d79e9780fa22d29f71fc876f40b2d3d0ed4cab7f5948937ddd276691
   languageName: node
   linkType: hard
 
@@ -33115,6 +33178,7 @@ __metadata:
     "@metamask/eth-json-rpc-middleware": "npm:^23.1.3"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
     "@metamask/eth-ledger-bridge-keyring": "npm:^13.0.1"
+    "@metamask/eth-money-keyring": "npm:3.0.0"
     "@metamask/eth-qr-keyring": "npm:^3.0.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/eth-snap-keyring": "npm:^24.0.0"
@@ -34220,7 +34284,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.10, nanoid@npm:^3.3.11, nanoid@npm:^3.3.16, nanoid@npm:^3.3.17, nanoid@npm:^3.3.8":
+"nanoid@npm:^3.3.10, nanoid@npm:^3.3.11, nanoid@npm:^3.3.16, nanoid@npm:^3.3.8":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.17":
   version: 3.3.17
   resolution: "nanoid@npm:3.3.17"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -34319,16 +34319,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.10, nanoid@npm:^3.3.11, nanoid@npm:^3.3.16, nanoid@npm:^3.3.8":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.17":
+"nanoid@npm:^3.3.10, nanoid@npm:^3.3.11, nanoid@npm:^3.3.16, nanoid@npm:^3.3.17, nanoid@npm:^3.3.8":
   version: 3.3.17
   resolution: "nanoid@npm:3.3.17"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -33245,6 +33245,7 @@ __metadata:
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"
     "@metamask/mobile-wallet-protocol-dapp-client": "npm:^0.3.0"
+    "@metamask/money-account-api-data-service": "npm:^0.4.0"
     "@metamask/money-account-balance-service": "npm:2.4.0"
     "@metamask/money-account-utils": "npm:^1.1.0"
     "@metamask/multichain-account-service": "npm:^13.0.1"


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR integrates the money balance service into extension, and adds the ability to derive the money account address from the SRP. These changes are laying groundwork for future PRs and do not have user facing impact.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: integrate money balance service

## **Related issues**

Fixes: MUSD-1262

## **Manual testing steps**
No user facing changes are added, so no manual testing is required

## **Screenshots/Recordings**
N/A
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Reads the primary HD mnemonic via `withKeyringUnsafe` to derive addresses, and adds authenticated money API services—security-sensitive keyring and credential paths even though the feature flag defaults off.
> 
> **Overview**
> Adds **Money Account groundwork**: derive a deterministic money address from the primary SRP, gate availability behind `moneyEnableMoneyAccount`, and wire balance/API data services into the messenger client init.
> 
> **Address derivation & availability.** New `deriveMoneyAccountAddress` uses `MoneyKeyring` and `KeyringController:withKeyringUnsafe` to read the primary HD mnemonic (unlocked wallet, no password) and derive at the money path. `MoneyAccountAvailabilityService` checks the remote flag first, then returns the cached derived address; cache clears on lock/unlock, and failures are not cached.
> 
> **Service integration.** Registers `MoneyAccountApiDataService` (prod env, bearer token) and `MoneyAccountBalanceService` with restricted messengers, adds them to `DATA_SERVICES`, and updates Lavamoat policies plus deps (`@metamask/eth-money-keyring`, money account packages). Flag defaults off—no user-facing surface yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa674cb2d584c6815d3625839d85b70a3aa13f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->