### PR TITLE
feat: persist selected toolbar viewport

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -28,6 +28,7 @@ import {
   ENVIRONMENT_TYPE_SIDEPANEL,
   PLATFORM_FIREFOX,
   MESSAGE_TYPE,
+  POPUP_INIT_FILE,
 } from '../../shared/constants/app';
 import { AccountOverviewTabKey } from '../../shared/constants/app-state';
 import { EXTENSION_MESSAGES } from '../../shared/constants/messages';
@@ -2323,7 +2324,7 @@ async function applyToolbarSidePanelBehavior() {
   });
   // Keep the persisted action popup aligned with the selected viewport.
   await browser.action?.setPopup?.({
-    popup: useSidePanelAsDefault ? '' : 'popup-init.html',
+    popup: useSidePanelAsDefault ? '' : POPUP_INIT_FILE,
   });
 }
 
@@ -2350,7 +2351,7 @@ const setupSidePanelToolbarBehavior = async () => {
             })
             .then(() =>
               browser.action?.setPopup?.({
-                popup: useSidePanelAsDefault ? '' : 'popup-init.html',
+                popup: useSidePanelAsDefault ? '' : POPUP_INIT_FILE,
               }),
             )
             .catch((error) =>

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -2321,6 +2321,7 @@ async function applyToolbarSidePanelBehavior() {
   await browser.sidePanel.setPanelBehavior({
     openPanelOnActionClick: useSidePanelAsDefault,
   });
+  // Keep the persisted action popup aligned with the selected viewport.
   await browser.action?.setPopup?.({
     popup: useSidePanelAsDefault ? '' : 'popup-init.html',
   });

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -300,6 +300,7 @@ function applyEarlySidePanelToolbarBehavior() {
   }
   browser.sidePanel
     .setPanelBehavior({ openPanelOnActionClick: true })
+    .then(() => browser.action?.setPopup?.({ popup: '' }))
     .catch(() => {
       // Non-fatal: `applyToolbarSidePanelBehavior` applies persisted preference once ready.
     });
@@ -2320,6 +2321,9 @@ async function applyToolbarSidePanelBehavior() {
   await browser.sidePanel.setPanelBehavior({
     openPanelOnActionClick: useSidePanelAsDefault,
   });
+  await browser.action?.setPopup?.({
+    popup: useSidePanelAsDefault ? '' : 'popup-init.html',
+  });
 }
 
 /**
@@ -2343,6 +2347,11 @@ const setupSidePanelToolbarBehavior = async () => {
             .setPanelBehavior({
               openPanelOnActionClick: useSidePanelAsDefault,
             })
+            .then(() =>
+              browser.action?.setPopup?.({
+                popup: useSidePanelAsDefault ? '' : 'popup-init.html',
+              }),
+            )
             .catch((error) =>
               console.error('Error updating panel behavior:', error),
             );

--- a/ui/store/actions.toggle-default-view.test.ts
+++ b/ui/store/actions.toggle-default-view.test.ts
@@ -17,6 +17,9 @@ jest.mock('webextension-polyfill', () => ({
     tabs: {
       query: jest.fn(),
     },
+    action: {
+      setPopup: jest.fn(),
+    },
     sidePanel: {
       open: jest.fn(),
     },
@@ -40,6 +43,7 @@ const mockGetIsSidePanelFeatureEnabled = jest.mocked(
 
 const browserMock = browser as unknown as {
   tabs: { query: jest.Mock };
+  action: { setPopup: jest.Mock };
   sidePanel: { open: jest.Mock };
 };
 
@@ -75,6 +79,7 @@ describe('toggleDefaultView', () => {
 
     mockGetIsSidePanelFeatureEnabled.mockReturnValue(true);
     browserMock.tabs.query.mockResolvedValue([{ windowId: 1 }]);
+    browserMock.action.setPopup.mockResolvedValue(undefined);
     browserMock.sidePanel.open.mockResolvedValue(undefined);
   });
 
@@ -105,6 +110,9 @@ describe('toggleDefaultView', () => {
         'useSidePanelAsDefault',
         false,
       ]);
+      expect(browserMock.action.setPopup).toHaveBeenCalledWith({
+        popup: 'popup-init.html',
+      });
       expect(browserMock.sidePanel.open).not.toHaveBeenCalled();
       expect(closeSpy).toHaveBeenCalled();
     });
@@ -118,6 +126,7 @@ describe('toggleDefaultView', () => {
       await store.dispatch(toggleDefaultView() as never);
 
       expect(browserMock.sidePanel.open).toHaveBeenCalledWith({ windowId: 1 });
+      expect(browserMock.action.setPopup).toHaveBeenCalledWith({ popup: '' });
       expect(setPreferenceCalls(setPreferenceBackground)).toContainEqual([
         'useSidePanelAsDefault',
         true,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4343,10 +4343,13 @@ export function toggleDefaultView(): ThunkAction<
     const currentEnvironment = getEnvironmentType();
     const isSidepanel = currentEnvironment === ENVIRONMENT_TYPE_SIDEPANEL;
     const isPopup = currentEnvironment === ENVIRONMENT_TYPE_POPUP;
+    const setActionPopup = (popup: string) =>
+      chrome.action?.setPopup({ popup });
 
     try {
       if (isSidepanel) {
         await dispatch(setUseSidePanelAsDefault(false));
+        await setActionPopup('popup-init.html');
         window.close();
         return;
       }
@@ -4391,6 +4394,7 @@ export function toggleDefaultView(): ThunkAction<
         // honors the side panel choice and the background toolbar-behavior
         // subscription flips to open-on-click.
         await dispatch(setUseSidePanelAsDefault(true));
+        await setActionPopup('');
         window.close();
       }
     } catch (error) {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4349,6 +4349,7 @@ export function toggleDefaultView(): ThunkAction<
     try {
       if (isSidepanel) {
         await dispatch(setUseSidePanelAsDefault(false));
+        // Restore the popup for future toolbar clicks.
         await setActionPopup('popup-init.html');
         window.close();
         return;
@@ -4394,6 +4395,7 @@ export function toggleDefaultView(): ThunkAction<
         // honors the side panel choice and the background toolbar-behavior
         // subscription flips to open-on-click.
         await dispatch(setUseSidePanelAsDefault(true));
+        // Disable the popup so future toolbar clicks open the sidepanel.
         await setActionPopup('');
         window.close();
       }


### PR DESCRIPTION
This PR fixed an issue where MetaMask could reopen as a popup after switching to Sidepanel

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: switch between viewports should be synced

## **Related issues**

Fixes: [issue](https://consensyssoftware.atlassian.net/browse/CEUX-1091)

## **Manual testing steps**

1. Open MetaMask as a popup and use the global menu to switch to Sidepanel.
2. Verify the popup closes and the Sidepanel opens.
3. Click the MetaMask toolbar icon several times; verify it opens/toggles the Sidepanel rather than opening a popup.
4. Close and reopen Chrome, then click the MetaMask toolbar icon; verify it opens the Sidepanel.
5. In Sidepanel, use the global menu to switch back to Popup.
6. Click the MetaMask toolbar icon and verify it opens the popup.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only extension API wiring with tests; no auth, vault, or transaction logic changes.
> 
> **Overview**
> Fixes toolbar clicks reopening the **popup** after the user chose **side panel** as the default viewport.
> 
> The extension now keeps **`chrome.action.setPopup`** in sync with **`useSidePanelAsDefault`**: an empty popup when side panel is default (so clicks use side-panel behavior), and **`popup-init.html`** when popup is default. **`toggleDefaultView`** updates the action popup immediately when switching from the menu, and the background applies the same rules on startup (including early side-panel setup), on preference load, and when the preference changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c1fa4560763c016030da05dd1a50735f06863bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->