### PR TITLE
fix: tolerate getter-only Sentry SDK loggers

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -705,15 +705,22 @@ function integrateLogging() {
     return;
   }
 
-  // Sentry exposes a mutable logger singleton. In debug mode we intentionally
-  // override its methods so SDK-internal logs flow through our module logger.
+  // In debug mode, route SDK-internal logs through our module logger when the
+  // installed SDK exposes mutable logger methods.
   const sentrySdkLogger = logger;
 
   for (const loggerType of ['log', 'error']) {
-    sentrySdkLogger[loggerType] = (...args) => {
-      const message = args[0].replace(`Sentry Logger [${loggerType}]: `, '');
-      internalLog(message, ...args.slice(1));
-    };
+    try {
+      sentrySdkLogger[loggerType] = (...args) => {
+        const message = args[0].replace(
+          `Sentry Logger [${loggerType}]: `,
+          '',
+        );
+        internalLog(message, ...args.slice(1));
+      };
+    } catch {
+      // Newer SDK versions can expose getter-only logger methods.
+    }
   }
 
   log('Integrated logging');

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -8,6 +8,8 @@ import {
   shouldCreateSpanForRequest,
 } from './setupSentry';
 
+const originalEnvironment = process.env;
+
 describe('Setup Sentry', () => {
   describe('rewriteReport', () => {
     it('should remove urls from error messages', () => {
@@ -679,5 +681,88 @@ describe('Setup Sentry', () => {
         '7EYnhQoR9YM3N7UoaKRoA44Uy8JeaZV3qyouov87awMs',
       );
     });
+  });
+});
+
+describe('setupSentry', () => {
+  afterEach(() => {
+    process.env = originalEnvironment;
+    jest.dontMock('@sentry/browser');
+    jest.dontMock('@sentry/core');
+    jest.dontMock('@metamask/utils');
+    jest.dontMock('./install-type');
+    jest.dontMock('./sentry-get-state');
+    jest.dontMock('./sentry-make-transport');
+    jest.dontMock('./sentry-metametrics');
+    jest.dontMock('./sentry-trace-propagation');
+    jest.dontMock('../../../shared/lib/manifestFlags');
+    jest.dontMock('../../../shared/lib/mv3.utils');
+    jest.resetModules();
+  });
+
+  it('initializes Sentry with getter-only SDK loggers', async () => {
+    const mockSentryInit = jest.fn();
+    const mockSdkLogger = {};
+
+    Object.defineProperties(mockSdkLogger, {
+      error: { get: jest.fn(), configurable: true },
+      log: { get: jest.fn(), configurable: true },
+    });
+
+    process.env = {
+      ...originalEnvironment,
+      METAMASK_DEBUG: 'true',
+    };
+    jest.resetModules();
+
+    let setupSentry;
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('@sentry/browser', () => ({
+        browserTracingIntegration: jest.fn(),
+        dedupeIntegration: jest.fn(),
+        extraErrorDataIntegration: jest.fn(),
+        getClient: jest.fn(),
+        init: mockSentryInit,
+        registerSpanErrorInstrumentation: jest.fn(),
+        setTag: jest.fn(),
+      }));
+      jest.doMock('@sentry/core', () => ({
+        ...jest.requireActual('@sentry/core'),
+        logger: mockSdkLogger,
+      }));
+      jest.doMock('@metamask/utils', () => ({
+        ...jest.requireActual('@metamask/utils'),
+        createModuleLogger: jest.fn(() => jest.fn()),
+      }));
+      jest.doMock('./install-type', () => ({
+        getInstallType: jest.fn(),
+        initInstallType: jest.fn(),
+      }));
+      jest.doMock('./sentry-get-state', () => ({
+        getAnalyticsState: jest.fn(),
+        getAnalyticsStateFromAppState: jest.fn(),
+        getState: jest.fn(),
+      }));
+      jest.doMock('./sentry-make-transport', () => ({
+        makeTransport: jest.fn(),
+      }));
+      jest.doMock('./sentry-metametrics', () => ({
+        metaMetricsIntegration: jest.fn(),
+      }));
+      jest.doMock('./sentry-trace-propagation', () => ({
+        BACKEND_TRACE_PROPAGATION_TARGETS: [],
+        consensysTracePropagationIntegration: jest.fn(),
+      }));
+      jest.doMock('../../../shared/lib/manifestFlags', () => ({
+        getManifestFlags: jest.fn(() => ({})),
+      }));
+      jest.doMock('../../../shared/lib/mv3.utils', () => ({
+        isManifestV3: false,
+      }));
+      setupSentry = (await import('./setupSentry')).default;
+    });
+
+    expect(() => setupSentry()).not.toThrow();
+    expect(mockSentryInit).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## **Description**

Prevents debug logger integration from throwing when the installed `@sentry/core`
SDK exposes getter-only `log` or `error` methods. Sentry initialization continues
when logger redirection is unavailable. This does not change DSN, sampling,
transport, or trace-propagation behavior.

Maintainer edits: allowed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #45206

## **Manual testing steps**

Automated verification performed:

1. `yarn test:unit app/scripts/lib/setupSentry.test.js -t 'initializes Sentry with getter-only SDK loggers'` passed (1 test passed, 48 skipped).
2. `yarn test:unit app/scripts/lib/setupSentry.test.js` passed (49/49).
3. `yarn test:unit app/scripts/lib` completed with JUnit reporting 2,130 tests and 0 failures.
4. `yarn lint:changed`, `yarn lint:tsc`, and `yarn circular-deps:check` passed.
5. `yarn env:e2e webpack --test --sentry` and, after `yarn webpack:tsc`, `yarn build:test` passed. Webpack emitted entrypoint-size recommendations; both builds exited successfully.

No full CI run is claimed here.

## **Screenshots/Recordings**

Not applicable: this is a non-visual background initialization compatibility fix.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
