### PR TITLE
fix: stabilize srp-input Act warning console baseline

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -295,7 +295,7 @@
       "React: Act warnings (component updates not wrapped)": 1
     },
     "ui/components/app/srp-input/srp-input.test.js": {
-      "React: Act warnings (component updates not wrapped)": 51678
+      "React: Act warnings (component updates not wrapped)": 17022
     },
     "ui/components/app/update-modal/update-modal.test.tsx": {
       "MetaMask: Background connection not initialized": 2,

--- a/ui/components/app/srp-input/srp-input.test.js
+++ b/ui/components/app/srp-input/srp-input.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { waitFor } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { enLocale } from '../../../../test/lib/i18n-helpers';
 import { renderWithLocalization } from '../../../../test/lib/render-helpers';
@@ -64,8 +64,9 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
-        await userEvent.keyboard('test');
+        fireEvent.change(getByTestId('import-srp__srp-word-0'), {
+          target: { value: 'test' },
+        });
 
         expect(onChange).toHaveBeenLastCalledWith('');
       });
@@ -81,8 +82,9 @@ describe('srp-input', () => {
         );
 
         for (const index of new Array(11).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard('test');
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: 'test' },
+          });
         }
 
         expect(onChange).toHaveBeenLastCalledWith('');
@@ -99,11 +101,13 @@ describe('srp-input', () => {
         );
 
         for (const index of new Array(11).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(index === 0 ? 'test test' : 'test');
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: index === 0 ? 'test test' : 'test' },
+          });
         }
-        getByTestId(`import-srp__srp-word-11`).focus();
-        await userEvent.keyboard('ball');
+        fireEvent.change(getByTestId(`import-srp__srp-word-11`), {
+          target: { value: 'ball' },
+        });
 
         expect(onChange).toHaveBeenLastCalledWith('');
       });
@@ -119,11 +123,13 @@ describe('srp-input', () => {
         );
 
         for (const index of new Array(10).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(index === 0 ? 'test test' : 'test');
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: index === 0 ? 'test test' : 'test' },
+          });
         }
-        getByTestId(`import-srp__srp-word-11`).focus();
-        await userEvent.keyboard('ball');
+        fireEvent.change(getByTestId(`import-srp__srp-word-11`), {
+          target: { value: 'ball' },
+        });
 
         expect(onChange).toHaveBeenLastCalledWith('');
       });
