### PR TITLE
feat: point add evm network skill to skills repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1718,7 +1718,9 @@ Performance Checks (React Components):
 ### EVM Swaps/Bridge Agent Entrypoints
 
 - **EVM Swaps/Bridge Standard:** [`docs/add-evm-swaps-bridge-network.md`](./docs/add-evm-swaps-bridge-network.md) - Canonical implementation and review standard for adding a new EVM network to the unified swaps/bridge flow (bridge allowlist, default token pair, stablecoin slippage, and `bridgeConfigV2` rollout). Follows the MegaETH/Robinhood pattern.
-- **Cursor Skill:** [`.cursor/skills/mms-add-evm-swaps-bridge-network/SKILL.md`](./.cursor/skills/mms-add-evm-swaps-bridge-network/SKILL.md) - Local Cursor skill entrypoint for the shared standard.
+- **OpenAI/Codex Skill:** [`.agents/skills/mms-add-evm-network/SKILL.md`](./.agents/skills/mms-add-evm-network/SKILL.md) - Multi-agent skill entrypoint for the shared standard.
+- **Cursor Rule:** [`.cursor/rules/mms-add-evm-network/RULE.md`](./.cursor/rules/mms-add-evm-network/RULE.md) - Cursor rule entrypoint for the shared standard.
+- **Claude Skill:** [`.claude/skills/mms-add-evm-network/SKILL.md`](./.claude/skills/mms-add-evm-network/SKILL.md) - Claude skill entrypoint for the shared standard.
 
 ### External Resources
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### **Context**

The Non-EVM Swaps/Bridge section in `AGENTS.md` already documents the centralized [MetaMask/skills](https://github.com/MetaMask/skills) entrypoints (Codex, Cursor rule, Claude skill). The EVM section still pointed at the legacy local path `.cursor/skills/mms-add-evm-swaps-bridge-network/SKILL.md`, which is out of date after the skills repo migration and `yarn skills` sync.

### **Problem**

AI agents following `AGENTS.md` for EVM swaps/bridge network tasks were directed to a stale skill path instead of the current multi-harness entrypoints. That mismatch could cause agents to miss or use the wrong guidance when adding a new EVM chain to the unified swaps/bridge flow.

### **Solution**

Update the **EVM Swaps/Bridge Agent Entrypoints** section in `AGENTS.md` to mirror the Non-EVM pattern, linking to:

- `.agents/skills/mms-add-evm-network/SKILL.md` (OpenAI/Codex)
- `.cursor/rules/mms-add-evm-network/RULE.md` (Cursor rule)
- `.claude/skills/mms-add-evm-network/SKILL.md` (Claude skill)

The canonical standard doc (`docs/add-evm-swaps-bridge-network.md`) is unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4896

## **Manual testing steps**

1. Open `AGENTS.md` and scroll to **EVM Swaps/Bridge Agent Entrypoints**.
2. Confirm the three linked paths exist locally (after `yarn skills` sync):
   - `.agents/skills/mms-add-evm-network/SKILL.md`
   - `.cursor/rules/mms-add-evm-network/RULE.md`
   - `.claude/skills/mms-add-evm-network/SKILL.md`
3. Confirm each entrypoint references `docs/add-evm-swaps-bridge-network.md` as the single source of truth.
4. Compare with the **Non-EVM Swaps/Bridge Agent Entrypoints** section above it and verify the structure matches.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent entrypoint links; no runtime or product behavior is affected.
> 
> **Overview**
> Updates **EVM Swaps/Bridge Agent Entrypoints** in `AGENTS.md` so agents use the same multi-harness layout as the Non-EVM section after the MetaMask/skills migration.
> 
> The legacy link to `.cursor/skills/mms-add-evm-swaps-bridge-network/SKILL.md` is removed and replaced with **OpenAI/Codex** (`.agents/skills/mms-add-evm-network/SKILL.md`), **Cursor rule** (`.cursor/rules/mms-add-evm-network/RULE.md`), and **Claude skill** (`.claude/skills/mms-add-evm-network/SKILL.md`). The canonical standard doc `docs/add-evm-swaps-bridge-network.md` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7d189d18f7210a8cff58480cda37882f933c62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->