### PR TITLE
fix: show network icon in token management filter

### DIFF
--- a/ui/components/app/assets/hooks/useNetworkFilterButtonLabel.ts
+++ b/ui/components/app/assets/hooks/useNetworkFilterButtonLabel.ts
@@ -10,6 +10,28 @@ import {
 } from '../../../../selectors';
 import { useNetworkManagerState } from '../../../multichain/network-manager/hooks/useNetworkManagerState';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { getNetworkIcon } from '../../../../../shared/lib/network.utils';
+
+const toCaipChainId = (chainId: string) =>
+  isStrictHexString(chainId) ? toEvmCaipChainId(chainId) : chainId;
+
+export function useNetworkFilterButtonIcon():
+  | { name: string; src?: string }
+  | undefined {
+  const enabledNetworks = useSelector(getAllEnabledNetworksForAllNamespaces);
+  const allCaipNetworks = useSelector(getAllNetworkConfigurationsByCaipChainId);
+
+  return useMemo(() => {
+    if (enabledNetworks.length !== 1) {
+      return undefined;
+    }
+
+    const network = allCaipNetworks[toCaipChainId(enabledNetworks[0])];
+    return network
+      ? { name: network.name, src: getNetworkIcon(network) }
+      : undefined;
+  }, [allCaipNetworks, enabledNetworks]);
+}
 
 export function useNetworkFilterButtonLabel(): string {
   const t = useI18nContext();
@@ -40,9 +62,7 @@ export function useNetworkFilterButtonLabel(): string {
   return useMemo(() => {
     if (totalEnabledNetworkCount === 1) {
       const chainId = allEnabledNetworksForAllNamespaces[0];
-      const caipChainId = isStrictHexString(chainId)
-        ? toEvmCaipChainId(chainId)
-        : chainId;
+      const caipChainId = toCaipChainId(chainId);
       const networkName =
         allCaipNetworks[caipChainId]?.name ?? t('currentNetwork');
       return `${t('network')}: ${networkName}`;

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -659,6 +659,14 @@ describe('TokenManagementPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows the selected network icon in the network filter button', () => {
+    renderPage();
+
+    expect(
+      screen.getByTestId('token-management-network-filter-icon'),
+    ).toBeInTheDocument();
+  });
+
   it('navigates to the dedicated networks page from manage networks in the shared modal', async () => {
     renderPage();
 

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -8,6 +8,8 @@ import React, {
 import { useSelector, useStore } from 'react-redux';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import {
+  AvatarNetwork,
+  AvatarNetworkSize,
   Box,
   BoxAlignItems,
   BoxBackgroundColor,
@@ -52,7 +54,10 @@ import {
   getSelectedMultichainNetworkConfiguration,
   selectEnabledNetworksAsCaipChainIds,
 } from '../../selectors/multichain/networks';
-import { useNetworkFilterButtonLabel } from '../../components/app/assets/hooks/useNetworkFilterButtonLabel';
+import {
+  useNetworkFilterButtonIcon,
+  useNetworkFilterButtonLabel,
+} from '../../components/app/assets/hooks/useNetworkFilterButtonLabel';
 import { getNetworkConfigurationsByChainId } from '../../../shared/lib/selectors/networks';
 import {
   addCustomAsset,
@@ -809,6 +814,7 @@ export const TokenManagementPage = () => {
   }, [commitStagedHides]);
 
   const networkFilterLabel = useNetworkFilterButtonLabel();
+  const networkFilterIcon = useNetworkFilterButtonIcon();
 
   const getTokenKey = useCallback((token: ManagedAsset) => {
     const address = 'address' in token ? token.address : token.assetId;
@@ -1584,6 +1590,14 @@ export const TokenManagementPage = () => {
           className="bg-default text-default border border-muted"
           onClick={handleOpenNetworkFilter}
         >
+          {networkFilterIcon ? (
+            <AvatarNetwork
+              data-testid="token-management-network-filter-icon"
+              name={networkFilterIcon.name}
+              src={networkFilterIcon.src}
+              size={AvatarNetworkSize.Xs}
+            />
+          ) : null}
           <Text
             variant={TextVariant.BodySm}
             fontWeight={FontWeight.Medium}


### PR DESCRIPTION
## **Description**

Show the selected network's icon beside the network filter label on the token management page. The icon is derived from the same single enabled-network selection used by the existing label and is omitted when multiple networks are selected.

## **Changelog**

CHANGELOG entry: Added the selected network icon to the token management network filter

## **Related issues**

Fixes: #45361

## **Manual testing steps**

1. Open the token management page with a single network selected.
2. Confirm the network avatar appears beside the network filter label.
3. Open the network filter and enable multiple networks; confirm the single-network avatar is not shown.

## **Screenshots/Recordings**

### **Before**

See the screenshot attached to #45361.

### **After**

Not attached; the regression is covered by the token management component test.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using JSDoc format if applicable
- [ ] I’ve applied the right labels on the PR. Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket.

## **Validation**

- `yarn jest ui/pages/token-management/token-management.test.tsx --runInBand` (45 tests)
- `NODE_OPTIONS=--max-old-space-size=6144 yarn lint:changed` (passes with three pre-existing warnings in the page)
