### PR TITLE
test: fix flaky survey toast E2E test mock ordering `TimeoutError: Waiting for element to be located By(xpath, .//*[./@data-testid = 'survey-toast'][(contains(string(.), 'Test survey 2') or contains(stri...`

### DIFF
--- a/test/e2e/tests/survey/survey.spec.ts
+++ b/test/e2e/tests/survey/survey.spec.ts
@@ -7,10 +7,10 @@ import Homepage from '../../page-objects/pages/home/homepage';
 import { login } from '../../page-objects/flows/login.flow';
 
 async function mockSurveys(mockServer: MockttpServer) {
+  const surveyUrl = `${ACCOUNTS_PROD_API_BASE_URL}/v1/users/${MOCK_ANALYTICS_ID}/surveys`;
+
   await mockServer
-    .forGet(
-      `${ACCOUNTS_PROD_API_BASE_URL}/v1/users/${MOCK_ANALYTICS_ID}/surveys`,
-    )
+    .forGet(surveyUrl)
     .once()
     .thenCallback(() => {
       return {
@@ -19,32 +19,28 @@ async function mockSurveys(mockServer: MockttpServer) {
           userId: '0x123',
           surveys: {
             url: 'https://example.com',
-            description: `Test survey ${1}`,
+            description: 'Test survey 1',
             cta: 'Take survey',
             id: 1,
           },
         },
       };
     });
-  await mockServer
-    .forGet(
-      `${ACCOUNTS_PROD_API_BASE_URL}/v1/users/${MOCK_ANALYTICS_ID}/surveys`,
-    )
-    .once()
-    .thenCallback(() => {
-      return {
-        statusCode: 200,
-        json: {
-          userId: '0x123',
-          surveys: {
-            url: 'https://example.com',
-            description: `Test survey ${2}`,
-            cta: 'Take survey',
-            id: 2,
-          },
+
+  await mockServer.forGet(surveyUrl).thenCallback(() => {
+    return {
+      statusCode: 200,
+      json: {
+        userId: '0x123',
+        surveys: {
+          url: 'https://example.com',
+          description: 'Test survey 2',
+          cta: 'Take survey',
+          id: 2,
         },
-      };
-    });
+      },
+    };
+  });
 }
 
 describe('Test Survey', function () {


### PR DESCRIPTION
## **Description**

The E2E test `Test Survey > should show 2 surveys, and then none` was flaky because the two `.once()` mock handlers for the survey API could be consumed out of order by React Query background refetches.

**Problem:** React Query's `staleTime: 0` (in test builds) combined with `refetchOnWindowFocus: true` (default) triggers background refetches that consume the Survey 2 `.once()` mock before the product code needs it. When `dismissSurvey` calls `invalidateQueries()`, the in-flight background refetch is cancelled and its Survey 2 response discarded. The subsequent refetch finds no mock handler left, so Survey 2 never appears in the UI.

**Solution:** Changed the mock strategy from two `.once()` handlers to a `.once()` for Survey 1 (registered first, matched first in Mockttp) plus a persistent fallback for Survey 2 (registered second, matched after `.once()` is consumed). This ensures Survey 1 is returned on the initial fetch, and all subsequent refetches — whether triggered by invalidation, background polling, or window focus — reliably return Survey 2.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Build a test extension: `yarn build:test`
2. Run the survey E2E test:
   ```
   SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/survey/survey.spec.ts
   ```
3. Verify the test passes consistently (run 3–5 times to confirm stability).

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock changes with no production code paths affected.
> 
> **Overview**
> Fixes flaky **survey toast E2E** behavior by changing how the accounts survey API is mocked in `survey.spec.ts`.
> 
> Instead of two sequential **`.once()`** handlers (which React Query background refetches could consume out of order), the test now uses a shared `surveyUrl`, a **single `.once()`** response for Survey 1, and a **persistent** handler that always returns Survey 2 for later refetches. Survey descriptions are normalized to plain string literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 135c3d204735dfe01f66085f2bec6450cac38b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->