### PR TITLE
feat(ci): measure the most recent release live, on a schedule

### DIFF
--- a/.github/scripts/benchmark-stats-commit.sh
+++ b/.github/scripts/benchmark-stats-commit.sh
@@ -224,12 +224,29 @@ jq . "${STATS_FILE}" > /dev/null || {
 }
 
 # --- Check for duplicate ---
+#
+# A push that re-runs CI for the same commit must not add a second point, so the
+# SHA is the dedup key there. A deliberate re-measure is the opposite case: the
+# scheduled live series measures one release SHA repeatedly, and every run is a
+# new point. ALLOW_REMEASURE is set by the caller exactly when it named the ref
+# it measured, which is what distinguishes the two.
+#
+# Suffixing is safe because nothing reads this file by exact SHA:
+# historical-comparison.ts takes Object.keys(), filters on timestamp and mock
+# mode, and sorts by timestamp, so the key is opaque to every consumer.
+
+ENTRY_KEY="${HEAD_COMMIT_HASH}"
 
 if jq -e "has(\"${HEAD_COMMIT_HASH}\")" "${STATS_FILE}" > /dev/null; then
-    echo "SHA ${HEAD_COMMIT_HASH} already exists in ${STATS_FILE}. No new commit needed."
-    cd ..
-    rm -rf "${CLONE_DIR}"
-    exit 0
+    if [[ "${ALLOW_REMEASURE:-false}" == "true" ]]; then
+        ENTRY_KEY="${HEAD_COMMIT_HASH}-${GITHUB_RUN_ID}"
+        echo "SHA ${HEAD_COMMIT_HASH} already present; re-measure stored under ${ENTRY_KEY}."
+    else
+        echo "SHA ${HEAD_COMMIT_HASH} already exists in ${STATS_FILE}. No new commit needed."
+        cd ..
+        rm -rf "${CLONE_DIR}"
+        exit 0
+    fi
 fi
 
 # --- Append and push ---
@@ -241,7 +258,7 @@ TEMP_FILE="${STATS_FILE}.tmp"
 # the blob on argv.
 data_file="$(mktemp)"
 printf '%s' "${COMMIT_DATA}" >"${data_file}"
-jq --arg sha "${HEAD_COMMIT_HASH}" --slurpfile data "${data_file}" \
+jq --arg sha "${ENTRY_KEY}" --slurpfile data "${data_file}" \
     '. + {($sha): $data[0]}' "${STATS_FILE}" > "${TEMP_FILE}"
 rm -f "${data_file}"
 mv "${TEMP_FILE}" "${STATS_FILE}"

--- a/.github/scripts/benchmark-stats-commit.sh
+++ b/.github/scripts/benchmark-stats-commit.sh
@@ -159,10 +159,14 @@ assemble_performance_data() {
 
     # presets_json can exceed ARG_MAX; pass it via stdin instead of as a jq argument
     # (a too-large argv makes the kernel fail to exec jq with "Argument list too long").
+    # `releaseTag` is empty for per-commit runs and carries the measured tag for
+    # scheduled ones, so a single series can be read release-over-release.
     printf '%s' "${presets_json}" | jq \
         --argjson timestamp "$(date +%s000)" \
         --arg mockMode "${mock_mode}" \
-        '{ timestamp: $timestamp, mockMode: $mockMode, presets: . }'
+        --arg releaseTag "${RELEASE_TAG:-}" \
+        '{ timestamp: $timestamp, mockMode: $mockMode, presets: . }
+         + (if $releaseTag == "" then {} else { releaseTag: $releaseTag } end)'
 }
 
 # Resolve stats file and assemble data

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -20,6 +20,16 @@ on:
         type: string
         default: ''
         description: Commit SHA of `measured-ref`. Required alongside it.
+      series-name:
+        required: false
+        type: string
+        default: ''
+        description: >-
+          Series to file results under, when it is not the branch. A scheduled
+          run measures a different release each time; filing under the tag would
+          produce one file per release holding a single datapoint, which is not
+          a series and which no retention cap can trim. The tag is recorded per
+          entry instead.
       benchmark-mock-mode:
         required: false
         type: string
@@ -348,7 +358,8 @@ jobs:
     env:
       HEAD_COMMIT_HASH: ${{ inputs.measured-sha || github.sha }}
       OWNER: ${{ github.repository_owner }}