@@ -140,8 +146,9 @@ describe('srp-input', () => {
 
         const srpParts = invalidChecksum.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
 
         expect(onChange).toHaveBeenLastCalledWith('');
@@ -159,8 +166,9 @@ describe('srp-input', () => {
 
         const srpParts = invalidWordCorrectChecksum.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
 
         expect(onChange).toHaveBeenLastCalledWith('');
@@ -178,8 +186,9 @@ describe('srp-input', () => {
 
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
         await userEvent.clear(getByTestId('import-srp__srp-word-0'));
 
@@ -198,12 +207,14 @@ describe('srp-input', () => {
 
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
         await userEvent.clear(getByTestId('import-srp__srp-word-0'));
-        getByTestId(`import-srp__srp-word-0`).focus();
-        await userEvent.keyboard('ball');
+        fireEvent.change(getByTestId(`import-srp__srp-word-0`), {
+          target: { value: 'ball' },
+        });
 
         expect(onChange).toHaveBeenLastCalledWith('');
       });
@@ -218,12 +229,13 @@ describe('srp-input', () => {
           />,
         );
 
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(correct);
         const srpParts = invalidWordCorrectChecksum.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
 
         expect(onChange).toHaveBeenLastCalledWith('');
@@ -240,7 +252,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste('test');
 
         expect(onChange).toHaveBeenLastCalledWith('');
@@ -257,7 +269,7 @@ describe('srp-input', () => {
         );
 
         for (const index of new Array(11).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste('test');
         }
 
@@ -276,7 +288,7 @@ describe('srp-input', () => {
 
         const srpParts = invalidChecksum.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
 
@@ -295,7 +307,7 @@ describe('srp-input', () => {
 
         const srpParts = invalidWordCorrectChecksum.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
 
@@ -314,7 +326,7 @@ describe('srp-input', () => {
 
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
         await userEvent.clear(getByTestId('import-srp__srp-word-0'));
@@ -334,11 +346,12 @@ describe('srp-input', () => {
 
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
         await userEvent.clear(getByTestId('import-srp__srp-word-0'));
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste('ball');
 
         expect(onChange).toHaveBeenLastCalledWith('');
@@ -354,11 +367,11 @@ describe('srp-input', () => {
           />,
         );
 
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(correct);
         const srpParts = invalidWordCorrectChecksum.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
 
@@ -376,7 +389,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste('test');
 
         expect(onChange).toHaveBeenLastCalledWith('');
@@ -391,7 +404,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(tooManyWords);
 
         expect(onChange).not.toHaveBeenCalled();
@@ -407,7 +420,7 @@ describe('srp-input', () => {
               srpText={enLocale.secretRecoveryPhrase.message}
             />,
           );
-          getByTestId('import-srp__srp-word-0').focus();
+          await userEvent.click(getByTestId('import-srp__srp-word-0'));
           await userEvent.paste(invalidInput);
 
           expect(onChange).toHaveBeenLastCalledWith('');
@@ -422,7 +435,7 @@ describe('srp-input', () => {
               srpText={enLocale.secretRecoveryPhrase.message}
             />,
           );
-          getByTestId('import-srp__srp-word-1').focus();
+          await userEvent.click(getByTestId('import-srp__srp-word-1'));
           await userEvent.paste(invalidInput);
 
           expect(onChange).toHaveBeenLastCalledWith('');
@@ -437,7 +450,7 @@ describe('srp-input', () => {
               srpText={enLocale.secretRecoveryPhrase.message}
             />,
           );
-          getByTestId('import-srp__srp-word-1').focus();
+          await userEvent.click(getByTestId('import-srp__srp-word-1'));
           await userEvent.paste(correct);
           await userEvent.paste(invalidInput);
 
@@ -454,7 +467,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-1').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-1'));
         await userEvent.paste(correct);
         await userEvent.paste('test test');
 
@@ -474,8 +487,9 @@ describe('srp-input', () => {
         );
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
 
         expect(onChange).toHaveBeenLastCalledWith(correct);
@@ -493,12 +507,14 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
-            await userEvent.keyboard(
-              index === 0
-                ? `${whitespaceCharacter}${srpParts[index]}`
-                : srpParts[index],
-            );
+            fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+              target: {
+                value:
+                  index === 0
+                    ? `${whitespaceCharacter}${srpParts[index]}`
+                    : srpParts[index],
+              },
+            });
           }
 
           expect(onChange).toHaveBeenLastCalledWith(correct);
@@ -515,12 +531,14 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
-            await userEvent.keyboard(
-              index === 11
-                ? `${srpParts[index]}${whitespaceCharacter}`
-                : srpParts[index],
-            );
+            fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+              target: {
+                value:
+                  index === 11
+                    ? `${srpParts[index]}${whitespaceCharacter}`
+                    : srpParts[index],
+              },
+            });
           }
 
           expect(onChange).toHaveBeenLastCalledWith(correct);
@@ -537,10 +555,9 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
-            await userEvent.keyboard(
-              `${srpParts[index]}${whitespaceCharacter}`,
-            );
+            fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+              target: { value: `${srpParts[index]}${whitespaceCharacter}` },
+            });
           }
 
           expect(onChange).toHaveBeenLastCalledWith(correct);
@@ -560,7 +577,7 @@ describe('srp-input', () => {
         );
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
 
@@ -578,7 +595,7 @@ describe('srp-input', () => {
         );
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index].slice(0, 2));
           await userEvent.paste(srpParts[index].slice(2));
         }
@@ -598,7 +615,7 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
+            await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
             await userEvent.paste(
               index === 0
                 ? `${whitespaceCharacter}${srpParts[index]}`
@@ -620,7 +637,7 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
+            await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
             await userEvent.paste(
               index === 11
                 ? `${srpParts[index]}${whitespaceCharacter}`
@@ -642,7 +659,7 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
+            await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
             await userEvent.paste(`${srpParts[index]}${whitespaceCharacter}`);
           }
 
@@ -661,7 +678,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(correct);
 
         expect(onChange).toHaveBeenLastCalledWith(correct);
@@ -676,7 +693,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(invalidChecksum);
         await userEvent.paste(correct);
 
@@ -693,7 +710,7 @@ describe('srp-input', () => {
               srpText={enLocale.secretRecoveryPhrase.message}
             />,
           );
-          getByTestId('import-srp__srp-word-0').focus();
+          await userEvent.click(getByTestId('import-srp__srp-word-0'));
           await userEvent.paste(poorlyFormattedInput);
 
           expect(onChange).toHaveBeenLastCalledWith(correct);
@@ -708,7 +725,7 @@ describe('srp-input', () => {
               srpText={enLocale.secretRecoveryPhrase.message}
             />,
           );
-          getByTestId('import-srp__srp-word-1').focus();
+          await userEvent.click(getByTestId('import-srp__srp-word-1'));
           await userEvent.paste(poorlyFormattedInput);
 
           expect(onChange).toHaveBeenLastCalledWith(correct);
@@ -749,8 +766,9 @@ describe('srp-input', () => {
         );
         const srpParts = tooFewWords.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
 
         expect(queryByText(enLocale.seedPhraseReq.message)).toBeInTheDocument();
@@ -771,8 +789,9 @@ describe('srp-input', () => {
         await userEvent.selectOptions(getByRole('combobox'), '15');
         const srpParts = invalidWordCount.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
 
         expect(queryByText(enLocale.seedPhraseReq.message)).toBeInTheDocument();
@@ -792,8 +811,9 @@ describe('srp-input', () => {
         );
         const srpParts = invalidChecksum.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
 
         expect(
@@ -815,8 +835,9 @@ describe('srp-input', () => {
         );
         const srpParts = invalidWordCorrectChecksum.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
 
         expect(
@@ -838,8 +859,9 @@ describe('srp-input', () => {
         );
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
 
         expect(
@@ -862,12 +884,14 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
-            await userEvent.keyboard(
-              index === 0
-                ? `${whitespaceCharacter}${srpParts[index]}`
-                : srpParts[index],
-            );
+            fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+              target: {
+                value:
+                  index === 0
+                    ? `${whitespaceCharacter}${srpParts[index]}`
+                    : srpParts[index],
+              },
+            });
           }
 
           expect(
@@ -889,12 +913,14 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
-            await userEvent.keyboard(
-              index === 11
-                ? `${srpParts[index]}${whitespaceCharacter}`
-                : srpParts[index],
-            );
+            fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+              target: {
+                value:
+                  index === 11
+                    ? `${srpParts[index]}${whitespaceCharacter}`
+                    : srpParts[index],
+              },
+            });
           }
 
           expect(
@@ -916,10 +942,9 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
-            await userEvent.keyboard(
-              `${srpParts[index]}${whitespaceCharacter}`,
-            );
+            fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+              target: { value: `${srpParts[index]}${whitespaceCharacter}` },
+            });
           }
 
           expect(
@@ -944,7 +969,7 @@ describe('srp-input', () => {
         );
         const srpParts = tooFewWords.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
 
@@ -966,7 +991,7 @@ describe('srp-input', () => {
         await userEvent.selectOptions(getByRole('combobox'), '15');
         const srpParts = invalidWordCount.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
 
@@ -987,7 +1012,7 @@ describe('srp-input', () => {
         );
         const srpParts = invalidChecksum.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
 
@@ -1010,7 +1035,7 @@ describe('srp-input', () => {
         );
         const srpParts = invalidWordCorrectChecksum.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
 
@@ -1033,7 +1058,7 @@ describe('srp-input', () => {
         );
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
 
@@ -1057,7 +1082,7 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
+            await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
             await userEvent.paste(
               index === 0
                 ? `${whitespaceCharacter}${srpParts[index]}`
@@ -1084,7 +1109,7 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
+            await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
             await userEvent.paste(
               index === 11
                 ? `${srpParts[index]}${whitespaceCharacter}`
@@ -1111,7 +1136,7 @@ describe('srp-input', () => {
           );
           const srpParts = correct.split(' ');
           for (const index of new Array(srpParts.length).keys()) {
-            getByTestId(`import-srp__srp-word-${index}`).focus();
+            await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
             await userEvent.paste(`${srpParts[index]}${whitespaceCharacter}`);
           }
 
@@ -1135,7 +1160,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(tooFewWords);
 
         expect(queryByText(enLocale.seedPhraseReq.message)).toBeInTheDocument();
@@ -1153,7 +1178,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(invalidWordCount);
 
         expect(queryByText(enLocale.seedPhraseReq.message)).toBeInTheDocument();
@@ -1171,7 +1196,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(invalidChecksum);
 
         expect(
@@ -1191,7 +1216,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(invalidWordCorrectChecksum);
 
         expect(
@@ -1211,7 +1236,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(correct);
 
         expect(
@@ -1232,7 +1257,7 @@ describe('srp-input', () => {
               srpText={enLocale.secretRecoveryPhrase.message}
             />,
           );
-          getByTestId('import-srp__srp-word-0').focus();
+          await userEvent.click(getByTestId('import-srp__srp-word-0'));
           await userEvent.paste(poorlyFormattedInput);
 
           expect(
@@ -1280,8 +1305,9 @@ describe('srp-input', () => {
         );
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
 
           expect(queryAllByRole('textbox')).toHaveLength(0);
         }
@@ -1298,7 +1324,7 @@ describe('srp-input', () => {
         );
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
 
           expect(queryAllByRole('textbox')).toHaveLength(0);
@@ -1314,7 +1340,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(correct);
 
         expect(queryAllByRole('textbox')).toHaveLength(0);
@@ -1336,8 +1362,9 @@ describe('srp-input', () => {
           await userEvent.click(
             getByTestId(`import-srp__srp-word-${index}-checkbox`),
           );
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
           await userEvent.click(
             getByTestId(`import-srp__srp-word-${index}-checkbox`),
           );
@@ -1363,7 +1390,7 @@ describe('srp-input', () => {
           await userEvent.click(
             getByTestId(`import-srp__srp-word-${index}-checkbox`),
           );
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
           await userEvent.click(
             getByTestId(`import-srp__srp-word-${index}-checkbox`),
@@ -1389,8 +1416,9 @@ describe('srp-input', () => {
         );
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
         }
 
         for (const index of new Array(srpParts.length).keys()) {
@@ -1422,7 +1450,7 @@ describe('srp-input', () => {
         );
         const srpParts = correct.split(' ');
         for (const index of new Array(srpParts.length).keys()) {
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
         }
 
@@ -1453,7 +1481,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-        getByTestId('import-srp__srp-word-0').focus();
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
         await userEvent.paste(correct);
 
         const srpParts = correct.split(' ');
@@ -1491,8 +1519,9 @@ describe('srp-input', () => {
           await userEvent.click(
             getByTestId(`import-srp__srp-word-${index}-checkbox`),
           );
-          getByTestId(`import-srp__srp-word-${index}`).focus();
-          await userEvent.keyboard(srpParts[index]);
+          fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+            target: { value: srpParts[index] },
+          });
 
           expect(
             getByTestId(`import-srp__srp-word-${index}-checkbox`),
@@ -1521,7 +1550,7 @@ describe('srp-input', () => {
           await userEvent.click(
             getByTestId(`import-srp__srp-word-${index}-checkbox`),
           );
-          getByTestId(`import-srp__srp-word-${index}`).focus();
+          await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
           await userEvent.paste(srpParts[index]);
 
           expect(
@@ -1549,8 +1578,10 @@ describe('srp-input', () => {
           />,
         );
         await userEvent.click(getByTestId('import-srp__srp-word-0-checkbox'));
-        getByTestId('import-srp__srp-word-0').focus();
-        await userEvent.keyboard('test');
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
+        fireEvent.change(getByTestId('import-srp__srp-word-0'), {
+          target: { value: 'test' },
+        });
         expect(queryAllByRole('textbox')).toHaveLength(1);
 
         await userEvent.paste(tooFewWords);
@@ -1572,8 +1603,10 @@ describe('srp-input', () => {
           />,
         );
         await userEvent.click(getByTestId('import-srp__srp-word-0-checkbox'));
-        getByTestId('import-srp__srp-word-0').focus();
-        await userEvent.keyboard('test');
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
+        fireEvent.change(getByTestId('import-srp__srp-word-0'), {
+          target: { value: 'test' },
+        });
         expect(queryAllByRole('textbox')).toHaveLength(1);
 
         await userEvent.paste(correct);
@@ -1595,8 +1628,10 @@ describe('srp-input', () => {
           />,
         );
         await userEvent.click(getByTestId('import-srp__srp-word-0-checkbox'));
-        getByTestId('import-srp__srp-word-0').focus();
-        await userEvent.keyboard('test');
+        await userEvent.click(getByTestId('import-srp__srp-word-0'));
+        fireEvent.change(getByTestId('import-srp__srp-word-0'), {
+          target: { value: 'test' },
+        });
         expect(queryAllByRole('textbox')).toHaveLength(1);
 
         await userEvent.paste('test');
@@ -1614,7 +1649,7 @@ describe('srp-input', () => {
           srpText={enLocale.secretRecoveryPhrase.message}
         />,
       );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(correct);
       await userEvent.click(getByTestId('import-srp__srp-word-0-checkbox'));
       expect(getByTestId('import-srp__srp-word-0-checkbox')).toBeChecked();
@@ -1639,8 +1674,9 @@ describe('srp-input', () => {
       );
       const srpParts = correct.split(' ');
       for (const index of new Array(srpParts.length).keys()) {
-        getByTestId(`import-srp__srp-word-${index}`).focus();
-        await userEvent.keyboard(srpParts[index]);
+        fireEvent.change(getByTestId(`import-srp__srp-word-${index}`), {
+          target: { value: srpParts[index] },
+        });
       }
 
       expect(writeTextSpy).not.toHaveBeenCalled();
@@ -1658,7 +1694,7 @@ describe('srp-input', () => {
       );
       const srpParts = correct.split(' ');
       for (const index of new Array(srpParts.length).keys()) {
-        getByTestId(`import-srp__srp-word-${index}`).focus();
+        await userEvent.click(getByTestId(`import-srp__srp-word-${index}`));
         await userEvent.paste(srpParts[index]);
       }
 
@@ -1675,7 +1711,7 @@ describe('srp-input', () => {
           srpText={enLocale.secretRecoveryPhrase.message}
         />,
       );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(tooManyWords);
 
       expect(writeTextSpy).not.toHaveBeenCalled();
@@ -1691,7 +1727,7 @@ describe('srp-input', () => {
           srpText={enLocale.secretRecoveryPhrase.message}
         />,
       );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(tooFewWords);
 
       expect(writeTextSpy).toHaveBeenCalledWith('');
@@ -1707,7 +1743,7 @@ describe('srp-input', () => {
           srpText={enLocale.secretRecoveryPhrase.message}
         />,
       );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(correct);
 
       expect(writeTextSpy).toHaveBeenCalledWith('');
@@ -1745,7 +1781,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(new Array(15).fill('test').join(' '));
 
       expect(
@@ -1769,7 +1805,7 @@ describe('srp-input', () => {
           />,
         );
       await userEvent.selectOptions(getByRole('combobox'), '15');
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(correct);
 
       expect(
@@ -1792,7 +1828,7 @@ describe('srp-input', () => {
             srpText={enLocale.secretRecoveryPhrase.message}
           />,
         );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(invalidWordCount);
 
       expect(
@@ -1835,7 +1871,7 @@ describe('srp-input', () => {
           srpText={enLocale.secretRecoveryPhrase.message}
         />,
       );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(new Array(15).fill('test').join(' '));
       await userEvent.selectOptions(getByRole('combobox'), '12');
       await userEvent.selectOptions(getByRole('combobox'), '15');
@@ -1859,7 +1895,7 @@ describe('srp-input', () => {
           srpText={enLocale.secretRecoveryPhrase.message}
         />,
       );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(tooManyWords);
 
       expect(
@@ -1876,7 +1912,7 @@ describe('srp-input', () => {
           srpText={enLocale.secretRecoveryPhrase.message}
         />,
       );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(tooManyWords);
       await userEvent.click(getByText(enLocale.dismiss.message));
 
@@ -1894,7 +1930,7 @@ describe('srp-input', () => {
           srpText={enLocale.secretRecoveryPhrase.message}
         />,
       );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(tooManyWords);
       await userEvent.paste(correct);
 
@@ -1912,7 +1948,7 @@ describe('srp-input', () => {
           srpText={enLocale.secretRecoveryPhrase.message}
         />,
       );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(tooManyWords);
       await userEvent.paste(tooManyWords);
 
@@ -1930,9 +1966,11 @@ describe('srp-input', () => {
           srpText={enLocale.secretRecoveryPhrase.message}
         />,
       );
-      getByTestId('import-srp__srp-word-0').focus();
+      await userEvent.click(getByTestId('import-srp__srp-word-0'));
       await userEvent.paste(tooManyWords);
-      await userEvent.keyboard('test');
+      fireEvent.change(getByTestId('import-srp__srp-word-0'), {
+        target: { value: 'test' },
+      });
 
       expect(
         queryByText(enLocale.srpPasteFailedTooManyWords.message),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
`ui/components/app/srp-input/srp-input.test.js` has been spotted a few times flaky in ci:

- https://github.com/MetaMask/metamask-extension/actions/runs/31185232406/job/92888665727
- https://github.com/MetaMask/metamask-extension/actions/runs/31507480239/job/93832868607

The solution is to replace native focus + per-keystroke typing with `fireEvent.change`/`userEvent.click` so MUI FormControl updates stay act-wrapped and the console baseline is less flaky in CI.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: null

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code impact; risk is limited to possible test behavior differences from the new input simulation approach.
> 
> **Overview**
> Reduces flaky CI failures in `srp-input.test.js` by changing how inputs are driven in tests.
> 
> Replaces native `.focus()` + per-keystroke `userEvent.keyboard` with `fireEvent.change` for typed cases, and uses `userEvent.click` before paste. That keeps MUI FormControl updates act-wrapped. Also lowers the unit console baseline for this file from **51678** to **17022** Act warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f4d810bf0583c66945a3e6fc4e089d08aefa67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->