### PR TITLE
ci: install anvil with retry

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -56,9 +56,13 @@ jobs:
           is-high-risk-environment: false
           skip-allow-scripts: true
 
-      - name: Install anvil
-        run: yarn mm-foundryup
-        shell: bash
+      - name: Install anvil with retry
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 1
+          max_attempts: 4
+          retry_wait_seconds: 30
+          command: yarn mm-foundryup
 
       - name: Download build artifact
         uses: actions/download-artifact@v7

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -91,8 +91,13 @@ jobs:
           is-high-risk-environment: false
           skip-allow-scripts: true
 
-      - name: Install anvil
-        run: yarn mm-foundryup
+      - name: Install anvil with retry
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 1
+          max_attempts: 4
+          retry_wait_seconds: 30
+          command: yarn mm-foundryup
 
       - name: Download build artifact
         if: ${{ inputs.build-artifact != '' }}

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -180,8 +180,13 @@ jobs:
           is-high-risk-environment: false
           skip-allow-scripts: true
 
-      - name: Install anvil
-        run: yarn mm-foundryup
+      - name: Install anvil with retry
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 1
+          max_attempts: 4
+          retry_wait_seconds: 30
+          command: yarn mm-foundryup
 
       - name: Download dist artifact
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## **Description**

We're having a problem, especially in the Merge Queue, where the anvil download keeps failing.  Now using `nick-fields/retry` to retry the download.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to how Anvil is installed; no application, auth, or data-path changes.
> 
> **Overview**
> Replaces the one-shot **`yarn mm-foundryup`** step with **`nick-fields/retry`** (pinned to v3.0.2) so flaky Anvil/Foundry downloads are retried instead of failing the job immediately.
> 
> The same retry settings are applied in **`run-e2e.yml`**, **`run-benchmarks.yml`**, and **`update-e2e-fixtures.yml`**: up to **4** attempts, **30** seconds between tries, and a **1**-minute per-attempt timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb599abb9bce3da54af8d8db11f0589da6e42eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->