### PR TITLE
feat: don't preserve tab scroll position while scrolling

### DIFF
--- a/ui/components/ui/tabs/tabs.test.tsx
+++ b/ui/components/ui/tabs/tabs.test.tsx
@@ -39,6 +39,27 @@ describe('Tabs', () => {
     expect(getByText('Tab 2 Content')).toBeInTheDocument();
   });
 
+  it('resets nested content scroll position when switching tabs', () => {
+    const { getByTestId, getByText } = render(
+      <Tabs onTabClick={() => null}>
+        <Tab tabKey="tab1" name="Tab 1">
+          <div data-testid="tab-content">Tab 1 Content</div>
+        </Tab>
+        <Tab tabKey="tab2" name="Tab 2">
+          <div data-testid="tab-content">Tab 2 Content</div>
+        </Tab>
+      </Tabs>,
+    );
+    const initialContent = getByTestId('tab-content');
+    initialContent.scrollTop = 100;
+
+    fireEvent.click(getByText('Tab 2'));
+
+    const activeContent = getByTestId('tab-content');
+    expect(activeContent).not.toBe(initialContent);
+    expect(activeContent.scrollTop).toBe(0);
+  });
+
   it('keeps clicked tab content visible while activeTab prop is still stale', () => {
     const onTabClick = jest.fn();
     const { getByText, queryByText } = render(

--- a/ui/components/ui/tabs/tabs.tsx
+++ b/ui/components/ui/tabs/tabs.tsx
@@ -172,7 +172,11 @@ export const Tabs = <TKey extends string = string>({
     }
 
     const activeChild = validChildren[clampedIndex];
-    return activeChild?.props.children || null;
+    return (
+      <React.Fragment key={activeChild.props.tabKey}>
+        {activeChild.props.children}
+      </React.Fragment>
+    );
   };
 
   return (


### PR DESCRIPTION
This PR ensures that on tabs switch, it shouldn't preserve the position

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/bb3a03a1-9ff9-4026-b754-0b9a39017920


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized `Tabs` rendering change with a dedicated test; no auth, data, or API impact.
> 
> **Overview**
> **Tab switches no longer keep scroll position** inside tab panel content. Active tab children are wrapped in a `React.Fragment` keyed by `tabKey`, so React remounts the panel subtree when the active tab changes and nested scroll containers start at the top.
> 
> A unit test asserts that after scrolling tab 1 and clicking tab 2, the visible content node is new and `scrollTop` is `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18902336c3c102f706a72024bfb00e58427e4516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->