### PR TITLE
fix(ci): run benchmarks when benchmark-owned files change on reused builds

### DIFF
--- a/.github/rules/filter-rules.yml
+++ b/.github/rules/filter-rules.yml
@@ -124,6 +124,19 @@ unit_integration_test_files:
   - 'jest.config.js'
   - 'jest.integration.config.js'
 
+# Benchmark-owned files — changes require running benchmarks even when builds are reused.
+#
+# The build hash covers application sources, so a PR that only changes the
+# measurement apparatus always matches the base branch, always reuses its
+# builds, and would otherwise never benchmark. That is backwards: the app is
+# unchanged, but what the gate measures about it is not.
+benchmark_files:
+  - 'test/e2e/benchmarks/**'
+  - 'development/metamaskbot-build-announce/**'
+  - 'shared/constants/benchmarks.ts'
+  - '.github/workflows/run-benchmarks.yml'
+  - '.github/scripts/benchmark-stats-commit.sh'
+
 # ALL CHANGED FILES
 all_changes:
   - '**'

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -663,15 +663,30 @@ jobs:
           }}
         env:
           BUILDS_FROM_BASE_BRANCH: ${{ steps.find-reusable-builds.outputs.builds-from-base-branch }}
+          FILTER_BENCHMARK_COUNT: ${{ steps.filter.outputs.benchmark_files_count }}
         run: |
           echo "=== Benchmarks skip decision ==="
           echo "  Builds from base branch: $BUILDS_FROM_BASE_BRANCH"
+          echo "  Benchmark-owned files changed: $FILTER_BENCHMARK_COUNT"
 
-          if [[ "$BUILDS_FROM_BASE_BRANCH" == "true" ]]; then
+          # A change to the measurement apparatus needs benchmarking even when
+          # builds are reused. The build hash covers application sources only, so
+          # a PR touching just the harness, the mocks, the thresholds or the gate
+          # allowlist always matches the base branch and would otherwise never
+          # run the benchmarks it changes. Mirrors the unit/integration rule above.
+          #
+          # Such a run measures the reused base build with the new apparatus,
+          # which is the comparison that isolates the apparatus change, and it is
+          # the cheap option since no fresh build is needed.
+          if [[ "$BUILDS_FROM_BASE_BRANCH" == "true" && "$FILTER_BENCHMARK_COUNT" == "0" ]]; then
             echo "-> needs-benchmarks=false (builds from base branch — identical output)"
           else
             echo "needs-benchmarks=true" >> "$GITHUB_OUTPUT"
-            echo "-> needs-benchmarks=true (fresh builds)"
+            if [[ "$BUILDS_FROM_BASE_BRANCH" == "true" ]]; then
+              echo "-> needs-benchmarks=true (benchmark-owned files changed)"
+            else
+              echo "-> needs-benchmarks=true (fresh builds)"
+            fi
           fi
 
       - name: Compute needs-e2e flag


### PR DESCRIPTION
## **Changelog**

CHANGELOG entry: null

## **Description**

> **Stacked on #45352.** Both change the same `set-needs-benchmarks` step; separate PRs would conflict in the same block. Base that PR, not `main`.

A PR that changes only the benchmark harness never runs the benchmarks.

`find-reusable-builds` hashes **application** sources. Benchmark-owned code — the harness, the mocks, the thresholds, the gate allowlist — is not in that hash by construction, so such a PR always matches its base branch, always reuses those builds, and `needs-benchmarks` resolves `false`. The application is unchanged; what the gate measures about it is not.

Observed across four PRs open on 2026-08-12:

| PR | changes | `builds-from-run` | `run-benchmarks` |
|---|---|---|---|
| #45443 | `test/e2e/benchmarks/mocks/` | `31579703000` (a **main** run) | **skipped** |
| #45444 | `gated-metrics.ts` + test | `31579703000` (**main**) | **skipped** |
| #45445 | `.github/scripts/`, `.github/workflows/` | `31579703000` (**main**) | **skipped** |
| #45455 | `.github/scripts/`, `.github/workflows/` | `31585190838` (**its own**) | **ran** |

#45455 is the control: same file types as #45445, but based on a feature branch, so no reusable build was found and its benchmarks ran. The variable is build reuse, not file type.

