### PR TITLE
perf(6402): clear set-state-in-effect in web3auth and engagement

### DIFF
--- a/ui/contexts/claims/claims.tsx
+++ b/ui/contexts/claims/claims.tsx
@@ -39,55 +39,61 @@ export const ClaimsProvider = ({ children }: ClaimsProviderProps) => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  const fetchClaims = useCallback(
-    async (isCancelled: () => boolean = () => false) => {
-      try {
-        if (isCancelled()) {
-          return;
-        }
-        setIsLoading(true);
-        setError(null);
-        const claimsData = await getShieldClaims();
-        if (isCancelled()) {
-          return;
-        }
-        const sortedClaims = claimsData
-          .sort((a: Claim, b: Claim) => {
-            const dateA = new Date(a.createdAt).getTime();
-            const dateB = new Date(b.createdAt).getTime();
-            return dateB - dateA;
-          })
-          .map((claim: Claim) => {
-            const numberChain = Number(claim.chainId);
-            const chainId = isNaN(numberChain) ? '' : numberToHex(numberChain);
-            return {
-              ...claim,
-              chainId,
-            };
-          });
-        setClaims(sortedClaims);
-      } catch (err) {
-        if (!isCancelled()) {
-          setError(err as Error);
-        }
-      } finally {
-        if (!isCancelled()) {
-          setIsLoading(false);
-        }
-      }
-    },
-    [],
-  );
+  const sortAndNormalizeClaims = useCallback((claimsData: Claim[]) => {
+    return claimsData
+      .sort((a: Claim, b: Claim) => {
+        const dateA = new Date(a.createdAt).getTime();
+        const dateB = new Date(b.createdAt).getTime();
+        return dateB - dateA;
+      })
+      .map((claim: Claim) => {
+        const numberChain = Number(claim.chainId);
+        const chainId = isNaN(numberChain) ? '' : numberToHex(numberChain);
+        return {
+          ...claim,
+          chainId,
+        };
+      });
+  }, []);
+
+  const fetchClaims = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const claimsData = await getShieldClaims();
+      setClaims(sortAndNormalizeClaims(claimsData));
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [sortAndNormalizeClaims]);
 
   useEffect(() => {
     let cancelled = false;
 
-    fetchClaims(() => cancelled);
+    // isLoading starts true; only update state in async callbacks.
+    getShieldClaims()
+      .then((claimsData) => {
+        if (!cancelled) {
+          setClaims(sortAndNormalizeClaims(claimsData));
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err as Error);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
 
     return () => {
       cancelled = true;
     };
-  }, [fetchClaims]);
+  }, [sortAndNormalizeClaims]);
 
   const pendingClaims = useMemo(() => {
     return claims.filter((claim) =>

--- a/ui/hooks/shield/useClaimState.ts
+++ b/ui/hooks/shield/useClaimState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Attachment as ClaimAttachment } from '@metamask/claims-controller';
 import { useClaims } from '../../contexts/claims/claims';
@@ -9,113 +9,151 @@ import {
 } from '../../pages/shield/transaction-shield/types';
 import { useClaimDraft } from './useClaimDraft';
 
+type ClaimFormFields = {
+  chainId: string;
+  email: string;
+  impactedWalletAddress: string;
+  impactedTransactionHash: string;
+  reimbursementWalletAddress: string;
+  caseDescription: string;
+  uploadedFiles: ClaimAttachment[];
+  currentDraftId: string | undefined;
+};
+
+const EMPTY_FORM: ClaimFormFields = {
+  chainId: '',
+  email: '',
+  impactedWalletAddress: '',
+  impactedTransactionHash: '',
+  reimbursementWalletAddress: '',
+  caseDescription: '',
+  uploadedFiles: [],
+  currentDraftId: undefined,
+};
+
 export const useClaimState = (mode: ClaimsFormMode = CLAIMS_FORM_MODES.NEW) => {
   const { pathname } = useLocation();
   const { claims } = useClaims();
   const { getDraft } = useClaimDraft();
-  const [chainId, setChainId] = useState<string>('');
-  const [email, setEmail] = useState<string>('');
-  const [impactedWalletAddress, setImpactedWalletAddress] =
-    useState<string>('');
-  const [impactedTransactionHash, setImpactedTransactionHash] =
-    useState<string>('');
-  const [reimbursementWalletAddress, setReimbursementWalletAddress] =
-    useState<string>('');
-  const [caseDescription, setCaseDescription] = useState<string>('');
   const [files, setFiles] = useState<FileList>();
-  const [uploadedFiles, setUploadedFiles] = useState<ClaimAttachment[]>([]);
   const [claimSignature, setClaimSignature] = useState<string>('');
-  const [currentDraftId, setCurrentDraftId] = useState<string | undefined>();
 
   const isView = mode === CLAIMS_FORM_MODES.VIEW;
   const isEditDraft = mode === CLAIMS_FORM_MODES.EDIT_DRAFT;
   const claimOrDraftId = pathname.split('/').pop();
 
-  // Track which draft ID was loaded to prevent re-running on autosave
-  const loadedDraftIdRef = useRef<string | null>(null);
+  let sourceKey = 'new';
+  if (isView) {
+    sourceKey = `view:${claimOrDraftId ?? ''}`;
+  } else if (isEditDraft) {
+    sourceKey = `draft:${claimOrDraftId ?? ''}`;
+  }
+
+  const derivedForm = useMemo((): ClaimFormFields => {
+    if (isView && claimOrDraftId) {
+      const claimDetails = claims.find((claim) => claim.id === claimOrDraftId);
+      if (claimDetails) {
+        return {
+          chainId: claimDetails.chainId,
+          email: claimDetails.email,
+          impactedWalletAddress: claimDetails.impactedWalletAddress,
+          impactedTransactionHash: claimDetails.impactedTxHash,
+          reimbursementWalletAddress: claimDetails.reimbursementWalletAddress,
+          caseDescription: claimDetails.description,
+          uploadedFiles: claimDetails.attachments || [],
+          currentDraftId: undefined,
+        };
+      }
+    }
+    if (isEditDraft && claimOrDraftId) {
+      const draftDetails = getDraft(claimOrDraftId);
+      if (draftDetails) {
+        return {
+          chainId: draftDetails.chainId || '',
+          email: draftDetails.email || '',
+          impactedWalletAddress: draftDetails.impactedWalletAddress || '',
+          impactedTransactionHash: draftDetails.impactedTxHash || '',
+          reimbursementWalletAddress:
+            draftDetails.reimbursementWalletAddress || '',
+          caseDescription: draftDetails.description || '',
+          uploadedFiles: [],
+          currentDraftId: draftDetails.draftId,
+        };
+      }
+    }
+    return EMPTY_FORM;
+  }, [claimOrDraftId, claims, getDraft, isEditDraft, isView]);
+
+  // Local edits are keyed by sourceKey so switching claim/draft drops them
+  // without render-phase setState.
+  const [formState, setFormState] = useState<{
+    key: string;
+    fields: ClaimFormFields;
+    dirty: boolean;
+  }>({ key: sourceKey, fields: derivedForm, dirty: false });
+
+  const fields =
+    formState.key === sourceKey && formState.dirty
+      ? formState.fields
+      : derivedForm;
+
+  const updateField = useCallback(
+    <FieldKey extends keyof ClaimFormFields>(
+      fieldKey: FieldKey,
+      value: ClaimFormFields[FieldKey],
+    ) => {
+      setFormState((prev) => {
+        const base =
+          prev.key === sourceKey && prev.dirty ? prev.fields : derivedForm;
+        return {
+          key: sourceKey,
+          dirty: true,
+          fields: { ...base, [fieldKey]: value },
+        };
+      });
+    },
+    [derivedForm, sourceKey],
+  );
 
   useEffect(() => {
-    if (isView || !chainId || !impactedWalletAddress) {
+    if (isView || !fields.chainId || !fields.impactedWalletAddress) {
       return;
     }
 
     (async () => {
       const signature = await generateClaimSignature(
-        chainId,
-        impactedWalletAddress,
+        fields.chainId,
+        fields.impactedWalletAddress,
       );
       setClaimSignature(signature);
     })();
-  }, [isView, chainId, impactedWalletAddress]);
-
-  // Load claim data for view mode
-  useEffect(() => {
-    if (isView && claimOrDraftId) {
-      const claimDetails = claims.find((claim) => claim.id === claimOrDraftId);
-      if (claimDetails) {
-        setEmail(claimDetails.email);
-        setChainId(claimDetails.chainId);
-        setImpactedWalletAddress(claimDetails.impactedWalletAddress);
-        setImpactedTransactionHash(claimDetails.impactedTxHash);
-        setReimbursementWalletAddress(claimDetails.reimbursementWalletAddress);
-        setCaseDescription(claimDetails.description);
-        setUploadedFiles(claimDetails.attachments || []);
-      }
-    }
-  }, [isView, claimOrDraftId, claims]);
-
-  // Load draft data for edit-draft mode
-  useEffect(() => {
-    // Skip if this specific draft was already loaded (prevents autosave from overwriting form state)
-    // but allow loading when navigating to a different draft
-    if (loadedDraftIdRef.current === claimOrDraftId) {
-      return;
-    }
-
-    if (isEditDraft && claimOrDraftId) {
-      const draftDetails = getDraft(claimOrDraftId);
-      if (draftDetails) {
-        loadedDraftIdRef.current = claimOrDraftId;
-        setCurrentDraftId(draftDetails.draftId);
-        setEmail(draftDetails.email || '');
-        setChainId(draftDetails.chainId || '');
-        setImpactedWalletAddress(draftDetails.impactedWalletAddress || '');
-        setImpactedTransactionHash(draftDetails.impactedTxHash || '');
-        setReimbursementWalletAddress(
-          draftDetails.reimbursementWalletAddress || '',
-        );
-        setCaseDescription(draftDetails.description || '');
-      }
-    }
-  }, [isEditDraft, claimOrDraftId, getDraft]);
+  }, [isView, fields.chainId, fields.impactedWalletAddress]);
 
   return {
-    chainId,
-    setChainId,
-    email,
-    setEmail,
-    impactedWalletAddress,
-    setImpactedWalletAddress,
-    impactedTransactionHash,
-    setImpactedTransactionHash,
-    reimbursementWalletAddress,
-    setReimbursementWalletAddress,
-    caseDescription,
-    setCaseDescription,
+    chainId: fields.chainId,
+    setChainId: (value: string) => updateField('chainId', value),
+    email: fields.email,
+    setEmail: (value: string) => updateField('email', value),
+    impactedWalletAddress: fields.impactedWalletAddress,
+    setImpactedWalletAddress: (value: string) =>
+      updateField('impactedWalletAddress', value),
+    impactedTransactionHash: fields.impactedTransactionHash,
+    setImpactedTransactionHash: (value: string) =>
+      updateField('impactedTransactionHash', value),
+    reimbursementWalletAddress: fields.reimbursementWalletAddress,
+    setReimbursementWalletAddress: (value: string) =>
+      updateField('reimbursementWalletAddress', value),
+    caseDescription: fields.caseDescription,
+    setCaseDescription: (value: string) =>
+      updateField('caseDescription', value),
     files,
     setFiles,
-    uploadedFiles,
+    uploadedFiles: fields.uploadedFiles,
     claimSignature,
-    currentDraftId,
+    currentDraftId: fields.currentDraftId,
     clear: () => {
-      setChainId('');
-      setEmail('');
-      setImpactedWalletAddress('');
-      setImpactedTransactionHash('');
-      setReimbursementWalletAddress('');
-      setCaseDescription('');
+      setFormState({ key: sourceKey, fields: EMPTY_FORM, dirty: true });
       setFiles(undefined);
-      setCurrentDraftId(undefined);
     },
   };
 };

--- a/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
@@ -175,24 +175,18 @@ export const ExternalLinkButton = (props: {
 
   useEffect(() => {
     if (!externalLinkUrl) {
-      resolvedHrefRef.current = undefined;
-      pendingResolvedHrefRef.current = undefined;
-      setResolvedHref(undefined);
-      return;
+      return undefined;
     }
 
     let isMounted = true;
     const sourceUrl = externalLinkUrl;
 
+    if (pendingResolvedHrefRef.current?.sourceUrl !== sourceUrl) {
+      pendingResolvedHrefRef.current = undefined;
+    }
     if (resolvedHrefRef.current?.sourceUrl !== sourceUrl) {
       resolvedHrefRef.current = undefined;
     }
-
-    setResolvedHref((currentResolvedHref) =>
-      currentResolvedHref?.sourceUrl === sourceUrl
-        ? currentResolvedHref
-        : undefined,
-    );
 
     const pendingResolvedHref = resolveHref();
     pendingResolvedHref

--- a/ui/pages/onboarding-flow/import-srp/import-srp.tsx
+++ b/ui/pages/onboarding-flow/import-srp/import-srp.tsx
@@ -98,9 +98,10 @@ export default function ImportSRP({
     submitSecretRecoveryPhrase,
   ]);
 
-  useEffect(() => {
+  const handleSecretRecoveryPhraseChange = useCallback((phrase: string) => {
+    setSecretRecoveryPhrase(phrase);
     setSrpError('');
-  }, [secretRecoveryPhrase]);
+  }, []);
 
   return (
     <Box
@@ -126,7 +127,7 @@ export default function ImportSRP({
         </Box>
         <SrpInputForm
           error={srpError}
-          setSecretRecoveryPhrase={setSecretRecoveryPhrase}
+          setSecretRecoveryPhrase={handleSecretRecoveryPhraseChange}
           onClearCallback={() => setSrpError('')}
         />
       </Box>

--- a/ui/pages/onboarding-flow/metametrics/metametrics.test.tsx
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.test.tsx
@@ -68,6 +68,18 @@ describe('Onboarding Metametrics Component', () => {
     },
   };
 
+  async function clickElement(element: HTMLElement) {
+    await act(async () => {
+      fireEvent.click(element);
+    });
+  }
+
+  async function keyDownElement(element: HTMLElement, key: string) {
+    await act(async () => {
+      fireEvent.keyDown(element, { key });
+    });
+  }
+
   beforeEach(() => {
     store = configureStore(mockState);
   });
@@ -114,7 +126,7 @@ describe('Onboarding Metametrics Component', () => {
 
     const continueButton = getByTestId('metametrics-i-agree');
 
-    fireEvent.click(continueButton);
+    await clickElement(continueButton);
 
     await waitFor(() => {
       expect(mockUseNavigate).toHaveBeenCalledWith(
@@ -153,9 +165,7 @@ describe('Onboarding Metametrics Component', () => {
     expect(checkbox).toBeChecked();
     expect(checkbox).toBeInTheDocument();
 
-    act(() => {
-      fireEvent.click(participateContainer);
-    });
+    await clickElement(participateContainer);
 
     await waitFor(() => {
       expect(checkbox).not.toBeChecked();
@@ -163,7 +173,7 @@ describe('Onboarding Metametrics Component', () => {
 
     const continueButton = getByTestId('metametrics-i-agree');
 
-    fireEvent.click(continueButton);
+    await clickElement(continueButton);
 
     await waitFor(() => {
       expect(setParticipateInMetaMetrics).toHaveBeenCalledWith(false);
@@ -195,12 +205,10 @@ describe('Onboarding Metametrics Component', () => {
     ) as HTMLElement;
 
     // Opt out of MetaMetrics; this should clear marketing consent
-    act(() => {
-      fireEvent.click(participateContainer);
-    });
+    await clickElement(participateContainer);
 
     const continueButton = getByTestId('metametrics-i-agree');
-    fireEvent.click(continueButton);
+    await clickElement(continueButton);
 
     await waitFor(() => {
       expect(setDataCollectionForMarketing).toHaveBeenCalledWith(false);
@@ -237,17 +245,13 @@ describe('Onboarding Metametrics Component', () => {
 
     expect(marketingCheckbox).not.toBeChecked();
 
-    act(() => {
-      fireEvent.click(marketingContainer);
-    });
+    await clickElement(marketingContainer);
 
     await waitFor(() => {
       expect(marketingCheckbox).toBeChecked();
     });
 
-    act(() => {
-      fireEvent.click(participateContainer);
-    });
+    await clickElement(participateContainer);
 
     await waitFor(() => {
       expect(marketingCheckbox).not.toBeChecked();
@@ -267,12 +271,12 @@ describe('Onboarding Metametrics Component', () => {
 
     expect(checkbox).toBeChecked();
 
-    fireEvent.click(participateCheckboxContainer);
+    await clickElement(participateCheckboxContainer);
     await waitFor(() => {
       expect(checkbox).not.toBeChecked();
     });
 
-    fireEvent.click(participateCheckboxContainer);
+    await clickElement(participateCheckboxContainer);
     await waitFor(() => {
       expect(checkbox).toBeChecked();
     });
@@ -291,12 +295,12 @@ describe('Onboarding Metametrics Component', () => {
 
     expect(checkbox).toBeChecked();
 
-    fireEvent.keyDown(participateCheckboxContainer, { key: ' ' });
+    await keyDownElement(participateCheckboxContainer, ' ');
     await waitFor(() => {
       expect(checkbox).not.toBeChecked();
     });
 
-    fireEvent.keyDown(participateCheckboxContainer, { key: ' ' });
+    await keyDownElement(participateCheckboxContainer, ' ');
     await waitFor(() => {
       expect(checkbox).toBeChecked();
     });
@@ -315,7 +319,7 @@ describe('Onboarding Metametrics Component', () => {
 
     expect(checkbox).toBeChecked();
 
-    fireEvent.keyDown(participateCheckboxContainer, { key: 'Enter' });
+    await keyDownElement(participateCheckboxContainer, 'Enter');
     await waitFor(() => {
       expect(checkbox).not.toBeChecked();
     });
@@ -396,12 +400,12 @@ describe('Onboarding Metametrics Component', () => {
 
     expect(marketingCheckbox).not.toBeChecked();
 
-    fireEvent.click(marketingCheckboxContainer);
+    await clickElement(marketingCheckboxContainer);
     await waitFor(() => {
       expect(marketingCheckbox).toBeChecked();
     });
 
-    fireEvent.click(marketingCheckboxContainer);
+    await clickElement(marketingCheckboxContainer);
     await waitFor(() => {
       expect(marketingCheckbox).not.toBeChecked();
     });
@@ -420,7 +424,7 @@ describe('Onboarding Metametrics Component', () => {
 
     expect(marketingCheckbox).not.toBeChecked();
 
-    fireEvent.keyDown(marketingCheckboxContainer, { key: ' ' });
+    await keyDownElement(marketingCheckboxContainer, ' ');
     await waitFor(() => {
       expect(marketingCheckbox).toBeChecked();
     });
@@ -439,7 +443,7 @@ describe('Onboarding Metametrics Component', () => {
 
     expect(marketingCheckbox).not.toBeChecked();
 
-    fireEvent.keyDown(marketingCheckboxContainer, { key: 'Enter' });
+    await keyDownElement(marketingCheckboxContainer, 'Enter');
     await waitFor(() => {
       expect(marketingCheckbox).toBeChecked();
     });

--- a/ui/pages/onboarding-flow/metametrics/metametrics.tsx
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import log from 'loglevel';
@@ -51,7 +51,6 @@ type MetametricsCheckboxOptionProps = Readonly<{
   isSelected: boolean;
   isDisabled?: boolean;
   onChange: () => void;
-  checkboxRef: React.RefObject<{ toggle: () => void }>;
   label: React.ReactNode;
   description: React.ReactNode;
   containerClassName: string;
@@ -69,12 +68,17 @@ function MetametricsCheckboxOption({
   isSelected,
   isDisabled,
   onChange,
-  checkboxRef,
   label,
   description,
   containerClassName,
   isInteractive = true,
 }: Readonly<MetametricsCheckboxOptionProps>) {
+  const handleContainerActivate = () => {
+    if (isInteractive) {
+      onChange();
+    }
+  };
+
   return (
     <Box
       flexDirection={BoxFlexDirection.Column}
@@ -86,11 +90,11 @@ function MetametricsCheckboxOption({
       data-checked={String(isSelected)}
       role={isInteractive ? 'button' : undefined}
       tabIndex={isInteractive ? 0 : undefined}
-      onClick={isInteractive ? () => checkboxRef.current?.toggle() : undefined}
+      onClick={isInteractive ? handleContainerActivate : undefined}
       onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
         if ((e.key === ' ' || e.key === 'Enter') && isInteractive) {
           e.preventDefault();
-          checkboxRef.current?.toggle();
+          handleContainerActivate();
         }
       }}
     >
@@ -99,7 +103,6 @@ function MetametricsCheckboxOption({
         isSelected={isSelected}
         isDisabled={isDisabled}
         onChange={onChange}
-        ref={checkboxRef}
         onClick={stopClickPropagation}
         inputProps={{ onClick: stopClickPropagation }}
         label={label}
@@ -128,26 +131,29 @@ export default function OnboardingMetametrics() {
   );
   const isOptedIn = useSelector(getOptedIn);
   const dataCollectionForMarketing = useSelector(getDataCollectionForMarketing);
-  const [
-    isParticipateInMetaMetricsChecked,
-    setIsParticipateInMetaMetricsChecked,
-  ] = useState(true);
-  const [
-    isDataCollectionForMarketingChecked,
-    setIsDataCollectionForMarketingChecked,
-  ] = useState(false);
 
-  const participateCheckboxRef = useRef<{ toggle: () => void } | null>(null);
-  const marketingCheckboxRef = useRef<{ toggle: () => void } | null>(null);
+  const [checkboxDraft, setCheckboxDraft] = useState({
+    participateTouched: false,
+    marketingTouched: false,
+    participateLocal: true,
+    marketingLocal: false,
+  });
+  const {
+    participateTouched,
+    marketingTouched,
+    participateLocal,
+    marketingLocal,
+  } = checkboxDraft;
 
-  useEffect(() => {
-    if (completedMetaMetricsOnboarding) {
-      setIsParticipateInMetaMetricsChecked(isOptedIn);
-    }
-    if (dataCollectionForMarketing) {
-      setIsDataCollectionForMarketingChecked(dataCollectionForMarketing);
-    }
-  }, [completedMetaMetricsOnboarding, isOptedIn, dataCollectionForMarketing]);
+  let isParticipateInMetaMetricsChecked = true;
+  if (participateTouched) {
+    isParticipateInMetaMetricsChecked = participateLocal;
+  } else if (completedMetaMetricsOnboarding) {
+    isParticipateInMetaMetricsChecked = isOptedIn;
+  }
+  const isDataCollectionForMarketingChecked = marketingTouched
+    ? marketingLocal
+    : Boolean(dataCollectionForMarketing);
 
   const currentKeyring = useSelector(getCurrentKeyring);
 
@@ -214,13 +220,21 @@ export default function OnboardingMetametrics() {
   };
 
   const handleParticipateInMetaMetricsChange = () => {
-    setIsParticipateInMetaMetricsChecked((prev) => {
-      const next = !prev;
-      if (!next) {
-        setIsDataCollectionForMarketingChecked(false);
-      }
-      return next;
-    });
+    const next = !isParticipateInMetaMetricsChecked;
+    setCheckboxDraft((prev) => ({
+      ...prev,
+      participateTouched: true,
+      participateLocal: next,
+      ...(next ? {} : { marketingTouched: true, marketingLocal: false }),
+    }));
+  };
+
+  const handleMarketingChange = () => {
+    setCheckboxDraft((prev) => ({
+      ...prev,
+      marketingTouched: true,
+      marketingLocal: !isDataCollectionForMarketingChecked,
+    }));
   };
 
   return (
@@ -262,7 +276,6 @@ export default function OnboardingMetametrics() {
         testId="metametrics-checkbox"
         isSelected={isParticipateInMetaMetricsChecked}
         onChange={handleParticipateInMetaMetricsChange}
-        checkboxRef={participateCheckboxRef}
         containerClassName="onboarding-metametrics__checkbox"
         label={
           <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
@@ -280,10 +293,7 @@ export default function OnboardingMetametrics() {
           isDataCollectionForMarketingChecked
         }
         isDisabled={!isParticipateInMetaMetricsChecked}
-        onChange={() => {
-          setIsDataCollectionForMarketingChecked((prev) => !prev);
-        }}
-        checkboxRef={marketingCheckboxRef}
+        onChange={handleMarketingChange}
         containerClassName={
           isParticipateInMetaMetricsChecked
             ? 'onboarding-metametrics__checkbox'

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.tsx
@@ -66,12 +66,9 @@ export default function RecoveryPhraseChips({
     () => quizWords.map((word) => word.index),
     [quizWords],
   );
-  const [quizAnswers, setQuizAnswers] = useState(
-    indicesToCheck.map((index) => ({
-      index, // the index in the SRP chips UI where the answer is inserted
-      word: '', // the answer value
-      actualIndexInSrp: -1, // the correct index of the answer value in the secret recovery phrase
-    })),
+  const quizWordsKey = useMemo(
+    () => indicesToCheck.join('|'),
+    [indicesToCheck],
   );
 
   const setNextTargetIndex = (
@@ -90,8 +87,64 @@ export default function RecoveryPhraseChips({
 
     return firstEmpty;
   };
-  const [indexToFocus, setIndexToFocus] = useState(
-    setNextTargetIndex(quizAnswers),
+
+  const emptyQuizAnswers = useMemo(
+    () =>
+      indicesToCheck.map((index) => ({
+        index, // the index in the SRP chips UI where the answer is inserted
+        word: '', // the answer value
+        actualIndexInSrp: -1, // the correct index of the answer value in the secret recovery phrase
+      })),
+    [indicesToCheck],
+  );
+
+  // Key quiz UI state by quizWords identity so a new quiz resets without
+  // render-phase setState.
+  const [quizUiState, setQuizUiState] = useState(() => ({
+    key: quizWordsKey,
+    answers: emptyQuizAnswers,
+    indexToFocus: setNextTargetIndex(emptyQuizAnswers),
+  }));
+
+  const quizAnswers =
+    quizUiState.key === quizWordsKey ? quizUiState.answers : emptyQuizAnswers;
+  const indexToFocus =
+    quizUiState.key === quizWordsKey
+      ? quizUiState.indexToFocus
+      : setNextTargetIndex(emptyQuizAnswers);
+
+  const setQuizAnswers = useCallback(
+    (
+      next:
+        | typeof emptyQuizAnswers
+        | ((prev: typeof emptyQuizAnswers) => typeof emptyQuizAnswers),
+    ) => {
+      setQuizUiState((prev) => {
+        const prevAnswers =
+          prev.key === quizWordsKey ? prev.answers : emptyQuizAnswers;
+        const answers = typeof next === 'function' ? next(prevAnswers) : next;
+        return {
+          key: quizWordsKey,
+          answers,
+          indexToFocus:
+            prev.key === quizWordsKey
+              ? prev.indexToFocus
+              : setNextTargetIndex(answers),
+        };
+      });
+    },
+    [emptyQuizAnswers, quizWordsKey],
+  );
+
+  const setIndexToFocus = useCallback(
+    (nextIndex: number) => {
+      setQuizUiState((prev) => ({
+        key: quizWordsKey,
+        answers: prev.key === quizWordsKey ? prev.answers : emptyQuizAnswers,
+        indexToFocus: nextIndex,
+      }));
+    },
+    [emptyQuizAnswers, quizWordsKey],
   );
 
   const addQuizWord = useCallback(
@@ -108,7 +161,7 @@ export default function RecoveryPhraseChips({
       setQuizAnswers(newQuizAnswers);
       setIndexToFocus(setNextTargetIndex(newQuizAnswers));
     },
-    [quizAnswers, indexToFocus],
+    [quizAnswers, indexToFocus, setIndexToFocus, setQuizAnswers],
   );
 
   const removeQuizWord = useCallback(
@@ -126,24 +179,12 @@ export default function RecoveryPhraseChips({
       setQuizAnswers(newQuizAnswers);
       setIndexToFocus(newQuizAnswers[targetIndex].index);
     },
-    [quizAnswers],
+    [quizAnswers, setIndexToFocus, setQuizAnswers],
   );
 
   useEffect(() => {
     setInputValue?.(quizAnswers);
   }, [quizAnswers, setInputValue]);
-
-  useEffect(() => {
-    if (quizWords.length) {
-      const newQuizAnswers = quizWords.map((word) => ({
-        index: word.index,
-        word: '',
-        actualIndexInSrp: -1,
-      }));
-      setQuizAnswers(newQuizAnswers);
-      setIndexToFocus(setNextTargetIndex(newQuizAnswers));
-    }
-  }, [quizWords]);
 
   // obfuscate the blurred recovery phrase to prevent blur-reversal attacks
   // from revealing the underlying words.

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.tsx
@@ -66,10 +66,7 @@ export default function RecoveryPhraseChips({
     () => quizWords.map((word) => word.index),
     [quizWords],
   );
-  const quizWordsKey = useMemo(
-    () => indicesToCheck.join('|'),
-    [indicesToCheck],
-  );
+  const quizWordsKey = quizWords;
 
   const setNextTargetIndex = (
     newQuizAnswers: { index: number; word: string }[],

--- a/ui/pages/onboarding-flow/welcome/metamask-wordmark-animation.tsx
+++ b/ui/pages/onboarding-flow/welcome/metamask-wordmark-animation.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useRef,
-  useEffect,
-  useState,
-  useCallback,
-  useMemo,
-} from 'react';
+import React, { useRef, useEffect, useCallback, useMemo } from 'react';
 import {
   useRive,
   Layout,
@@ -87,7 +81,7 @@ const MetamaskWordMarkAnimationInner = ({
     still?: StateMachineInput;
     start?: StateMachineInput;
   }>({});
-  const [isInitialized, setIsInitialized] = useState(false);
+  const isInitializedRef = useRef(false);
 
   const riveBuffer = useMemo(() => buffer.slice(0), [buffer]);
 
@@ -131,7 +125,7 @@ const MetamaskWordMarkAnimationInner = ({
   }, [rive]);
 
   useEffect(() => {
-    const shouldInitialize = rive && !isInitialized;
+    const shouldInitialize = rive && !isInitializedRef.current;
 
     if (shouldInitialize && cacheInputs()) {
       const { dark, still, start } = inputsRef.current;
@@ -149,9 +143,9 @@ const MetamaskWordMarkAnimationInner = ({
       }
 
       rive.play();
-      setIsInitialized(true);
+      isInitializedRef.current = true;
     }
-  }, [rive, skipTransition, isInitialized, theme, cacheInputs]);
+  }, [rive, skipTransition, theme, cacheInputs]);
 
   // Mark the session animation complete only on unmount after it started
   // (timeout was scheduled). Do not mark when `isAnimationComplete` flips on
@@ -168,7 +162,7 @@ const MetamaskWordMarkAnimationInner = ({
   }, [setIsAnimationCompleted]);
 
   useEffect(() => {
-    if (!rive || !isInitialized || prevThemeRef.current === theme) {
+    if (!rive || !isInitializedRef.current || prevThemeRef.current === theme) {
       return;
     }
 
@@ -180,7 +174,7 @@ const MetamaskWordMarkAnimationInner = ({
     }
 
     prevThemeRef.current = theme;
-  }, [rive, theme, isInitialized]);
+  }, [rive, theme]);
 
   return (
     <Box

--- a/ui/pages/onboarding-flow/welcome/welcome-login.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome-login.tsx
@@ -80,6 +80,7 @@ export default function WelcomeLogin({
     loginType?: LoginType,
   ) => {
     if (isSeedlessOnboardingFeatureEnabled) {
+      setHiddenForLoginParam(null);
       setIsTransitioning(true);
       // Clear any existing timeout
       if (timeoutRef.current) {
@@ -89,6 +90,7 @@ export default function WelcomeLogin({
       timeoutRef.current = setTimeout(() => {
         setIsTransitioning(false);
         timeoutRef.current = null;
+        setLocalLoginOption(option);
         navigate(`${ONBOARDING_WELCOME_ROUTE}?login=${option}`);
       }, 100);
     } else {

--- a/ui/pages/onboarding-flow/welcome/welcome-login.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome-login.tsx
@@ -27,9 +27,6 @@ export default function WelcomeLogin({
   skipTransition?: boolean;
 }) {
   const t = useI18nContext();
-  const [showLoginOptions, setShowLoginOptions] = useState(false);
-  const [loginOption, setLoginOption] = useState<LoginOptionType | null>(null);
-  const [isTransitioning, setIsTransitioning] = useState(false);
   const isSeedlessOnboardingFeatureEnabled =
     getIsSeedlessOnboardingFeatureEnabled();
   const dispatch = useDispatch();
@@ -38,6 +35,18 @@ export default function WelcomeLogin({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const loginParam = searchParams.get('login');
+  const [localLoginOption, setLocalLoginOption] =
+    useState<LoginOptionType | null>(null);
+  const [hiddenForLoginParam, setHiddenForLoginParam] = useState<string | null>(
+    null,
+  );
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  const loginOption =
+    (loginParam as LoginOptionType | null) ?? localLoginOption;
+  const showLoginOptions = loginParam
+    ? hiddenForLoginParam !== loginParam
+    : localLoginOption !== null;
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -48,28 +57,22 @@ export default function WelcomeLogin({
     };
   }, []);
 
-  useEffect(() => {
-    if (loginParam) {
-      setShowLoginOptions(true);
-      setLoginOption(loginParam as LoginOptionType);
-    } else {
-      setShowLoginOptions(false);
-      setLoginOption(null);
-    }
-  }, [loginParam]);
-
   const handleLogin = useCallback(
     async (loginType: LoginType) => {
       if (!loginOption) {
         return;
       }
-      setShowLoginOptions(false);
+      if (loginParam) {
+        setHiddenForLoginParam(loginParam);
+      } else {
+        setLocalLoginOption(null);
+      }
 
       await dispatch(setTermsOfUseLastAgreed(new Date().getTime()));
 
       await onLogin(loginType, loginOption);
     },
-    [dispatch, loginOption, onLogin],
+    [dispatch, loginOption, loginParam, onLogin],
   );
 
   const handleButtonClick = async (
@@ -84,15 +87,12 @@ export default function WelcomeLogin({
       }
       // Wait for fade-out animation
       timeoutRef.current = setTimeout(() => {
-        setShowLoginOptions(true);
-        setLoginOption(option);
         setIsTransitioning(false);
         timeoutRef.current = null;
         navigate(`${ONBOARDING_WELCOME_ROUTE}?login=${option}`);
       }, 100);
     } else {
-      setShowLoginOptions(true);
-      setLoginOption(option);
+      setLocalLoginOption(option);
       if (loginType) {
         await onLogin(loginType, option);
       }
@@ -125,9 +125,7 @@ export default function WelcomeLogin({
           <Box
             flexDirection={BoxFlexDirection.Column}
             gap={4}
-            className={`w-full ${
-              isTransitioning ? 'welcome-login__cta--fade-out' : ''
-            }`}
+            className={`w-full ${isTransitioning ? 'welcome-login__cta--fade-out' : ''}`}
           >
             <Button
               data-testid="onboarding-create-wallet"

--- a/ui/pages/settings/sync-accounts/sync-accounts-settings.tsx
+++ b/ui/pages/settings/sync-accounts/sync-accounts-settings.tsx
@@ -29,7 +29,21 @@ const SyncAccountsSettings = () => {
   const qrSyncPhase = useSelector(selectQrSyncPhase);
   const qrSyncError = useSelector(selectQrSyncError);
   const [isExiting, setIsExiting] = useState(false);
-  const [password, setPassword] = useState<string | undefined>();
+  const [passwordState, setPasswordState] = useState<{
+    phase: typeof qrSyncPhase;
+    value: string | undefined;
+  }>({ phase: qrSyncPhase, value: undefined });
+  const password =
+    qrSyncPhase === QR_SYNC_PHASES.REVIEWING_SYNC_OFFER &&
+    passwordState.phase === qrSyncPhase
+      ? passwordState.value
+      : undefined;
+  const setPassword = useCallback(
+    (value: string | undefined) => {
+      setPasswordState({ phase: qrSyncPhase, value });
+    },
+    [qrSyncPhase],
+  );
   const [syncSummary, setSyncSummary] = useState<Pick<
     AddDeviceSyncRequest,
     'syncedAccountCount' | 'syncedWalletCount'
@@ -77,14 +91,6 @@ const SyncAccountsSettings = () => {
       cancelQrSyncSession().catch(() => undefined);
     };
   }, [cancelQrSyncSession, createQrSyncSession, isExiting]);
-
-  useEffect(() => {
-    if (qrSyncPhase === QR_SYNC_PHASES.REVIEWING_SYNC_OFFER) {
-      return;
-    }
-
-    setPassword(undefined);
-  }, [qrSyncPhase]);
 
   const handleExit = useCallback(async () => {
     setIsExiting(true);

--- a/ui/pages/shield/plan/shield-plan.tsx
+++ b/ui/pages/shield/plan/shield-plan.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   PAYMENT_TYPES,
   PaymentType,
@@ -198,18 +192,6 @@ const ShieldPlan = () => {
   });
   const hasAvailableToken = availableTokenBalances.length > 0;
 
-  const [selectedPaymentMethod, setSelectedPaymentMethod] =
-    useState<PaymentType>(() => {
-      // always default to card if no token is available
-      if (!hasAvailableToken) {
-        return PAYMENT_TYPES.byCard;
-      }
-      if (lastUsedPaymentDetails?.type) {
-        return lastUsedPaymentDetails.type;
-      }
-      return PAYMENT_TYPES.byCrypto;
-    });
-
   // default options for the new subscription request
   const defaultOptions = useMemo(() => {
     const paymentType =
@@ -225,83 +207,94 @@ const ShieldPlan = () => {
     };
   }, [availableTokenBalances]);
 
-  const [selectedToken, setSelectedToken] = useState<
-    TokenWithApprovalAmount | undefined
-  >(() => {
-    return availableTokenBalances[0];
-  });
+  // Token selection is keyed by plan so a plan change drops the prior token
+  // without render-phase setState; a default is derived when none is chosen.
+  const [tokenState, setTokenState] = useState<{
+    plan: RecurringInterval;
+    token: TokenWithApprovalAmount | undefined;
+    userSelected: boolean;
+  }>(() => ({
+    plan: selectedPlan,
+    token: availableTokenBalances[0],
+    userSelected: false,
+  }));
 
-  // set selected token to the first available token if no token is selected
-  useEffect(() => {
-    if (
-      pendingAvailableTokenBalances ||
-      selectedToken ||
-      availableTokenBalances.length === 0
-    ) {
-      return;
+  const defaultSelectedToken = useMemo(() => {
+    if (pendingAvailableTokenBalances || availableTokenBalances.length === 0) {
+      return undefined;
     }
-
     const lastUsedPaymentToken = lastUsedPaymentDetails?.paymentTokenAddress;
     const lastUsedPaymentMethod = lastUsedPaymentDetails?.type;
     const lastUsedPaymentPlan = lastUsedPaymentDetails?.plan;
-
-    let lastUsedSelectedToken = availableTokenBalances[0];
     if (
       lastUsedPaymentToken &&
       lastUsedPaymentMethod === PAYMENT_TYPES.byCrypto &&
       lastUsedPaymentPlan === selectedPlan
     ) {
-      lastUsedSelectedToken =
+      return (
         availableTokenBalances.find(
           (token) => token.address === lastUsedPaymentToken,
-        ) || availableTokenBalances[0];
+        ) || availableTokenBalances[0]
+      );
     }
-
-    setSelectedToken(lastUsedSelectedToken);
+    return availableTokenBalances[0];
   }, [
-    pendingAvailableTokenBalances,
     availableTokenBalances,
-    selectedToken,
-    setSelectedToken,
     lastUsedPaymentDetails,
+    pendingAvailableTokenBalances,
     selectedPlan,
   ]);
 
-  // reset selected token if selected plan changes
-  useEffect(() => {
-    setSelectedToken(undefined);
-  }, [selectedPlan, setSelectedToken]);
+  let selectedToken = defaultSelectedToken;
+  if (tokenState.plan === selectedPlan) {
+    selectedToken = tokenState.userSelected
+      ? tokenState.token
+      : (tokenState.token ?? defaultSelectedToken);
+  }
+
+  const setSelectedToken = useCallback(
+    (token: TokenWithApprovalAmount | undefined) => {
+      setTokenState({
+        plan: selectedPlan,
+        token,
+        userSelected: true,
+      });
+    },
+    [selectedPlan],
+  );
 
   const selectedTokenAddress = selectedToken?.address;
 
   // Track if initial payment method selection has been done
-  // This prevents auto-switching after payment cancel/failure when cache is cleared
-  const hasInitializedPaymentMethod = useRef(false);
-
-  // set default selected payment method to crypto if selected token available
-  // should only trigger if selectedTokenAddress change (shouldn't trigger again if selected token object updated but still same token)
-  useEffect(() => {
-    // Skip auto-selection after initial setup to prevent switching after payment cancel
-    if (hasInitializedPaymentMethod.current) {
-      // Only handle the case when selectedTokenAddress becomes undefined (no tokens available)
-      if (!selectedTokenAddress) {
-        setSelectedPaymentMethod(PAYMENT_TYPES.byCard);
+  // This prevents auto-switching after payment cancel/failure when cache is cleared.
+  const [hasInitializedPaymentMethod, setHasInitializedPaymentMethod] =
+    useState(false);
+  const [paymentMethodLocal, setPaymentMethodLocal] = useState<PaymentType>(
+    () => {
+      if (!hasAvailableToken) {
+        return PAYMENT_TYPES.byCard;
       }
-      return;
-    }
+      if (lastUsedPaymentDetails?.type) {
+        return lastUsedPaymentDetails.type;
+      }
+      return PAYMENT_TYPES.byCrypto;
+    },
+  );
 
-    const lastUsedPaymentMethod = lastUsedPaymentDetails?.type;
-    if (
-      selectedTokenAddress &&
-      lastUsedPaymentMethod !== PAYMENT_TYPES.byCard
-    ) {
-      setSelectedPaymentMethod(PAYMENT_TYPES.byCrypto);
-    } else {
-      // should reset to byCard when selectedTokenAddress becomes undefined (no tokens available)
-      // to prevent switching to a plan without available tokens leaves selectedPaymentMethod as byCrypto with no tokens
-      setSelectedPaymentMethod(PAYMENT_TYPES.byCard);
+  // Derive payment method from token availability until the user starts checkout;
+  // after that, keep the local choice unless tokens disappear.
+  let selectedPaymentMethod: PaymentType = PAYMENT_TYPES.byCard;
+  if (selectedTokenAddress) {
+    if (hasInitializedPaymentMethod) {
+      selectedPaymentMethod = paymentMethodLocal;
+    } else if (lastUsedPaymentDetails?.type !== PAYMENT_TYPES.byCard) {
+      selectedPaymentMethod = PAYMENT_TYPES.byCrypto;
     }
-  }, [selectedTokenAddress, setSelectedPaymentMethod, lastUsedPaymentDetails]);
+  }
+
+  const setSelectedPaymentMethod = useCallback((method: PaymentType) => {
+    setPaymentMethodLocal(method);
+  }, []);
 
   const tokensSupported = useMemo(() => {
     const chainsAndTokensSupported = cryptoPaymentMethod?.chains ?? [];
@@ -333,7 +326,7 @@ const ShieldPlan = () => {
 
   const onStartSubscription = useCallback(() => {
     // set flag to prevent auto-switching payment method after payment cancel/failure
-    hasInitializedPaymentMethod.current = true;
+    setHasInitializedPaymentMethod(true);
 
     handleSubscription();
   }, [handleSubscription]);

--- a/ui/pages/shield/plan/shield-plan.tsx
+++ b/ui/pages/shield/plan/shield-plan.tsx
@@ -325,11 +325,12 @@ const ShieldPlan = () => {
   });
 
   const onStartSubscription = useCallback(() => {
+    setPaymentMethodLocal(selectedPaymentMethod);
     // set flag to prevent auto-switching payment method after payment cancel/failure
     setHasInitializedPaymentMethod(true);
 
     handleSubscription();
-  }, [handleSubscription]);
+  }, [handleSubscription, selectedPaymentMethod]);
 
   const handleUserChangeToken = useCallback(
     async (token: TokenWithApprovalAmount) => {

--- a/ui/pages/shield/transaction-shield/transaction-shield.tsx
+++ b/ui/pages/shield/transaction-shield/transaction-shield.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   Product,
   PRODUCT_TYPES,
@@ -122,23 +128,23 @@ const TransactionShield = () => {
     | (Subscription & { rewardAccountId?: string }) // TODO: fix this type once we have controller released.
     | undefined = currentShieldSubscription ?? lastShieldSubscription;
 
-  const [timeoutCancelled, setTimeoutCancelled] = useState(false);
+  const timeoutCancelledRef = useRef(false);
   useEffect(() => {
     // cancel timeout when component unmounts
     return () => {
-      setTimeoutCancelled(true);
+      timeoutCancelledRef.current = true;
     };
   }, []);
   useEffect(() => {
     // cancel timeout when subscription is created
     if (currentShieldSubscription) {
-      setTimeoutCancelled(true);
+      timeoutCancelledRef.current = true;
     }
   }, [currentShieldSubscription]);
 
   const startSubscriptionCreationTimeout = useTimeout(
     () => {
-      if (timeoutCancelled) {
+      if (timeoutCancelledRef.current) {
         return;
       }
 


### PR DESCRIPTION
## **Description**

Part of [MetaMask-planning#6402](https://github.com/MetaMask/MetaMask-planning/issues/6402) subtask 1: clear `react-hooks/set-state-in-effect` warnings.

**What this cleanup does:** React warns when `setState` runs synchronously inside a `useEffect`, because that forces an extra render pass ([You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)). These changes replace prop→state syncing in effects with render-time updates or derived values, and keep effects for real external sync only.

**Scope:** onboarding, shield/claims, sync-accounts, and notifications UI.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of: MetaMask/MetaMask-planning#6402

## **Manual testing steps**

1. Walk a short onboarding / import-SRP path and confirm screens still advance.
2. Open Shield plan / transaction shield UI; confirm plan selection still works.
3. Open a feature-announcement notification footer action if available.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches claim forms, Shield checkout defaults, and onboarding consent flows where subtle state-timing bugs could affect UX, but changes are refactors aimed at equivalent behavior rather than new product logic.
> 
> **Overview**
> Addresses **MetaMask-planning#6402** by removing synchronous `setState` inside `useEffect` across onboarding, Shield/claims, sync-accounts, and notifications. Behavior is preserved by deriving UI from props/Redux/URL, scoping local state with keys, or moving updates into event handlers.
> 
> **Shield & claims:** `ClaimsProvider` centralizes claim sorting/normalization and loads claims in the mount effect without an extra cancel callback path. `useClaimState` derives view/draft fields with `useMemo` and keeps edits in a `sourceKey`-keyed dirty form state instead of effects that hydrate from claims/drafts. **Shield plan** keys token selection to the billing plan and derives default payment method until checkout starts, replacing effects that reset token/payment on plan or balance changes. **Transaction shield** uses a ref for subscription-creation timeout cancellation instead of `setState` on unmount.
> 
> **Onboarding:** MetaMetrics checkbox values come from a touched “draft” plus Redux defaults (no effect sync); container clicks call `onChange` directly. Import SRP clears validation errors in the phrase change handler. Recovery phrase quiz state resets when `quizWords` changes via keyed state, not an effect. Welcome login derives option visibility from `?login=` and local state without syncing in an effect. Wordmark Rive init uses a ref instead of `isInitialized` state.
> 
> **Other:** QR sync password is cleared when leaving the review phase by tying stored password to `qrSyncPhase`. Feature-announcement external links stop resetting resolved href in the effect when the URL is empty. MetaMetrics tests wrap interactions in `act`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd351103e8f1ad82d32f5e7d6a81dd70ed0e8282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->