### PR TITLE
fix: QR code being cut off in popup

### DIFF
--- a/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.tsx
+++ b/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.tsx
@@ -86,8 +86,14 @@ export default function HardwareWalletSignatures() {
           />
         }
       />
+      {/*
+        This box must not have a fixed height. It grows with its content so the
+        scroll container (`Content`) can scroll and the footer stays below it.
+        A `h-full` here caps it at the viewport, so tall content (the inline QR
+        code on a two-confirmation flow) overflows and renders behind the footer.
+      */}
       <Box
-        className="hardware-wallet-signatures__content h-full"
+        className="hardware-wallet-signatures__content"
         flexDirection={BoxFlexDirection.Column}
         paddingTop={6}
         paddingHorizontal={4}

--- a/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.tsx
+++ b/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.tsx
@@ -86,12 +86,6 @@ export default function HardwareWalletSignatures() {
           />
         }
       />
-      {/*
-        This box must not have a fixed height. It grows with its content so the
-        scroll container (`Content`) can scroll and the footer stays below it.
-        A `h-full` here caps it at the viewport, so tall content (the inline QR
-        code on a two-confirmation flow) overflows and renders behind the footer.
-      */}
       <Box
         className="hardware-wallet-signatures__content"
         flexDirection={BoxFlexDirection.Column}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


1. What is the reason for the change?
In popup mode, when scanning a complex transaction, the final qr code was cut off by a button and not scannable. This blocked swapping in popup mode when using a QR hardware wallet. 
2. What is the improvement/solution?
- Remove the h-full from the container to accommodate the fixed size of the qr code. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix QR code not being fully scannable in popup mode.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/45088

## **Manual testing steps**

1. Switch to pop-up view in MM
2. Connect Keystone QR wallet
5. Send or swap using other tokens for gas
6. Notice it's not possible to scan the final QR code, as it's not fully visible

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="803" height="599" alt="Screenshot 2026-08-13 at 8 18 50 PM" src="https://github.com/user-attachments/assets/6aa0f14d-0550-4e8f-bfcb-e859e8f3f3d5" />


### **After**

In popup on Firefox
(now its scrollable)

<img width="438" height="686" alt="Screenshot 2026-08-13 at 8 57 00 PM" src="https://github.com/user-attachments/assets/e03b06dc-c118-45b8-a48a-4a76b00e8e8d" />

<img width="544" height="715" alt="Screenshot 2026-08-13 at 8 56 56 PM" src="https://github.com/user-attachments/assets/dffdfd64-7033-4e94-9203-dd8129bc98e6" />

Still working in sidepanel:

<img width="437" height="1066" alt="Screenshot 2026-08-13 at 8 59 45 PM" src="https://github.com/user-attachments/assets/dccbf468-6082-4ce6-aa43-abc9dfd06eda" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout class change on a hardware-wallet signing screen with no logic, auth, or data-path changes.
> 
> **Overview**
> Fixes **Keystone QR signing** in extension popup mode where the final scan QR was partially cut off and hard to scan (e.g. swap/send with pay-with-other-token gas).
> 
> The only code change removes the **`h-full`** Tailwind class from the main content `Box` on `hardware-wallet-signatures`, so that section no longer forces a fixed full viewport height inside the constrained popup. Content (including the QR from the full-page `QrHardwareSigningPage` flow) can size and scroll naturally instead of being clipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cab6be5cc91d84747f173de6a6b368ea02801e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->