### PR TITLE
fix: resolve native currency icons for custom networks

### DIFF
--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -18,8 +18,10 @@ import {
   fetchAssetMetadata,
   toAssetId,
   fetchAssetMetadataForAssetIds,
+  getFallbackNativeAssetId,
   getNativeAssetId,
   isEvmChainId,
+  isNativeAssetId,
   isTronSpecialAsset,
 } from './asset-utils';
 
@@ -53,6 +55,46 @@ describe('asset-utils', () => {
     it('returns undefined for a chain unknown to the asset map', () => {
       // getNativeAssetForChainId throws on custom/unsupported networks.
       expect(getNativeAssetId('0x123456' as Hex)).toBeUndefined();
+    });
+  });
+
+  describe('getFallbackNativeAssetId', () => {
+    it('builds a zero-address erc20 placeholder for an EVM chain', () => {
+      expect(getFallbackNativeAssetId('eip155:88888' as CaipChainId)).toBe(
+        'eip155:88888/erc20:0x0000000000000000000000000000000000000000',
+      );
+    });
+
+    it('returns undefined for a non-EVM chain', () => {
+      expect(
+        getFallbackNativeAssetId(MultichainNetworks.SOLANA as CaipChainId),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('isNativeAssetId', () => {
+    it('returns true for a slip44 asset id', () => {
+      expect(isNativeAssetId('eip155:1/slip44:60' as CaipAssetType)).toBe(true);
+    });
+
+    it('returns true for the zero-address erc20 placeholder', () => {
+      expect(
+        isNativeAssetId(
+          'eip155:88888/erc20:0x0000000000000000000000000000000000000000' as CaipAssetType,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for a real erc20 token', () => {
+      expect(
+        isNativeAssetId(
+          'eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f' as CaipAssetType,
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isNativeAssetId(undefined)).toBe(false);
     });
   });
 

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -22,10 +22,14 @@ import {
 
 import { MultichainNetworks } from '../constants/multichain/networks';
 import {
+  SLIP44_ASSET_NAMESPACE,
   TRON_SPECIAL_ASSET_CAIP_TYPES_SET,
   type TronSpecialAssetCaipType,
 } from '../constants/multichain/assets';
-import { POLYGON_NATIVE_TOKEN_ADDRESS } from '../constants/transaction';
+import {
+  NATIVE_TOKEN_ADDRESS,
+  POLYGON_NATIVE_TOKEN_ADDRESS,
+} from '../constants/transaction';
 import getFetchWithTimeout from './fetch-with-timeout';
 import { decimalToPrefixedHex } from './conversion.utils';
 import { TEN_SECONDS_IN_MILLISECONDS } from './transactions-controller-utils';
@@ -117,6 +121,44 @@ export const getNativeAssetId = (
     return getNativeAssetForChainId(chainId).assetId;
   } catch {
     return undefined;
+  }
+};
+
+/**
+ * Builds a synthetic native asset id (`<chainId>/erc20:<zero address>`) for
+ * chains missing from the swaps map, so callers that already know an asset
+ * is native (e.g. `assetType === 'native'`) have something to key off. EVM
+ * only - returns `undefined` for non-EVM chains.
+ *
+ * @param chainId - The chain id, in CAIP-2 format.
+ * @returns The synthetic native asset id, or `undefined` for non-EVM chains.
+ */
+export const getFallbackNativeAssetId = (
+  chainId: CaipChainId,
+): CaipAssetType | undefined =>
+  isNonEvmChainId(chainId)
+    ? undefined
+    : (`${chainId}/erc20:${NATIVE_TOKEN_ADDRESS}` as CaipAssetType);
+
+/**
+ * Determines whether a CAIP-19 asset id is a chain's native currency, purely
+ * from its shape: the `slip44` namespace, or an EVM zero address.
+ *
+ * @param assetId - The CAIP-19 asset id to check.
+ * @returns Whether the asset id represents a native currency.
+ */
+export const isNativeAssetId = (assetId?: CaipAssetType): boolean => {
+  if (!assetId) {
+    return false;
+  }
+  try {
+    const { assetNamespace, assetReference } = parseCaipAssetType(assetId);
+    return (
+      assetNamespace === SLIP44_ASSET_NAMESPACE ||
+      isNativeAddress(assetReference)
+    );
+  } catch {
+    return false;
   }
 };
 

--- a/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.test.tsx
+++ b/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.test.tsx
@@ -7,6 +7,8 @@ import {
 
 const ethTokenAssetId = 'eip155:1/slip44:60';
 const usdcAssetId = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const chzFallbackAssetId =
+  'eip155:88888/erc20:0x0000000000000000000000000000000000000000';
 
 function renderAvatar(tokens: ActivityListItemAvatarTokens) {
   return render(<ActivityListItemAvatar tokens={tokens} />);
@@ -49,5 +51,32 @@ describe('ActivityListItemAvatar', () => {
     expect(
       screen.getByTestId('activity-list-item-avatar-fallback'),
     ).toBeInTheDocument();
+  });
+
+  it('uses the bundled local icon for a native asset, not the CDN', () => {
+    renderAvatar([ethTokenAssetId]);
+
+    const img = screen
+      .getByTestId('activity-list-item-avatar-token')
+      .querySelector('img');
+    expect(img?.getAttribute('src')).toBe('./images/eth_logo.svg');
+  });
+
+  it('uses the bundled local icon for a native asset on a custom network', () => {
+    renderAvatar([chzFallbackAssetId]);
+
+    const img = screen
+      .getByTestId('activity-list-item-avatar-token')
+      .querySelector('img');
+    expect(img?.getAttribute('src')).not.toContain('static.cx.metamask.io');
+  });
+
+  it('falls back to the CDN for a non-native asset', () => {
+    renderAvatar([usdcAssetId]);
+
+    const img = screen
+      .getByTestId('activity-list-item-avatar-token')
+      .querySelector('img');
+    expect(img?.getAttribute('src')).toContain('static.cx.metamask.io');
   });
 });

--- a/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.tsx
+++ b/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.tsx
@@ -7,7 +7,37 @@ import {
   AvatarTokenSize,
 } from '@metamask/design-system-react';
 import type { CaipAssetType } from '@metamask/utils';
-import { getCaipAssetImageUrl } from '../../../../shared/lib/asset-utils';
+import {
+  getCaipAssetImageUrl,
+  getChainIdFromAssetId,
+  isNativeAssetId,
+} from '../../../../shared/lib/asset-utils';
+import { convertCaipToHexChainId } from '../../../../shared/lib/network.utils';
+import { CHAIN_ID_TOKEN_IMAGE_MAP } from '../../../../shared/constants/network';
+
+/**
+ * For a native asset, prefer the icon bundled with the app over a CDN fetch.
+ *
+ * @param assetId - The CAIP-19 asset id to look up a local icon for.
+ */
+const getLocalNativeIconSrc = (assetId: CaipAssetType): string | undefined => {
+  if (!isNativeAssetId(assetId)) {
+    return undefined;
+  }
+  const chainId = getChainIdFromAssetId(assetId);
+  if (!chainId) {
+    return undefined;
+  }
+  try {
+    const hexChainId = convertCaipToHexChainId(chainId);
+    return CHAIN_ID_TOKEN_IMAGE_MAP[
+      hexChainId as keyof typeof CHAIN_ID_TOKEN_IMAGE_MAP
+    ];
+  } catch {
+    // Non-EVM chain id - fall through to the CDN lookup.
+    return undefined;
+  }
+};
 
 export type ActivityListItemAvatarTokens = readonly (string | undefined)[];
 
@@ -20,11 +50,15 @@ const ActivityTokenAvatar = ({
   assetId,
   className,
 }: Readonly<{ assetId: string; className?: string }>) => {
+  const src =
+    getLocalNativeIconSrc(assetId as CaipAssetType) ??
+    getCaipAssetImageUrl(assetId as CaipAssetType);
+
   return (
     <AvatarToken
       size={AvatarTokenSize.Md}
       name={fallbackText}
-      src={getCaipAssetImageUrl(assetId as CaipAssetType)}
+      src={src}
       className={classnames(className)}
       imageProps={{ className: 'bg-alternative' }}
       data-testid="activity-list-item-avatar-token"

--- a/ui/selectors/activity/enrich-local-activity.test.ts
+++ b/ui/selectors/activity/enrich-local-activity.test.ts
@@ -154,4 +154,54 @@ describe('enrichLocalActivity', () => {
 
     expect(enrichLocalActivity(activity, group)).toBe(activity);
   });
+
+  it('backfills a missing native assetId from the activity chainId', () => {
+    const group = buildTokenTransferGroup({ type: TransactionType.simpleSend });
+    const activity = {
+      type: 'send',
+      chainId: 'eip155:88888',
+      status: 'success',
+      timestamp: 1,
+      data: {
+        from: '0x1111111111111111111111111111111111111111',
+        to: RECIPIENT,
+        token: {
+          direction: 'out',
+          symbol: 'CHZ',
+          assetType: 'native',
+        },
+      },
+    } as ActivityListItem;
+
+    const enriched = enrichLocalActivity(activity, group);
+
+    expect(enriched.data).toMatchObject({
+      token: {
+        assetId:
+          'eip155:88888/erc20:0x0000000000000000000000000000000000000000',
+      },
+    });
+  });
+
+  it('does not touch a native token that already has an assetId', () => {
+    const group = buildTokenTransferGroup({ type: TransactionType.simpleSend });
+    const activity = {
+      type: 'send',
+      chainId: 'eip155:1',
+      status: 'success',
+      timestamp: 1,
+      data: {
+        from: '0x1111111111111111111111111111111111111111',
+        to: RECIPIENT,
+        token: {
+          direction: 'out',
+          symbol: 'ETH',
+          assetType: 'native',
+          assetId: 'eip155:1/slip44:60',
+        },
+      },
+    } as ActivityListItem;
+
+    expect(enrichLocalActivity(activity, group)).toBe(activity);
+  });
 });

--- a/ui/selectors/activity/enrich-local-activity.ts
+++ b/ui/selectors/activity/enrich-local-activity.ts
@@ -1,11 +1,58 @@
 import { TransactionType } from '@metamask/transaction-controller';
-import type { ActivityListItem } from '../../../shared/lib/activity/types';
+import type {
+  ActivityListItem,
+  TokenAmount,
+} from '../../../shared/lib/activity/types';
 import type { TransactionGroup } from '../../../shared/lib/multichain/types';
+import { getFallbackNativeAssetId } from '../../../shared/lib/asset-utils';
 import {
   parseApprovalTransactionData,
   parseStandardTokenTransactionData,
 } from '../../../shared/lib/transaction.utils';
 import { enrichLocalMusdClaimActivity } from './enrich-local-musd-claim';
+
+// Token-bearing fields across the ActivityItem union (shared/lib/activity/types.ts).
+const TOKEN_FIELDS = [
+  'token',
+  'sourceToken',
+  'destinationToken',
+  'paymentToken',
+] as const;
+
+/**
+ * Backfills a missing native `assetId` using the activity's `chainId`. The
+ * upstream mapper resolves native `assetId` via a SLIP44-by-symbol lookup
+ * that misses many custom networks, even though `assetType: 'native'` is
+ * still set correctly.
+ *
+ * @param activity - The activity item to backfill.
+ * @returns The activity, patched (or the same reference if unchanged).
+ */
+function enrichNativeAssetIds(activity: ActivityListItem): ActivityListItem {
+  const data = activity.data as Record<string, TokenAmount | undefined>;
+  let changed = false;
+  const patchedData: Record<string, TokenAmount> = {};
+
+  for (const field of TOKEN_FIELDS) {
+    const token = data[field];
+    if (token && !token.assetId && token.assetType === 'native') {
+      const assetId = getFallbackNativeAssetId(activity.chainId);
+      if (assetId) {
+        patchedData[field] = { ...token, assetId };
+        changed = true;
+      }
+    }
+  }
+
+  if (!changed) {
+    return activity;
+  }
+
+  return {
+    ...activity,
+    data: { ...activity.data, ...patchedData },
+  } as ActivityListItem;
+}
 
 const TOKEN_TRANSFER_TYPES = new Set<TransactionType>([
   TransactionType.tokenMethodTransfer,
@@ -121,5 +168,6 @@ export function enrichLocalActivity(
   next = enrichTokenTransferActivity(next, transactionGroup);
   next = enrichApprovalActivity(next, transactionGroup);
   next = enrichLocalMusdClaimActivity(next, transactionGroup);
+  next = enrichNativeAssetIds(next);
   return next;
 }


### PR DESCRIPTION
The upstream activity mapper resolves a native asset's assetId via a SLIP44-by-symbol lookup that misses many custom networks (e.g. Chiliz, Stable), even though assetType stays correctly set to 'native'. Backfill assetId once in enrichLocalActivity from the activity's own chainId, so every consumer (list, detail, fees) sees a usable assetId. Also prefer the app's bundled icon over the CDN for native assets, since a custom-network CDN entry may not exist under the synthesized id.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: resolve native currency icons for custom networks

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and activity-enrichment only; changes are gated on `assetType === 'native'` and existing assetId preservation, with unit test coverage.
> 
> **Overview**
> Fixes **missing native token icons** on custom EVM networks in the activity list by backfilling `assetId` when the mapper leaves it empty and by preferring **bundled chain icons** over CDN URLs for native assets.
> 
> **`enrichLocalActivity`** now runs `enrichNativeAssetIds`, which sets a synthetic EVM native id (`<chainId>/erc20:0x000…000`) on `token`, `sourceToken`, `destinationToken`, and `paymentToken` when `assetType === 'native'` but `assetId` is missing—addressing SLIP44-by-symbol gaps on chains like Chiliz.
> 
> **`asset-utils`** adds `getFallbackNativeAssetId` and `isNativeAssetId` (SLIP44 or zero-address shape). **`ActivityListItemAvatar`** resolves native icons via `CHAIN_ID_TOKEN_IMAGE_MAP` before `getCaipAssetImageUrl`, so known chains use local assets instead of a CDN path that may not exist for the synthesized id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49f6fe61b2cd436626e26c1c9cb33b8c750b7378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->