### PR TITLE
fix: show network icon in token management filter

### DIFF
--- a/ui/components/app/assets/hooks/useNetworkFilterButtonLabel.test.ts
+++ b/ui/components/app/assets/hooks/useNetworkFilterButtonLabel.test.ts
@@ -1,7 +1,113 @@
+import { it } from '@jest/globals';
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
-import { useNetworkFilterButtonLabel } from './useNetworkFilterButtonLabel';
+import { ETH_TOKEN_IMAGE_URL } from '../../../../../shared/constants/network';
+import { SOLANA_TOKEN_IMAGE_URL } from '../../../../../shared/constants/multichain/networks';
+import {
+  useNetworkFilterButtonIcon,
+  useNetworkFilterButtonLabel,
+} from './useNetworkFilterButtonLabel';
+
+describe('useNetworkFilterButtonIcon', () => {
+  it('returns the Ethereum image for a single enabled EVM network', () => {
+    const { result } = renderHookWithProvider(useNetworkFilterButtonIcon, {
+      metamask: {
+        ...mockState.metamask,
+        enabledNetworkMap: {
+          eip155: { '0x1': true, '0x5': false },
+        },
+      },
+    });
+
+    expect(result.current).toStrictEqual({
+      name: 'Custom Mainnet RPC',
+      src: ETH_TOKEN_IMAGE_URL,
+    });
+  });
+
+  it('returns the Solana image for a single enabled non-EVM network', () => {
+    const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+    const { result } = renderHookWithProvider(useNetworkFilterButtonIcon, {
+      metamask: {
+        ...mockState.metamask,
+        remoteFeatureFlags: {
+          ...mockState.metamask.remoteFeatureFlags,
+          solanaAccounts: { enabled: true, minimumVersion: '13.6.0' },
+        },
+        enabledNetworkMap: {
+          eip155: { '0x1': false },
+          solana: { [solanaChainId]: true },
+        },
+      },
+    });
+
+    expect(result.current).toStrictEqual({
+      name: 'Solana',
+      src: SOLANA_TOKEN_IMAGE_URL,
+    });
+  });
+
+  it.each([
+    {
+      description: 'no networks',
+      enabledNetworkMap: { eip155: { '0x1': false } },
+    },
+    {
+      description: 'multiple EVM networks',
+      enabledNetworkMap: { eip155: { '0x1': true, '0x5': true } },
+    },
+    {
+      description: 'multiple namespaces',
+      enabledNetworkMap: {
+        eip155: { '0x1': true },
+        solana: { 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': true },
+      },
+    },
+  ])('omits the icon with $description enabled', ({ enabledNetworkMap }) => {
+    const { result } = renderHookWithProvider(useNetworkFilterButtonIcon, {
+      metamask: {
+        ...mockState.metamask,
+        enabledNetworkMap,
+      },
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('omits the icon when the enabled network has no configuration', () => {
+    const { result } = renderHookWithProvider(useNetworkFilterButtonIcon, {
+      metamask: {
+        ...mockState.metamask,
+        enabledNetworkMap: { eip155: { '0x123456': true } },
+      },
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns the network name for a custom EVM network without an image', () => {
+    const { result } = renderHookWithProvider(useNetworkFilterButtonIcon, {
+      metamask: {
+        ...mockState.metamask,
+        enabledNetworkMap: { eip155: { '0x123456': true } },
+        networkConfigurationsByChainId: {
+          ...mockState.metamask.networkConfigurationsByChainId,
+          '0x123456': {
+            ...mockState.metamask.networkConfigurationsByChainId['0x1'],
+            chainId: '0x123456',
+            name: 'Custom Network',
+          },
+        },
+      },
+    });
+
+    expect(result.current).toStrictEqual({
+      name: 'Custom Network',
+      src: undefined,
+    });
+  });
+});
 
 describe('useNetworkFilterButtonLabel', () => {
   const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';

--- a/ui/components/app/assets/hooks/useNetworkFilterButtonLabel.ts
+++ b/ui/components/app/assets/hooks/useNetworkFilterButtonLabel.ts
@@ -2,7 +2,10 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { isStrictHexString } from '@metamask/utils';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
-import { getAllEnabledNetworksForAllNamespaces } from '../../../../selectors/multichain/networks';
+import {
+  getAllEnabledNetworksForAllNamespaces,
+  getAllMultichainNetworkConfigurations,
+} from '../../../../selectors/multichain/networks';
 import { getAllNetworkConfigurationsByCaipChainId } from '../../../../../shared/lib/selectors/networks';
 import {
   getShowTestNetworks,
@@ -19,18 +22,18 @@ export function useNetworkFilterButtonIcon():
   | { name: string; src?: string }
   | undefined {
   const enabledNetworks = useSelector(getAllEnabledNetworksForAllNamespaces);
-  const allCaipNetworks = useSelector(getAllNetworkConfigurationsByCaipChainId);
+  const allNetworks = useSelector(getAllMultichainNetworkConfigurations);
 
   return useMemo(() => {
     if (enabledNetworks.length !== 1) {
       return undefined;
     }
 
-    const network = allCaipNetworks[toCaipChainId(enabledNetworks[0])];
+    const network = allNetworks[toCaipChainId(enabledNetworks[0])];
     return network
       ? { name: network.name, src: getNetworkIcon(network) }
       : undefined;
-  }, [allCaipNetworks, enabledNetworks]);
+  }, [allNetworks, enabledNetworks]);
 }
 
 export function useNetworkFilterButtonLabel(): string {

--- a/ui/components/app/assets/hooks/useNetworkFilterButtonLabel.ts
+++ b/ui/components/app/assets/hooks/useNetworkFilterButtonLabel.ts
@@ -10,6 +10,28 @@ import {
 } from '../../../../selectors';
 import { useNetworkManagerState } from '../../../multichain/network-manager/hooks/useNetworkManagerState';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { getNetworkIcon } from '../../../../../shared/lib/network.utils';
+
+const toCaipChainId = (chainId: string) =>
+  isStrictHexString(chainId) ? toEvmCaipChainId(chainId) : chainId;
+
+export function useNetworkFilterButtonIcon():
+  | { name: string; src?: string }
+  | undefined {
+  const enabledNetworks = useSelector(getAllEnabledNetworksForAllNamespaces);
+  const allCaipNetworks = useSelector(getAllNetworkConfigurationsByCaipChainId);
+
+  return useMemo(() => {
+    if (enabledNetworks.length !== 1) {
+      return undefined;
+    }
+
+    const network = allCaipNetworks[toCaipChainId(enabledNetworks[0])];
+    return network
+      ? { name: network.name, src: getNetworkIcon(network) }
+      : undefined;
+  }, [allCaipNetworks, enabledNetworks]);
+}
 
 export function useNetworkFilterButtonLabel(): string {
   const t = useI18nContext();
@@ -40,9 +62,7 @@ export function useNetworkFilterButtonLabel(): string {
   return useMemo(() => {
     if (totalEnabledNetworkCount === 1) {
       const chainId = allEnabledNetworksForAllNamespaces[0];
-      const caipChainId = isStrictHexString(chainId)
-        ? toEvmCaipChainId(chainId)
-        : chainId;
+      const caipChainId = toCaipChainId(chainId);
       const networkName =
         allCaipNetworks[caipChainId]?.name ?? t('currentNetwork');
       return `${t('network')}: ${networkName}`;

--- a/ui/components/app/assets/hooks/useNetworkFilterButtonLabel.ts
+++ b/ui/components/app/assets/hooks/useNetworkFilterButtonLabel.ts
@@ -5,6 +5,7 @@ import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import {
   getAllEnabledNetworksForAllNamespaces,
   getAllMultichainNetworkConfigurations,
+  selectEnabledNetworksAsCaipChainIds,
 } from '../../../../selectors/multichain/networks';
 import { getAllNetworkConfigurationsByCaipChainId } from '../../../../../shared/lib/selectors/networks';
 import {
@@ -21,7 +22,7 @@ const toCaipChainId = (chainId: string) =>
 export function useNetworkFilterButtonIcon():
   | { name: string; src?: string }
   | undefined {
-  const enabledNetworks = useSelector(getAllEnabledNetworksForAllNamespaces);
+  const enabledNetworks = useSelector(selectEnabledNetworksAsCaipChainIds);
   const allNetworks = useSelector(getAllMultichainNetworkConfigurations);
 
   return useMemo(() => {
@@ -29,7 +30,7 @@ export function useNetworkFilterButtonIcon():
       return undefined;
     }
 
-    const network = allNetworks[toCaipChainId(enabledNetworks[0])];
+    const network = allNetworks[enabledNetworks[0]];
     return network
       ? { name: network.name, src: getNetworkIcon(network) }
       : undefined;

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -659,6 +659,14 @@ describe('TokenManagementPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows the selected network icon in the network filter button', () => {
+    renderPage();
+
+    expect(
+      screen.getByTestId('token-management-network-filter-icon'),
+    ).toBeInTheDocument();
+  });
+
   it('navigates to the dedicated networks page from manage networks in the shared modal', async () => {
     renderPage();
 

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import {
   en as messages,
   renderWithProvider,
@@ -18,6 +18,7 @@ import {
 } from '../../../shared/constants/metametrics';
 import { setBackgroundConnection } from '../../store/background-connection';
 import { AssetType } from '../../../shared/constants/transaction';
+import { ETH_TOKEN_IMAGE_URL } from '../../../shared/constants/network';
 import { TokenManagementPage } from './token-management';
 
 const METRICS_PROPERTIES = {
@@ -662,9 +663,15 @@ describe('TokenManagementPage', () => {
   it('shows the selected network icon in the network filter button', () => {
     renderPage();
 
+    const networkFilterIcon = screen.getByTestId(
+      'token-management-network-filter-icon',
+    );
+
     expect(
-      screen.getByTestId('token-management-network-filter-icon'),
-    ).toBeInTheDocument();
+      within(networkFilterIcon).getByRole('img', {
+        name: 'Ethereum Mainnet',
+      }),
+    ).toHaveAttribute('src', ETH_TOKEN_IMAGE_URL);
   });
 
   it('navigates to the dedicated networks page from manage networks in the shared modal', async () => {

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import {
   en as messages,
   renderWithProvider,
@@ -672,6 +678,18 @@ describe('TokenManagementPage', () => {
         name: 'Ethereum Mainnet',
       }),
     ).toHaveAttribute('src', ETH_TOKEN_IMAGE_URL);
+  });
+
+  it('omits the network filter icon when multiple networks are enabled', () => {
+    renderPage(
+      createState({
+        enabledNetworks: { '0x1': true, '0x5': true },
+      }),
+    );
+
+    expect(
+      screen.queryByTestId('token-management-network-filter-icon'),
+    ).not.toBeInTheDocument();
   });
 
   it('navigates to the dedicated networks page from manage networks in the shared modal', async () => {

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -8,6 +8,8 @@ import React, {
 import { useSelector, useStore } from 'react-redux';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import {
+  AvatarNetwork,
+  AvatarNetworkSize,
   Box,
   BoxAlignItems,
   BoxBackgroundColor,
@@ -52,7 +54,10 @@ import {
   getSelectedMultichainNetworkConfiguration,
   selectEnabledNetworksAsCaipChainIds,
 } from '../../selectors/multichain/networks';
-import { useNetworkFilterButtonLabel } from '../../components/app/assets/hooks/useNetworkFilterButtonLabel';
+import {
+  useNetworkFilterButtonIcon,
+  useNetworkFilterButtonLabel,
+} from '../../components/app/assets/hooks/useNetworkFilterButtonLabel';
 import { getNetworkConfigurationsByChainId } from '../../../shared/lib/selectors/networks';
 import {
   addCustomAsset,
@@ -809,6 +814,7 @@ export const TokenManagementPage = () => {
   }, [commitStagedHides]);
 
   const networkFilterLabel = useNetworkFilterButtonLabel();
+  const networkFilterIcon = useNetworkFilterButtonIcon();
 
   const getTokenKey = useCallback((token: ManagedAsset) => {
     const address = 'address' in token ? token.address : token.assetId;
@@ -1584,6 +1590,14 @@ export const TokenManagementPage = () => {
           className="bg-default text-default border border-muted"
           onClick={handleOpenNetworkFilter}
         >
+          {networkFilterIcon ? (
+            <AvatarNetwork
+              data-testid="token-management-network-filter-icon"
+              name={networkFilterIcon.name}
+              src={networkFilterIcon.src}
+              size={AvatarNetworkSize.Xs}
+            />
+          ) : null}
           <Text
             variant={TextVariant.BodySm}
             fontWeight={FontWeight.Medium}


### PR DESCRIPTION
## **Description**

Show the selected network's icon beside the network filter label on the token management page. The icon is derived from the same single enabled-network selection used by the existing label and is omitted when multiple networks are selected.

## **Changelog**

CHANGELOG entry: Added the selected network icon to the token management network filter

## **Related issues**

Fixes: #45361

## **Manual testing steps**

1. Open the token management page with a single network selected.
2. Confirm the network avatar appears beside the network filter label.
3. Open the network filter and enable multiple networks; confirm the single-network avatar is not shown.

## **Screenshots/Recordings**

### **Before**

<img width="945" height="874" alt="Token management network filter without a network icon" src="https://github.com/user-attachments/assets/3634f40b-e8a7-478b-92e5-14f62ed81ef1" />

### **After**

Single network: the Ethereum Mainnet avatar is visible beside the filter label.

<img width="1280" height="720" alt="Token management with the Ethereum Mainnet avatar visible" src="https://github.com/user-attachments/assets/3a12e789-9919-41d1-bc1a-711c53403560" />

Multiple networks: the filter shows all default networks and omits the single-network avatar.

<img width="1280" height="720" alt="Token management with multiple networks and no single-network avatar" src="https://github.com/user-attachments/assets/6d2af009-267c-45e3-a070-0933e5641663" />

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
- [x] I've completed the PR template to the best of ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using JSDoc format if applicable
- [ ] I’ve applied the right labels on the PR. Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket.

## **Validation**

- `yarn jest ui/pages/token-management/token-management.test.tsx --runInBand` (45 tests)
- `NODE_OPTIONS=--max-old-space-size=6144 yarn lint:changed` (passes with three pre-existing warnings in the page)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to the token management network filter with no auth, data, or network-selection logic changes beyond display.
> 
> **Overview**
> Adds a **selected-network avatar** next to the network filter label on the token management page when exactly one network is enabled in the home network filter; the icon is hidden when zero or multiple networks are selected, matching the existing label rules.
> 
> Introduces **`useNetworkFilterButtonIcon`** alongside the existing label hook: it reads enabled CAIP chain IDs and multichain network config, returns `{ name, src? }` from **`getNetworkIcon`**, and falls back to name-only for custom networks without artwork. The token management filter button renders an **`AvatarNetwork`** when that hook returns data.
> 
> Hook and page behavior are covered by new unit tests (EVM, Solana, multi-network, missing config) and integration tests on the filter button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e8f01f616feb02e2734145c2a7fd5b3e060d9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

