### PR TITLE
fix: swap src amount becomes undefined or uncontrolled after token switch

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -576,8 +576,7 @@
       "Reselect: Identity function warnings": 1
     },
     "ui/pages/bridge/prepare/prepare-bridge-page.test.tsx": {
-      "Reselect: Identity function warnings": 1,
-      "error: Warning: A component is changing": 2
+      "Reselect: Identity function warnings": 1
     },
     "ui/pages/bridge/quotes/multichain-bridge-quote-card.test.tsx": {
       "Reselect: Identity function warnings": 1

--- a/ui/ducks/bridge/actions.ts
+++ b/ui/ducks/bridge/actions.ts
@@ -286,9 +286,9 @@ export const setToToken = (newToToken: TokenPayload) => {
           typeof dispatch
         >[0],
       );
+      dispatch(setFromTokenInputValue(currentFromAmount));
     }
 
     dispatch(setToTokenAction(newToToken));
-    dispatch(setFromTokenInputValue(currentFromAmount));
   };
 };

--- a/ui/ducks/bridge/bridge.ts
+++ b/ui/ducks/bridge/bridge.ts
@@ -131,11 +131,16 @@ const bridgeSlice = createSlice({
       ) {
         state.toToken = currentFromToken;
       }
+      if (
+        previousFromAssetId?.toLowerCase() !==
+        newFromToken?.assetId.toLowerCase()
+      ) {
+        state.fromTokenInputValue = initialState.fromTokenInputValue;
+      }
       state.fromToken = newFromToken;
       state.fromTokenBalance = initialState.fromTokenBalance;
       state.fromTokenExchangeRate = initialState.fromTokenExchangeRate;
       state.fromNativeBalance = initialState.fromNativeBalance;
-      state.fromTokenInputValue = initialState.fromTokenInputValue;
       state.txAlertStatus = initialState.txAlertStatus;
       state.txAlert = initialState.txAlert;
       if (

--- a/ui/hooks/bridge/useSourceInputAmount.ts
+++ b/ui/hooks/bridge/useSourceInputAmount.ts
@@ -30,7 +30,7 @@ type UseSourceInputAmountParams = {
 };
 
 type UseSourceInputAmountResult = {
-  amount: string | undefined;
+  amount: string;
   tokenAmount: string | null;
   selectedDenomination: InputPrimaryDenomination;
   isFiatPrimary: boolean;
@@ -180,7 +180,7 @@ export const useSourceInputAmount = ({
   ]);
 
   return {
-    amount: isFiatPrimary ? displayedFiatAmount : (sourceAmount ?? undefined),
+    amount: (isFiatPrimary ? displayedFiatAmount : sourceAmount) ?? '',
     tokenAmount: sourceAmount,
     selectedDenomination,
     isFiatPrimary,

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -573,7 +573,6 @@ const PrepareBridgePage = ({
                       formatTokenAmount(locale, previousDestAmount),
                     ),
                   );
-                dispatch(setToToken(fromToken));
               }}
             />
           </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Changes
- `useSourceInputAmount.ts`: fallback to an empty string when amount is not defined to prevent the input component from becoming uncontrolled when `fromTokenInputAmount` is unset
- Remove redundant amount input actions that preserve stale data

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: f[ix: swap src amount becomes undefined or uncontrolled after token switch](https://github.com/MetaMask/metamask-extension/pull/45469#top)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to Swap page and enter quote
2. Spam "switch" button
3. Input amount should eventually get cleared

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/f2873fdc-acba-4362-9377-f1870e2c69ea

https://github.com/user-attachments/assets/08dcd77f-2d17-4a56-8559-0039859943de


### **After**



https://github.com/user-attachments/assets/ccccc38f-1a22-493c-912a-564a09b65df9



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bridge/swap UI state and input wiring with no auth, transaction signing, or persistence changes; main risk is edge cases in token-pair swapping behavior.
> 
> **Overview**
> Fixes the bridge/swap **source amount** becoming **undefined** or flipping between controlled and uncontrolled when users rapidly hit the token **switch** control.
> 
> **`useSourceInputAmount`** now always exposes `amount` as a **string** (empty when unset) so the amount field never receives `undefined`.
> 
> **`setFromToken`** in the bridge slice only resets **`fromTokenInputValue`** when the **from asset id actually changes**, instead of clearing on every from-token update. **`setToToken`** moves preserving the current amount into the branch that reassigns the from token when it collides with the new to token, and drops a redundant input-value dispatch at the end.
> 
> The prepare-bridge **switch** handler no longer dispatches **`setToToken(fromToken)`**; the reducer already swaps the pair when the new from token matches the current to token. Jest console baseline drops related React controlled/uncontrolled warnings for **`prepare-bridge-page.test.tsx`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 580550bfe3aefc00be3d83563e948efe76b7104e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->