### PR TITLE
chore: align scam questionnaire support event name with segment schema convention cp-13.44.0

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -1006,7 +1006,7 @@ export enum MetaMetricsEventName {
   SimulationFails = 'Simulation Fails',
   SimulationIncompleteAssetDisplayed = 'Incomplete Asset Displayed',
   ScamQuestionnaireCompleted = 'Scam Questionnaire Completed',
-  ScamQuestionnaireContactSupport = 'Scam Questionnaire Contact Support',
+  ScamQuestionnaireSupportContacted = 'Scam Questionnaire Support Contacted',
   ScamQuestionnaireViewed = 'Scam Questionnaire Viewed',
   SecurityPageCtaClicked = 'security_page_cta_clicked',
   SecurityPageDismissed = 'security_page_dismissed',

--- a/ui/components/app/product-safety/scam-questionnaire/useScamQuestionnaireMetrics.test.ts
+++ b/ui/components/app/product-safety/scam-questionnaire/useScamQuestionnaireMetrics.test.ts
@@ -97,7 +97,7 @@ describe('useScamQuestionnaireMetrics', () => {
       metrics.trackContactSupport(ANSWERS);
 
       expect(firedEvent(trackEvent)).toMatchObject({
-        name: MetaMetricsEventName.ScamQuestionnaireContactSupport as string,
+        name: MetaMetricsEventName.ScamQuestionnaireSupportContacted as string,
         properties: {
           category: MetaMetricsEventCategory.Confirmations,
           q1_answer: 'q1_yes',

--- a/ui/components/app/product-safety/scam-questionnaire/useScamQuestionnaireMetrics.ts
+++ b/ui/components/app/product-safety/scam-questionnaire/useScamQuestionnaireMetrics.ts
@@ -73,7 +73,7 @@ export function useScamQuestionnaireMetrics() {
         }),
 
       trackContactSupport: (answers: Answers) =>
-        fire(MetaMetricsEventName.ScamQuestionnaireContactSupport, {
+        fire(MetaMetricsEventName.ScamQuestionnaireSupportContacted, {
           ...getAnswerRecord(answers),
           red_flag_count: getRedFlagCount(answers),
           simulation_sending_assets_total_value: valueAtRisk,


### PR DESCRIPTION
## **Description**

Rename the `ScamQuestionnaireContactSupport` enum key and its string value (`'Scam Questionnaire Contact Support'` → `'Scam Questionnaire Support Contacted'`) to match the `Object Action` naming convention enforced by the segment schema. The previous name read as a button label ("Contact Support") rather than an event that occurred ("Support Contacted").

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: https://github.com/Consensys/segment-schema/pull/702
Related: https://github.com/MetaMask/metamask-mobile/pull/34612

## **Manual testing steps**

1. Trigger the scam questionnaire flow and reach the support step
2. Confirm the fired event name is `Scam Questionnaire Support Contacted` in the MetaMetrics event log

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk analytics rename with no product or security logic changes; dashboards or funnels keyed on the old event name need updating.
> 
> **Overview**
> **Analytics naming only** — the scam questionnaire support action now fires **`Scam Questionnaire Support Contacted`** instead of **`Scam Questionnaire Contact Support`**.
> 
> The `MetaMetricsEventName` member is renamed from `ScamQuestionnaireContactSupport` to **`ScamQuestionnaireSupportContacted`**, and `useScamQuestionnaireMetrics`’s `trackContactSupport` uses that enum. Event **properties** (answers, red flags, USD at risk, etc.) are unchanged; only the event name string changes for Segment’s **Object Action** convention (past-tense outcome vs. button label).
> 
> The unit test expectation is updated to match the new enum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75cec4c081c2e49e4d72e550de08cb9de72ca520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->