### PR TITLE
fix(release): use Flask publisher vars and prevent AMO retries

### DIFF
--- a/.github/workflows/adjust-cws-rollout.yml
+++ b/.github/workflows/adjust-cws-rollout.yml
@@ -90,6 +90,7 @@ jobs:
           EXTENSION_ID_PROD: ${{ vars.EXTENSION_ID }}
           EXTENSION_ID_FLASK: ${{ vars.EXTENSION_ID_FLASK }}
           PUBLISHER_ID_PROD: ${{ vars.PUBLISHER_ID }}
+          PUBLISHER_ID_FLASK: ${{ vars.PUBLISHER_ID_FLASK }}
         run: |
           set -euo pipefail
           GITHUB_REF="${{ github.ref }}"
@@ -114,7 +115,7 @@ jobs:
             WIF_PROVIDER="${WIF_PROVIDER_PROD}"
             WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_PROD}"
             EXTENSION_ID="${EXTENSION_ID_FLASK}"
-            PUBLISHER_ID="${PUBLISHER_ID_PROD}"
+            PUBLISHER_ID="${PUBLISHER_ID_FLASK}"
           else
             echo "::error::Invalid target: ${TARGET}"
             exit 1

--- a/.github/workflows/upload-extension-to-amo.yml
+++ b/.github/workflows/upload-extension-to-amo.yml
@@ -269,6 +269,11 @@ jobs:
 
       - name: Submit AMO upload via Lambda invoke (B1)
         id: amo-upload
+        env:
+          # A successful AMO Flask submission took 103 seconds. Wait for the
+          # synchronous Lambda response without AWS CLI retries spawning
+          # overlapping submissions for the same version.
+          AWS_MAX_ATTEMPTS: '1'
         run: |
           set -euo pipefail
 
@@ -298,6 +303,7 @@ jobs:
             --qualifier "${LAMBDA_QUALIFIER}" \
             --invocation-type RequestResponse \
             --cli-binary-format raw-in-base64-out \
+            --cli-read-timeout 600 \
             --payload "${PAYLOAD}" \
             /tmp/amo-response.json || INVOKE_RESULT=$?
 

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -79,6 +79,8 @@ jobs:
           EXTENSION_ID_FLASK: ${{ vars.EXTENSION_ID_FLASK }}
           PUBLISHER_ID_PROD: ${{ vars.PUBLISHER_ID }}
           PUBLISHER_EMAIL_PROD: ${{ vars.PUBLISHER_EMAIL }}
+          PUBLISHER_ID_FLASK: ${{ vars.PUBLISHER_ID_FLASK }}
+          PUBLISHER_EMAIL_FLASK: ${{ vars.PUBLISHER_EMAIL_FLASK }}
         run: |
           set -euo pipefail
           GITHUB_REF="${{ github.ref }}"
@@ -127,8 +129,8 @@ jobs:
             WIF_PROVIDER="${WIF_PROVIDER_PROD}"
             WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_PROD}"
             EXTENSION_ID="${EXTENSION_ID_FLASK}"
-            PUBLISHER_ID="${PUBLISHER_ID_PROD}"
-            PUBLISHER_EMAIL="${PUBLISHER_EMAIL_PROD}"
+            PUBLISHER_ID="${PUBLISHER_ID_FLASK}"
+            PUBLISHER_EMAIL="${PUBLISHER_EMAIL_FLASK}"
             ZIP_NAME="metamask-chrome-${VERSION}-flask.0.zip"
             CWS_EXPECTED_VERSION="${VERSION}-flask.0"
           else


### PR DESCRIPTION
## **Description**

The Runway 13.43.0 submission exposed two independent release automation problems:

- CWS Flask used the production publisher UUID, causing `fetchStatus` to return HTTP 403 for the Flask listing under metamask-labs.
- The synchronous AMO Lambda completed successfully in 103 seconds, but the AWS CLI timed out and retried twice, creating overlapping submissions that failed with `amo_version_create_failed`.

This change routes Flask upload and rollout through `PUBLISHER_ID_FLASK` / `PUBLISHER_EMAIL_FLASK`. It also gives the AMO invocation a 600-second read timeout and sets `AWS_MAX_ATTEMPTS=1`, ensuring one invocation waits for the Lambda response without duplicate retries.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3734](https://consensyssoftware.atlassian.net/browse/INFRA-3734)

Related: [Runway submission 31491738111](https://github.com/MetaMask/metamask-extension/actions/runs/31491738111)

## **Manual testing steps**

1. Dispatch the Runway release submission for a release branch with production CWS skipped and CWS Flask enabled.
2. Verify the CWS Flask job summary uses publisher ID `60806bac-480e-4365-bc2e-37952c85412f` and `fetchStatus` succeeds.
3. Dispatch AMO Flask and verify the workflow waits for the synchronous Lambda response and CloudWatch records only one invocation for the run ID.

## **Screenshots/Recordings**

N/A — release workflow configuration only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

[INFRA-3734]: https://consensyssoftware.atlassian.net/browse/INFRA-3734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