### PR TITLE
test(benchmarks): port the completed Solana discovery mocks into the benchmark suite

### DIFF
--- a/test/e2e/benchmarks/mocks/mock-responses.ts
+++ b/test/e2e/benchmarks/mocks/mock-responses.ts
@@ -517,3 +517,45 @@ export function solanaCatchAllResponse(id: string | number = '1337') {
     },
   };
 }
+
+const SOLANA_RPC_CONTEXT = { apiVersion: '2.0.18', slot: 308460925 };
+
+const SOLANA_MAINNET_GENESIS_HASH =
+  '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d';
+
+/**
+ * Well-formed results for the Solana discovery JSON-RPC methods this suite does
+ * not mock individually.
+ *
+ * Ported from `SOLANA_DISCOVERY_RPC_RESULTS` in `test/e2e/mock-e2e.js`, which
+ * #43961 completed for the shared e2e environment. The benchmark suite is a
+ * separate mock implementation and never loaded that helper, so it kept the
+ * defect: every method below fell through to `solanaCatchAllResponse`, whose
+ * `{ context, value: null }` is the wrong shape for a genesis hash, a version
+ * object, a slot number or a health string. Malformed bodies throw inside the
+ * Solana snap and restart discovery — the ~516-request retry storm #43961
+ * measured, and the ~6.5s slow path #45266 sees on 37% of iterations.
+ *
+ * Each entry is the empty/identity result for a wallet with no Solana activity,
+ * which is what the benchmark fixtures represent.
+ */
+export const SOLANA_DISCOVERY_RPC_RESULTS: Record<string, unknown> = {
+  getGenesisHash: SOLANA_MAINNET_GENESIS_HASH,
+  getHealth: 'ok',
+  getVersion: { 'solana-core': '2.0.18', 'feature-set': 3271415109 },
+  getSlot: SOLANA_RPC_CONTEXT.slot,
+  getMultipleAccounts: { context: SOLANA_RPC_CONTEXT, value: [] },
+  getProgramAccounts: [],
+  getTokenAccountBalance: {
+    context: SOLANA_RPC_CONTEXT,
+    value: { amount: '0', decimals: 9, uiAmount: null, uiAmountString: '0' },
+  },
+  getEpochInfo: {
+    absoluteSlot: 308460925,
+    blockHeight: 286665030,
+    epoch: 762,
+    slotIndex: 156925,
+    slotsInEpoch: 432000,
+    transactionCount: 386021115957,
+  },
+};

--- a/test/e2e/benchmarks/mocks/performance-mocks.ts
+++ b/test/e2e/benchmarks/mocks/performance-mocks.ts
@@ -54,6 +54,7 @@ import {
   SOLANA_SIMULATE_TRANSACTION,
   SOLANA_GET_SIGNATURES_FOR_ADDRESS,
   solanaCatchAllResponse,
+  SOLANA_DISCOVERY_RPC_RESULTS,
 } from './mock-responses';
 
 const AuthMocks = AuthenticationController.Mocks;
@@ -1168,6 +1169,28 @@ export async function mockBenchmarkEndpoints(
       .always()
       .thenCallback(delayedResponse(350, SOLANA_GET_SIGNATURES_FOR_ADDRESS)),
   );