-      BRANCH_NAME: ${{ inputs.measured-ref || github.ref_name }}
+      BRANCH_NAME: ${{ inputs.series-name || inputs.measured-ref || github.ref_name }}
+      RELEASE_TAG: ${{ inputs.measured-ref }}
       BENCHMARK_MOCK_MODE: ${{ inputs.benchmark-mock-mode }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -357,6 +357,9 @@ jobs:
     environment: ${{ github.ref_name == github.event.repository.default_branch && 'default-branch' || 'release-ci' }}
     env:
       HEAD_COMMIT_HASH: ${{ inputs.measured-sha || github.sha }}
+      # A named measured-ref means the caller re-measured on purpose, so the
+      # same SHA may legitimately produce more than one point.
+      ALLOW_REMEASURE: ${{ inputs.measured-ref != '' && 'true' || 'false' }}
       OWNER: ${{ github.repository_owner }}
       BRANCH_NAME: ${{ inputs.series-name || inputs.measured-ref || github.ref_name }}
       RELEASE_TAG: ${{ inputs.measured-ref }}

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -7,6 +7,19 @@ on:
         required: true
         type: string
         description: The run ID to get builds from
+      measured-ref:
+        required: false
+        type: string
+        default: ''
+        description: >-
+          The ref actually under measurement, when it is not the workflow's own.
+          A scheduled run measures a release tag while `github.ref_name` is the
+          default branch, so without this the results are filed against `main`.
+      measured-sha:
+        required: false
+        type: string
+        default: ''
+        description: Commit SHA of `measured-ref`. Required alongside it.
       benchmark-mock-mode:
         required: false
         type: string
@@ -315,20 +328,27 @@ jobs:
     needs:
       - benchmarks
       - benchmarks-page-load
+    # Two ways to be a publishable measurement: a push to main/release, or an
+    # explicitly-named ref that the caller measured on purpose. A scheduled run
+    # is the second — without that branch the job is skipped and the series it
+    # exists to build is never written.
     if: >-
       ${{
         !cancelled() &&
-        github.event_name == 'push' &&
-        (github.ref_name == 'main' || startsWith(github.ref, 'refs/heads/release/')) &&
-        !github.event.repository.fork
+        !github.event.repository.fork &&
+        (
+          (github.event_name == 'push' &&
+           (github.ref_name == 'main' || startsWith(github.ref, 'refs/heads/release/')))
+          || inputs.measured-ref != ''
+        )
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: ${{ github.ref_name == github.event.repository.default_branch && 'default-branch' || 'release-ci' }}
     env:
-      HEAD_COMMIT_HASH: ${{ github.sha }}
+      HEAD_COMMIT_HASH: ${{ inputs.measured-sha || github.sha }}
       OWNER: ${{ github.repository_owner }}
-      BRANCH_NAME: ${{ github.ref_name }}
+      BRANCH_NAME: ${{ inputs.measured-ref || github.ref_name }}
       BENCHMARK_MOCK_MODE: ${{ inputs.benchmark-mock-mode }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -15,6 +15,15 @@ on:
         required: true
         type: string
         description: The run ID to get builds from
+      ref:
+        required: false
+        type: string
+        default: ''
+        description: >-
+          Branch, tag or SHA to build. Defaults to the calling workflow's own
+          ref, which is what every per-commit caller wants. A scheduled workflow
+          has no meaningful ref of its own — on `schedule` it resolves to the
+          default branch — so it must name what it is building.
       bundle-analyzer:
         type: boolean
         default: false
@@ -85,6 +94,7 @@ jobs:
         with:
           is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           skip-allow-scripts: true
+          ref: ${{ inputs.ref }}
 
       # Webpack uses TypeScript, but lavamoat node can only run JavaScript, so we need a transpilation step before building.
       - name: Run tsc

--- a/.github/workflows/scheduled-live-benchmarks.yml
+++ b/.github/workflows/scheduled-live-benchmarks.yml
@@ -1,0 +1,108 @@
+name: Scheduled live benchmarks
+
+# Measures the most recent release against live endpoints, on a schedule.
+#
+# This is deliberately NOT the per-commit path. Per-commit runs measure the
+# mocked population, because a live timing is substantially a property of CDN
+# cache state rather than of the commit (extension#45446) and cannot decide
+# whether a merge proceeds.
+#
+# What this series is for: a consistent real-world measure over time. The most
+# recent release is the only reference that is both real and stable — production
+# moves with userbase, device mix and browser versions, and `main` moves with
+# whatever landed that hour, so one bad commit contaminates the series. Neither
+# `main` nor the release candidate is affected by bugs that never shipped.
+#
+# Tracked by extension#45472. Mock-drift detection is a different question with a
+# different source and is tracked separately by extension#45446.
+#
+# This workflow gates nothing.
+
+on:
+  schedule:
+    # 03:17 UTC daily. Off-hour and off-minute deliberately: this competes with
+    # nothing for runners, and the exact minute carries no meaning.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        required: false
+        type: string
+        description: >-
+          Release tag to measure. Defaults to the most recent published release.
+          Set explicitly to backfill a point or to re-measure after an incident.
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  resolve-release:
+    name: Resolve the release under measurement
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.pick.outputs.tag }}
+    steps:
+      - name: Pick the release tag
+        id: pick
+        uses: actions/github-script@v8
+        env:
+          REQUESTED_TAG: ${{ inputs.release-tag }}
+        with:
+          script: |
+            const requested = process.env.REQUESTED_TAG;
+            if (requested) {
+              core.info(`Using requested tag: ${requested}`);
+              core.setOutput('tag', requested);
+              return;
+            }
+
+            // The most recent *published* release, not the newest tag. A tag can
+            // exist for a build that was never shipped, and measuring one would
+            // put a number in this series that no user ever ran.
+            const { data: release } = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            core.info(`Latest published release: ${release.tag_name}`);
+            core.setOutput('tag', release.tag_name);
+
+  build-test-webpack:
+    needs: resolve-release
+    uses: ./.github/workflows/run-build.yml
+    with:
+      build-name: build-test-webpack
+      build-command: yarn build:test --zip
+      builds-from-run: ${{ github.run_id }}
+      ref: ${{ needs.resolve-release.outputs.tag }}
+    secrets: inherit
+
+  build-test-mv2-webpack:
+    needs: resolve-release
+    uses: ./.github/workflows/run-build.yml
+    with:
+      build-name: build-test-mv2-webpack
+      build-command: yarn build:test:mv2 --zip
+      builds-from-run: ${{ github.run_id }}
+      ref: ${{ needs.resolve-release.outputs.tag }}
+    secrets: inherit
+
+  benchmarks:
+    name: live benchmarks (${{ needs.resolve-release.outputs.tag }})
+    needs:
+      - resolve-release
+      - build-test-webpack
+      - build-test-mv2-webpack
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: read
+    uses: ./.github/workflows/run-benchmarks.yml
+    with:
+      builds-from-run: ${{ github.run_id }}
+      # Overrides the branch heuristic in resolveBenchmarkMockMode(). A release
+      # *tag* is neither `main` nor `release/*`, so the heuristic alone would
+      # resolve `mocked` and measure the wrong population.
+      benchmark-mock-mode: live
+    secrets: inherit

--- a/.github/workflows/scheduled-live-benchmarks.yml
+++ b/.github/workflows/scheduled-live-benchmarks.yml
@@ -43,6 +43,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       tag: ${{ steps.pick.outputs.tag }}
+      sha: ${{ steps.pick.outputs.sha }}
     steps:
       - name: Pick the release tag
         id: pick
@@ -52,9 +53,30 @@ jobs:
         with:
           script: |
             const requested = process.env.REQUESTED_TAG;
+            const resolve = async (tag) => {
+              // The stats entry is keyed by commit, so the tag alone is not
+              // enough — a tag can be moved, and an entry filed under a moved
+              // tag would silently describe different code than it claims.
+              const { data: ref } = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${tag}`,
+              });
+              const sha = ref.object.type === 'tag'
+                ? (await github.rest.git.getTag({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    tag_sha: ref.object.sha,
+                  })).data.object.sha
+                : ref.object.sha;
+              core.info(`${tag} -> ${sha}`);
+              core.setOutput('tag', tag);
+              core.setOutput('sha', sha);
+            };
+
             if (requested) {
               core.info(`Using requested tag: ${requested}`);
-              core.setOutput('tag', requested);
+              await resolve(requested);
               return;
             }
 
@@ -66,7 +88,7 @@ jobs:
               repo: context.repo.repo,
             });
             core.info(`Latest published release: ${release.tag_name}`);
-            core.setOutput('tag', release.tag_name);
+            await resolve(release.tag_name);
 
   build-test-webpack:
     needs: resolve-release
@@ -101,6 +123,11 @@ jobs:
     uses: ./.github/workflows/run-benchmarks.yml
     with:
       builds-from-run: ${{ github.run_id }}
+      # On a schedule `github.ref_name` is the default branch and `github.sha`
+      # is its head, so without these the results are stored against `main`
+      # rather than the release they describe.
+      measured-ref: ${{ needs.resolve-release.outputs.tag }}
+      measured-sha: ${{ needs.resolve-release.outputs.sha }}
       # Overrides the branch heuristic in resolveBenchmarkMockMode(). A release
       # *tag* is neither `main` nor `release/*`, so the heuristic alone would
       # resolve `mocked` and measure the wrong population.

--- a/.github/workflows/scheduled-live-benchmarks.yml
+++ b/.github/workflows/scheduled-live-benchmarks.yml
@@ -128,6 +128,10 @@ jobs:
       # rather than the release they describe.
       measured-ref: ${{ needs.resolve-release.outputs.tag }}
       measured-sha: ${{ needs.resolve-release.outputs.sha }}
+      # One series across all releases, not one file per tag. Entries are keyed
+      # by the release commit and carry `releaseTag`, so the file reads
+      # release-over-release and the retention cap in #45451 applies to it.
+      series-name: scheduled-live
       # Overrides the branch heuristic in resolveBenchmarkMockMode(). A release
       # *tag* is neither `main` nor `release/*`, so the heuristic alone would
       # resolve `mocked` and measure the wrong population.


### PR DESCRIPTION
## **Changelog**

CHANGELOG entry: null

## **Description**

> **Stacked on #45455.** Base that PR, not `main` — the `benchmark-mock-mode` input this passes lives there.

#45455 moves the per-commit path to mocks, because a live timing is substantially a property of CDN cache state rather than of the commit (#45446: `max-age=10800`, a miss costs 292ms against 105ms for a hit). That is right for the gate, and it leaves no stable real-world measure behind. This restores one.

How the data is used decides where it is collected. Four purposes were separated in the release thread and do not share an answer:

| purpose | source |
|---|---|
| How the app performs for users | production telemetry |
| **A consistent real-world measure over time** | **this workflow** |
| Drift between mock timings and reality | scheduled on `main` — #45446 |
| Client-side regressions and the gate | mocks — #45204, #45455 |

The most recent **published** release is the only reference that is both real and stable. Production moves with userbase, device mix and browser versions; `main` moves with whatever landed that hour, so one bad commit contaminates the series. Neither `main` nor the release candidate is affected by bugs that never shipped.

It uses `getLatestRelease`, not the newest tag: a tag can exist for a build that was never shipped, and measuring one would put a number in this series that no user ever ran.

### `run-build.yml` gains an optional `ref`

This is the part worth reviewing. `run-build.yml` had no way to say what it builds — it checks out the calling workflow's own context ref. On a `schedule` trigger that resolves to the **default branch**, so a first draft of this workflow would have benchmarked `main` while reporting a release tag, and the series would have looked plausible and been wrong.

The input defaults to `''`, and `action-checkout-and-setup` treats an empty `ref` as "use the default", so **every existing caller is unaffected by omitting it**. That is the whole compatibility argument and it is worth checking rather than taking on trust.

### Deliberately not decided here

The `17 3 * * *` cadence is a starting point, not a conclusion. #45446 shows live variance is large, so one run per day may be too few samples to trend on — that should be set from the first weeks of data. `workflow_dispatch` takes an explicit `release-tag` so a point can be backfilled or re-measured without waiting.

Extending to the last N releases turns a moving point into a release-over-release comparison. Deferred until the single-release version produces something.

### What this does not do

It **gates nothing** and blocks no merge. It does not detect API performance regressions — that was raised alongside this and has a different consumer, different endpoints and different alerting; it is out of scope for this epic deliberately, not by oversight.

There is no executed run behind this PR. A scheduled workflow cannot be exercised before it lands, and `workflow_dispatch` is the mechanism for the first real sample. What is checked here is structural: both files parse, the job graph resolves, and every input passed matches the callee's declared inputs.

## **Related issues**

Fixes: #45472

- #45455 — the base of this branch; supplies `benchmark-mock-mode`
- #45446 — mock-drift detection, the other scheduled job and a different question
- #45451 — series size cap; a third series otherwise hits the same limit
- #45205 — recalibration

## **Manual testing steps**

1. `workflow_dispatch` with no input — confirm it resolves the latest published release and that the benchmark jobs report that tag, not `main`.
2. Confirm the results land in the `live` series and not the mocked one.
3. Confirm an ordinary PR still builds normally, i.e. omitting `ref` changed nothing.

## **Screenshots/Recordings**

CI workflow-only change with no user-visible surface; nothing to capture.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how benchmark stats are written and deduplicated in an external repo; mistakes could mis-attribute or duplicate series data, but the workflow does not gate merges.
> 
> **Overview**
> Adds a **daily scheduled workflow** (plus `workflow_dispatch`) that builds the latest **published** release tag, runs benchmarks against **live** endpoints, and publishes results into a single cross-release series (`scheduled-live`) instead of per-commit mocked stats.
> 
> **`run-build`** gains an optional **`ref`** checkout input so scheduled callers can build a release tag while the workflow context still points at the default branch.
> 
> **`run-benchmarks` / stats commit** are extended so callers can pass **`measured-ref`**, **`measured-sha`**, and **`series-name`**: `store-benchmark-stats` runs when a ref is explicitly measured (not only on `main`/`release/*` pushes), files under the named series, stamps **`releaseTag`** on each entry, and allows **re-measures** of the same SHA via `ALLOW_REMEASURE` (dedup key becomes `SHA-runId`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84cad20186705fc47e2424b5e8e83bb36c32a714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->