### PR TITLE
fix(ci): cap the benchmark stats series and unmask its publish failures

### DIFF
--- a/.github/scripts/benchmark-stats-commit.sh
+++ b/.github/scripts/benchmark-stats-commit.sh
@@ -200,11 +200,48 @@ TEMP_FILE="${STATS_FILE}.tmp"
 # COMMIT_DATA wraps presets_json and is strictly larger, so it can exceed
 # ARG_MAX too. Read it via --slurpfile from a temp file rather than passing
 # the blob on argv.
+# Keep only the newest RETAINED_COMMITS entries by timestamp.
+#
+# Without this the file grows without bound and eventually cannot be pushed:
+# `stats/main/performance_data.json` reached 99.92 MiB against GitHub's 100 MiB
+# hard limit, leaving 84,667 bytes against a per-publish growth of 180-270 KB.
+# `main` stopped publishing on 2026-07-28 and every push since has been
+# rejected. The release series are 1-5 MiB and were unaffected, which is why
+# the failure looked like nothing was wrong.
+#
+# 100 is chosen against a consumer that reads 5: `aggregateHistoricalData` in
+# development/metamaskbot-build-announce/historical-comparison.ts takes
+# `.slice(0, 5)` of the commits sorted by timestamp. Any value >= 5 preserves
+# current behaviour exactly; 100 leaves 20x headroom for a wider window later
+# and holds the file near 20 MiB.
+#
+# Entries with no timestamp sort last and are dropped first — they are already
+# unusable to the consumer, which filters on `data[hash]?.timestamp`.
+RETAINED_COMMITS="${RETAINED_COMMITS:-100}"
+
 data_file="$(mktemp)"
 printf '%s' "${COMMIT_DATA}" >"${data_file}"
