### PR TITLE
fix: allowed users to continue after valid 12-word SRP in import wallet cp-13.44.0

### DIFF
--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import * as browserRuntime from '../../../../shared/lib/browser-runtime.utils';
 import {
@@ -57,27 +56,32 @@ describe('SrpInputImport', () => {
     const words = COLLIDING_24_WORD_SRP.split(' ');
     const firstTwelveWords = words.slice(0, 12).join(' ');
 
-    await userEvent.type(
-      getByTestId('srp-input-import__srp-note'),
-      firstTwelveWords,
-    );
+    const initialInput = getByTestId('srp-input-import__srp-note');
+    fireEvent.change(initialInput, { target: { value: words[0] } });
+    fireEvent.keyDown(initialInput, { key: ' ' });
+
+    for (let index = 1; index < 12; index += 1) {
+      const input = getByTestId(`import-srp__srp-word-${index}`);
+      fireEvent.change(input, { target: { value: words[index] } });
+      if (index < 11) {
+        fireEvent.keyDown(input, { key: ' ' });
+      }
+    }
 
     await waitFor(() => {
       expect(onChange).toHaveBeenLastCalledWith(firstTwelveWords);
     });
 
-    await userEvent.keyboard(' ');
+    fireEvent.keyDown(getByTestId('import-srp__srp-word-11'), { key: ' ' });
 
     expect(getByTestId('import-srp__srp-word-12')).toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith('');
 
     for (let index = 12; index < words.length; index += 1) {
-      await userEvent.type(
-        getByTestId(`import-srp__srp-word-${index}`),
-        words[index],
-      );
+      const input = getByTestId(`import-srp__srp-word-${index}`);
+      fireEvent.change(input, { target: { value: words[index] } });
       if (index < words.length - 1) {
-        await userEvent.keyboard(' ');
+        fireEvent.keyDown(input, { key: ' ' });
       }
     }
 
@@ -85,7 +89,7 @@ describe('SrpInputImport', () => {
       expect(onChange).toHaveBeenLastCalledWith(COLLIDING_24_WORD_SRP);
     });
 
-    await userEvent.keyboard(' ');
+    fireEvent.keyDown(getByTestId('import-srp__srp-word-23'), { key: ' ' });
 
     expect(getByTestId('import-srp__srp-word-23')).toBeInTheDocument();
     expect(queryByTestId('import-srp__srp-word-24')).not.toBeInTheDocument();

--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import * as browserRuntime from '../../../../shared/lib/browser-runtime.utils';
 import {
@@ -25,6 +26,9 @@ jest.mock('../../../../shared/lib/environment-type', () => ({
 
 const mockClipboardReadText = jest.fn().mockResolvedValue('some mock text');
 
+const COLLIDING_24_WORD_SRP =
+  'tumble heart quit undo right legal salute lizard tape unveil art lava filter fee snack fragile duck impact oven come cram tourist casino sort';
+
 Object.defineProperty(navigator, 'clipboard', {
   value: {
     readText: mockClipboardReadText,
@@ -43,6 +47,48 @@ describe('SrpInputImport', () => {
       <SrpInputImport onChange={jest.fn()} />,
     );
     expect(getByTestId('srp-input-import__srp-note')).toBeInTheDocument();
+  });
+
+  it('allows entry to continue when a valid SRP is a prefix of a longer SRP', async () => {
+    const onChange = jest.fn();
+    const { getByTestId, queryByTestId } = renderWithProvider(
+      <SrpInputImport onChange={onChange} />,
+    );
+    const words = COLLIDING_24_WORD_SRP.split(' ');
+    const firstTwelveWords = words.slice(0, 12).join(' ');
+
+    await userEvent.type(
+      getByTestId('srp-input-import__srp-note'),
+      firstTwelveWords,
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(firstTwelveWords);
+    });
+
+    await userEvent.keyboard(' ');
+
+    expect(getByTestId('import-srp__srp-word-12')).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith('');
+
+    for (let index = 12; index < words.length; index += 1) {
+      await userEvent.type(
+        getByTestId(`import-srp__srp-word-${index}`),
+        words[index],
+      );
+      if (index < words.length - 1) {
+        await userEvent.keyboard(' ');
+      }
+    }
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(COLLIDING_24_WORD_SRP);
+    });
+
+    await userEvent.keyboard(' ');
+
+    expect(getByTestId('import-srp__srp-word-23')).toBeInTheDocument();
+    expect(queryByTestId('import-srp__srp-word-24')).not.toBeInTheDocument();
   });
 
   it('should ask for explicit permission to read the clipboard in firefox', async () => {

--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -157,11 +157,7 @@ export default function SrpInputImport({
         checkForInvalidWords();
       }
 
-      if (
-        (SRP_LENGTHS.includes(draftSrp.length) &&
-          isValidMnemonic(draftSrp.map((word) => word.word).join(' '))) ||
-        draftSrp.length === MAX_SRP_LENGTH
-      ) {
+      if (draftSrp.length === MAX_SRP_LENGTH) {
         return;
       }
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -4102,7 +4102,7 @@ export function getDeferredDeepLink(state) {
 export const getDeferredDeepLinkParameters = createResultEqualSelector(
   getDeferredDeepLink,
   (deferredDeepLink) => {
-    if (!deferredDeepLink || !deferredDeepLink.referringLink) {
+    if (!deferredDeepLink?.referringLink) {
       return null;
     }
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -4102,7 +4102,7 @@ export function getDeferredDeepLink(state) {
 export const getDeferredDeepLinkParameters = createResultEqualSelector(
   getDeferredDeepLink,
   (deferredDeepLink) => {
-    if (!deferredDeepLink) {
+    if (!deferredDeepLink || !deferredDeepLink.referringLink) {
       return null;
     }
 


### PR DESCRIPTION
## **Description**

Fixes an issue where users could not manually enter a 15, 18, 21, or 24-word Secret Recovery Phrase if an intermediate valid-length prefix—such as the first 12 words—was independently checksum-valid.

SRP validity no longer determines whether another word can be entered. Users can continue entering words until the 24-word maximum, while checksum validation continues to control whether the phrase can be submitted.

Also prevents malformed deferred deep-link state without a `referringLink` from producing an `Invalid URL` console error during onboarding.

Adds regression coverage using a valid 24-word SRP whose first 12 words are also independently valid.

## **Changelog**

CHANGELOG entry: Fixed an issue that prevented importing longer Secret Recovery Phrases when their first 12 words formed a valid phrase.

## **Related issues**

Fixes: #43145

## **Manual testing steps**

1. Start the extension and select **Import an existing wallet**.
2. Enter the following SRP one word at a time:
   `tumble heart quit undo right legal salute lizard tape unveil art lava filter fee snack fragile duck impact oven come cram tourist casino sort`
3. After entering the first 12 words, press Space.
4. Verify that input 13 appears and entry can continue.
5. Enter the remaining words.
6. Verify that Continue becomes enabled after all 24 words are entered.
7. Complete onboarding and verify the wallet is imported successfully.
8. Verify that no `Failed to parse deferred deep link: Invalid URL` error appears when no valid deferred deep link is present.

## **Screenshots/Recordings**

### **Before**

<!-- Add a recording showing entry stopping after the valid 12-word prefix. -->

### **After**

<!-- Add a recording showing successful entry and submission of all 24 words. -->

https://github.com/user-attachments/assets/ba0250ad-4e55-41ce-9b30-2895ea2329ce



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused onboarding/import UX and a defensive selector guard; mnemonic submit validation is unchanged aside from allowing more words to be typed.
> 
> **Overview**
> Fixes wallet import when a **valid 12-word prefix** is also a standalone checksum-valid mnemonic, which previously blocked adding words 13–24.
> 
> **SRP import UI** no longer treats an intermediate valid mnemonic as “complete” for word entry. Adding another word after space is only blocked at the **24-word maximum**; checksum validation for Continue/submit is unchanged.
> 
> **Deferred deep link** UTM parsing now requires `referringLink` before calling `new URL`, avoiding `Invalid URL` console noise when onboarding state is partial.
> 
> Adds a regression test for a 24-word phrase whose first 12 words are independently valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1f3dec4ed3ed27c9db455ac649dc2fe5122d7ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->