### PR TITLE
fix(sentry): stop force-promoting child spans into billed transactions in `trace.ts`

### DIFF
--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -406,6 +406,32 @@ describe('Trace', () => {
       );
     });
 
+    it('does not force-promote the inherited active span to a transaction', () => {
+      const activeSpanMock = {
+        spanContext: jest.fn().mockReturnValue({
+          traceId: 'abc123',
+          spanId: 'def456',
+        }),
+      } as unknown as Sentry.Span;
+
+      getActiveSpanMock.mockReturnValue(activeSpanMock);
+
+      trace({ name: NAME_MOCK }, () => true);
+
+      // An operation that inherits the ambient active span must stay a child
+      // span of it. No `forceTransaction` may be inferred from the fallback,
+      // otherwise every timer/poll/messenger-driven trace is manufactured into
+      // a billed Sentry transaction. See #45393.
+      expect(startSpanMock).toHaveBeenCalledWith(
+        {
+          name: NAME_MOCK,
+          parentSpan: activeSpanMock,
+          op: 'custom',
+        },
+        expect.any(Function),
+      );
+    });
+
     it('does not call getActiveSpan when parentContext is provided', () => {
       trace(
         { name: NAME_MOCK, parentContext: PARENT_CONTEXT_MOCK },

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -200,6 +200,18 @@ export type TraceRequest = {
    * Custom operation name to associate with the trace.
    */
   op?: string;
+
+  /**
+   * Explicitly promote this trace to a Sentry transaction, even when it falls
+   * back to the ambient active span as its parent.
+   *
+   * Prefer leaving this unset. A trace that inherits the ambient span should
+   * remain a child span of it: only set this for operations that genuinely
+   * warrant transaction-level visibility, and opt in by name rather than
+   * having the promotion acquired by accident. See
+   * https://github.com/MetaMask/metamask-extension/issues/45393
+   */
+  forceTransaction?: boolean;
 };
 
 /**
@@ -526,20 +538,28 @@ function startSpan<T>(
   request: TraceRequest,
   callback: (spanOptions: StartSpanOptions) => T,
 ) {
-  const { data: attributes, name, parentContext, startTime, op } = request;
+  const {
+    data: attributes,
+    forceTransaction,
+    name,
+    parentContext,
+    startTime,
+    op,
+  } = request;
   let parentSpan = resolveParentSpan(parentContext);
 
   // Inherit from active span (e.g. browserTracingIntegration's pageload/navigation)
   // when no explicit parent is provided. Must capture before withIsolationScope
   // severs the active span context chain.
-  // forceTransaction preserves transaction-level visibility for monitoring while
-  // linking to the auto-instrumentation hierarchy.
-  let forceTransaction: boolean | undefined;
+  //
+  // The operation becomes a child span of the active span, not a transaction:
+  // transaction-level promotion is only available through an explicit
+  // `forceTransaction` on the request and is never inferred from the ambient
+  // span. See https://github.com/MetaMask/metamask-extension/issues/45393
   if (!parentSpan && !parentContext) {
     const activeSpan = sentryGetActiveSpan();
     if (activeSpan) {
       parentSpan = activeSpan;
-      forceTransaction = true;
     }
   }
 


### PR DESCRIPTION
## **Description**

Fixes #45393.

`shared/lib/trace.ts` promoted an operation to a Sentry **transaction** whenever it fell back to the ambient active span as its parent:

```ts
if (!parentSpan && !parentContext) {
  const activeSpan = sentryGetActiveSpan();
  if (activeSpan) {
    parentSpan = activeSpan;
    forceTransaction = true; // a child span becomes a billed transaction
  }
}
```

Sentry bills the `transaction` category (the constrained performance unit), not spans. Every timer-, poll- and messenger-driven operation that never passes an explicit parent — which is most of them — was therefore manufactured into a billed transaction, inflating `transaction accepted` volume. The issue measures the force-promoted rows at ~8.6M/day estimated, roughly 21% of all transactions.

### Root cause

The active-span fallback unconditionally set `forceTransaction = true` for any trace that inherited the ambient span. That converted child spans into billed transactions by accident rather than by intent, and it was invisible because span volume and transaction volume move independently.

### Change

- Removed `forceTransaction = true` from the active-span fallback. A trace that inherits the ambient span now remains a **child span** of it.
- Added an explicit, optional `forceTransaction` field to `TraceRequest` so operations that genuinely warrant transaction-level visibility can still opt in by name — the promotion is no longer acquired by accident.
- Explicit Sentry-level opt-ins that already set `forceTransaction` (e.g. `shared/lib/stores/utils/run-tracked-task.ts`, which calls `sentry.startSpan` directly) are unaffected.

### Test

Added a regression test in `shared/lib/trace.test.ts` asserting that when a trace inherits the ambient active span, `startSpan` is invoked with the parent span but without a `forceTransaction` promotion.

### Notes

Per the issue, the per-op rooting work (#7355 / #43931) makes these operations their own trace roots, and a root *is* a transaction — so rooting does not deliver this saving. This change is coordinated with that work rather than duplicating it; no dashboards or alerts are touched here. The per-operation audit in the issue's acceptance criteria remains a follow-up decision.

## **Changelog**

CHANGELOG entry: null (internal observability change; not end-user-facing)

## **Related issues**

- Fixes #45393

## **Manual testing steps**

No manual testing steps required — internal observability change covered by the unit test in `shared/lib/trace.test.ts`.

## **Screenshots/Recordings**

N/A (internal observability change).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://docs.metamask.io/developer-docs/contributing/)
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels type and category

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (where applicable)
- [ ] I've confirmed that issues are fixed / don't exist (where applicable)