-jq --arg sha "${HEAD_COMMIT_HASH}" --slurpfile data "${data_file}" \
-    '. + {($sha): $data[0]}' "${STATS_FILE}" > "${TEMP_FILE}"
+jq --arg sha "${HEAD_COMMIT_HASH}" \
+   --argjson keep "${RETAINED_COMMITS}" \
+   --slurpfile data "${data_file}" \
+    '(. + {($sha): $data[0]})
+     | to_entries
+     | sort_by(.value.timestamp // 0)
+     | reverse
+     | .[:$keep]
+     | from_entries' "${STATS_FILE}" > "${TEMP_FILE}"
 rm -f "${data_file}"
+
+# A truncation bug that silently emptied the series would be invisible until a
+# baseline went missing weeks later, so refuse to publish a file that lost the
+# entry we just wrote or came back empty.
+written_count="$(jq 'length' "${TEMP_FILE}")"
+if [[ "${written_count}" -eq 0 ]] || ! jq -e --arg sha "${HEAD_COMMIT_HASH}" 'has($sha)' "${TEMP_FILE}" > /dev/null; then
+    echo "Error: retention step produced ${written_count} entries and/or dropped ${HEAD_COMMIT_HASH}" >&2
+    exit 1
+fi
+echo "Retained ${written_count} commit(s) (cap ${RETAINED_COMMITS})" >&2
+
 mv "${TEMP_FILE}" "${STATS_FILE}"
 
 git add "${STATS_FILE}"

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -295,7 +295,12 @@ jobs:
   # Skip on fork repos — only store stats on the canonical repository.
   store-benchmark-stats:
     name: store-benchmark-stats (main/release only)
-    continue-on-error: true
+    # Not continue-on-error. This job publishes the series every historical
+    # comparison is built from, and a silent failure here is indistinguishable
+    # from a healthy run: `main` stopped publishing on 2026-07-28 and reported
+    # success for the two weeks that followed. The job runs only on main and
+    # release pushes and gates nothing, so a red here costs a notification and
+    # buys the ability to notice.
     needs:
       - benchmarks
       - benchmarks-page-load
@@ -338,7 +343,6 @@ jobs:
 
       - name: Commit performance stats to extension_benchmark_stats
         if: steps.download-perf-benchmark.outcome == 'success'
-        continue-on-error: true
         run: .github/scripts/benchmark-stats-commit.sh
         env:
           BENCHMARK_DATA_TYPE: performance


### PR DESCRIPTION
## **Changelog**

CHANGELOG entry: null

## **Description**

`main` has not published benchmark statistics since **2026-07-28T09:05:23Z**. The `release/*` series kept publishing throughout — most recently 2026-08-11T19:14:50Z — which is why nothing looked broken.

The cause is a file-size limit:

| | bytes | |
|---|---:|---|
| `stats/main/performance_data.json` | 104,772,933 | **99.92 MiB** |
| GitHub hard limit | 104,857,600 | 100.00 MiB |
| **headroom** | **84,667** | |

Growth per publish, from three consecutive commits on the stats repo:

```
244cf7bcfa  2026-07-27 23:23   104,051,391
6c0c7bbe0a  2026-07-28 00:05   104,234,780   (+183,389)
7260d170ed  2026-07-28 09:05   104,772,933   (+538,153 over two)
```

180–270 KB per publish against 84,667 bytes remaining — less than a third of a single append. The next `main` push was rejected and every one since has been too. The release files are 0.9–4.6 MiB and nowhere near the limit.

The failure was invisible because **two** `continue-on-error` flags cover it: one on the `store-benchmark-stats` job, one on the step that runs the script. Removing either alone leaves it silent.

### Why 100

`aggregateHistoricalData` in `development/metamaskbot-build-announce/historical-comparison.ts` reads five entries:

```ts
const latestCommits = Object.keys(data)
  .filter((hash) => data[hash]?.timestamp)
  .sort((a, b) => data[b].timestamp - data[a].timestamp)
  .slice(0, 5);
```

The file was carrying ~100 MiB to serve a five-element window. Any cap >= 5 preserves current behaviour exactly; 100 leaves 20× headroom for a wider window later and holds the file near 20 MiB. The value is overridable via `RETAINED_COMMITS` without editing the script.

### Verification

Full executed output, all six checks: [`retention-verification.txt`](https://majorlift-artifacts-share.s3.us-west-1.amazonaws.com/public/metamask/benchmarks/2026-08-12-stats-retention/retention-verification.txt)

The retention expression was run against a synthetic 120-entry series with ascending timestamps, appending one new entry:

```
baseline (plain append, no cap)   entries: 121      grows without bound

keep=100    entries          : 100
            contains new sha : true
            oldest retained  : sha_021
            newest retained  : sha_NEW
            dropped          : 21

keep=5      entries: 5   keys: sha_NEW,sha_119,sha_118,sha_117,sha_116
```

The `keep=5` arm is the important one: it returns exactly the five the consumer would have selected, so the cap cannot change what any comparison sees.

Entries with no `timestamp` sort last and drop first — check D in the artifact returns `kept_the_untimestamped: false`. They are already unusable to the consumer, which filters on `data[hash]?.timestamp`.

A guard refuses to publish if the retention step returns zero entries or loses the SHA just written, because a truncation bug would otherwise stay invisible until a baseline went missing weeks later.

Checks E and F in the artifact: `bash -n` exits 0 on the script, and reading the parsed YAML back reports `ABSENT` for `continue-on-error` on both the job and the step.

**What this does not do:** it does not shrink the existing 99.92 MiB file. The first publish after this lands rewrites it to the capped set, and that push has to succeed — a >100 MiB blob already in history is not what GitHub rejects, the incoming blob is. If that first push is still rejected, the file needs a one-off truncation commit before this takes effect. Flagging it rather than asserting it will be fine.

## **Related issues**

~Fixes: #45451~

- #45205 — recalibration, blocked on a published series existing
- #45204 — the mocked/live split; the two populations will need separate series

## **Manual testing steps**

1. Confirm the next `main` push publishes, and that `stats/main/performance_data.json` drops to ~100 entries.
2. Confirm the PR comment on a subsequent PR still renders historical deltas.
3. Confirm a forced failure in the publish step now turns the job red instead of green.

## **Screenshots/Recordings**

CI-only change with no user-visible surface; nothing to capture.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the CI path that publishes historical benchmark baselines used in PR comparisons; a bad retention rewrite could drop usable history, and the first post-merge publish must succeed against the already oversized file.
> 
> **Overview**
> Stops unbounded growth of `performance_data.json` that hit GitHub’s 100 MiB limit and silently blocked `main` publishes since 2026-07-28.
> 
> On each publish, `benchmark-stats-commit.sh` now keeps only the newest **100** commits (overridable via `RETAINED_COMMITS`), sorted by timestamp, and refuses to push if the new SHA is missing or the file is empty. Cap is well above the 5 entries `aggregateHistoricalData` reads, so historical PR comparisons stay unchanged.
> 
> Also removes `continue-on-error` from the `store-benchmark-stats` job and commit step so publish failures surface as red checks instead of looking healthy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85517c082c2daa12bbc317a25df5b741cfe220c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
