### PR TITLE
fix(ui): add keyboard navigation to Tabs (DSYS-1045)

### DIFF
--- a/ui/components/ui/tabs/tabs.test.tsx
+++ b/ui/components/ui/tabs/tabs.test.tsx
@@ -360,6 +360,90 @@ describe('Tabs', () => {
       expect(getByText('Tab 2 Content')).toBeInTheDocument();
       expect(tabs[1]).toHaveFocus();
     });
+
+    it('does not navigate when every tab is disabled', () => {
+      const onTabClick = jest.fn();
+      const { getByText, getByRole } = render(
+        <Tabs activeTab="tab1" onTabClick={onTabClick}>
+          <Tab tabKey="tab1" name="Tab 1" disabled>
+            Tab 1 Content
+          </Tab>
+          <Tab tabKey="tab2" name="Tab 2" disabled>
+            Tab 2 Content
+          </Tab>
+        </Tabs>,
+      );
+
+      const tabList = getByRole('tablist');
+      fireEvent.keyDown(tabList, { key: 'ArrowRight' });
+      fireEvent.keyDown(tabList, { key: 'Home' });
+      fireEvent.keyDown(tabList, { key: 'End' });
+
+      expect(onTabClick).not.toHaveBeenCalled();
+      expect(getByText('Tab 1 Content')).toBeInTheDocument();
+    });
+
+    it('falls back from a disabled active tab to the previous enabled tab', () => {
+      const onTabClick = jest.fn();
+      const { getByText, getByRole, getAllByRole } = render(
+        <Tabs activeTab="tab2" onTabClick={onTabClick}>
+          <Tab tabKey="tab1" name="Tab 1">
+            Tab 1 Content
+          </Tab>
+          <Tab tabKey="tab2" name="Tab 2" disabled>
+            Tab 2 Content
+          </Tab>
+          <Tab tabKey="tab3" name="Tab 3">
+            Tab 3 Content
+          </Tab>
+        </Tabs>,
+      );
+
+      const tabList = getByRole('tablist');
+      const tabs = getAllByRole('tab');
+
+      fireEvent.keyDown(tabList, { key: 'ArrowRight' });
+
+      expect(onTabClick).toHaveBeenCalledWith('tab3');
+      expect(getByText('Tab 3 Content')).toBeInTheDocument();
+      expect(tabs[2]).toHaveFocus();
+    });
+
+    it('falls back to the first enabled tab when the active tab is disabled and has no prior enabled tab', () => {
+      const onTabClick = jest.fn();
+      const { getByText, getByRole, getAllByRole } = render(
+        <Tabs activeTab="tab1" onTabClick={onTabClick}>
+          <Tab tabKey="tab1" name="Tab 1" disabled>
+            Tab 1 Content
+          </Tab>
+          <Tab tabKey="tab2" name="Tab 2">
+            Tab 2 Content
+          </Tab>
+          <Tab tabKey="tab3" name="Tab 3">
+            Tab 3 Content
+          </Tab>
+        </Tabs>,
+      );
+
+      const tabList = getByRole('tablist');
+      const tabs = getAllByRole('tab');
+
+      fireEvent.keyDown(tabList, { key: 'Home' });
+
+      expect(onTabClick).toHaveBeenCalledWith('tab2');
+      expect(getByText('Tab 2 Content')).toBeInTheDocument();
+      expect(tabs[1]).toHaveFocus();
+    });
+
+    it('ignores keys that are not part of the tabs keyboard pattern', () => {
+      const { onTabClick, tabList, getByText } = renderKeyboardTabs();
+
+      fireEvent.keyDown(tabList, { key: 'Enter' });
+      fireEvent.keyDown(tabList, { key: 'a' });
+
+      expect(onTabClick).not.toHaveBeenCalled();
+      expect(getByText('Tab 1 Content')).toBeInTheDocument();
+    });
   });
 
   it('clamps to last tab when activeTab key does not exist', () => {

--- a/ui/components/ui/tabs/tabs.test.tsx
+++ b/ui/components/ui/tabs/tabs.test.tsx
@@ -184,6 +184,184 @@ describe('Tabs', () => {
     expect(onTabClick).not.toHaveBeenCalled();
   });
 
+  describe('keyboard navigation', () => {
+    const renderKeyboardTabs = (onTabClick = jest.fn()) => {
+      const result = render(
+        <Tabs activeTab="tab1" onTabClick={onTabClick}>
+          <Tab tabKey="tab1" name="Tab 1">
+            Tab 1 Content
+          </Tab>
+          <Tab tabKey="tab2" name="Tab 2">
+            Tab 2 Content
+          </Tab>
+          <Tab tabKey="tab3" name="Tab 3">
+            Tab 3 Content
+          </Tab>
+        </Tabs>,
+      );
+
+      const tabList = result.getByRole('tablist');
+      const tabs = result.getAllByRole('tab');
+      return { ...result, onTabClick, tabList, tabs };
+    };
+
+    it('moves to the next tab on ArrowRight', () => {
+      const { getByText, queryByText, onTabClick, tabList, tabs } =
+        renderKeyboardTabs();
+
+      tabs[0].focus();
+      fireEvent.keyDown(tabList, { key: 'ArrowRight' });
+
+      expect(onTabClick).toHaveBeenCalledWith('tab2');
+      expect(queryByText('Tab 1 Content')).not.toBeInTheDocument();
+      expect(getByText('Tab 2 Content')).toBeInTheDocument();
+      expect(tabs[1]).toHaveFocus();
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+      expect(tabs[1]).toHaveAttribute('tabIndex', '0');
+      expect(tabs[0]).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('moves to the previous tab on ArrowLeft and wraps from first to last', () => {
+      const { getByText, queryByText, onTabClick, tabList, tabs } =
+        renderKeyboardTabs();
+
+      tabs[0].focus();
+      fireEvent.keyDown(tabList, { key: 'ArrowLeft' });
+
+      expect(onTabClick).toHaveBeenCalledWith('tab3');
+      expect(queryByText('Tab 1 Content')).not.toBeInTheDocument();
+      expect(getByText('Tab 3 Content')).toBeInTheDocument();
+      expect(tabs[2]).toHaveFocus();
+    });
+
+    it('wraps from last to first on ArrowRight', () => {
+      const onTabClick = jest.fn();
+      const { getByText, getByRole, getAllByRole } = render(
+        <Tabs activeTab="tab3" onTabClick={onTabClick}>
+          <Tab tabKey="tab1" name="Tab 1">
+            Tab 1 Content
+          </Tab>
+          <Tab tabKey="tab2" name="Tab 2">
+            Tab 2 Content
+          </Tab>
+          <Tab tabKey="tab3" name="Tab 3">
+            Tab 3 Content
+          </Tab>
+        </Tabs>,
+      );
+
+      const tabList = getByRole('tablist');
+      const tabs = getAllByRole('tab');
+
+      tabs[2].focus();
+      fireEvent.keyDown(tabList, { key: 'ArrowRight' });
+
+      expect(onTabClick).toHaveBeenCalledWith('tab1');
+      expect(getByText('Tab 1 Content')).toBeInTheDocument();
+      expect(tabs[0]).toHaveFocus();
+    });
+
+    it('moves to the first enabled tab on Home', () => {
+      const onTabClick = jest.fn();
+      const { getByText, getByRole, getAllByRole } = render(
+        <Tabs activeTab="tab3" onTabClick={onTabClick}>
+          <Tab tabKey="tab1" name="Tab 1">
+            Tab 1 Content
+          </Tab>
+          <Tab tabKey="tab2" name="Tab 2">
+            Tab 2 Content
+          </Tab>
+          <Tab tabKey="tab3" name="Tab 3">
+            Tab 3 Content
+          </Tab>
+        </Tabs>,
+      );
+
+      const tabList = getByRole('tablist');
+      const tabs = getAllByRole('tab');
+
+      tabs[2].focus();
+      fireEvent.keyDown(tabList, { key: 'Home' });
+
+      expect(onTabClick).toHaveBeenCalledWith('tab1');
+      expect(getByText('Tab 1 Content')).toBeInTheDocument();
+      expect(tabs[0]).toHaveFocus();
+    });
+
+    it('moves to the last enabled tab on End', () => {
+      const { getByText, queryByText, onTabClick, tabList, tabs } =
+        renderKeyboardTabs();
+
+      tabs[0].focus();
+      fireEvent.keyDown(tabList, { key: 'End' });
+
+      expect(onTabClick).toHaveBeenCalledWith('tab3');
+      expect(queryByText('Tab 1 Content')).not.toBeInTheDocument();
+      expect(getByText('Tab 3 Content')).toBeInTheDocument();
+      expect(tabs[2]).toHaveFocus();
+    });
+
+    it('skips disabled tabs when navigating with arrow keys', () => {
+      const onTabClick = jest.fn();
+      const { getByText, queryByText, getByRole, getAllByRole } = render(
+        <Tabs activeTab="tab1" onTabClick={onTabClick}>
+          <Tab tabKey="tab1" name="Tab 1">
+            Tab 1 Content
+          </Tab>
+          <Tab tabKey="tab2" name="Tab 2" disabled>
+            Tab 2 Content
+          </Tab>
+          <Tab tabKey="tab3" name="Tab 3">
+            Tab 3 Content
+          </Tab>
+        </Tabs>,
+      );
+
+      const tabList = getByRole('tablist');
+      const tabs = getAllByRole('tab');
+
+      tabs[0].focus();
+      fireEvent.keyDown(tabList, { key: 'ArrowRight' });
+
+      expect(onTabClick).toHaveBeenCalledWith('tab3');
+      expect(onTabClick).not.toHaveBeenCalledWith('tab2');
+      expect(queryByText('Tab 2 Content')).not.toBeInTheDocument();
+      expect(getByText('Tab 3 Content')).toBeInTheDocument();
+      expect(tabs[2]).toHaveFocus();
+    });
+
+    it('skips disabled tabs when using Home and End', () => {
+      const onTabClick = jest.fn();
+      const { getByText, getByRole, getAllByRole } = render(
+        <Tabs activeTab="tab2" onTabClick={onTabClick}>
+          <Tab tabKey="tab1" name="Tab 1" disabled>
+            Tab 1 Content
+          </Tab>
+          <Tab tabKey="tab2" name="Tab 2">
+            Tab 2 Content
+          </Tab>
+          <Tab tabKey="tab3" name="Tab 3" disabled>
+            Tab 3 Content
+          </Tab>
+        </Tabs>,
+      );
+
+      const tabList = getByRole('tablist');
+      const tabs = getAllByRole('tab');
+
+      tabs[1].focus();
+      fireEvent.keyDown(tabList, { key: 'Home' });
+      expect(onTabClick).not.toHaveBeenCalled();
+      expect(getByText('Tab 2 Content')).toBeInTheDocument();
+      expect(tabs[1]).toHaveFocus();
+
+      fireEvent.keyDown(tabList, { key: 'End' });
+      expect(onTabClick).not.toHaveBeenCalled();
+      expect(getByText('Tab 2 Content')).toBeInTheDocument();
+      expect(tabs[1]).toHaveFocus();
+    });
+  });
+
   it('clamps to last tab when activeTab key does not exist', () => {
     const { getByText } = render(
       <Tabs activeTab={'nonexistent' as string} onTabClick={() => null}>

--- a/ui/components/ui/tabs/tabs.tsx
+++ b/ui/components/ui/tabs/tabs.tsx
@@ -243,7 +243,7 @@ export const Tabs = <TKey extends string = string>({
       }
       case 'End': {
         event.preventDefault();
-        nextIndex = enabledIndices[enabledIndices.length - 1];
+        nextIndex = enabledIndices.at(-1);
         break;
       }
       default:

--- a/ui/components/ui/tabs/tabs.tsx
+++ b/ui/components/ui/tabs/tabs.tsx
@@ -147,6 +147,114 @@ export const Tabs = <TKey extends string = string>({
     }
   };
 
+  /**
+   * Returns indices of tabs that are not disabled, for keyboard navigation.
+   */
+  const getEnabledTabIndices = (): number[] => {
+    return getValidChildren.reduce<number[]>((indices, child, index) => {
+      if (!child.props.disabled) {
+        indices.push(index);
+      }
+      return indices;
+    }, []);
+  };
+
+  /**
+   * Focuses the tab button at the given index within the tab list.
+   *
+   * @param index - Zero-based index of the tab to focus.
+   */
+  const focusTabAtIndex = (index: number): void => {
+    const tabs =
+      tabListRef.current?.querySelectorAll<HTMLElement>('[role="tab"]');
+    tabs?.[index]?.focus();
+  };
+
+  /**
+   * Activates and focuses the tab at the given index if it is enabled.
+   * Follows the WAI-ARIA Tabs "automatic activation" pattern used by
+   * Chakra UI and Radix UI: arrow keys both move focus and select the tab.
+   *
+   * @param index - Zero-based index of the tab to activate.
+   * @see https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+   */
+  const activateTabByIndex = (index: number): void => {
+    const child = getValidChildren[index];
+    if (!child || child.props.disabled) {
+      return;
+    }
+
+    handleTabClick(index, child.props.tabKey);
+    focusTabAtIndex(index);
+  };
+
+  /**
+   * Keyboard handler for the tab list (WAI-ARIA Tabs pattern).
+   * - ArrowRight / ArrowLeft: move to next / previous enabled tab (wraps)
+   * - Home / End: first / last enabled tab
+   * Disabled tabs are skipped.
+   *
+   * @param event - Keyboard event from the tablist.
+   * @see https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+   * @see https://chakra-ui.com/docs/components/tabs
+   * @see https://www.radix-ui.com/primitives/docs/components/tabs
+   */
+  const handleTabListKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ): void => {
+    const enabledIndices = getEnabledTabIndices();
+    if (enabledIndices.length === 0) {
+      return;
+    }
+
+    let currentEnabledPos = enabledIndices.indexOf(clampedIndex);
+    if (currentEnabledPos === -1) {
+      // Active tab may be disabled; fall back to the nearest enabled tab
+      // before the active index, or the first enabled tab.
+      currentEnabledPos = enabledIndices.findLastIndex(
+        (index) => index < clampedIndex,
+      );
+      if (currentEnabledPos === -1) {
+        currentEnabledPos = 0;
+      }
+    }
+
+    let nextIndex: number | undefined;
+
+    switch (event.key) {
+      case 'ArrowRight': {
+        event.preventDefault();
+        const nextPos = (currentEnabledPos + 1) % enabledIndices.length;
+        nextIndex = enabledIndices[nextPos];
+        break;
+      }
+      case 'ArrowLeft': {
+        event.preventDefault();
+        const nextPos =
+          (currentEnabledPos - 1 + enabledIndices.length) %
+          enabledIndices.length;
+        nextIndex = enabledIndices[nextPos];
+        break;
+      }
+      case 'Home': {
+        event.preventDefault();
+        nextIndex = enabledIndices[0];
+        break;
+      }
+      case 'End': {
+        event.preventDefault();
+        nextIndex = enabledIndices[enabledIndices.length - 1];
+        break;
+      }
+      default:
+        return;
+    }
+
+    if (nextIndex !== undefined) {
+      activateTabByIndex(nextIndex);
+    }
+  };
+
   const renderTabs = (): React.ReactNode => {
     const validChildren = getValidChildren;
     const numberOfTabs = validChildren.length;
@@ -185,6 +293,7 @@ export const Tabs = <TKey extends string = string>({
         backgroundColor={BoxBackgroundColor.BackgroundDefault}
         gap={4}
         {...tabListProps}
+        onKeyDown={handleTabListKeyDown}
       >
         {renderTabs()}
       </Box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Keyboard users could Tab-focus the Tabs component, but Arrow keys did not switch tabs because the `tablist` had no `onKeyDown` handler (only click activated tabs).

This change implements the WAI-ARIA Tabs **automatic activation** keyboard pattern on `ui/components/ui/tabs/`:

- **ArrowRight / ArrowLeft**: move focus and activate the next/previous **enabled** tab (wraps)
- **Home / End**: jump to the first/last **enabled** tab
- **Roving tabindex** preserved (`tabIndex={isActive ? 0 : -1}` on each tab)
- Disabled tabs are skipped

### Accessibility references

- [WAI-ARIA Authoring Practices Guide — Tabs](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)
- [Chakra UI Tabs](https://chakra-ui.com/docs/components/tabs)
- [Radix UI Tabs](https://www.radix-ui.com/primitives/docs/components/tabs)

## **Changelog**

CHANGELOG entry: Fixed Tabs so keyboard users can switch tabs with arrow keys, Home, and End

## **Related issues**

Fixes: [DSYS-1045](https://consensyssoftware.atlassian.net/browse/DSYS-1045)

## **Manual testing steps**

1. Run the extension and open a screen that uses the Tabs component (for example home asset tabs).
2. Press Tab until focus lands on the active tab.
3. Press ArrowRight and ArrowLeft and confirm focus and the selected tab move between enabled tabs (wrapping at the ends).
4. Press Home and End and confirm the first and last enabled tabs are selected.
5. If a disabled tab is present, confirm arrow navigation skips it.
6. Confirm Tab / Shift+Tab still move focus into and out of the tablist (only the selected tab is in the tab order).

## **Screenshots/Recordings**

### **Before**

Arrow keys did nothing while a tab was focused (click-only activation).

### **After**

[dsys-1045-tabs-keyboard-navigation.webm](https://github.com/user-attachments/assets/70b23a33-96a9-4315-ac1d-a2828752f9c1)


[dsys-1045-tabs-keyboard-navigation.webm](https://cursor.com/agents/bc-1c59bab2-c51f-5be8-a06c-78a51b931b69/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdsys-1045-tabs-keyboard-navigation.webm)

Demo shows ArrowRight/Left (including skipping Disabled), Home, and End navigation.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C0354T27M5M/p1786390369465269?thread_ts=1786390369.465269&cid=C0354T27M5M)

<div><a href="https://cursor.com/agents/bc-1c59bab2-c51f-5be8-a06c-78a51b931b69?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c59bab2-c51f-5be8-a06c-78a51b931b69&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[DSYS-1045]: https://consensyssoftware.atlassian.net/browse/DSYS-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