### PR TITLE
fix: fall back to client map when icon cannot be found

### DIFF
--- a/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.test.tsx
+++ b/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import {
   ActivityListItemAvatar,
   type ActivityListItemAvatarTokens,
@@ -7,6 +7,8 @@ import {
 
 const ethTokenAssetId = 'eip155:1/slip44:60';
 const usdcAssetId = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const chilizNativeAssetId =
+  'eip155:88888/erc20:0x0000000000000000000000000000000000000000';
 
 function renderAvatar(tokens: ActivityListItemAvatarTokens) {
   return render(<ActivityListItemAvatar tokens={tokens} />);
@@ -49,5 +51,43 @@ describe('ActivityListItemAvatar', () => {
     expect(
       screen.getByTestId('activity-list-item-avatar-fallback'),
     ).toBeInTheDocument();
+  });
+
+  it('falls back to the local chain native image when a native CDN icon 404s', () => {
+    renderAvatar([chilizNativeAssetId]);
+
+    const avatar = screen.getByTestId('activity-list-item-avatar-token');
+    const image = avatar.querySelector('img');
+    expect(image).toBeTruthy();
+    expect(image).toHaveAttribute(
+      'src',
+      expect.stringContaining('tokenIcons'),
+    );
+
+    fireEvent.error(image as HTMLImageElement);
+
+    const fallbackImage = screen
+      .getByTestId('activity-list-item-avatar-token')
+      .querySelector('img');
+    expect(fallbackImage).toHaveAttribute(
+      'src',
+      expect.stringContaining('chiliz'),
+    );
+  });
+
+  it('does not fall back to the chain native image for non-native token CDN failures', () => {
+    renderAvatar([usdcAssetId]);
+
+    const image = screen
+      .getByTestId('activity-list-item-avatar-token')
+      .querySelector('img') as HTMLImageElement;
+
+    fireEvent.error(image);
+
+    const imageAfter = screen
+      .getByTestId('activity-list-item-avatar-token')
+      .querySelector('img');
+    // AvatarToken may hide the broken CDN img; we must not swap to a local native icon.
+    expect(imageAfter?.getAttribute('src') ?? '').not.toContain('/images/');
   });
 });

--- a/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.test.tsx
+++ b/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.test.tsx
@@ -1,17 +1,29 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import {
+  CHILIZ_IMAGE_URL,
+  ETH_TOKEN_IMAGE_URL,
+} from '../../../../shared/constants/network';
+import { getCaipAssetImageUrl } from '../../../../shared/lib/asset-utils';
+import {
   ActivityListItemAvatar,
   type ActivityListItemAvatarTokens,
 } from './activity-list-item-avatar';
 
 const ethTokenAssetId = 'eip155:1/slip44:60';
 const usdcAssetId = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+// Zero-address CAIP for Chiliz native (what core emits when there is no slip44).
 const chilizNativeAssetId =
   'eip155:88888/erc20:0x0000000000000000000000000000000000000000';
 
 function renderAvatar(tokens: ActivityListItemAvatarTokens) {
   return render(<ActivityListItemAvatar tokens={tokens} />);
+}
+
+function getTokenImage() {
+  return screen
+    .getByTestId('activity-list-item-avatar-token')
+    .querySelector('img');
 }
 
 describe('ActivityListItemAvatar', () => {
@@ -53,41 +65,29 @@ describe('ActivityListItemAvatar', () => {
     ).toBeInTheDocument();
   });
 
-  it('falls back to the local chain native image when a native CDN icon 404s', () => {
+  it('uses the local CHAIN_ID_TOKEN_IMAGE_MAP icon when a native CDN image errors', () => {
     renderAvatar([chilizNativeAssetId]);
 
-    const avatar = screen.getByTestId('activity-list-item-avatar-token');
-    const image = avatar.querySelector('img');
-    expect(image).toBeTruthy();
-    expect(image).toHaveAttribute(
+    const cdnImage = getTokenImage();
+    expect(cdnImage).toHaveAttribute(
       'src',
-      expect.stringContaining('tokenIcons'),
+      getCaipAssetImageUrl(chilizNativeAssetId),
     );
 
-    fireEvent.error(image as HTMLImageElement);
+    // Simulate the CDN 404 (img onError).
+    fireEvent.error(cdnImage as HTMLImageElement);
 
-    const fallbackImage = screen
-      .getByTestId('activity-list-item-avatar-token')
-      .querySelector('img');
-    expect(fallbackImage).toHaveAttribute(
-      'src',
-      expect.stringContaining('chiliz'),
-    );
+    expect(getTokenImage()).toHaveAttribute('src', CHILIZ_IMAGE_URL);
   });
 
-  it('does not fall back to the chain native image for non-native token CDN failures', () => {
+  it('does not swap a broken ERC-20 CDN icon for the chain native local icon', () => {
     renderAvatar([usdcAssetId]);
 
-    const image = screen
-      .getByTestId('activity-list-item-avatar-token')
-      .querySelector('img') as HTMLImageElement;
+    const cdnImage = getTokenImage();
+    fireEvent.error(cdnImage as HTMLImageElement);
 
-    fireEvent.error(image);
-
-    const imageAfter = screen
-      .getByTestId('activity-list-item-avatar-token')
-      .querySelector('img');
-    // AvatarToken may hide the broken CDN img; we must not swap to a local native icon.
-    expect(imageAfter?.getAttribute('src') ?? '').not.toContain('/images/');
+    // AvatarToken may drop the broken <img>. We only care that we did not
+    // replace it with mainnet's local native icon (./images/eth_logo.svg).
+    expect(getTokenImage()?.getAttribute('src')).not.toBe(ETH_TOKEN_IMAGE_URL);
   });
 });

--- a/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.tsx
+++ b/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import classnames from 'clsx';
 import {
   AvatarBase,
@@ -6,12 +6,43 @@ import {
   AvatarToken,
   AvatarTokenSize,
 } from '@metamask/design-system-react';
-import type { CaipAssetType } from '@metamask/utils';
+import type { CaipAssetType, CaipChainId } from '@metamask/utils';
+import { parseCaipAssetType } from '@metamask/utils';
+import { CHAIN_ID_TOKEN_IMAGE_MAP } from '../../../../shared/constants/network';
 import { getCaipAssetImageUrl } from '../../../../shared/lib/asset-utils';
+import { convertCaipToHexChainId } from '../../../../shared/lib/network.utils';
 
 export type ActivityListItemAvatarTokens = readonly (string | undefined)[];
 
 const fallbackText = '?';
+
+const zeroAddressPattern = /^0x0+$/iu;
+
+function isNativeAssetId(assetId: string): boolean {
+  try {
+    const { assetNamespace, assetReference } = parseCaipAssetType(
+      assetId as CaipAssetType,
+    );
+    return (
+      assetNamespace === 'slip44' ||
+      (assetNamespace === 'erc20' && zeroAddressPattern.test(assetReference))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function getNativeImageForAssetId(assetId: string): string | undefined {
+  try {
+    const { chainId } = parseCaipAssetType(assetId as CaipAssetType);
+    const hexChainId = convertCaipToHexChainId(chainId as CaipChainId);
+    return CHAIN_ID_TOKEN_IMAGE_MAP[
+      hexChainId as keyof typeof CHAIN_ID_TOKEN_IMAGE_MAP
+    ];
+  } catch {
+    return undefined;
+  }
+}
 
 const sanitizeTokens = (tokens: ActivityListItemAvatarTokens): string[] =>
   tokens.filter((token): token is string => Boolean(token));
@@ -20,13 +51,36 @@ const ActivityTokenAvatar = ({
   assetId,
   className,
 }: Readonly<{ assetId: string; className?: string }>) => {
+  const cdnSrc = getCaipAssetImageUrl(assetId as CaipAssetType);
+  const [src, setSrc] = useState(cdnSrc);
+
+  useEffect(() => {
+    setSrc(cdnSrc);
+  }, [cdnSrc]);
+
+  const handleImageError = () => {
+    if (!isNativeAssetId(assetId)) {
+      return;
+    }
+
+    const localNativeImage = getNativeImageForAssetId(assetId);
+    if (localNativeImage && localNativeImage !== src) {
+      setSrc(localNativeImage);
+    }
+  };
+
   return (
+    // Remount when src changes so AvatarToken clears its internal error state.
     <AvatarToken
+      key={src}
       size={AvatarTokenSize.Md}
       name={fallbackText}
-      src={getCaipAssetImageUrl(assetId as CaipAssetType)}
+      src={src}
       className={classnames(className)}
-      imageProps={{ className: 'bg-alternative' }}
+      imageProps={{
+        className: 'bg-alternative',
+        onError: handleImageError,
+      }}
       data-testid="activity-list-item-avatar-token"
     />
   );


### PR DESCRIPTION
## **Description**

Some custom networks (e.g. Chiliz) do not have icons in the CDN. This PR adds `onError` handling for native `assetId`s, fall back to a local mapping.

Depends on MetaMask/core#9833

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

Related: https://github.com/MetaMask/core/pull/9833

## **Manual testing steps**

1. With core#9833 (or equivalent) producing `eip155:88888/erc20:0x000…000` for Chiliz natives, open Activity on Chiliz.
2. Confirm the chili icon appears after the CDN miss (may briefly flash `?`).
3. Confirm a random ERC-20 with a missing CDN icon still shows `?`, not the chain native image.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)