### PR TITLE
chore: add mobile-parity props to activity details opened

### DIFF
--- a/ui/pages/activity/activity-list.tsx
+++ b/ui/pages/activity/activity-list.tsx
@@ -109,15 +109,20 @@ export function ActivityList({
       return;
     }
 
+    /* eslint-disable @typescript-eslint/naming-convention -- Segment event properties use snake_case */
     trackEvent(
       createEventBuilder(MetaMetricsEventName.ActivityDetailsOpened)
         .addCategory(MetaMetricsEventCategory.Navigation)
         .addProperties({
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           activity_type: item.type,
+          transaction_status: item.status,
+          location: filter && 'assetId' in filter ? 'asset_details' : 'home',
+          chain_id_source: item.chainId,
+          chain_id_destination: item.chainId,
         })
         .build(),
     );
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     setSelectedItem(item);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Extension's `Activity Details Opened` event previously only sent `activity_type`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: CEUX-1090

## **Manual testing steps**

1. Open the Activity tab
2. Click an activity row
3. Confirm segment events includes `transaction_status`, `transaction_type`, `location`, `chain_id_source`, and `chain_id_destination`

## **Screenshots/Recordings**

<!--
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)