### PR TITLE
test: fix flaky goToActivityList for bottom-nav AB test

### DIFF
--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -50,6 +50,9 @@ class HomePage {
 
   private readonly bitcoinAccountIcon = 'img[src="./images/bitcoin-logo.svg"]';
 
+  private readonly bottomNavActivityButton =
+    '[data-testid="bottom-nav-activity"]';
+
   protected readonly bridgeButton: string =
     '[data-testid="eth-overview-bridge"]';
 
@@ -529,7 +532,16 @@ class HomePage {
 
   async goToActivityList(): Promise<void> {
     console.log(`Open activity tab on homepage`);
-    await this.driver.clickElement(this.activityTab);
+    await this.checkPageIsLoaded();
+    const isBottomNav = await this.driver.isElementPresentAndVisible(
+      this.bottomNavActivityButton,
+      3000,
+    );
+    if (isBottomNav) {
+      await this.driver.clickElement(this.bottomNavActivityButton);
+    } else {
+      await this.driver.clickElement(this.activityTab);
+    }
   }
 
   async goToBackupSRPPage(): Promise<void> {

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -171,8 +171,17 @@ export class PerpsTab extends PerpsPositionsBase {
    * Waits for the Perps tab to be present, clicks it, then waits for the Perps Home view to load.
    */
   async navigateToPerpsHome(): Promise<void> {
-    await this.driver.waitForSelector(this.accountOverviewPerpsTab);
-    await this.driver.clickElement(this.accountOverviewPerpsTab);
+    console.log('Navigate to Perps home');
+    const isBottomNav = await this.driver.isElementPresentAndVisible(
+      this.bottomNavPerpsButton,
+      3000,
+    );
+    if (isBottomNav) {
+      await this.driver.clickElement(this.bottomNavPerpsButton);
+    } else {
+      await this.driver.waitForSelector(this.accountOverviewPerpsTab);
+      await this.driver.clickElement(this.accountOverviewPerpsTab);
+    }
     await this.checkPageIsLoaded();
   }
 

--- a/test/e2e/page-objects/pages/perps/perps-positions-base.ts
+++ b/test/e2e/page-objects/pages/perps/perps-positions-base.ts
@@ -9,8 +9,7 @@ export class PerpsPositionsBase extends HomePage {
     testId: 'account-overview__perps-tab',
   };
 
-  protected readonly bottomNavPerpsButton =
-    '[data-testid="bottom-nav-perps"]';
+  protected readonly bottomNavPerpsButton = '[data-testid="bottom-nav-perps"]';
 
   private readonly perpsPositionsSection = {
     testId: 'perps-positions-section',

--- a/test/e2e/page-objects/pages/perps/perps-positions-base.ts
+++ b/test/e2e/page-objects/pages/perps/perps-positions-base.ts
@@ -9,6 +9,9 @@ export class PerpsPositionsBase extends HomePage {
     testId: 'account-overview__perps-tab',
   };
 
+  protected readonly bottomNavPerpsButton =
+    '[data-testid="bottom-nav-perps"]';
+
   private readonly perpsPositionsSection = {
     testId: 'perps-positions-section',
   };


### PR DESCRIPTION
## **Description**

**Problem:** The `coreExtensionUxCeux1141AbtestBottomNav` AB test (widened from 1% to 5% treatment in PR #45389) randomly removes the classic account-overview tab buttons from the DOM when the wallet is bucketed into "treatment", relocating them to the bottom navigation bar. This causes two families of flakes:

1. **Activity tab (~55 tests):** `homepage.goToActivityList()` unconditionally waits for `[data-testid="account-overview__activity-tab"]`, which never appears when the bottom nav is active.
2. **Perps tab (perps-activity, perps-watchlist, and other perps specs):** `perpsTab.navigateToPerpsHome()` unconditionally waits for `[data-testid="account-overview__perps-tab"]`, which similarly never appears in the bottom-nav variant — the Perps button moves to `[data-testid="bottom-nav-perps"]`.

**Solution:** Updated both page-object navigation methods to detect which layout is active using `isElementPresentAndVisible` with a short (3 s) timeout, then click the appropriate element:

- `goToActivityList()` in `HomePage` — checks for `bottom-nav-activity` first, falls back to the classic activity tab.
- `navigateToPerpsHome()` in `PerpsTab` — checks for `bottom-nav-perps` first, falls back to the classic perps tab. The new `bottomNavPerpsButton` locator is declared in `PerpsPositionsBase` (the base class) alongside the existing `accountOverviewPerpsTab` locator.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Build a test extension: `yarn build:test`
2. Force treatment variant by temporarily setting `coreExtensionUxCeux1141AbtestBottomNav` control threshold to `0` in `test/e2e/feature-flags/feature-flag-registry.ts`.
3. Run any test that uses `goToActivityList()`, for example:
   ```
   SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/confirmations/transactions/gas-fee-tokens-smart-transactions.spec.ts
   ```
4. Run a Perps test that uses `navigateToPerpsHome()`:
   ```
   SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/perps/perps-activity.spec.ts
   ```
5. Revert the threshold change and run both tests again to confirm they work with the classic tabs too.
6. Verify each test passes consistently in both variants (run 3–5 times each).

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
