### PR TITLE
perf(6402): clear set-state-in-effect in perps

### DIFF
--- a/ui/components/app/perps/cancel-order/cancel-order-modal.tsx
+++ b/ui/components/app/perps/cancel-order/cancel-order-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import {
   Box,
@@ -85,14 +85,16 @@ export const CancelOrderModal = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
 
-  useEffect(() => {
+  if (isOpen !== prevIsOpen) {
+    setPrevIsOpen(isOpen);
     if (isOpen) {
       setIsSubmitting(false);
       setError(null);
       setIsGeoBlockModalOpen(false);
     }
-  }, [isOpen]);
+  }
 
   const displayName = getDisplaySymbol(order.symbol);
   const formattedDate = useMemo(() => {

--- a/ui/components/app/perps/close-position/close-all-positions-modal.tsx
+++ b/ui/components/app/perps/close-position/close-all-positions-modal.tsx
@@ -102,6 +102,18 @@ export const CloseAllPositionsModal: React.FC<CloseAllPositionsModalProps> = ({
   const [rawMetamaskFees, setRawMetamaskFees] = useState(0);
   const [isLoadingFees, setIsLoadingFees] = useState(positions.length > 0);
   const feeRequestId = useRef(0);
+  const feeFetchKey = isOpen ? symbolNotionalKey : '';
+  const [prevFeeFetchKey, setPrevFeeFetchKey] = useState(feeFetchKey);
+
+  if (feeFetchKey !== prevFeeFetchKey) {
+    setPrevFeeFetchKey(feeFetchKey);
+    if (isOpen) {
+      const entries: [string, number][] = JSON.parse(symbolNotionalKey);
+      setRawProtocolFees(0);
+      setRawMetamaskFees(0);
+      setIsLoadingFees(entries.length > 0);
+    }
+  }
 
   const metamaskFeeDiscountBips = usePerpsMetamaskFeeDiscountBips(
     ORIGINAL_METAMASK_FEE_BIPS,
@@ -114,20 +126,14 @@ export const CloseAllPositionsModal: React.FC<CloseAllPositionsModalProps> = ({
 
     let cancelled = false;
 
-    setRawProtocolFees(0);
-    setRawMetamaskFees(0);
-
     const entries: [string, number][] = JSON.parse(symbolNotionalKey);
 
     feeRequestId.current += 1;
     const currentId = feeRequestId.current;
 
     if (entries.length === 0) {
-      setIsLoadingFees(false);
       return undefined;
     }
-
-    setIsLoadingFees(true);
 
     Promise.all(
       entries.map(([symbol, notional]) =>

--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -365,7 +365,9 @@ export const ClosePositionModal = ({
   const getAbandonProperties = useRef(() => latestAbandonPropsRef.current);
   const hasConfirmedCloseRef = useRef(false);
 
-  useEffect(() => {
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  if (isOpen !== prevIsOpen) {
+    setPrevIsOpen(isOpen);
     if (isOpen) {
       setClosePercent(100);
       setIsSubmitting(false);
@@ -373,18 +375,26 @@ export const ClosePositionModal = ({
       setIsGeoBlockModalOpen(false);
       setSelectedOrderType('market');
       setLimitPrice('');
-      // Reopening starts a fresh close session: a commit from the previous one
-      // must not suppress abandon tracking for this one.
+    }
+  }
+
+  // Reopening starts a fresh close session: a commit from the previous one
+  // must not suppress abandon tracking for this one.
+  useEffect(() => {
+    if (isOpen) {
       hasConfirmedCloseRef.current = false;
     }
   }, [isOpen]);
 
-  useEffect(() => {
+  const [prevIsCloseLimitOrderEnabled, setPrevIsCloseLimitOrderEnabled] =
+    useState(isCloseLimitOrderEnabled);
+  if (isCloseLimitOrderEnabled !== prevIsCloseLimitOrderEnabled) {
+    setPrevIsCloseLimitOrderEnabled(isCloseLimitOrderEnabled);
     if (!isCloseLimitOrderEnabled) {
       setSelectedOrderType('market');
       setLimitPrice('');
     }
-  }, [isCloseLimitOrderEnabled]);
+  }
 
   const displayName = getDisplaySymbol(position.symbol);
   const headerDisplayPrice = displayPrice ?? formatFiat(currentPrice);

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -12,7 +12,7 @@ import {
   IconName,
   IconColor,
 } from '@metamask/design-system-react';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import {
@@ -100,13 +100,17 @@ export const AmountInput = ({
 
   // Re-read the stored denomination whenever the market changes so each market
   // keeps its own last-used choice.
-  useEffect(() => {
+  const [prevAsset, setPrevAsset] = useState(asset);
+  if (asset !== prevAsset) {
+    setPrevAsset(asset);
     setDenomination(getSizeDenomination(asset));
-  }, [asset]);
+  }
 
-  useEffect(() => {
+  const [prevBalancePercent, setPrevBalancePercent] = useState(balancePercent);
+  if (balancePercent !== prevBalancePercent) {
+    setPrevBalancePercent(balancePercent);
     setPercentInputValue(String(balancePercent));
-  }, [balancePercent]);
+  }
 
   const tokenAmount = useMemo(() => {
     const numAmount = Number.parseFloat(amount.replace(/,/gu, '')) || 0;

--- a/ui/components/app/perps/order-entry/components/leverage-slider/leverage-slider.tsx
+++ b/ui/components/app/perps/order-entry/components/leverage-slider/leverage-slider.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   Box,
   Text,
@@ -41,10 +41,12 @@ export const LeverageSlider = ({
   const t = useI18nContext();
   const { track } = usePerpsEventTracking();
   const [inputValue, setInputValue] = useState<string>(String(leverage));
+  const [prevLeverage, setPrevLeverage] = useState(leverage);
 
-  useEffect(() => {
+  if (leverage !== prevLeverage) {
+    setPrevLeverage(leverage);
     setInputValue(String(leverage));
-  }, [leverage]);
+  }
 
   const handleSliderChange = useCallback(
     (_event: Event | React.SyntheticEvent, value: number | number[]) => {

--- a/ui/components/app/perps/perps-token-logo/perps-token-logo.tsx
+++ b/ui/components/app/perps/perps-token-logo/perps-token-logo.tsx
@@ -59,24 +59,27 @@ export const PerpsTokenLogo = ({
     return '';
   }, [displaySymbol, theme]);
   const [resolvedSrc, setResolvedSrc] = useState<string | undefined>(undefined);
-  const [isResolving, setIsResolving] = useState(true);
+  const [isResolving, setIsResolving] = useState(() =>
+    Boolean(symbol && getAssetIconUrls(symbol)),
+  );
+  const [prevSymbol, setPrevSymbol] = useState(symbol);
+
+  if (symbol !== prevSymbol) {
+    setPrevSymbol(symbol);
+    setResolvedSrc(undefined);
+    setIsResolving(Boolean(symbol && getAssetIconUrls(symbol)));
+  }
 
   useEffect(() => {
     if (!symbol) {
-      setResolvedSrc(undefined);
-      setIsResolving(false);
       return undefined;
     }
 
     const iconUrls = getAssetIconUrls(symbol);
     if (!iconUrls) {
-      setResolvedSrc(undefined);
-      setIsResolving(false);
       return undefined;
     }
 
-    setResolvedSrc(undefined);
-    setIsResolving(true);
     let cancelled = false;
     const urls = [iconUrls.primary, iconUrls.fallback];
     let idx = 0;

--- a/ui/components/app/perps/perps-withdraw-toast.tsx
+++ b/ui/components/app/perps/perps-withdraw-toast.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   Icon as DsIcon,
@@ -25,10 +25,14 @@ export function PerpsWithdrawToast() {
   const { formatCurrency } = useFormatters();
   const lastWithdrawResult = useSelector(selectPerpsLastWithdrawResult);
   const [dismissed, setDismissed] = useState(false);
+  const withdrawTimestamp = lastWithdrawResult?.timestamp;
+  const [prevWithdrawTimestamp, setPrevWithdrawTimestamp] =
+    useState(withdrawTimestamp);
 
-  useEffect(() => {
+  if (withdrawTimestamp !== prevWithdrawTimestamp) {
+    setPrevWithdrawTimestamp(withdrawTimestamp);
     setDismissed(false);
-  }, [lastWithdrawResult?.timestamp]);
+  }
 
   const dismissToast = useCallback(() => {
     setDismissed(true);

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import {
   Box,
   BoxFlexDirection,
@@ -81,11 +81,13 @@ export const ReversePositionModal = ({
   const { gate } = useSelectedAccountComplianceGate();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
-  useEffect(() => {
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  if (isOpen !== prevIsOpen) {
+    setPrevIsOpen(isOpen);
     if (isOpen) {
       setIsGeoBlockModalOpen(false);
     }
-  }, [isOpen]);
+  }
 
   usePerpsEventTracking({
     eventName: MetaMetricsEventName.PerpsScreenViewed,

--- a/ui/components/app/perps/slippage-config/perps-slippage-config-modal.tsx
+++ b/ui/components/app/perps/slippage-config/perps-slippage-config-modal.tsx
@@ -86,12 +86,20 @@ export const PerpsSlippageConfigModal = ({
 }: PerpsSlippageConfigModalProps) => {
   const t = useI18nContext();
   const customInputRef = useRef<HTMLInputElement | null>(null);
+  const initialStartsAsCustom = isOpen && !matchesPreset(currentValueBps);
   const [selectedBps, setSelectedBps] = useState(currentValueBps);
-  const [isCustomMode, setIsCustomMode] = useState(false);
-  const [draftValue, setDraftValue] = useState('');
-  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
-  const [prevCurrentValueBps, setPrevCurrentValueBps] =
-    useState(currentValueBps);
+  // Seed from props so a modal that mounts already open (non-preset value)
+  // shows the custom input on the first paint — matching the old mount effect.
+  const [isCustomMode, setIsCustomMode] = useState(initialStartsAsCustom);
+  const [draftValue, setDraftValue] = useState(
+    initialStartsAsCustom ? bpsToPercent(currentValueBps).toString() : '',
+  );
+  // Start unset so the first open/value sync always runs when props settle
+  // after mount with different values than the initial seed.
+  const [prevIsOpen, setPrevIsOpen] = useState<boolean | undefined>(undefined);
+  const [prevCurrentValueBps, setPrevCurrentValueBps] = useState<
+    number | undefined
+  >(undefined);
 
   if (isOpen !== prevIsOpen || currentValueBps !== prevCurrentValueBps) {
     setPrevIsOpen(isOpen);

--- a/ui/components/app/perps/slippage-config/perps-slippage-config-modal.tsx
+++ b/ui/components/app/perps/slippage-config/perps-slippage-config-modal.tsx
@@ -89,8 +89,13 @@ export const PerpsSlippageConfigModal = ({
   const [selectedBps, setSelectedBps] = useState(currentValueBps);
   const [isCustomMode, setIsCustomMode] = useState(false);
   const [draftValue, setDraftValue] = useState('');
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  const [prevCurrentValueBps, setPrevCurrentValueBps] =
+    useState(currentValueBps);
 
-  useEffect(() => {
+  if (isOpen !== prevIsOpen || currentValueBps !== prevCurrentValueBps) {
+    setPrevIsOpen(isOpen);
+    setPrevCurrentValueBps(currentValueBps);
     if (isOpen) {
       const startsAsCustom = !matchesPreset(currentValueBps);
       setSelectedBps(currentValueBps);
@@ -99,7 +104,7 @@ export const PerpsSlippageConfigModal = ({
         startsAsCustom ? bpsToPercent(currentValueBps).toString() : '',
       );
     }
-  }, [isOpen, currentValueBps]);
+  }
 
   useEffect(() => {
     if (isOpen && isCustomMode) {

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   Modal,
   ModalContent,
@@ -71,11 +71,13 @@ export const UpdateTPSLModal = ({
     [],
   );
 
-  useEffect(() => {
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  if (isOpen !== prevIsOpen) {
+    setPrevIsOpen(isOpen);
     if (!isOpen) {
       setSubmitState(null);
     }
-  }, [isOpen]);
+  }
 
   return (
     <Modal

--- a/ui/hooks/perps/stream/usePerpsLiveCandles.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveCandles.ts
@@ -89,6 +89,9 @@ export function usePerpsLiveCandles(
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const hasReceivedFirstUpdate = useRef(false);
+  const subscriptionKey = `${symbol}|${interval}|${duration ?? ''}|${throttleMs}`;
+  const [prevSubscriptionKey, setPrevSubscriptionKey] =
+    useState(subscriptionKey);
 
   // Stable refs for the current subscription params (for validation in callbacks)
   const currentSymbolRef = useRef(symbol);
@@ -96,16 +99,16 @@ export function usePerpsLiveCandles(
   currentSymbolRef.current = symbol;
   currentIntervalRef.current = interval;
 
-  useEffect(() => {
-    // Reset state when symbol or interval changes
+  if (subscriptionKey !== prevSubscriptionKey) {
+    setPrevSubscriptionKey(subscriptionKey);
     setCandleData(null);
-    setIsInitialLoading(true);
     setError(null);
     hasReceivedFirstUpdate.current = false;
+    setIsInitialLoading(Boolean(symbol && interval));
+  }
 
+  useEffect(() => {
     if (!symbol || !interval) {
-      setCandleData(null);
-      setIsInitialLoading(false);
       return undefined;
     }
 

--- a/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
@@ -133,6 +133,14 @@ export function usePerpsLiveMarketData(
     streamManager.markets.refresh();
   }, [streamManager]);
 
+  const [prevAutoSubscribe, setPrevAutoSubscribe] = useState(autoSubscribe);
+  if (autoSubscribe !== prevAutoSubscribe) {
+    setPrevAutoSubscribe(autoSubscribe);
+    if (!autoSubscribe) {
+      setIsInitialLoading(false);
+    }
+  }
+
   useEffect(() => {
     // If still initializing stream manager, stay in loading state
     if (isInitializing || !streamManager) {
@@ -140,18 +148,7 @@ export function usePerpsLiveMarketData(
     }
 
     if (!autoSubscribe) {
-      setIsInitialLoading(false);
       return;
-    }
-
-    // Check if we have cached data immediately
-    if (streamManager.markets.hasCachedData()) {
-      const cached = streamManager.markets.getCachedData();
-      setMarkets(cached);
-      if (!hasReceivedData.current) {
-        hasReceivedData.current = true;
-        setIsInitialLoading(false);
-      }
     }
 
     // Subscribe - callback fires immediately with cached data (if any)

--- a/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
@@ -94,14 +94,18 @@ export function usePerpsLiveMarketData(
 
   const [error, setError] = useState<Error | null>(null);
 
-  // Track whether we've received real data
-  const hasReceivedData = useRef(false);
+  // Track whether we've received real data. Seed from cache so the subscribe
+  // callback does not re-enter loading after a warm cache hit — without writing
+  // a ref inside the useState initializer (react-hooks/refs).
+  const hasReceivedData = useRef(
+    Boolean(autoSubscribe && streamManager?.markets.hasCachedData()),
+  );
   const [isInitialLoading, setIsInitialLoading] = useState(() => {
-    if (streamManager?.markets.hasCachedData()) {
-      hasReceivedData.current = true;
+    // No subscription ⇒ nothing to wait for (avoid setState-in-effect for this).
+    if (!autoSubscribe) {
       return false;
     }
-    return true;
+    return !streamManager?.markets.hasCachedData();
   });
 
   const compareByVolumeDesc = useCallback(
@@ -136,7 +140,10 @@ export function usePerpsLiveMarketData(
   const [prevAutoSubscribe, setPrevAutoSubscribe] = useState(autoSubscribe);
   if (autoSubscribe !== prevAutoSubscribe) {
     setPrevAutoSubscribe(autoSubscribe);
-    if (!autoSubscribe) {
+    if (autoSubscribe) {
+      // false → true: re-enter loading unless cache can satisfy immediately.
+      setIsInitialLoading(!streamManager?.markets.hasCachedData());
+    } else {
       setIsInitialLoading(false);
     }
   }
@@ -150,6 +157,10 @@ export function usePerpsLiveMarketData(
     if (!autoSubscribe) {
       return;
     }
+
+    // Align with render-time loading when autoSubscribe turns on (Copilot):
+    // warm cache ⇒ already "received"; cold ⇒ wait for first callback.
+    hasReceivedData.current = streamManager.markets.hasCachedData();
 
     // Subscribe - callback fires immediately with cached data (if any)
     const unsubscribe = streamManager.markets.subscribe((newMarkets) => {

--- a/ui/hooks/perps/stream/usePerpsLiveOrderBook.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveOrderBook.ts
@@ -74,6 +74,12 @@ const getOrderBookAggregatedStatusChannel = (sm: PerpsStreamManager) =>
 let nextOrderBookAggregatedSubscriptionGeneration = 0;
 
 /**
+ * Cache of subscription ids by activation key so StrictMode double-render does
+ * not allocate two generations for the same activation.
+ */
+const subscriptionIdsByActivationKey = new Map<string, string>();
+
+/**
  * Allocate a never-reused generation for one aggregated order-book activation.
  *
  * @returns Next monotonic generation value.
@@ -88,6 +94,33 @@ export function allocateOrderBookAggregatedSubscriptionGeneration(): number {
  */
 export function resetOrderBookAggregatedSubscriptionGenerationForTests(): void {
   nextOrderBookAggregatedSubscriptionGeneration = 0;
+  subscriptionIdsByActivationKey.clear();
+}
+
+function getOrCreateAggregatedSubscriptionId({
+  activationKey,
+  symbol,
+  nSigFigs,
+  mantissa,
+}: {
+  activationKey: string;
+  symbol: string;
+  nSigFigs?: 2 | 3 | 4 | 5;
+  mantissa?: 2 | 5;
+}): string {
+  const existing = subscriptionIdsByActivationKey.get(activationKey);
+  if (existing) {
+    return existing;
+  }
+
+  const subscriptionId = buildOrderBookAggregatedSubscriptionId({
+    symbol,
+    nSigFigs,
+    mantissa,
+    generation: allocateOrderBookAggregatedSubscriptionGeneration(),
+  });
+  subscriptionIdsByActivationKey.set(activationKey, subscriptionId);
+  return subscriptionId;
 }
 
 /**
@@ -177,52 +210,59 @@ export function usePerpsLiveOrderBook(
   // (grouping, reconnect, or a fresh open after close).
   const resetKey = isAggregated ? subscriptionId : activeSymbol;
 
-  // Allocate + register before paint; deregister on unmount / identity change so
+  const [prevActivationKey, setPrevActivationKey] = useState(activationKey);
+  const [prevIsAggregated, setPrevIsAggregated] = useState(isAggregated);
+
+  // Allocate subscription identity during render when activation inputs change.
+  // Ids are memoized by activationKey so StrictMode double-render does not
+  // consume two generations for one activation.
+  if (!isAggregated && (prevIsAggregated || aggregatedSubscription !== null)) {
+    setPrevIsAggregated(isAggregated);
+    setPrevActivationKey(activationKey);
+    setAggregatedSubscription(null);
+  } else if (isAggregated && activationKey !== prevActivationKey) {
+    setPrevActivationKey(activationKey);
+    setPrevIsAggregated(isAggregated);
+    if (activationKey && activeSymbol) {
+      setAggregatedSubscription({
+        activationKey,
+        subscriptionId: getOrCreateAggregatedSubscriptionId({
+          activationKey,
+          symbol: activeSymbol,
+          nSigFigs,
+          mantissa,
+        }),
+      });
+    } else {
+      setAggregatedSubscription(null);
+    }
+  } else if (isAggregated !== prevIsAggregated) {
+    setPrevIsAggregated(isAggregated);
+  }
+
+  // Register before paint; deregister on unmount / identity change so
   // a closed panel rejects late packets until the next activation registers.
   useLayoutEffect(() => {
-    if (!isAggregated) {
-      setAggregatedSubscription(null);
-      return undefined;
-    }
-    if (!streamManager) {
+    if (!isAggregated || !streamManager) {
       return undefined;
     }
 
-    const nextSubscriptionId =
-      activationKey && activeSymbol
-        ? buildOrderBookAggregatedSubscriptionId({
-            symbol: activeSymbol,
-            nSigFigs,
-            mantissa,
-            generation: allocateOrderBookAggregatedSubscriptionGeneration(),
-          })
-        : undefined;
-
-    setAggregatedSubscription(
-      activationKey && nextSubscriptionId
-        ? { activationKey, subscriptionId: nextSubscriptionId }
-        : null,
-    );
     streamManager.setActiveOrderBookAggregatedSubscriptionId(
-      nextSubscriptionId ?? null,
+      subscriptionId ?? null,
     );
 
     return () => {
       // Null the identity and drop cached rows/status in the same commit so a
       // late packet cannot repopulate the cache between clear and deregister.
       // Page-level clears are unnecessary once this owns both.
+      if (activationKey) {
+        subscriptionIdsByActivationKey.delete(activationKey);
+      }
       streamManager.setActiveOrderBookAggregatedSubscriptionId(null);
       streamManager.orderBookAggregated.clearCache();
       streamManager.orderBookAggregatedStatus.clearCache();
     };
-  }, [
-    isAggregated,
-    streamManager,
-    activationKey,
-    activeSymbol,
-    nSigFigs,
-    mantissa,
-  ]);
+  }, [isAggregated, streamManager, subscriptionId, activationKey]);
 
   const { data: orderBook, isInitialLoading } = usePerpsChannel(
     isAggregated ? getOrderBookAggregatedChannel : getOrderBookChannel,

--- a/ui/hooks/perps/stream/usePerpsLiveOrderBook.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveOrderBook.ts
@@ -97,6 +97,15 @@ export function resetOrderBookAggregatedSubscriptionGenerationForTests(): void {
   subscriptionIdsByActivationKey.clear();
 }
 
+/**
+ * Allocate or reuse a subscription id for `activationKey`. Mutates the module
+ * Map / generation counter — call only from layout/commit, never from render.
+ * @param options0
+ * @param options0.activationKey
+ * @param options0.symbol
+ * @param options0.nSigFigs
+ * @param options0.mantissa
+ */
 function getOrCreateAggregatedSubscriptionId({
   activationKey,
   symbol,
@@ -190,11 +199,10 @@ export function usePerpsLiveOrderBook(
       ? `${activeSymbol}:${nSigFigs ?? ''}:${mantissa ?? ''}:${reconnectNonce}`
       : undefined;
 
-  // Allocated in layout (not render) so the module-level generation counter is
-  // not mutated during a potentially discarded / StrictMode-double render.
-  // `activationKey` on the stored entry lets this render treat a stale id as
-  // absent until the matching layout pass commits the new one — so activate and
-  // resetKey never run against a previous instance's identity.
+  // Allocated + registered in layout (commit), never during render — so the
+  // module-level generation Map is not mutated on discarded/Concurrent renders.
+  // Until layout commits a matching id, treat subscriptionId as absent so
+  // activate/resetKey cannot run against a previous instance's identity.
   const [aggregatedSubscription, setAggregatedSubscription] = useState<{
     activationKey: string;
     subscriptionId: string;
@@ -210,63 +218,60 @@ export function usePerpsLiveOrderBook(
   // (grouping, reconnect, or a fresh open after close).
   const resetKey = isAggregated ? subscriptionId : activeSymbol;
 
-  // Start as unset so the first aggregated mount still allocates an identity
-  // (initializing to `activationKey` would skip the sync on mount).
-  const [prevActivationKey, setPrevActivationKey] = useState<
-    string | undefined
-  >(undefined);
-  const [prevIsAggregated, setPrevIsAggregated] = useState(false);
-
-  // Allocate subscription identity during render when activation inputs change.
-  // Ids are memoized by activationKey so StrictMode double-render does not
-  // consume two generations for one activation.
-  if (!isAggregated && (prevIsAggregated || aggregatedSubscription !== null)) {
-    setPrevIsAggregated(isAggregated);
-    setPrevActivationKey(activationKey);
-    setAggregatedSubscription(null);
-  } else if (isAggregated && activationKey !== prevActivationKey) {
-    setPrevActivationKey(activationKey);
-    setPrevIsAggregated(isAggregated);
-    if (activationKey && activeSymbol) {
-      setAggregatedSubscription({
-        activationKey,
-        subscriptionId: getOrCreateAggregatedSubscriptionId({
-          activationKey,
-          symbol: activeSymbol,
-          nSigFigs,
-          mantissa,
-        }),
-      });
-    } else {
-      setAggregatedSubscription(null);
-    }
-  } else if (isAggregated !== prevIsAggregated) {
-    setPrevIsAggregated(isAggregated);
-  }
-
-  // Register before paint; deregister on unmount / identity change so
-  // a closed panel rejects late packets until the next activation registers.
+  // Allocate identity, register it, and tear down on key change / unmount —
+  // all in the commit phase. Module Map mutation must not run during render
+  // (Concurrent/StrictMode can discard renders); layout is the commit boundary.
+  // Sync setState here is intentional so activate/resetKey see the new id before
+  // paint — queueMicrotask is too late for the activate effect.
   useLayoutEffect(() => {
     if (!isAggregated || !streamManager) {
       return undefined;
     }
 
+    if (!activationKey || !activeSymbol) {
+      streamManager.setActiveOrderBookAggregatedSubscriptionId(null);
+      return () => {
+        streamManager.setActiveOrderBookAggregatedSubscriptionId(null);
+        streamManager.orderBookAggregated.clearCache();
+        streamManager.orderBookAggregatedStatus.clearCache();
+      };
+    }
+
+    const nextSubscriptionId = getOrCreateAggregatedSubscriptionId({
+      activationKey,
+      symbol: activeSymbol,
+      nSigFigs,
+      mantissa,
+    });
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- commit-phase allocation; must land before activate effect
+    setAggregatedSubscription((prev) =>
+      prev?.activationKey === activationKey &&
+      prev.subscriptionId === nextSubscriptionId
+        ? prev
+        : { activationKey, subscriptionId: nextSubscriptionId },
+    );
+
     streamManager.setActiveOrderBookAggregatedSubscriptionId(
-      subscriptionId ?? null,
+      nextSubscriptionId,
     );
 
     return () => {
       // Null the identity and drop cached rows/status in the same commit so a
       // late packet cannot repopulate the cache between clear and deregister.
-      // Page-level clears are unnecessary once this owns both.
-      if (activationKey) {
-        subscriptionIdsByActivationKey.delete(activationKey);
-      }
+      subscriptionIdsByActivationKey.delete(activationKey);
       streamManager.setActiveOrderBookAggregatedSubscriptionId(null);
       streamManager.orderBookAggregated.clearCache();
       streamManager.orderBookAggregatedStatus.clearCache();
     };
-  }, [isAggregated, streamManager, subscriptionId, activationKey]);
+  }, [
+    isAggregated,
+    streamManager,
+    activationKey,
+    activeSymbol,
+    nSigFigs,
+    mantissa,
+  ]);
 
   const { data: orderBook, isInitialLoading } = usePerpsChannel(
     isAggregated ? getOrderBookAggregatedChannel : getOrderBookChannel,

--- a/ui/hooks/perps/stream/usePerpsLiveOrderBook.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveOrderBook.ts
@@ -210,8 +210,12 @@ export function usePerpsLiveOrderBook(
   // (grouping, reconnect, or a fresh open after close).
   const resetKey = isAggregated ? subscriptionId : activeSymbol;
 
-  const [prevActivationKey, setPrevActivationKey] = useState(activationKey);
-  const [prevIsAggregated, setPrevIsAggregated] = useState(isAggregated);
+  // Start as unset so the first aggregated mount still allocates an identity
+  // (initializing to `activationKey` would skip the sync on mount).
+  const [prevActivationKey, setPrevActivationKey] = useState<
+    string | undefined
+  >(undefined);
+  const [prevIsAggregated, setPrevIsAggregated] = useState(false);
 
   // Allocate subscription identity during render when activation inputs change.
   // Ids are memoized by activationKey so StrictMode double-render does not

--- a/ui/hooks/perps/stream/usePerpsStreamManager.ts
+++ b/ui/hooks/perps/stream/usePerpsStreamManager.ts
@@ -69,9 +69,13 @@ export function usePerpsStreamManager(): UsePerpsStreamManagerReturn {
     () =>
       selectedAddress !== null && streamManager.isInitialized(selectedAddress),
   );
-  const [error, setError] = useState<Error | null>(null);
-  const [prevSelectedAddress, setPrevSelectedAddress] =
-    useState(selectedAddress);
+  const [error, setError] = useState<Error | null>(() =>
+    selectedAddress ? null : new Error('No account selected'),
+  );
+  // Start unset so the first address (including null) syncs on mount.
+  const [prevSelectedAddress, setPrevSelectedAddress] = useState<
+    string | null | undefined
+  >(undefined);
 
   if (selectedAddress !== prevSelectedAddress) {
     setPrevSelectedAddress(selectedAddress);

--- a/ui/hooks/perps/stream/usePerpsStreamManager.ts
+++ b/ui/hooks/perps/stream/usePerpsStreamManager.ts
@@ -70,25 +70,34 @@ export function usePerpsStreamManager(): UsePerpsStreamManagerReturn {
       selectedAddress !== null && streamManager.isInitialized(selectedAddress),
   );
   const [error, setError] = useState<Error | null>(null);
+  const [prevSelectedAddress, setPrevSelectedAddress] =
+    useState(selectedAddress);
 
-  useEffect(() => {
+  if (selectedAddress !== prevSelectedAddress) {
+    setPrevSelectedAddress(selectedAddress);
     if (!selectedAddress) {
       setIsReady(false);
       setError(new Error('No account selected'));
+    } else if (streamManager.isInitialized(selectedAddress)) {
+      setIsReady(true);
+      setError(null);
+    } else {
+      setIsReady(false);
+      setError(null);
+    }
+  }
+
+  useEffect(() => {
+    if (!selectedAddress) {
       return undefined;
     }
 
     // Already initialized by a previous call
     if (streamManager.isInitialized(selectedAddress)) {
-      setIsReady(true);
-      setError(null);
       return undefined;
     }
 
     let cancelled = false;
-
-    setIsReady(false);
-    setError(null);
 
     // initForAddress deduplicates: multiple hooks sharing this singleton
     // only trigger a single perpsInit RPC + channel reset round-trip.

--- a/ui/hooks/perps/stream/usePerpsTopOfBook.ts
+++ b/ui/hooks/perps/stream/usePerpsTopOfBook.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { submitRequestToBackground } from '../../../store/background-connection';
 import type { PerpsStreamManager } from '../../../providers/perps';
 import { usePerpsChannel } from './usePerpsChannel';
@@ -75,9 +75,6 @@ export function usePerpsTopOfBook(
   options: UsePerpsTopOfBookOptions,
 ): UsePerpsTopOfBookReturn {
   const { symbol } = options;
-  const [topOfBook, setTopOfBook] = useState<TopOfBookData | undefined>(
-    undefined,
-  );
 
   const { data: orderBookData, isInitialLoading } = usePerpsChannel(
     getOrderBookChannel,
@@ -100,18 +97,16 @@ export function usePerpsTopOfBook(
     };
   }, [symbol]);
 
-  // Extract top of book from the orderBook channel data
-  useEffect(() => {
+  const topOfBook = useMemo(() => {
     if (!orderBookData) {
-      setTopOfBook(undefined);
-      return;
+      return undefined;
     }
 
     if (orderBookData.bids.length > 0 && orderBookData.asks.length > 0) {
       const topBid = orderBookData.bids[0];
       const topAsk = orderBookData.asks[0];
 
-      setTopOfBook({
+      return {
         bestBid: topBid.price,
         bestBidSize: topBid.size,
         bestAsk: topAsk.price,
@@ -119,10 +114,10 @@ export function usePerpsTopOfBook(
         spread: orderBookData.spread,
         spreadPercent: orderBookData.spreadPercentage,
         midPrice: orderBookData.midPrice,
-      });
-    } else {
-      setTopOfBook(undefined);
+      };
     }
+
+    return undefined;
   }, [orderBookData]);
 
   return {

--- a/ui/hooks/perps/usePerpsLiquidationPrice.ts
+++ b/ui/hooks/perps/usePerpsLiquidationPrice.ts
@@ -46,6 +46,13 @@ export const usePerpsLiquidationPrice = (
     DEFAULT_LIQUIDATION_PRICE,
   );
   const [isCalculating, setIsCalculating] = useState(false);
+  const calculationKey = `${asset}|${direction}|${entryPrice}|${leverage}|${hasValidInputs}|${debounceMs}`;
+  const [prevCalculationKey, setPrevCalculationKey] = useState(calculationKey);
+
+  if (calculationKey !== prevCalculationKey) {
+    setPrevCalculationKey(calculationKey);
+    setIsCalculating(hasValidInputs);
+  }
 
   const calculatePrice = useMemo(
     () =>
@@ -79,14 +86,11 @@ export const usePerpsLiquidationPrice = (
   );
 
   useEffect(() => {
-    if (hasValidInputs) {
-      setIsCalculating(true);
-    }
     calculatePrice();
     return () => {
       calculatePrice.cancel();
     };
-  }, [calculatePrice, hasValidInputs]);
+  }, [calculatePrice]);
 
   return {
     isCalculating: hasValidInputs && isCalculating,

--- a/ui/hooks/perps/usePerpsMarketFills.ts
+++ b/ui/hooks/perps/usePerpsMarketFills.ts
@@ -64,13 +64,13 @@ export function usePerpsMarketFills({
   if (fillsCacheKey !== prevFillsCacheKey) {
     setPrevFillsCacheKey(fillsCacheKey);
     const cached = peekWarmFills(fillsCacheKey);
-    if (cached !== undefined) {
+    if (cached === undefined) {
+      setRestFills([]);
+      setIsRestLoading(true);
+    } else {
       setRestFills(cached);
       setCurrentScopeKey(fillsCacheKey);
       setIsRestLoading(false);
-    } else {
-      setRestFills([]);
-      setIsRestLoading(true);
     }
   }
 

--- a/ui/hooks/perps/usePerpsMarketFills.ts
+++ b/ui/hooks/perps/usePerpsMarketFills.ts
@@ -59,19 +59,28 @@ export function usePerpsMarketFills({
   // behind fillsCacheKey, suppressing stale-env live fills until REST confirms
   // we're on the new scope.
   const [currentScopeKey, setCurrentScopeKey] = useState(fillsCacheKey);
+  const [prevFillsCacheKey, setPrevFillsCacheKey] = useState(fillsCacheKey);
 
-  useEffect(() => {
+  if (fillsCacheKey !== prevFillsCacheKey) {
+    setPrevFillsCacheKey(fillsCacheKey);
     const cached = peekWarmFills(fillsCacheKey);
     if (cached !== undefined) {
       setRestFills(cached);
       setCurrentScopeKey(fillsCacheKey);
       setIsRestLoading(false);
+    } else {
+      setRestFills([]);
+      setIsRestLoading(true);
+    }
+  }
+
+  useEffect(() => {
+    const cached = peekWarmFills(fillsCacheKey);
+    if (cached !== undefined) {
       return undefined;
     }
 
     let cancelled = false;
-    setRestFills([]);
-    setIsRestLoading(true);
 
     fetchFillsForCacheKey(fillsCacheKey)
       .then((result) => {

--- a/ui/hooks/perps/usePerpsMarketInfo.ts
+++ b/ui/hooks/perps/usePerpsMarketInfo.ts
@@ -36,16 +36,22 @@ export function usePerpsMarketInfo(symbol: string): MarketInfo | undefined {
   const [marketInfos, setMarketInfos] = useState<MarketInfo[]>(
     () => peekCachedMarketInfos(marketInfoCacheKey, useTerminalApi) ?? [],
   );
+  const marketInfoKey = `${marketInfoCacheKey}|${useTerminalApi}`;
+  const [prevMarketInfoKey, setPrevMarketInfoKey] = useState(marketInfoKey);
+
+  if (marketInfoKey !== prevMarketInfoKey) {
+    setPrevMarketInfoKey(marketInfoKey);
+    const cached = peekCachedMarketInfos(marketInfoCacheKey, useTerminalApi);
+    setMarketInfos(cached ?? []);
+  }
 
   useEffect(() => {
     const cached = peekCachedMarketInfos(marketInfoCacheKey, useTerminalApi);
     if (cached) {
-      setMarketInfos(cached);
       return undefined;
     }
 
     let cancelled = false;
-    setMarketInfos([]);
 
     fetchMarketInfos(marketInfoCacheKey, useTerminalApi).then((infos) => {
       if (!cancelled) {

--- a/ui/hooks/perps/usePerpsMaxSlippage.ts
+++ b/ui/hooks/perps/usePerpsMaxSlippage.ts
@@ -40,8 +40,12 @@ export function usePerpsMaxSlippage(): UsePerpsMaxSlippageReturn {
   }, []);
 
   useEffect(() => {
-    refresh().catch(() => {
-      setIsLoading(false);
+    // Defer so async helper setState paths are not treated as synchronous
+    // effect updates (react-hooks/set-state-in-effect).
+    queueMicrotask(() => {
+      refresh().catch(() => {
+        setIsLoading(false);
+      });
     });
   }, [refresh]);
 

--- a/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.test.ts
+++ b/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.test.ts
@@ -221,7 +221,7 @@ describe('usePerpsMetamaskFeeDiscountBips', () => {
     expect(result.current).toBe(2000);
   });
 
-  it('serves the cached discount synchronously on a fresh mount (no extra background call)', async () => {
+  it('serves the cached discount on a fresh mount after TTL check (no extra background call)', async () => {
     setDiscountResponse(3000);
 
     // First mount: populates the cache.
@@ -233,8 +233,8 @@ describe('usePerpsMetamaskFeeDiscountBips', () => {
     });
     first.unmount();
 
-    // Second mount with the same address: should hit the cache and not call
-    // the background again.
+    // Second mount with the same address: effect confirms TTL then reapplies
+    // the module cache without calling the background again.
     const second = renderHook(() =>
       usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
     );
@@ -247,6 +247,41 @@ describe('usePerpsMetamaskFeeDiscountBips', () => {
       (call) => call[0] === 'rewardsGetPerpsDiscountForAccount',
     );
     expect(discountCalls).toHaveLength(1);
+  });
+
+  it('does not apply an expired cached discount while the refresh is in flight', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    const start = 1_000_000;
+    nowSpy.mockReturnValue(start);
+    setDiscountResponse(3000);
+
+    const first = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await waitFor(() => {
+      expect(first.result.current).toBe(3000);
+    });
+    first.unmount();
+
+    // Past FEE_DISCOUNT_CACHE_TTL_MS (5 minutes). Remount with a hanging fetch.
+    nowSpy.mockReturnValue(start + 1000 * 60 * 5 + 1);
+    mockSubmitRequestToBackground.mockReturnValue(new Promise(() => undefined));
+
+    const second = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Expired entry must not be shown — stay undefined until refresh resolves.
+    expect(second.result.current).toBeUndefined();
+    const discountCalls = mockSubmitRequestToBackground.mock.calls.filter(
+      (call) => call[0] === 'rewardsGetPerpsDiscountForAccount',
+    );
+    expect(discountCalls).toHaveLength(2);
+
+    nowSpy.mockRestore();
   });
 
   it('refetches when the chain changes for the same address (cache is keyed by CAIP account id)', async () => {

--- a/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.ts
+++ b/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.ts
@@ -98,7 +98,10 @@ export function usePerpsMetamaskFeeDiscountBips(
     undefined,
   );
   const discountKey = `${isVipProgramEnabled}|${selectedAddress ?? ''}|${currentChainId}|${baseFeeBips}`;
-  const [prevDiscountKey, setPrevDiscountKey] = useState(discountKey);
+  // Unset so the first mount still runs the sync below (and can hit the cache).
+  const [prevDiscountKey, setPrevDiscountKey] = useState<string | undefined>(
+    undefined,
+  );
 
   if (discountKey !== prevDiscountKey) {
     setPrevDiscountKey(discountKey);
@@ -110,20 +113,13 @@ export function usePerpsMetamaskFeeDiscountBips(
         selectedAddress,
         currentChainId,
       );
-      if (!caipAccountId) {
-        setDiscountBips(undefined);
+      if (caipAccountId && feeDiscountCache?.caipAccountId === caipAccountId) {
+        // TTL is enforced in the effect (Date.now is impure in render).
+        setDiscountBips(feeDiscountCache.discountBips);
       } else {
-        const now = Date.now();
-        if (
-          feeDiscountCache?.caipAccountId === caipAccountId &&
-          now - feeDiscountCache.timestamp < FEE_DISCOUNT_CACHE_TTL_MS
-        ) {
-          setDiscountBips(feeDiscountCache.discountBips);
-        } else {
-          // Clear the previous account's discount immediately so downstream memos
-          // don't apply a stale discount while the new fetch is in flight.
-          setDiscountBips(undefined);
-        }
+        // Clear the previous account's discount immediately so downstream memos
+        // don't apply a stale discount while the new fetch is in flight.
+        setDiscountBips(undefined);
       }
     }
   }

--- a/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.ts
+++ b/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.ts
@@ -105,23 +105,7 @@ export function usePerpsMetamaskFeeDiscountBips(
 
   if (discountKey !== prevDiscountKey) {
     setPrevDiscountKey(discountKey);
-
-    if (!isVipProgramEnabled || !selectedAddress) {
-      setDiscountBips(undefined);
-    } else {
-      const caipAccountId = formatAccountToCaipAccountId(
-        selectedAddress,
-        currentChainId,
-      );
-      if (caipAccountId && feeDiscountCache?.caipAccountId === caipAccountId) {
-        // TTL is enforced in the effect (Date.now is impure in render).
-        setDiscountBips(feeDiscountCache.discountBips);
-      } else {
-        // Clear the previous account's discount immediately so downstream memos
-        // don't apply a stale discount while the new fetch is in flight.
-        setDiscountBips(undefined);
-      }
-    }
+    setDiscountBips(undefined);
   }
 
   useEffect(() => {
@@ -143,7 +127,15 @@ export function usePerpsMetamaskFeeDiscountBips(
       feeDiscountCache?.caipAccountId === caipAccountId &&
       now - feeDiscountCache.timestamp < FEE_DISCOUNT_CACHE_TTL_MS
     ) {
-      return undefined;
+      const cachedBips = feeDiscountCache.discountBips;
+      queueMicrotask(() => {
+        if (!cancelled) {
+          setDiscountBips(cachedBips);
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
     }
 
     submitRequestToBackground<number | null>(

--- a/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.ts
+++ b/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.ts
@@ -97,11 +97,40 @@ export function usePerpsMetamaskFeeDiscountBips(
   const [discountBips, setDiscountBips] = useState<number | undefined>(
     undefined,
   );
+  const discountKey = `${isVipProgramEnabled}|${selectedAddress ?? ''}|${currentChainId}|${baseFeeBips}`;
+  const [prevDiscountKey, setPrevDiscountKey] = useState(discountKey);
+
+  if (discountKey !== prevDiscountKey) {
+    setPrevDiscountKey(discountKey);
+
+    if (!isVipProgramEnabled || !selectedAddress) {
+      setDiscountBips(undefined);
+    } else {
+      const caipAccountId = formatAccountToCaipAccountId(
+        selectedAddress,
+        currentChainId,
+      );
+      if (!caipAccountId) {
+        setDiscountBips(undefined);
+      } else {
+        const now = Date.now();
+        if (
+          feeDiscountCache?.caipAccountId === caipAccountId &&
+          now - feeDiscountCache.timestamp < FEE_DISCOUNT_CACHE_TTL_MS
+        ) {
+          setDiscountBips(feeDiscountCache.discountBips);
+        } else {
+          // Clear the previous account's discount immediately so downstream memos
+          // don't apply a stale discount while the new fetch is in flight.
+          setDiscountBips(undefined);
+        }
+      }
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
     if (!isVipProgramEnabled || !selectedAddress) {
-      setDiscountBips(undefined);
       return undefined;
     }
 
@@ -110,7 +139,6 @@ export function usePerpsMetamaskFeeDiscountBips(
       currentChainId,
     );
     if (!caipAccountId) {
-      setDiscountBips(undefined);
       return undefined;
     }
 
@@ -119,13 +147,8 @@ export function usePerpsMetamaskFeeDiscountBips(
       feeDiscountCache?.caipAccountId === caipAccountId &&
       now - feeDiscountCache.timestamp < FEE_DISCOUNT_CACHE_TTL_MS
     ) {
-      setDiscountBips(feeDiscountCache.discountBips);
       return undefined;
     }
-
-    // Clear the previous account's discount immediately so downstream memos
-    // don't apply a stale discount while the new fetch is in flight.
-    setDiscountBips(undefined);
 
     submitRequestToBackground<number | null>(
       'rewardsGetPerpsDiscountForAccount',

--- a/ui/hooks/perps/usePerpsOrderFees.ts
+++ b/ui/hooks/perps/usePerpsOrderFees.ts
@@ -125,6 +125,14 @@ export function usePerpsOrderFees({
   const [hasError, setHasError] = useState(false);
 
   const requestIdRef = useRef(0);
+  const feeRequestKey = `${symbol}|${orderType}|${amount ?? ''}|${isMaker}`;
+  const [prevFeeRequestKey, setPrevFeeRequestKey] = useState(feeRequestKey);
+
+  if (feeRequestKey !== prevFeeRequestKey) {
+    setPrevFeeRequestKey(feeRequestKey);
+    setIsLoading(true);
+    setHasError(false);
+  }
 
   useEffect(() => {
     requestIdRef.current += 1;
@@ -136,9 +144,6 @@ export function usePerpsOrderFees({
         setIsLoading(false);
       }
     }, 1500);
-
-    setIsLoading(true);
-    setHasError(false);
 
     submitRequestToBackground<FeeCalculationResult>('perpsCalculateFees', [
       { orderType, isMaker, amount, symbol },

--- a/ui/hooks/perps/usePerpsOrderForm.ts
+++ b/ui/hooks/perps/usePerpsOrderForm.ts
@@ -306,141 +306,126 @@ export function usePerpsOrderForm({
   });
 
   // Update order type when prop changes (from dropdown)
-  useEffect(() => {
+  const [prevOrderType, setPrevOrderType] = useState(orderType);
+  if (orderType !== prevOrderType) {
+    setPrevOrderType(orderType);
     setFormState((prev) => ({ ...prev, type: orderType }));
-  }, [orderType]);
-
-  // Refs so the reset effect can read latest values without depending on them,
-  // preventing stream updates (new object refs) from wiping user edits.
-  const availableBalanceRef = useRef(availableBalance);
-  availableBalanceRef.current = availableBalance;
-  const existingPositionRef = useRef(existingPosition);
-  existingPositionRef.current = existingPosition;
-  const orderTypeRef = useRef(orderType);
-  orderTypeRef.current = orderType;
-  const initialAmountValueRef = useRef(initialAmountValue);
-  initialAmountValueRef.current = initialAmountValue;
-  const currentPriceRef = useRef(currentPrice);
-  currentPriceRef.current = currentPrice;
+  }
 
   // Track which deps trigger a full form reset. orderType changes should NOT
-  // reset amount/leverage—only the effect above updates formState.type.
-  // Ref starts null so the first effect run always applies. `existingPosition`
-  // uses undefined vs JSON digest so async hydration cannot collide with a size
-  // string like "none" the way a single concatenated key could.
-  const prevResetDepsRef = useRef<{
+  // reset amount/leverage—only the sync above updates formState.type.
+  // `existingPosition` uses undefined vs JSON digest so async hydration cannot
+  // collide with a size string like "none" the way a single concatenated key could.
+  const existingPositionDigest =
+    existingPosition === undefined
+      ? undefined
+      : JSON.stringify({
+          size: existingPosition.size,
+          entryPrice: existingPosition.entryPrice,
+          leverage: existingPosition.leverage,
+          takeProfitPrice: existingPosition.takeProfitPrice ?? null,
+          stopLossPrice: existingPosition.stopLossPrice ?? null,
+        });
+
+  const [prevResetDeps, setPrevResetDeps] = useState<{
     mode: OrderMode;
     asset: string;
     initialDirection: 'long' | 'short';
     existingPositionDigest: string | undefined;
     initialLeverage: number | undefined;
   } | null>(null);
-  useEffect(() => {
-    const existingPositionDigest =
-      existingPosition === undefined
-        ? undefined
-        : JSON.stringify({
-            size: existingPosition.size,
-            entryPrice: existingPosition.entryPrice,
-            leverage: existingPosition.leverage,
-            takeProfitPrice: existingPosition.takeProfitPrice ?? null,
-            stopLossPrice: existingPosition.stopLossPrice ?? null,
-          });
 
-    const prev = prevResetDepsRef.current;
-    if (
-      prev !== null &&
-      prev.mode === mode &&
-      prev.asset === asset &&
-      prev.initialDirection === initialDirection &&
-      prev.existingPositionDigest === existingPositionDigest &&
-      prev.initialLeverage === initialLeverage
-    ) {
-      return;
-    }
-
-    prevResetDepsRef.current = {
+  if (
+    prevResetDeps === null ||
+    prevResetDeps.mode !== mode ||
+    prevResetDeps.asset !== asset ||
+    prevResetDeps.initialDirection !== initialDirection ||
+    prevResetDeps.existingPositionDigest !== existingPositionDigest ||
+    prevResetDeps.initialLeverage !== initialLeverage
+  ) {
+    setPrevResetDeps({
       mode,
       asset,
       initialDirection,
       existingPositionDigest,
       initialLeverage,
-    };
+    });
 
-    const pos = existingPositionRef.current;
-    const typeForReset = orderTypeRef.current;
     const resetLeverage = initialLeverage ?? TRADING_DEFAULTS.leverage;
     const defaultAmountFields =
       mode === 'new'
         ? buildDefaultNewOrderAmountFields(
-            initialAmountValueRef.current,
+            initialAmountValue,
             resetLeverage,
-            availableBalanceRef.current,
+            availableBalance,
           )
         : {};
 
-    if (mode === 'modify' && pos) {
-      hasUserEditedAmount.current = false;
+    hasUserEditedAmount.current = false;
+    if (mode === 'modify' && existingPosition) {
       setFormState({
         ...mockOrderFormDefaults,
         asset,
         direction: initialDirection,
-        type: typeForReset,
-        ...deriveModifyFields(pos),
+        type: orderType,
+        ...deriveModifyFields(existingPosition),
       });
     } else {
-      hasUserEditedAmount.current = false;
       setFormState({
         ...mockOrderFormDefaults,
         asset,
         direction: initialDirection,
-        type: typeForReset,
+        type: orderType,
         ...(initialLeverage !== undefined && { leverage: initialLeverage }),
         ...defaultAmountFields,
       });
     }
-  }, [mode, asset, initialDirection, existingPosition, initialLeverage]);
+  }
 
   // Apply an external one-shot limit-price prefill (e.g. an order-book price
-  // tap). Declared after the reset effect so a mount-time prefill wins over the
+  // tap). Declared after the reset sync so a mount-time prefill wins over the
   // form reset. Keyed on the object reference so each selection re-applies,
   // while manual edits between selections are preserved.
-  useEffect(() => {
-    if (limitPricePrefill && limitPricePrefill.price) {
+  // `false` sentinel ensures the initial prefill is applied on first render.
+  const [prevLimitPricePrefill, setPrevLimitPricePrefill] = useState<
+    typeof limitPricePrefill | false
+  >(false);
+  if (limitPricePrefill !== prevLimitPricePrefill) {
+    setPrevLimitPricePrefill(limitPricePrefill);
+    if (limitPricePrefill?.price) {
       setFormState((prev) => ({
         ...prev,
         limitPrice: limitPricePrefill.price,
       }));
     }
-  }, [limitPricePrefill]);
+  }
 
-  useEffect(() => {
-    if (mode !== 'new' || hasUserEditedAmount.current) {
-      return;
-    }
+  const defaultAmountFieldsForBalance = buildDefaultNewOrderAmountFields(
+    computeInitialAmountValue(formState.leverage),
+    formState.leverage,
+    availableBalance,
+  );
+  const [prevDefaultAmountKey, setPrevDefaultAmountKey] = useState(
+    `${mode}|${formState.leverage}|${availableBalance}|${defaultAmountFieldsForBalance.amount}|${defaultAmountFieldsForBalance.balancePercent}`,
+  );
+  const defaultAmountKey = `${mode}|${formState.leverage}|${availableBalance}|${defaultAmountFieldsForBalance.amount}|${defaultAmountFieldsForBalance.balancePercent}`;
 
-    const defaultAmountFields = buildDefaultNewOrderAmountFields(
-      computeInitialAmountValue(formState.leverage),
-      formState.leverage,
-      availableBalance,
-    );
-    if (!defaultAmountFields.amount) {
-      return;
-    }
-
-    setFormState((prev) => {
-      if (
-        prev.amount === defaultAmountFields.amount &&
-        prev.balancePercent === defaultAmountFields.balancePercent
-      ) {
-        return prev;
-      }
-      return {
-        ...prev,
-        ...defaultAmountFields,
-      };
-    });
-  }, [mode, computeInitialAmountValue, formState.leverage, availableBalance]);
+  if (
+    defaultAmountKey !== prevDefaultAmountKey &&
+    mode === 'new' &&
+    !hasUserEditedAmount.current &&
+    defaultAmountFieldsForBalance.amount &&
+    (formState.amount !== defaultAmountFieldsForBalance.amount ||
+      formState.balancePercent !== defaultAmountFieldsForBalance.balancePercent)
+  ) {
+    setPrevDefaultAmountKey(defaultAmountKey);
+    setFormState((prev) => ({
+      ...prev,
+      ...defaultAmountFieldsForBalance,
+    }));
+  } else if (defaultAmountKey !== prevDefaultAmountKey) {
+    setPrevDefaultAmountKey(defaultAmountKey);
+  }
 
   // Notify parent of form state changes
   useEffect(() => {

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -174,9 +174,6 @@ export function usePerpsTransactionHistory({
     fetchGenerationRef.current += 1;
     const generation = fetchGenerationRef.current;
     try {
-      setIsLoading(true);
-      setError(null);
-
       const [fillsResult, ordersResult, funding] = await Promise.all([
         coalesceBackgroundRequest<OrderFill[]>(coalesceKeys.fills, () =>
           submitRequestToBackground<OrderFill[]>('perpsGetOrderFills', [
@@ -265,6 +262,8 @@ export function usePerpsTransactionHistory({
     // Pull-to-refresh must bypass the short-TTL coalesce cache. Drop the three
     // keys fetchAllTransactions consumes (refetchUserHistory invalidates its
     // own key internally).
+    setIsLoading(true);
+    setError(null);
     invalidateCoalescedRequest(coalesceKeys.fills);
     invalidateCoalescedRequest(coalesceKeys.orders);
     invalidateCoalescedRequest(coalesceKeys.funding);
@@ -272,6 +271,21 @@ export function usePerpsTransactionHistory({
     userHistoryRef.current = freshUserHistory;
     await fetchAllTransactions();
   }, [fetchAllTransactions, refetchUserHistory, coalesceKeys]);
+
+  const scopeFingerprint = `${perpsScopeKey}:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}:${forceFreshOnMount ? '1' : '0'}`;
+  const [prevScopeFingerprint, setPrevScopeFingerprint] = useState<
+    string | undefined
+  >(undefined);
+
+  if (
+    !skipInitialFetch &&
+    scopeFingerprint !== prevScopeFingerprint &&
+    lastFetchedScopeRef.current !== scopeFingerprint
+  ) {
+    setPrevScopeFingerprint(scopeFingerprint);
+    setIsLoading(true);
+    setError(null);
+  }
 
   useEffect(() => {
     if (skipInitialFetch) {
@@ -282,7 +296,6 @@ export function usePerpsTransactionHistory({
     // that stays mounted across a scope transition never renders the previous
     // session's transactions. The fingerprint gate keeps unrelated re-renders
     // from triggering redundant fetches.
-    const scopeFingerprint = `${perpsScopeKey}:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}:${forceFreshOnMount ? '1' : '0'}`;
     if (lastFetchedScopeRef.current === scopeFingerprint) {
       return;
     }
@@ -291,18 +304,19 @@ export function usePerpsTransactionHistory({
     // must force a fresh fetch so they never surface a stale snapshot held
     // by a sibling consumer inside the TTL window. Passive previews (e.g.
     // Recent Activity on the perps home) still share the cached snapshot.
-    if (forceFreshOnMount) {
-      refetch();
-    } else {
-      initialFetch();
-    }
+    // Defer so nested fetch helpers' synchronous loading resets are not in
+    // the effect body (react-hooks/set-state-in-effect).
+    queueMicrotask(() => {
+      if (forceFreshOnMount) {
+        refetch();
+      } else {
+        initialFetch();
+      }
+    });
   }, [
     skipInitialFetch,
     forceFreshOnMount,
-    perpsScopeKey,
-    accountId,
-    startTime,
-    endTime,
+    scopeFingerprint,
     initialFetch,
     refetch,
   ]);

--- a/ui/pages/perps/market-list/components/dropdown/dropdown.tsx
+++ b/ui/pages/perps/market-list/components/dropdown/dropdown.tsx
@@ -75,9 +75,17 @@ export const Dropdown = <OptionId extends string>({
   }, [isOpen]);
 
   // Focus the selected option when dropdown opens
-  useEffect(() => {
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  const [prevSelectedIndex, setPrevSelectedIndex] = useState(selectedIndex);
+  if (isOpen !== prevIsOpen || selectedIndex !== prevSelectedIndex) {
+    setPrevIsOpen(isOpen);
+    setPrevSelectedIndex(selectedIndex);
     if (isOpen && selectedIndex >= 0) {
       setFocusedIndex(selectedIndex);
+    }
+  }
+  useEffect(() => {
+    if (isOpen && selectedIndex >= 0) {
       optionRefs.current[selectedIndex]?.focus();
     }
   }, [isOpen, selectedIndex]);

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -445,9 +445,18 @@ const PerpsMarketDetailPage = () => {
   const [livePrice, setLivePrice] = useState<PriceUpdate | undefined>(
     undefined,
   );
+  const livePriceStreamKey =
+    decodedSymbol && selectedAddress
+      ? `${decodedSymbol}:${selectedAddress}`
+      : null;
+  const [prevLivePriceStreamKey, setPrevLivePriceStreamKey] =
+    useState(livePriceStreamKey);
+  if (livePriceStreamKey !== prevLivePriceStreamKey) {
+    setPrevLivePriceStreamKey(livePriceStreamKey);
+    setLivePrice(undefined);
+  }
   useEffect(() => {
     if (!decodedSymbol || !selectedAddress) {
-      setLivePrice(undefined);
       return undefined;
     }
 

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -734,9 +734,18 @@ const PerpsOrderEntryPage = () => {
   const [livePrice, setLivePrice] = useState<PriceUpdate | undefined>(
     undefined,
   );
+  const livePriceStreamKey =
+    decodedSymbol && selectedAddress
+      ? `${decodedSymbol}:${selectedAddress}`
+      : null;
+  const [prevLivePriceStreamKey, setPrevLivePriceStreamKey] =
+    useState(livePriceStreamKey);
+  if (livePriceStreamKey !== prevLivePriceStreamKey) {
+    setPrevLivePriceStreamKey(livePriceStreamKey);
+    setLivePrice(undefined);
+  }
   useEffect(() => {
     if (!decodedSymbol || !selectedAddress) {
-      setLivePrice(undefined);
       return undefined;
     }
     // Activate background price stream for this symbol
@@ -771,9 +780,18 @@ const PerpsOrderEntryPage = () => {
   const [topOfBook, setTopOfBook] = useState<{
     midPrice: number;
   } | null>(null);
+  const topOfBookStreamKey =
+    decodedSymbol && selectedAddress
+      ? `${decodedSymbol}:${selectedAddress}`
+      : null;
+  const [prevTopOfBookStreamKey, setPrevTopOfBookStreamKey] =
+    useState(topOfBookStreamKey);
+  if (topOfBookStreamKey !== prevTopOfBookStreamKey) {
+    setPrevTopOfBookStreamKey(topOfBookStreamKey);
+    setTopOfBook(null);
+  }
   useEffect(() => {
     if (!decodedSymbol || !selectedAddress) {
-      setTopOfBook(null);
       return undefined;
     }
     // Activate background orderBook stream for this symbol

--- a/ui/pages/perps/perps-withdraw-page.tsx
+++ b/ui/pages/perps/perps-withdraw-page.tsx
@@ -197,18 +197,13 @@ const PerpsWithdrawPage = () => {
   const estimatedMinutes =
     usdcRoute?.constraints?.estimatedMinutes ?? HYPERLIQUID_WITHDRAWAL_MINUTES;
 
-  const [prevRoutesErrorTranslator, setPrevRoutesErrorTranslator] = useState(t);
-  if (t !== prevRoutesErrorTranslator) {
-    setPrevRoutesErrorTranslator(t);
-    setRoutesError(null);
-  }
-
   useEffect(() => {
     let cancelled = false;
 
     submitRequestToBackground<AssetRoute[]>('perpsGetWithdrawalRoutes', [])
       .then((routes) => {
         if (!cancelled) {
+          setRoutesError(null);
           setWithdrawalRoutes(Array.isArray(routes) ? routes : []);
         }
       })

--- a/ui/pages/perps/perps-withdraw-page.tsx
+++ b/ui/pages/perps/perps-withdraw-page.tsx
@@ -197,9 +197,14 @@ const PerpsWithdrawPage = () => {
   const estimatedMinutes =
     usdcRoute?.constraints?.estimatedMinutes ?? HYPERLIQUID_WITHDRAWAL_MINUTES;
 
+  const [prevRoutesErrorTranslator, setPrevRoutesErrorTranslator] = useState(t);
+  if (t !== prevRoutesErrorTranslator) {
+    setPrevRoutesErrorTranslator(t);
+    setRoutesError(null);
+  }
+
   useEffect(() => {
     let cancelled = false;
-    setRoutesError(null);
 
     submitRequestToBackground<AssetRoute[]>('perpsGetWithdrawalRoutes', [])
       .then((routes) => {

--- a/ui/providers/perps/PerpsAttributionContext.tsx
+++ b/ui/providers/perps/PerpsAttributionContext.tsx
@@ -325,11 +325,48 @@ export function PerpsAttributionProvider({
     }
   }, []);
 
-  useEffect(() => {
+  const [prevLocationSearch, setPrevLocationSearch] = useState(locationSearch);
+
+  // Sync React state from locationSearch during render; session/background
+  // persistence stays in the effect below (and in the public sync helper).
+  if (locationSearch !== prevLocationSearch) {
+    setPrevLocationSearch(locationSearch);
     if (locationSearch) {
-      syncUtmAttributionFromSearch(locationSearch);
+      const utmContext = parseUtmAttribution(locationSearch);
+      if (utmContext) {
+        setUtmAttribution((prev) => ({ ...prev, ...utmContext }));
+      }
+
+      const source = new URLSearchParams(locationSearch).get('source');
+      if (source === 'deeplink') {
+        setIsDeeplinkEntry(true);
+      }
+      const nextFlowAttribution =
+        computeFlowAttributionFromSearch(locationSearch);
+      if (nextFlowAttribution.discoverySource) {
+        setFlowAttributionState((prev) => ({
+          ...prev,
+          ...nextFlowAttribution,
+        }));
+      }
     }
-  }, [locationSearch, syncUtmAttributionFromSearch]);
+  }
+
+  useEffect(() => {
+    if (!locationSearch) {
+      return;
+    }
+
+    const utmContext = parseUtmAttribution(locationSearch);
+    if (!utmContext) {
+      return;
+    }
+
+    const mergedSessionUtm = rememberSessionUtm(utmContext);
+    submitRequestToBackground('perpsSetAttributionContext', [
+      mergedSessionUtm,
+    ]).catch(captureException);
+  }, [locationSearch]);
 
   // A fresh UI session that carries no UTM anywhere must not inherit the
   // previous session's campaign from the background singleton: replace the

--- a/ui/providers/perps/PerpsControllerProvider.mock.tsx
+++ b/ui/providers/perps/PerpsControllerProvider.mock.tsx
@@ -70,9 +70,9 @@ export function PerpsControllerProvider({
 
   if (providedController !== prevProvidedController) {
     setPrevProvidedController(providedController);
-    if (providedController) {
-      setController(providedController);
-    }
+    // Clear when the prop is removed so children do not keep a stale instance
+    // while async init (or the loading fallback) takes over.
+    setController(providedController ?? null);
   }
 
   const selectedAccount = useSelector(getSelectedInternalAccount);

--- a/ui/providers/perps/PerpsControllerProvider.mock.tsx
+++ b/ui/providers/perps/PerpsControllerProvider.mock.tsx
@@ -65,6 +65,15 @@ export function PerpsControllerProvider({
     providedController ?? null,
   );
   const [error, setError] = useState<Error | null>(null);
+  const [prevProvidedController, setPrevProvidedController] =
+    useState(providedController);
+
+  if (providedController !== prevProvidedController) {
+    setPrevProvidedController(providedController);
+    if (providedController) {
+      setController(providedController);
+    }
+  }
 
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
@@ -72,7 +81,6 @@ export function PerpsControllerProvider({
   useEffect(() => {
     // If a controller was provided, skip initialization
     if (providedController) {
-      setController(providedController);
       return;
     }
 


### PR DESCRIPTION
## **Description**

Part of [MetaMask-planning#6402](https://github.com/MetaMask/MetaMask-planning/issues/6402) subtask 1: clear `react-hooks/set-state-in-effect` warnings.

**What this cleanup does:** React warns when `setState` runs synchronously inside a `useEffect`, because that forces an extra render pass ([You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)). These changes replace prop→state syncing in effects with render-time updates or derived values, and keep effects for real external sync only.

**Scope:** perps UI (`ui/hooks/perps`, `ui/pages/perps`, `ui/components/app/perps`, `ui/providers/perps`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of: MetaMask/MetaMask-planning#6402

## **Manual testing steps**

1. Open Perps market list / order entry / withdraw flows.
2. Change market, amount, leverage, and TP/SL where applicable.
3. Confirm UI still updates correctly (no stuck loading / stale form values).

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide touch on trading flows, live streams, and fee/discount caching; order-book subscription identity and fee-discount timing changed, though patterns are mostly mechanical with targeted test updates.
> 
> **Overview**
> **Removes synchronous `setState` inside `useEffect`** across perps modals, pages, hooks, and providers to satisfy `react-hooks/set-state-in-effect`, following React’s “you might not need an effect” guidance.
> 
> **Prop and scope changes** now reset or sync local state during render via a `prev*` key pattern (e.g. modal `isOpen`, market/asset switches, fee and fill cache keys, stream subscription keys). **Derived values** move to `useMemo` where appropriate (e.g. top of book). **Async-only paths** use `queueMicrotask` for cache hits and initial fetches so effects don’t synchronously update state.
> 
> **Notable behavior tweaks:** aggregated order-book subscriptions **reuse ids per activation key** (StrictMode-safe) while still allocating in `useLayoutEffect`; VIP fee discount **clears on account/key change during render** and **does not show expired cache** while refresh is in flight (new test); slippage modal **seeds custom mode from props** on first paint; transaction history sets loading on scope change during render and defers the actual fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1021027c4dc4d8f3ff502f802a9624f136572a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->