### PR TITLE
test: fix flaky BTC activity navigation after send

### DIFF
--- a/test/e2e/page-objects/components/tx-toast-notification.ts
+++ b/test/e2e/page-objects/components/tx-toast-notification.ts
@@ -14,6 +14,9 @@ export class TxToastNotification {
     text: 'Transaction confirmed',
   };
 
+  private readonly transactionSubmittedToast =
+    '[data-testid="transaction-submitted-toast"]';
+
   constructor(driver: Driver) {
     this.driver = driver;
   }
@@ -21,6 +24,11 @@ export class TxToastNotification {
   async checkTxConfirmedToast(): Promise<void> {
     console.log('Check transaction confirmed toast is displayed');
     await this.driver.waitForSelector(this.transactionConfirmedText);
+  }
+
+  async checkTxSubmittedToast(): Promise<void> {
+    console.log('Check transaction submitted toast is displayed');
+    await this.driver.waitForSelector(this.transactionSubmittedToast);
   }
 
   async closeToastNotification(): Promise<void> {

--- a/test/e2e/page-objects/flows/bitcoin-send.flow.ts
+++ b/test/e2e/page-objects/flows/bitcoin-send.flow.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_BTC_BALANCE } from '../../constants';
 import { Driver } from '../../webdriver/driver';
+import { TxToastNotification } from '../components/tx-toast-notification';
 import HomePage from '../pages/home/homepage';
 import TokensTab from '../pages/home/tokens-tab';
 import BitcoinReviewTxPage from '../pages/send/bitcoin-review-tx-page';
@@ -42,4 +43,7 @@ export const broadcastBitcoinSend = async ({
   const reviewPage = new BitcoinReviewTxPage(driver);
   await reviewPage.checkPageIsLoaded();
   await reviewPage.clickConfirmButton();
+
+  const txToast = new TxToastNotification(driver);
+  await txToast.checkTxSubmittedToast();
 };

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -1,4 +1,5 @@
 import { WebElement } from 'selenium-webdriver';
+import { ACTIVITY_ROUTE } from '../../../../../ui/helpers/constants/routes';
 import { Driver } from '../../../webdriver/driver';
 import { Anvil } from '../../../seeder/anvil';
 import HeaderNavbar from '../header-navbar';
@@ -554,6 +555,9 @@ class HomePage {
     );
     if (isBottomNav) {
       await this.driver.clickElement(this.bottomNavActivityButton);
+      await this.driver.waitForUrl({
+        url: `${this.driver.extensionUrl}/home.html#${ACTIVITY_ROUTE}`,
+      });
     } else {
       await this.driver.clickElement(this.activityTab);
     }

--- a/ui/components/app/toast-listener/shared.test.tsx
+++ b/ui/components/app/toast-listener/shared.test.tsx
@@ -24,11 +24,13 @@ jest.mock('../../ui/toast/toast', () => ({
   ToastContent: ({
     title,
     description,
+    dataTestId,
   }: {
     title: string;
     description?: string;
+    dataTestId?: string;
   }) => (
-    <div>
+    <div data-testid={dataTestId}>
       <p>{title}</p>
       {description ? <p>{description}</p> : null}
     </div>
@@ -113,5 +115,15 @@ describe('toast-listener/shared', () => {
     render(mockToastSuccess.mock.calls[0][0]);
 
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('sets a data-testid on the pending toast content', () => {
+    showPendingToast('pending-id');
+
+    render(mockToastLoading.mock.calls[0][0]);
+
+    expect(
+      screen.getByTestId('transaction-submitted-toast'),
+    ).toBeInTheDocument();
   });
 });

--- a/ui/components/app/toast-listener/shared.tsx
+++ b/ui/components/app/toast-listener/shared.tsx
@@ -5,6 +5,12 @@ import { useToastLabel } from './useToastLabel';
 
 export type ToastStatus = 'pending' | 'success' | 'failed';
 
+const transactionToastTestIds: Record<ToastStatus, string> = {
+  pending: 'transaction-submitted-toast',
+  success: 'transaction-confirmed-toast',
+  failed: 'transaction-failed-toast',
+};
+
 type Props = {
   toastId?: string;
   transactionId?: string;
@@ -21,7 +27,11 @@ const TransactionToastContent = ({
 
   return (
     <>
-      <ToastContent title={title} description={description} />
+      <ToastContent
+        title={title}
+        description={description}
+        dataTestId={transactionToastTestIds[status]}
+      />
 
       {to && (
         <Link


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Problem:** `BTC Account - Activity Transaction details show Title / Time / Status / TXID / From / To / Amount / View details` flakes with a 10s timeout waiting for `Sending BTC` on the activity list. After BTC confirm, the snap dialog disappears before `useSendActions` finishes `sendMultichainTransactionForReview` and runs `navigate('/?tab=activity')`. The spec then clicks the bottom-nav Activity tab (treatment of `coreExtensionUxCeux1141AbtestBottomNav`) and immediately asserts the activity row. That click can land on `/activity`, then the product navigate overwrites the URL back to Home (`/` is always the Home tab when bottom nav is on; Activity is `/activity`, not `/?tab=activity`). Selenium reports the click as successful, but the screenshot is still Home with a "Transaction submitted" toast, so `Sending BTC` never appears.

**Why / solution:** Wait for the submitted toast after confirm so the product's post-send `navigate('/?tab=activity')` has already fired and cannot overwrite `/activity`. The toast wait uses `[data-testid="transaction-submitted-toast"]` (added on `TransactionToastContent`). Then, when bottom nav is present, wait for `#/activity` after the Activity click so a swallowed click fails at `goToActivityList()` instead of 10s later on the activity-row assert. This is a test-only workaround for [Bug #43641](https://github.com/MetaMask/metamask-extension/issues/43641); the product should eventually navigate to `/activity` when bottom nav is enabled.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:
Slack: https://consensys.slack.com/archives/CTQAGKY5V/p1786611507987829?thread_ts=1786610144.729389&cid=CTQAGKY5V

## **Manual testing steps**

1. Build a test extension: `yarn start:test`
2. Run the failing spec:
   ```
   SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/btc/activity.spec.ts
   ```
3. After BTC confirm, wait until the "Transaction submitted" toast is visible, then confirm the UI is on the Activity page (`#/activity`) before the `Sending BTC` row is asserted.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI test-hook additions and E2E timing waits; no auth, transaction, or routing logic changes in product code beyond toast test IDs.
> 
> **Overview**
> Reduces flakiness in BTC send → activity E2E by **synchronizing on UI signals** instead of racing post-confirm navigation.
> 
> Transaction toasts now expose stable **`data-testid`** values (`transaction-submitted-toast`, `transaction-confirmed-toast`, `transaction-failed-toast`) via `TransactionToastContent`. The Bitcoin send flow **waits for the submitted toast** after confirm so late `navigate('/?tab=activity')` does not clobber a bottom-nav jump to Activity. **`goToActivityList`** waits for `#/activity` when bottom nav is shown so a failed Activity click surfaces earlier.
> 
> A unit test asserts the pending toast renders `transaction-submitted-toast`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 582a4376d3c21ac8026ee51fb2e627be2af116c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->