### PR TITLE
fix: Fix re-selecting selected token

### DIFF
--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -75,6 +75,17 @@ jest.mock('../../send/asset', () => ({
           Select Token
         </button>
         <button
+          data-testid="select-current-token"
+          onClick={() =>
+            onAssetSelect?.({
+              address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x1',
+            })
+          }
+        >
+          Select Current Token
+        </button>
+        <button
           data-testid="select-disabled-token"
           onClick={() =>
             onAssetSelect?.({
@@ -294,6 +305,15 @@ describe('PayWithModal', () => {
         chainId: '0x1',
       });
       expect(onMusdPaymentTokenChangeMock).not.toHaveBeenCalled();
+    });
+
+    it('does not call setPayToken when the selected token matches the current payToken', () => {
+      renderModal({ isOpen: true, onClose: onCloseMock });
+
+      fireEvent.click(screen.getByTestId('select-current-token'));
+
+      expect(setPayTokenMock).not.toHaveBeenCalled();
+      expect(onCloseMock).toHaveBeenCalled();
     });
   });
 

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -69,6 +69,16 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
         return;
       }
 
+      if (
+        payToken &&
+        payToken.address.toLowerCase() === token.address?.toLowerCase() &&
+        payToken.chainId.toLowerCase() === (token.chainId as string)?.toLowerCase()
+      ) {
+        console.log("OGP - Token already selected");
+        handleClose();
+        return;
+      }
+
       const tokenSelection = {
         address: token.address as Hex,
         chainId: token.chainId as Hex,
@@ -127,6 +137,7 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
       handleClose,
       isPostQuoteWithdraw,
       onMusdPaymentTokenChange,
+      payToken,
       setPayToken,
     ],
   );

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -75,7 +75,6 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
         payToken.chainId.toLowerCase() ===
           (token.chainId as string)?.toLowerCase()
       ) {
-        console.log('OGP - Token already selected');
         handleClose();
         return;
       }

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -72,9 +72,10 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
       if (
         payToken &&
         payToken.address.toLowerCase() === token.address?.toLowerCase() &&
-        payToken.chainId.toLowerCase() === (token.chainId as string)?.toLowerCase()
+        payToken.chainId.toLowerCase() ===
+          (token.chainId as string)?.toLowerCase()
       ) {
-        console.log("OGP - Token already selected");
+        console.log('OGP - Token already selected');
         handleClose();
         return;
       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a user taps a token that is already selected in the Pay With modal, the full selection handler (`setPayToken`, `onMusdPaymentTokenChange`, withdraw token import, etc.) fires unnecessarily, causing redundant controller calls for a no-op selection.

This PR adds an early-return guard to `handleTokenSelect` in `pay-with-modal.tsx` so that re-selecting the currently active token skips the selection logic and simply closes the modal.

Mirrors the same fix applied to metamask-mobile in https://github.com/MetaMask/metamask-mobile/pull/34337.

## **Changelog**

CHANGELOG entry: Fixed redundant token selection logic when re-selecting the already active payment token in the Pay With modal

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open a transaction that shows the Pay With modal (e.g. a Money Account deposit)
2. Note which token is currently selected as the payment token
3. Open the Pay With modal and tap that same token
4. Verify the modal closes without triggering any state update (no flash, no spinner, no redundant network call)
5. Open the modal again and select a *different* token
6. Verify the new token is selected and the modal closes normally

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<!--
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in confirmation UI token selection with unit test coverage; no auth, data, or payment pipeline changes.
> 
> **Overview**
> **Pay With modal** now treats tapping the **already selected** payment token as a no-op: it **closes the modal** without running `setPayToken`, mUSD payment handlers, or withdraw token import logic.
> 
> Matching uses **case-insensitive** comparison on **address** and **chainId** against the current `payToken`. Tests cover that `setPayToken` is not invoked when the mock selects the current token, while `onClose` still runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216e3a2bae0e87f4ee34c1983b694b7e1721662a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->