### PR TITLE
fix(ui): polish SRP backup screens and auto-open confirm modal

### DIFF
--- a/test/e2e/page-objects/pages/onboarding/secure-wallet-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/secure-wallet-page.ts
@@ -4,9 +4,6 @@ class SecureWalletPage {
   private readonly confirmPasswordButton =
     '[data-testid="reveal-recovery-phrase-continue"]';
 
-  private readonly confirmRecoveryPhraseButton =
-    '[data-testid="recovery-phrase-confirm"]';
-
   private readonly confirmSecretRecoveryPhraseMessage = {
     text: 'Confirm your Secret Recovery Phrase',
     tag: 'h2',
@@ -113,8 +110,7 @@ class SecureWalletPage {
     await this.driver.clickElement(quizInputSelector1);
     await this.driver.clickElement(quizInputSelector2);
 
-    await this.driver.clickElement(this.confirmRecoveryPhraseButton);
-
+    // Modal opens automatically after all three quiz words are selected
     await this.driver.waitForMultipleSelectors([
       this.confirmSrpSuccessMessage,
       this.confirmSrpConfirmButton,

--- a/ui/pages/onboarding-flow/onboarding-flow.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.tsx
@@ -401,7 +401,8 @@ export default function OnboardingFlow() {
     }
     if (
       pathname?.startsWith(ONBOARDING_REVEAL_SRP_ROUTE) ||
-      pathname?.startsWith(ONBOARDING_REVIEW_SRP_ROUTE)
+      pathname?.startsWith(ONBOARDING_REVIEW_SRP_ROUTE) ||
+      pathname?.startsWith(ONBOARDING_CONFIRM_SRP_ROUTE)
     ) {
       return 'var(--color-background-default)';
     }

--- a/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/recovery-phrase-chips.test.tsx.snap
+++ b/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/recovery-phrase-chips.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
     class="flex flex-col gap-4"
   >
     <div
-      class="bg-section recovery-phrase__secret rounded-lg w-full"
+      class="recovery-phrase__secret rounded-lg w-full"
     >
       <div
         class="items-center justify-center recovery-phrase__chips grid"
@@ -218,7 +218,7 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
     class="flex flex-col gap-4"
   >
     <div
-      class="bg-section recovery-phrase__secret rounded-lg w-full"
+      class="recovery-phrase__secret rounded-lg w-full"
     >
       <div
         class="items-center justify-center recovery-phrase__chips grid"

--- a/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/review-recovery-phrase.test.tsx.snap
+++ b/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/review-recovery-phrase.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`Review Recovery Phrase Component renders match snapshot when isFromRemi
         class="flex flex-col gap-4"
       >
         <div
-          class="bg-section recovery-phrase__secret rounded-lg w-full"
+          class="recovery-phrase__secret rounded-lg w-full"
         >
           <div
             class="items-center justify-center recovery-phrase__chips grid recovery-phrase__chips--hidden"
@@ -382,7 +382,7 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
         class="flex flex-col gap-4"
       >
         <div
-          class="bg-section recovery-phrase__secret rounded-lg w-full"
+          class="recovery-phrase__secret rounded-lg w-full"
         >
           <div
             class="items-center justify-center recovery-phrase__chips grid recovery-phrase__chips--hidden"
@@ -695,7 +695,7 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
         class="flex flex-col gap-4"
       >
         <div
-          class="bg-section recovery-phrase__secret rounded-lg w-full"
+          class="recovery-phrase__secret rounded-lg w-full"
         >
           <div
             class="items-center justify-center recovery-phrase__chips grid"

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.tsx
@@ -113,6 +113,7 @@ describe('Confirm Recovery Phrase Component', () => {
       replace: true,
     });
   });
+
   it('should have 3 recovery phrase inputs', () => {
     const { queryAllByTestId } = renderWithProvider(
       <ConfirmRecoveryPhrase {...props} />,
@@ -124,7 +125,7 @@ describe('Confirm Recovery Phrase Component', () => {
     );
   });
 
-  it('should not enable confirm recovery phrase with two missing words', () => {
+  it('does not show the confirm modal when words are still missing', () => {
     const { queryByTestId, queryAllByTestId } = renderWithProvider(
       <ConfirmRecoveryPhrase {...props} />,
       mockStore,
@@ -134,74 +135,14 @@ describe('Confirm Recovery Phrase Component', () => {
       /recovery-phrase-quiz-unanswered-/u,
     );
 
-    const wrongInputEvent = {
-      target: {
-        value: 'wrong',
-      },
-    };
+    fireEvent.click(recoveryPhraseInputs[0]);
+    fireEvent.click(recoveryPhraseInputs[1]);
 
-    fireEvent.change(recoveryPhraseInputs[0], wrongInputEvent);
-
-    const confirmRecoveryPhraseButton = queryByTestId(
-      'recovery-phrase-confirm',
-    );
-    expect(confirmRecoveryPhraseButton).toBeDisabled();
+    expect(queryByTestId('confirm-srp-modal')).not.toBeInTheDocument();
+    expect(queryByTestId('recovery-phrase-confirm')).not.toBeInTheDocument();
   });
 
-  it('should not enable confirm recovery phrase with one missing words', () => {
-    const { queryByTestId, queryAllByTestId } = renderWithProvider(
-      <ConfirmRecoveryPhrase {...props} />,
-      mockStore,
-    );
-
-    const recoveryPhraseInputs = queryAllByTestId(
-      /recovery-phrase-quiz-unanswered-/u,
-    );
-
-    const wrongInputEvent = {
-      target: {
-        value: 'wrong',
-      },
-    };
-
-    fireEvent.change(recoveryPhraseInputs[0], wrongInputEvent);
-    fireEvent.change(recoveryPhraseInputs[1], wrongInputEvent);
-
-    const confirmRecoveryPhraseButton = queryByTestId(
-      'recovery-phrase-confirm',
-    );
-
-    expect(confirmRecoveryPhraseButton).toBeDisabled();
-  });
-
-  it('should not enable confirm recovery phrase with wrong word inputs', () => {
-    const { queryByTestId, queryAllByTestId } = renderWithProvider(
-      <ConfirmRecoveryPhrase {...props} />,
-      mockStore,
-    );
-
-    const recoveryPhraseInputs = queryAllByTestId(
-      /recovery-phrase-quiz-unanswered-/u,
-    );
-
-    const wrongInputEvent = {
-      target: {
-        value: 'wrong',
-      },
-    };
-
-    fireEvent.change(recoveryPhraseInputs[0], wrongInputEvent);
-    fireEvent.change(recoveryPhraseInputs[1], wrongInputEvent);
-    fireEvent.change(recoveryPhraseInputs[2], wrongInputEvent);
-
-    const confirmRecoveryPhraseButton = queryByTestId(
-      'recovery-phrase-confirm',
-    );
-
-    expect(confirmRecoveryPhraseButton).toBeDisabled();
-  });
-
-  it('should enable confirm recovery phrase with correct word inputs', () => {
+  it('shows the success modal automatically after selecting all quiz words', () => {
     const { queryByTestId, queryAllByTestId, getByText } = renderWithProvider(
       <ConfirmRecoveryPhrase {...props} />,
       mockStore,
@@ -211,20 +152,10 @@ describe('Confirm Recovery Phrase Component', () => {
       /recovery-phrase-quiz-unanswered-/u,
     );
 
-    // click and answer the srp quiz
     clickAndAnswerSrpQuiz(quizUnansweredChips);
 
-    // assert the unanswered chips are not in the document
-    const quizAnsweredChips = queryAllByTestId(
-      /recovery-phrase-quiz-answered-/u,
-    );
-    expect(quizAnsweredChips).toHaveLength(3);
-
-    const confirmRecoveryPhraseButton = queryByTestId(
-      'recovery-phrase-confirm',
-    );
-    expect(confirmRecoveryPhraseButton).not.toBeDisabled();
-    fireEvent.click(confirmRecoveryPhraseButton as HTMLElement);
+    expect(queryByTestId('confirm-srp-modal')).toBeInTheDocument();
+    expect(queryByTestId('recovery-phrase-confirm')).not.toBeInTheDocument();
 
     const gotItButton = getByText(messages.gotIt.message);
     expect(gotItButton).toBeInTheDocument();
@@ -241,7 +172,7 @@ describe('Confirm Recovery Phrase Component', () => {
       .spyOn(BrowserRuntimeUtils, 'getBrowserName')
       .mockReturnValue(PLATFORM_FIREFOX);
 
-    const { queryByTestId, queryAllByTestId, getByText } = renderWithProvider(
+    const { queryAllByTestId, getByText } = renderWithProvider(
       <ConfirmRecoveryPhrase {...props} />,
       mockStore,
     );
@@ -250,19 +181,8 @@ describe('Confirm Recovery Phrase Component', () => {
       /recovery-phrase-quiz-unanswered-/u,
     );
 
-    // click and answer the srp quiz
     clickAndAnswerSrpQuiz(quizUnansweredChips);
 
-    const quizAnsweredChips = queryAllByTestId(
-      /recovery-phrase-quiz-answered-/u,
-    );
-    expect(quizAnsweredChips).toHaveLength(3);
-
-    const confirmRecoveryPhraseButton = queryByTestId(
-      'recovery-phrase-confirm',
-    );
-
-    fireEvent.click(confirmRecoveryPhraseButton as HTMLElement);
     fireEvent.click(getByText(messages.gotIt.message));
 
     expect(setSeedPhraseBackedUp).toHaveBeenCalledWith(true);

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.tsx
@@ -10,11 +10,8 @@ import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   Box,
-  Button,
   ButtonIcon,
   ButtonIconSize,
-  ButtonSize,
-  ButtonVariant,
   IconName,
   Text,
   TextVariant,
@@ -99,7 +96,6 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
   const [quizWords, setQuizWords] = useState(
     generateQuizWords(splitSecretRecoveryPhrase),
   );
-  const [answerSrp, setAnswerSrp] = useState('');
 
   useEffect(() => {
     if (!secretRecoveryPhrase) {
@@ -138,23 +134,19 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
         (answer: { word: string }) => !answer.word,
       );
       if (isNotAnswered) {
-        setAnswerSrp('');
-      } else {
-        const copySplitSrp = [...splitSecretRecoveryPhrase];
-        inputValue.forEach((answer: { index: number; word: string }) => {
-          copySplitSrp[answer.index] = answer.word;
-        });
-        setAnswerSrp(copySplitSrp.join(' '));
+        return;
       }
-    },
-    [splitSecretRecoveryPhrase],
-  );
 
-  const onContinue = useCallback(() => {
-    const isMatching = answerSrp === secretRecoveryPhrase;
-    setMatching(isMatching);
-    setShowConfirmModal(true);
-  }, [answerSrp, secretRecoveryPhrase]);
+      const copySplitSrp = [...splitSecretRecoveryPhrase];
+      inputValue.forEach((answer: { index: number; word: string }) => {
+        copySplitSrp[answer.index] = answer.word;
+      });
+      const nextAnswerSrp = copySplitSrp.join(' ');
+      setMatching(nextAnswerSrp === secretRecoveryPhrase);
+      setShowConfirmModal(true);
+    },
+    [secretRecoveryPhrase, splitSecretRecoveryPhrase],
+  );
 
   const handleConfirmedPhrase = useCallback(() => {
     dispatch(setSeedPhraseBackedUp(true));
@@ -200,7 +192,7 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
   return (
     <Box
       flexDirection={BoxFlexDirection.Column}
-      justifyContent={BoxJustifyContent.Between}
+      justifyContent={BoxJustifyContent.Start}
       gap={6}
       className="recovery-phrase recovery-phrase__confirm h-full"
       data-testid="confirm-recovery-phrase"
@@ -285,18 +277,6 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
             setInputValue={handleQuizInput}
           />
         )}
-      </Box>
-      <Box className="w-full">
-        <Button
-          variant={ButtonVariant.Primary}
-          data-testid="recovery-phrase-confirm"
-          size={ButtonSize.Lg}
-          className="recovery-phrase__footer__confirm--button w-full"
-          onClick={() => onContinue()}
-          disabled={answerSrp.trim() === ''}
-        >
-          {t('continue')}
-        </Button>
       </Box>
     </Box>
   );

--- a/ui/pages/onboarding-flow/recovery-phrase/index.scss
+++ b/ui/pages/onboarding-flow/recovery-phrase/index.scss
@@ -8,7 +8,7 @@
   &__chips {
     grid-template-columns: 1fr 1fr 1fr;
     column-gap: 8px;
-    row-gap: 4px;
+    row-gap: 8px;
     padding-top: 8px;
     padding-bottom: 8px;
 
@@ -41,12 +41,10 @@
       }
     }
 
-    .mm-text-field.mm-text-field--target-index {
-      outline: 5px auto var(--color-primary-default);
-    }
-
+    .mm-text-field.mm-text-field--target-index,
     .mm-text-field.mm-text-field--focused {
-      outline: 5px auto var(--color-primary-default);
+      outline: none;
+      border-color: var(--color-icon-default);
     }
 
     .mm-input {

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.tsx
@@ -156,7 +156,6 @@ export default function RecoveryPhraseChips({
   return (
     <Box flexDirection={BoxFlexDirection.Column} gap={4}>
       <Box
-        backgroundColor={BoxBackgroundColor.BackgroundSection}
         className={classnames(
           'recovery-phrase__secret rounded-lg w-full',
           recoveryPhraseChipsContainerClassName,
@@ -186,20 +185,20 @@ export default function RecoveryPhraseChips({
                 className="recovery-phrase__text rounded-lg px-2"
                 flexDirection={BoxFlexDirection.Row}
                 alignItems={BoxAlignItems.Center}
-                backgroundColor={
-                  isQuizWord
-                    ? BoxBackgroundColor.BackgroundDefault
-                    : BoxBackgroundColor.BackgroundMuted
-                }
-                borderColor={
-                  isTargetIndex
-                    ? BoxBorderColor.PrimaryDefault
-                    : BoxBorderColor.BorderMuted
-                }
-                borderWidth={isTargetIndex ? 2 : 1}
+                backgroundColor={BoxBackgroundColor.BackgroundMuted}
+                borderColor={BoxBorderColor.BorderMuted}
+                borderWidth={1}
                 paddingTop={1}
                 paddingBottom={1}
                 gap={1}
+                style={
+                  isTargetIndex
+                    ? {
+                        borderColor: 'var(--color-icon-default)',
+                        borderWidth: '1.5px',
+                      }
+                    : undefined
+                }
                 onClick={() => {
                   if (!isQuizWord) {
                     return;
@@ -305,7 +304,7 @@ export default function RecoveryPhraseChips({
                 data-testid={`recovery-phrase-quiz-answered-${actualIdxInSrp}`}
                 key={quizWord.index}
                 color={TextColor.TextAlternative}
-                className="rounded-lg w-full bg-muted"
+                className="rounded-lg w-full bg-muted hover:bg-muted-hover active:bg-muted-pressed"
                 onClick={() => {
                   removeQuizWord(quizWord.word);
                 }}
@@ -317,7 +316,7 @@ export default function RecoveryPhraseChips({
                 data-testid={`recovery-phrase-quiz-unanswered-${actualIdxInSrp}`}
                 key={quizWord.index}
                 variant={ButtonVariant.Secondary}
-                className="rounded-lg w-full bg-muted border-primary-default border text-primary-default"
+                className="rounded-lg w-full"
                 onClick={() => {
                   addQuizWord(quizWord.word, actualIdxInSrp);
                 }}


### PR DESCRIPTION
## **Description**

### Context
The Secret Recovery Phrase backup flow (onboarding and post-onboarding reminder) had visual inconsistencies: an extra gray section behind the word chips, confirm-screen background using muted instead of default, and quiz controls styled with primary/blue accents.

### Problem
- Save SRP showed a large gray container behind the 12 word chips.
- Confirm SRP used a muted page background and black/default missing-word fields.
- Quiz word buttons used primary border/text, and the focused missing-word field used a blue highlight.
- Users had to click Continue after selecting all three quiz words.

### Solution
- Remove the outer `BackgroundSection` wrapper around the chips; keep individual chip styling.
- Use `background/default` for the confirm onboarding container.
- Style missing-word fields with `background/muted` and an `icon/default` 1.5px focus stroke; equalize chip row/column gaps to 8px.
- Restyle unanswered quiz buttons as secondary (no stroke, keep hover).
- Auto-open the Perfect / Not quite right modal when all three quiz words are selected; remove the Continue button.
- Update unit tests and the onboarding E2E page object accordingly.

## **Changelog**

CHANGELOG entry: Improved Secret Recovery Phrase backup screen styling and automatically showed confirmation after selecting the quiz words

## **Related issues**

Fixes:

<!--
## **Related issues**
Fixes:
-->

## **Manual testing steps**

1. Create a new wallet (or use backup reminder) and open Save Secret Recovery Phrase.
2. Confirm there is no large gray panel behind the 12 word chips (light and dark mode).
3. Continue to Confirm Secret Recovery Phrase.
4. Confirm page background is `background/default`, missing fields use muted fill, active field uses icon/default stroke, and the three word buttons have no border but still hover.
5. Select all three quiz words and verify the Perfect / Not quite right modal opens without clicking Continue.
6. Repeat for both onboarding and settings/reminder backup flows.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/9e4e8200-cc6a-4e83-b517-dcd9483325b0

<img width="364" height="715" alt="Screenshot 2026-08-12 at 10 02 50 AM" src="https://github.com/user-attachments/assets/02a04639-5b5e-4136-bdac-175be619508d" />
<img width="371" height="732" alt="Screenshot 2026-08-11 at 5 02 39 PM" src="https://github.com/user-attachments/assets/4ad81c93-5764-4e9f-8d2b-bc96dfed2d75" />



### **After**

https://github.com/user-attachments/assets/cc77ae40-a936-464c-8f2e-b3e6aaa32d27

<img width="381" height="726" alt="Screenshot 2026-08-12 at 12 37 23 PM" src="https://github.com/user-attachments/assets/c904bf52-8c69-4197-b881-b56b9a6a124b" />
<img width="375" height="757" alt="Screenshot 2026-08-12 at 12 37 43 PM" src="https://github.com/user-attachments/assets/0e681996-f7b6-4136-9a53-e136fe8876bb" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)