### PR TITLE
fix: guard CriticalStartupErrorHandler port.onMessage against browsers with a native browser namespace

### DIFF
--- a/ui/helpers/utils/critical-startup-error-handler.test.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.test.ts
@@ -494,4 +494,20 @@ describe('CriticalStartupErrorHandler', () => {
       handler.uninstall();
     });
   });
+
+  describe('port without onMessage (browser-namespace regression)', () => {
+    it('install() does not throw when the port lacks onMessage (browser-namespace regression)', () => {
+      // A raw browser-namespace port has no `onMessage`/`onDisconnect` because
+      // webextension-polyfill is a no-op when the native `browser` namespace is
+      // present (Chromium 151+ Dev). Names deliberately avoid shadowing the
+      // shared `port`/`container` fixtures above.
+      const bareContainer = document.createElement('div');
+      const barePort = { name: 'popup', postMessage: jest.fn() };
+      const handler = new CriticalStartupErrorHandler(
+        barePort as never,
+        bareContainer,
+      );
+      expect(() => handler.install()).not.toThrow();
+    });
+  });
 });

--- a/ui/helpers/utils/critical-startup-error-handler.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.ts
@@ -395,7 +395,10 @@ export class CriticalStartupErrorHandler {
    * it minimize abstractions that could cause further issues.
    */
   install() {
-    this.#port.onMessage.addListener(this.#handler);
+    // The port may lack `onMessage` in browsers where the native `browser`
+    // namespace is present, making webextension-polyfill a no-op. Guard so a
+    // missing listener sink doesn't crash UI startup (see #45337).
+    this.#port.onMessage?.addListener(this.#handler);
 
     // Pre-register all phase completion callbacks so messages can arrive before we enter
     // the corresponding phase (avoids race where BACKGROUND_INITIALIZED or START_UI_SYNC
@@ -426,7 +429,7 @@ export class CriticalStartupErrorHandler {
    */
   uninstall() {
     this.#uninstalled = true;
-    this.#port.onMessage.removeListener(this.#handler);
+    this.#port.onMessage?.removeListener(this.#handler);
 
     clearTimeout(this.#livenessCheckTimeoutId);
     clearTimeout(this.#initializationCheckTimeoutId);


### PR DESCRIPTION
## **Description**

Fixes #45337

Opening the extension (side panel or fullscreen) in Chrome/Edge 151-152 Dev crashes before the UI can start:

```
TypeError: Cannot read properties of undefined (reading 'addListener')
```

Chromium 151+ Dev exposes a native `browser` namespace, which makes `webextension-polyfill@0.8.0` a no-op: it stops wrapping `browser.runtime`, so `browser.runtime.connect()` returns a raw port whose `onMessage` is `undefined`.

`CriticalStartupErrorHandler` is instantiated for both `sidepanel.html` and `home.html` in `app/scripts/ui.js`, and its `install()` unconditionally called `this.#port.onMessage.addListener(...)` right after `browser.runtime.connect()`. With a polyfill no-op port, `onMessage` is `undefined` and the `.addListener` call throws the TypeError above, preventing the extension from opening.

The fix guards the listener attachment with optional chaining in `ui/helpers/utils/critical-startup-error-handler.ts`:

- `install()`: `this.#port.onMessage?.addListener(this.#handler)`
- `uninstall()`: `this.#port.onMessage?.removeListener(this.#handler)`

This matches the pattern already used in the UI codebase (e.g. `ui/pages/onboarding-flow/creation-successful/creation-successful.tsx` guards `browserWithSidePanel?.sidePanel?.onClosed?.addListener`). When messaging is healthy (`onMessage` present) behavior is unchanged; when the polyfill is a no-op the handler skips attaching and the existing liveness/timeout checks surface the connection problem instead of crashing on startup.

## **Changelog**

CHANGELOG entry: Guard CriticalStartupErrorHandler against no-op polyfill browsers where port.onMessage is undefined

## **Related issues**

Fixes: #45337

## **Manual testing steps**

1. Open the extension side panel or fullscreen window in Chrome/Edge Dev (151-152) where the native `browser` namespace makes the polyfill a no-op; verify the extension opens without the `Cannot read properties of undefined (reading 'addListener')` TypeError.
2. Run the regression test: `ui/helpers/utils/critical-startup-error-handler.test.ts` — constructs the handler with a raw port lacking `onMessage`/`onDisconnect` and asserts `install()` does not throw.
3. Run the existing test suite for the helper file; all pre-existing tests should still pass.

## **Screenshots/Recordings**

### **Before**

<!-- Not applicable: startup crash, no stable screenshot of the pre-fix failure state. -->

### **After**

<!-- Not applicable: behavior is unchanged when messaging is healthy; the crash is prevented at startup. -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
