### PR TITLE
test: fix flaky tests Perps Position Lifecycle and Perps Withdraw

### DIFF
--- a/.github/scripts/known-feature-flag-constants.mts
+++ b/.github/scripts/known-feature-flag-constants.mts
@@ -75,6 +75,11 @@ const FILE_SOURCES: Array<{
     file: 'shared/lib/assets/security-trust-feature-flags.ts',
     exportName: 'EXTENSION_TRUST_AND_SECURITY_TDP_FLAG',
   },
+  {
+    key: 'BOTTOM_NAV_AB_TEST_KEY',
+    file: 'shared/lib/ab-testing/configs/bottom-nav-bar.ts',
+    exportName: 'BOTTOM_NAV_AB_TEST_KEY',
+  },
 ];
 
 /**

--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -7,6 +7,7 @@ import {
   getProductionRemoteFlagDefaults,
 } from '../../feature-flags/feature-flag-registry';
 import { formatUnits } from '../../../../shared/lib/unit';
+import { BOTTOM_NAV_AB_TEST_KEY } from '../../../../shared/lib/ab-testing/configs/bottom-nav-bar';
 import {
   MOCK_ETH_OPEN_LONG_FILL,
   MOCK_ETH_LIMIT_ORDER,
@@ -105,6 +106,12 @@ const PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS = {
   // is on in production (registry value), so it stays registered; tests that
   // need the slippage UI can opt in explicitly. Covered by unit tests + recipe.
   perpsSlippageConfig2: { enabled: false, minimumVersion: '0.0.0' },
+  // Pin the bottom-nav-bar A/B test to control. The production default is a
+  // percentage rollout (threshold array), which otherwise buckets each E2E
+  // run randomly and hides account-overview__perps-tab / __activity-tab in
+  // favor of bottom-nav-perps / bottom-nav-activity when a run lands in
+  // treatment, causing flaky TimeoutErrors on those selectors.
+  [BOTTOM_NAV_AB_TEST_KEY]: 'control',
 };
 
 /**
@@ -120,6 +127,8 @@ export const PERPS_ELIGIBLE_FLAG = {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     confirmations_pay_post_quote:
       PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS.confirmations_pay_post_quote,
+    [BOTTOM_NAV_AB_TEST_KEY]:
+      PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS[BOTTOM_NAV_AB_TEST_KEY],
   },
 };
 
@@ -147,6 +156,10 @@ const PERPS_WITHDRAW_CONFIRMATION_MANIFEST_FLAG = {
     confirmations_pay_post_quote:
       PERPS_WITHDRAW_CONFIRMATION_FLAG.remoteFeatureFlags
         .confirmations_pay_post_quote,
+    [BOTTOM_NAV_AB_TEST_KEY]:
+      PERPS_WITHDRAW_CONFIRMATION_FLAG.remoteFeatureFlags[
+        BOTTOM_NAV_AB_TEST_KEY
+      ],
   },
 };
 
@@ -164,6 +177,8 @@ const PERPS_GEO_BLOCKED_REMOTE_FEATURE_FLAGS = {
     PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS.confirmations_pay_post_quote,
   perpsEnabledVersion: { enabled: true, minimumVersion: '0.0.0' },
   perpsPerpTradingGeoBlockedCountriesV2: { blockedRegions: ['US'] },
+  // See PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS for why this is pinned.
+  [BOTTOM_NAV_AB_TEST_KEY]: 'control',
 };
 
 const PERPS_GEO_BLOCKED_FLAG = {
@@ -175,6 +190,8 @@ const PERPS_GEO_BLOCKED_FLAG = {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     confirmations_pay_post_quote:
       PERPS_GEO_BLOCKED_REMOTE_FEATURE_FLAGS.confirmations_pay_post_quote,
+    [BOTTOM_NAV_AB_TEST_KEY]:
+      PERPS_GEO_BLOCKED_REMOTE_FEATURE_FLAGS[BOTTOM_NAV_AB_TEST_KEY],
   },
 };
 
@@ -224,6 +241,7 @@ export function getPerpsGeoBlockConfig(title?: string) {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         confirmations_pay: { name: 'empty' },
         perpsPerpTradingGeoBlockedCountriesV2: { blockedRegions: ['US'] },
+        [BOTTOM_NAV_AB_TEST_KEY]: 'control',
       });
       await server
         .forGet('https://client-config.api.cx.metamask.io/v1/flags')
@@ -284,6 +302,7 @@ async function mockEligibleFeatureFlags(
     // market submit disabled without order-book estimates.
     perpsSlippageConfig2:
       PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS.perpsSlippageConfig2,
+    [BOTTOM_NAV_AB_TEST_KEY]: 'control',
     ...overrides,
   });
   await server


### PR DESCRIPTION
## **Description**


The `coreExtensionUxCeux1141AbtestBottomNav` A/B test flag was inheriting its raw production threshold-array default in the Perps E2E fixtures,causing random per-run bucketing between the tab UI and bottom-nav UI. This made `account-overview__perps-tab` intermittently absent, causing flaky TimeoutErrors in Perps Position Lifecycle and Perps Withdraw tests. 
Pin the flag to 'control' in the seeded controller state, manifest flag overrides, and live `/v1/flags` mocks, same approach `test/e2e/tests/bridge/bridge-positive-cases.spec.ts ` uses to pin this flag to 'treatment'.

CI logs failures:

[Perps Position Lifecycle position card is visible on Perps home when user has open ETH position](https://github.com/MetaMask/metamask-extension/actions/runs/31563896968/job/94018220895)

[Perps Withdraw withdraw page loads with header and summary rows visible](https://github.com/MetaMask/metamask-extension/actions/runs/31531371068/job/93913944548)


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check CI

## **Screenshots/Recordings**

<img width="780" height="493" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/5b7d4c97-78ff-4eaa-ae37-c4f052363783" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture and CI registry mapping changes; no production app or security-sensitive logic is modified.
> 
> **Overview**
> Fixes flaky Perps E2E failures by **pinning** `BOTTOM_NAV_AB_TEST_KEY` to `'control'` in Perps fixture remote-flag state, manifest overrides, and `/v1/flags` mocks.
> 
> Without this, the production threshold-array default randomly buckets runs into treatment, swapping `account-overview__perps-tab` for bottom-nav selectors and causing TimeoutErrors in Position Lifecycle and Withdraw tests.
> 
> Also registers `BOTTOM_NAV_AB_TEST_KEY` in `known-feature-flag-constants.mts` so bracket access resolves in the feature-flag registry check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f46e879ef6cbb70d3fb0de0143db8bc298a74446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->