From the requirements job of [run 31582455153](https://github.com/MetaMask/metamask-extension/actions/runs/31582455153):

```
Searching branch 'jongsun/test/benchmark-solana-discovery-mocks' for matching build hash...
No match on 'jongsun/test/benchmark-solana-discovery-mocks', trying 'main'...
```

It matched `main` and skipped. That head SHA carries `build-source-hash` and `builds-from-run` statuses but **no `benchmarks-required` status** — #45352's pin never fires, because the decision short-circuits before it.

### What changed

A `benchmark_files` filter, ORed into the decision. This mirrors the existing `unit_integration_test_files` rule, which already carries exactly this reasoning — *"changes require running unit/integration even when builds are reused"* — for test files.

```js
const benchmarkFilesChanged = process.env.FILTER_BENCHMARK_COUNT !== '0';
const freshBuilds = process.env.BUILDS_FROM_BASE_BRANCH !== 'true';
const required = freshBuilds || benchmarkFilesChanged;
```

The forced run measures the **reused base build** with the new apparatus. That is deliberate and is the cheaper option: for a harness-only change it is also the comparison that isolates the change, since holding the application constant is what makes the apparatus difference legible. A fresh build would vary both at once.

The decision still flows into #45352's `benchmarks-required` pinning, so it stays fixed per commit and a re-run cannot flip it.

### Verification

Decision table, logic extracted verbatim from the step, run against the four PRs above plus two controls: [`bench-decision-check.txt`](https://majorlift-artifacts-share.s3.us-west-1.amazonaws.com/public/metamask/benchmarks/2026-08-12-needs-benchmarks-force/bench-decision-check.txt)

```
ok   #45443 benchmark mocks, builds reused        before=false after=true  (benchmark-owned files changed)
ok   #45444 gated-metrics + test, builds reused   before=false after=true  (benchmark-owned files changed)
ok   #45445 workflow + script, builds reused      before=false after=true  (benchmark-owned files changed)
ok   #45455 workflow + script, own build          before=true  after=true  (fresh builds)
ok   CONTROL app-only change, builds reused       before=false after=false (builds from base branch)
ok   CONTROL app-only change, own build           before=true  after=true  (fresh builds)

6/6 match expectation
```

The first control is the one that matters: an ordinary PR that touches no benchmark paths and reuses base builds **still skips**. This widens the trigger, it does not remove it.

Both files parse (`yaml.safe_load` on `filter-rules.yml` and `get-requirements.yml`).

**What this does not prove:** that a forced run produces usable numbers against a reused build. The decision logic is checked here; the end-to-end behaviour is only observable once this lands and a harness-only PR runs. The falsifier is direct — #45443 should stop showing `run-benchmarks: skipped`.

## **Related issues**

Fixes: #45456

- #45352 — pins the decision per commit; this is why that pin never fires on harness-only PRs
- #45443 — the PR whose falsifier is unreadable without this
- #45351, #45450 — the same shape: a missing input scoring as a pass

## **Manual testing steps**

1. **This PR does not self-trigger, by design.** It changes `filter-rules.yml` and `get-requirements.yml`, neither of which is in `benchmark_files` — `get-requirements.yml` is touched by many unrelated CI PRs, and listing it would run the full benchmark matrix on all of them. (An earlier revision of this section claimed the opposite; that was wrong.) Verify via step 2 instead.
2. Re-run #45443 after this lands and confirm `run-benchmarks` is no longer skipped, and that its head SHA gains a `benchmarks-required` commit status.
3. Confirm an unrelated app-only PR reusing base builds still skips benchmarks.

## **Screenshots/Recordings**

CI-only change with no user-visible surface; nothing to capture.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI decision logic, workflow retries, and ownership/docs; no runtime wallet or auth behavior is modified by the benchmark gate fix itself.
> 
> **Overview**
> **Benchmark gating** no longer skips the benchmark job when a PR reuses base-branch builds but touches benchmark harness paths. A new `benchmark_files` path filter (e2e benchmarks, metamaskbot announce, `shared/constants/benchmarks.ts`, and related workflow/script) feeds `FILTER_BENCHMARK_COUNT` into `get-requirements`; benchmarks run if there are fresh builds **or** any of those files changed—matching the existing unit/integration “reuse builds but still test” pattern.
> 
> **Other CI/docs tweaks** in the same diff: `yarn mm-foundryup` for benchmarks, e2e, and e2e-fixtures now runs behind a retry action; Core Platform **CODEOWNERS** cover UI/route messenger files; the known feature-flag list adds **Money account**; `.metamaskrc.dist` documents **remote Sentry sample-rate** overrides. The diff also includes **13.43.0 changelog** and broad **locale** string updates (ramps activity, perps order book, dapp disconnect copy, etc.) that look like release-branch content alongside the CI fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9d30bedec7d67137638b9c4806eee9e80b6830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
