### PR TITLE
test: fix perps E2E flakiness from duplicate candle timestamps in candleSnapshot mock

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -2097,13 +2097,27 @@ async function setupMocking(
         const coin = (parsed && parsed.req && parsed.req.coin) || 'BTC';
         const prices = { BTC: '50000', ETH: '3000', AVAX: '25' };
         const price = prices[coin] || '100';
-        const now = Date.now();
+        // Respect endTime so load-more fetches don't overlap with existing candles.
+        // Use 40 candles (> DEFAULT_CANDLES=30 + EDGE_DETECTION_THRESHOLD=5) so the
+        // chart's initial visible range starts above the edge-detection threshold and
+        // onNeedMoreHistory does not fire immediately on first render.
+        //
+        // Place the LAST candle one full interval before endTime: endTime is
+        // oldestExistingCandle.time - 1 ms, which truncates to the same second as
+        // the oldest existing candle. Placing the last returned candle at
+        // endTime - interval guarantees at least one full period gap between the
+        // "older" batch and the existing candles so setData never receives
+        // duplicate second-level timestamps.
+        const endTime =
+          (parsed && parsed.req && parsed.req.endTime) || Date.now();
         const interval = 300000; // 5m in ms
+        const count = 40;
+        const lastCandleTime = endTime - interval;
         const candles = [];
-        for (let i = 4; i >= 0; i--) {
+        for (let i = count - 1; i >= 0; i--) {
           candles.push({
-            t: now - i * interval,
-            T: now - i * interval + interval - 1,
+            t: lastCandleTime - i * interval,
+            T: lastCandleTime - i * interval + interval - 1,
             s: coin,
             i: (parsed && parsed.req && parsed.req.interval) || '5m',
             o: price,

--- a/test/e2e/tests/perps/mocks/websocketDefaultMocks.ts
+++ b/test/e2e/tests/perps/mocks/websocketDefaultMocks.ts
@@ -412,13 +412,26 @@ export const DEFAULT_HYPERLIQUID_WS_MOCKS: WebSocketMessageMock[] = [
         AVAX: '25',
       };
       const price = prices[coin] || '100';
-      const now = Date.now();
+      // Respect endTime so load-more fetches don't overlap with existing candles.
+      // Use 40 candles (> DEFAULT_CANDLES=30 + EDGE_DETECTION_THRESHOLD=5) so the
+      // chart's initial visible range starts above the edge-detection threshold and
+      // onNeedMoreHistory does not fire immediately on first render.
+      //
+      // Place the LAST candle one full interval before endTime: endTime is
+      // oldestExistingCandle.time - 1 ms, which truncates to the same second as
+      // the oldest existing candle. Placing the last returned candle at
+      // endTime - interval guarantees at least one full period gap between the
+      // "older" batch and the existing candles so setData never receives
+      // duplicate second-level timestamps.
+      const endTime = (req.req?.endTime as number) || Date.now();
       const interval = 300000;
+      const count = 40;
+      const lastCandleTime = endTime - interval;
       const candles = [];
-      for (let i = 4; i >= 0; i--) {
+      for (let i = count - 1; i >= 0; i--) {
         candles.push({
-          t: now - i * interval,
-          T: now - i * interval + interval - 1,
+          t: lastCandleTime - i * interval,
+          T: lastCandleTime - i * interval + interval - 1,
           s: coin,
           i: (req.req?.interval as string) || '5m',
           o: price,


### PR DESCRIPTION
## **Description**

The perps E2E tests `perps-tpsl.spec.ts` (take-profit and stop-loss scenarios) were failing with a `MetaMask encountered an error` crash page before `setTakeProfit` / `setStopLoss` was even reached.

**Root cause — three cascading issues in the `candleSnapshot` mock:**

1. **Only 5 candles returned, `endTime` ignored.** Both the HTTP mock (`mock-e2e.js`) and the WS POST mock (`websocketDefaultMocks.ts`) were generating 5 candles anchored at `Date.now()` without reading the requested `endTime`.

2. **Immediate edge-detection trigger.** `PerpsCandlestickChart` tries to show `DEFAULT_CANDLES = 30` candles. With only 5, the initial visible range starts at logical index `max(0, 5 − 30) = 0`, which is ≤ `EDGE_DETECTION_THRESHOLD = 5`. This fires `onNeedMoreHistory` immediately — even during the transient range-change event that `lightweight-charts` emits while `setData` is executing.

3. **Duplicate second-level timestamps crash `setData`.** The load-more fetch (triggered in step 2) called the same mock again, which returned 5 new candles at a slightly different `Date.now()` (different milliseconds, same second). `CandleStreamChannel.fetchHistoricalCandles` deduplicates by raw millisecond, so both batches survived the filter. `formatCandleDataForChart` then truncates timestamps to seconds (`Math.floor(t / 1000)`) before calling `setData`. Pairs of candles from the two batches mapped to the same second, and `lightweight-charts` threw:
   > `Assertion failed: data must be asc ordered by time, index=N, time=T, prev time=T`

The extension crashed and the test failed appearing to be a `setTakeProfit` / `setStopLoss` failure.

**Fix:**
- Return **40 candles** (> `DEFAULT_CANDLES=30` + `EDGE_DETECTION_THRESHOLD=5` = 35), so the initial `from = max(0, 40 − 30) = 10 > 5` suppresses the immediate edge-detection trigger.
- **Respect `endTime`** from the request so paginated load-more fetches return genuinely older candles.
- Place the **last returned candle one full interval before `endTime`** (`lastCandleTime = endTime − interval`). Since `endTime = oldestExistingCandle.time − 1 ms`, which truncates to the same second as the oldest existing candle, placing the boundary one full 5-minute period back ensures no second-level overlap between the older batch and the existing candles.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build the extension with `PERPS_ENABLED=true` in `.metamaskrc`: `yarn build:test`
2. Run the perps TP/SL E2E tests:
   ```
   yarn test:e2e:single test/e2e/tests/perps/perps-tpsl.spec.ts --browser chrome
   ```
3. Confirm both scenarios (take-profit and stop-loss) pass without the chart crash.

## **Screenshots/Recordings**

### **Before**

Chart crashes with `Assertion failed: data must be asc ordered by time` before `setTakeProfit` / `setStopLoss` can execute.

### **After**

Both TP and SL E2E scenarios complete without chart crash.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock changes with no production or runtime behavior impact.
> 
> **Overview**
> Aligns the Hyperliquid **`candleSnapshot`** E2E mocks in `mock-e2e.js` and `websocketDefaultMocks.ts` so perps chart tests stop crashing before TP/SL flows run.
> 
> Both handlers now return **40** 5m candles (instead of 5 anchored at `Date.now()`), honor request **`endTime`**, and build the series ending at **`endTime - interval`** so paginated “load more” batches stay older than existing data and avoid duplicate second-level timestamps after chart formatting.
> 
> This prevents immediate **`onNeedMoreHistory`** on first render and the **`lightweight-charts`** `setData` ordering assertion that was surfacing as flaky MetaMask error pages in `perps-tpsl.spec.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 635fa9cd414ff782619589fd1bfe7c13edcd94bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->