+
+  // The remaining discovery methods the Solana snap calls. Each is matched on
+  // its own method name, so these never shadow the handlers above; they only
+  // answer what would otherwise reach the catch-all with a wrong-shaped body.
+  // 100 ms matches the "simple calls" band in the table above.
+  for (const [method, result] of Object.entries(SOLANA_DISCOVERY_RPC_RESULTS)) {
+    endpoints.push(
+      await server
+        .forPost(SOLANA_URL_REGEX)
+        .withJsonBodyIncluding({ method })
+        .asPriority(MOCK_PRIORITIES.HIGH_PRIORITY)
+        .always()
+        .thenCallback(async (req) => {
+          const body = (await req.body.getJson()) as { id?: string };
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          return {
+            statusCode: 200,
+            json: { id: body?.id ?? '1337', jsonrpc: '2.0', result },
+          };
+        }),
+    );
+  }
 
   endpoints.push(
     await server


### PR DESCRIPTION
## **Changelog**

CHANGELOG entry: null

## **Description**

`#43961` completed `SOLANA_DISCOVERY_RPC_RESULTS` in `test/e2e/mock-e2e.js`, giving every JSON-RPC method the Solana snap calls during account discovery a well-formed result. The benchmark suite is a separate mock implementation in `test/e2e/benchmarks/mocks/` and never loaded that helper, so it kept the defect the earlier PR removed.

It matched 8 of the 15 discovery methods. The other 7 — `getGenesisHash`, `getHealth`, `getVersion`, `getSlot`, `getMultipleAccounts`, `getProgramAccounts`, `getTokenAccountBalance`, `getEpochInfo` — fell through to `solanaCatchAllResponse`, which returns:

```ts
result: { context: { slot: 250000000 }, value: null },
```

That is a valid JSON-RPC envelope with the wrong shape for every one of them: `getGenesisHash` expects a string, `getVersion` an object, `getSlot` a number, `getHealth` `"ok"`. This is the condition `#43961` measured — malformed bodies throw inside the snap and restart discovery, a ~516-request retry storm.

This commit ports that result map into the benchmark fixtures and registers each method at `HIGH_PRIORITY`. Each is matched on its own method name, so the 8 existing handlers and their calibrated delays are untouched.

### Verification

Coverage of the discovery method set, computed from the two files:

```
explicit handlers : 8
ported defaults   : 8   getEpochInfo getGenesisHash getHealth getMultipleAccounts
                        getProgramAccounts getSlot getTokenAccountBalance getVersion
overlap           : none
snap discovery set covered: 15/15
still uncovered           : NONE
```

`tsc` clean on both files, `oxfmt` clean, and the benchmark tooling suites pass (16 suites, 414 tests).

**There is no test here that fails without this change, and this PR does not claim one.** The benchmark mock suite has no unit coverage, and the defect only manifests when a real Solana snap parses a real response — the passing suites show nothing regressed, not that this fixes anything.

The check is the next `main` run, and it is falsifiable: `onboardingNewWallet.doneButtonToAssetList` currently lands at ~1.7–2.5s or ~8.4–10.2s with nothing between, on 24 of 65 sampled iterations slow (#45266). If this is the cause, that collapses to the single fast mode. If it does not move, the Solana attribution in #45266 is wrong and the search reopens — which is a useful result either way, and the reason this is worth landing before the instrumentation rather than after it.

### Follow-up

The two mock suites are parallel implementations of overlapping behaviour, and this is the second fix to one that did not reach the other. Filed separately rather than expanded here.

## **Related issues**

Fixes: #45266

- #43961, #43958 — the same defect, fixed in the shared e2e suite
- #45205 — recalibration, blocked on the bimodality this targets

## **Manual testing steps**

1. `yarn jest development/metamaskbot-build-announce/ test/e2e/benchmarks/utils/`
2. On the next `main` run, read per-iteration `doneButtonToAssetList` from the `run-benchmarks / chrome-webpack-userJourneyOnboardingNew` job log and confirm the slow cluster is absent.

## **Screenshots/Recordings**

CI-only change with no user-visible surface; nothing to capture.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock changes in the benchmark suite; no production, auth, or data-handling code is modified.
> 
> **Overview**
> Ports the completed `SOLANA_DISCOVERY_RPC_RESULTS` map from the shared e2e suite into the **benchmark** mocks so Solana discovery methods no longer fall through to the wrong-shaped catch-all.
> 
> Adds well-formed responses for `getGenesisHash`, `getHealth`, `getVersion`, `getSlot`, `getMultipleAccounts`, `getProgramAccounts`, `getTokenAccountBalance`, and `getEpochInfo`, and registers each at `HIGH_PRIORITY` with a 100ms delay. Existing calibrated handlers are left untouched.
> 
> This targets the intermittent ~6.5s slow path in onboarding benchmarks caused by malformed RPC bodies restarting Solana snap discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f798148aae4b6653f48dc26ec3e9320bdc805145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
