### PR TITLE
refactor: refactor useTokenExchangeRate

### DIFF
--- a/ui/components/app/currency-input/hooks/useTokenExchangeRate.test.tsx
+++ b/ui/components/app/currency-input/hooks/useTokenExchangeRate.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Hex } from '@metamask/utils';
 import type { Store } from 'redux';
 import { MetaMaskTestReduxProvider } from '../../../../../test/lib/redux-test-provider';
 import mockState from '../../../../../test/data/mock-state.json';
 import configureStore from '../../../../store/store';
-import { UPDATE_METAMASK_STATE } from '../../../../store/actionConstants';
 import { fetchTokenExchangeRates } from '../../../../helpers/utils/util';
 import useTokenExchangeRate from './useTokenExchangeRate';
 
@@ -87,48 +86,52 @@ describe('useTokenExchangeRate', () => {
   });
 
   it('ERC-20: price is available', () => {
-    const { result } = renderUseTokenExchangeRate(
+    const {
+      result: { current: exchangeRate },
+    } = renderUseTokenExchangeRate(
       '0xdac17f958d2ee523a2206206994597c13d831ec7',
     );
 
-    expect(String(result.current?.value)).toEqual('5.55');
-    expect(fetchTokenExchangeRates).not.toHaveBeenCalled();
+    expect(String(exchangeRate?.value)).toEqual('5.55');
   });
 
   it('ERC-20: price is unavailable through state but available through API', async () => {
-    (fetchTokenExchangeRates as jest.Mock).mockResolvedValue({
-      '0x0000000000000000000000000000000000000001': '2.34',
-    });
+    (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
+      Promise.resolve({
+        '0x0000000000000000000000000000000000000001': '2.34',
+      }),
+    );
 
     const { result } = renderUseTokenExchangeRate(
       '0x0000000000000000000000000000000000000001',
     );
 
     await waitFor(() => {
-      // 2.34 * ETH conversion rate (11.1) = 25.974
-      expect(String(result.current?.value)).toEqual('25.974');
+      expect(String(result.current?.value)).toBe('25.974');
     });
-    expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(1);
+    expect(fetchTokenExchangeRates).toBeCalledTimes(1);
   });
 
   it('ERC-20: price is unavailable through state and through API', async () => {
-    (fetchTokenExchangeRates as jest.Mock).mockResolvedValue({
-      'Not token': '2.34',
-    });
+    (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
+      Promise.resolve({
+        'Not token': '2.34',
+      }),
+    );
 
     const { result } = renderUseTokenExchangeRate(
       '0x0000000000000000000000000000000000000001',
     );
 
     await waitFor(() => {
-      expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(1);
+      expect(fetchTokenExchangeRates).toBeCalledTimes(1);
     });
-    expect(result.current).toBeUndefined();
+    expect(result.current?.value).toBe(undefined);
   });
 
   it('ERC-20: price is unavailable through state but API call fails', async () => {
-    (fetchTokenExchangeRates as jest.Mock).mockRejectedValue(
-      new Error('error'),
+    (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
+      Promise.reject(new Error('error')),
     );
 
     const { result } = renderUseTokenExchangeRate(
@@ -136,99 +139,51 @@ describe('useTokenExchangeRate', () => {
     );
 
     await waitFor(() => {
-      expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(1);
+      expect(fetchTokenExchangeRates).toBeCalledTimes(1);
     });
-    expect(result.current).toBeUndefined();
-  });
-
-  it('ERC-20: uses Redux market rate after a failed fetch once rates arrive', async () => {
-    const tokenAddress = '0x0000000000000000000000000000000000000001';
-    (fetchTokenExchangeRates as jest.Mock).mockRejectedValue(
-      new Error('error'),
-    );
-
-    const store = configureStore({
-      ...mockState,
-      metamask: {
-        ...mockState.metamask,
-        currencyRates: {
-          ETH: {
-            conversionRate: 11.1,
-          },
-        },
-        marketData: {
-          '0x5': {},
-        },
-      },
-    });
-
-    const { result } = renderUseTokenExchangeRate(
-      tokenAddress,
-      undefined,
-      undefined,
-      { store },
-    );
-
-    await waitFor(() => {
-      expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(1);
-      expect(result.current).toBeUndefined();
-    });
-
-    await act(async () => {
-      store.dispatch({
-        type: UPDATE_METAMASK_STATE,
-        value: {
-          marketData: {
-            '0x5': {
-              [tokenAddress]: { price: 2 },
-            },
-          },
-        },
-      });
-    });
-
-    await waitFor(() => {
-      // price (2) * ETH conversion rate (11.1) = 22.2
-      expect(String(result.current?.value)).toEqual('22.2');
-    });
+    expect(result.current?.value).toBe(undefined);
   });
 
   it('native: price is available', () => {
-    const { result } = renderUseTokenExchangeRate(undefined);
+    const {
+      result: { current: exchangeRate },
+    } = renderUseTokenExchangeRate(undefined);
 
-    expect(String(result.current?.value)).toBe('11.1');
-    expect(fetchTokenExchangeRates).not.toHaveBeenCalled();
+    expect(String(exchangeRate?.value)).toBe('11.1');
   });
 
   it('native: price is unavailable', () => {
-    const { result } = renderUseTokenExchangeRate(undefined, {
-      currencyRates: {},
-    });
+    const {
+      result: { current: exchangeRate },
+    } = renderUseTokenExchangeRate(undefined, { currencyRates: {} });
 
-    expect(result.current).toBe(undefined);
-    expect(fetchTokenExchangeRates).not.toHaveBeenCalled();
+    expect(exchangeRate?.value).toBe(undefined);
   });
 
   describe('with overrideChainId', () => {
     it('ERC-20: returns price from override chain market data', () => {
-      const { result } = renderUseTokenExchangeRate(
+      // Current chain is 0x5 (Goerli), but we request price for token on 0x89 (Polygon)
+      const {
+        result: { current: exchangeRate },
+      } = renderUseTokenExchangeRate(
         '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
         undefined,
         '0x89',
       );
 
       // price (1.0) * POL conversion rate (0.25) = 0.25
-      expect(String(result.current?.value)).toEqual('0.25');
-      expect(fetchTokenExchangeRates).not.toHaveBeenCalled();
+      expect(String(exchangeRate?.value)).toEqual('0.25');
     });
 
     it('ERC-20: fetches from API when token not in override chain market data', async () => {
+      // Token exists on 0x5 but not on 0x89
       renderUseTokenExchangeRate(
         '0xdAC17F958D2ee523a2206206994597C13D831ec7',
         undefined,
         '0x89',
       );
 
+      // Should trigger API fetch since token not in 0x89 market data
       await waitFor(() => {
         expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
           'POL',
@@ -239,35 +194,39 @@ describe('useTokenExchangeRate', () => {
     });
 
     it('native: returns conversion rate for override chain', () => {
-      const { result } = renderUseTokenExchangeRate(
-        undefined,
-        undefined,
-        '0x89',
-      );
+      // Current chain is 0x5 (ETH), but we request native rate for 0x89 (POL)
+      const {
+        result: { current: exchangeRate },
+      } = renderUseTokenExchangeRate(undefined, undefined, '0x89');
 
-      expect(String(result.current?.value)).toEqual('0.25');
+      expect(String(exchangeRate?.value)).toEqual('0.25');
     });
 
     it('native: returns undefined when override chain has no conversion rate', () => {
-      const { result } = renderUseTokenExchangeRate(
+      const {
+        result: { current: exchangeRate },
+      } = renderUseTokenExchangeRate(
         undefined,
         {
           currencyRates: {
             ETH: { conversionRate: 11.1 },
+            // POL not included
           },
         },
         '0x89',
       );
 
-      expect(result.current).toBe(undefined);
+      expect(exchangeRate?.value).toBe(undefined);
     });
 
     it('ERC-20: fetches from API with override chainId when not in state', async () => {
-      (fetchTokenExchangeRates as jest.Mock).mockResolvedValue({
-        '0x0000000000000000000000000000000000000002': 2.0,
-      });
+      (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
+        Promise.resolve({
+          '0x0000000000000000000000000000000000000002': 2.0,
+        }),
+      );
 
-      const { result } = renderUseTokenExchangeRate(
+      renderUseTokenExchangeRate(
         '0x0000000000000000000000000000000000000002',
         undefined,
         '0x89',
@@ -280,23 +239,16 @@ describe('useTokenExchangeRate', () => {
           '0x89',
         );
       });
-
-      await waitFor(() => {
-        // 2.0 * POL conversion rate (0.25) = 0.5
-        expect(String(result.current?.value)).toEqual('0.5');
-      });
     });
 
     it('ERC-20: caches rates per chain to prevent cross-chain contamination', async () => {
       const tokenAddress = '0x0000000000000000000000000000000000000003';
-      const queryClient = createQueryClient();
-      (fetchTokenExchangeRates as jest.Mock).mockResolvedValue({
-        [tokenAddress]: 1.5,
-      });
+      (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
+        Promise.resolve({ [tokenAddress]: 1.5 }),
+      );
 
-      renderUseTokenExchangeRate(tokenAddress, undefined, '0x5', {
-        queryClient,
-      });
+      // First render on chain 0x5
+      renderUseTokenExchangeRate(tokenAddress, undefined, '0x5');
 
       await waitFor(() => {
         expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
@@ -306,9 +258,8 @@ describe('useTokenExchangeRate', () => {
         );
       });
 
-      renderUseTokenExchangeRate(tokenAddress, undefined, '0x89', {
-        queryClient,
-      });
+      // Second render on chain 0x89 - should trigger a new fetch, not use cached rate
+      renderUseTokenExchangeRate(tokenAddress, undefined, '0x89');
 
       await waitFor(() => {
         expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
@@ -346,7 +297,7 @@ describe('useTokenExchangeRate', () => {
       );
 
       await waitFor(() => {
-        expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(1);
+        expect(fetchTokenExchangeRates).toBeCalledTimes(1);
       });
 
       resolveFetch({ [tokenAddress]: 1.5 });

--- a/ui/components/app/currency-input/hooks/useTokenExchangeRate.test.tsx
+++ b/ui/components/app/currency-input/hooks/useTokenExchangeRate.test.tsx
@@ -1,230 +1,302 @@
 import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Hex } from '@metamask/utils';
+import type { Store } from 'redux';
 import { MetaMaskTestReduxProvider } from '../../../../../test/lib/redux-test-provider';
 import mockState from '../../../../../test/data/mock-state.json';
 import configureStore from '../../../../store/store';
+import { UPDATE_METAMASK_STATE } from '../../../../store/actionConstants';
 import { fetchTokenExchangeRates } from '../../../../helpers/utils/util';
 import useTokenExchangeRate from './useTokenExchangeRate';
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+    logger: {
+      log: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+  });
 
 const renderUseTokenExchangeRate = (
   tokenAddress?: string,
   metaMaskState?: Record<string, unknown>,
   overrideChainId?: Hex,
+  options?: {
+    store?: Store;
+    queryClient?: QueryClient;
+  },
 ) => {
-  const state = {
-    ...mockState,
-    metamask: {
-      ...mockState.metamask,
-      currencyRates: {
-        ETH: {
-          conversionRate: 11.1,
+  const store =
+    options?.store ??
+    configureStore({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        currencyRates: {
+          ETH: {
+            conversionRate: 11.1,
+          },
+          POL: {
+            conversionRate: 0.25,
+          },
         },
-        POL: {
-          conversionRate: 0.25,
+        marketData: {
+          '0x5': {
+            '0xdAC17F958D2ee523a2206206994597C13D831ec7': { price: 0.5 },
+            '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e': { price: 3.304588 },
+          },
+          '0x89': {
+            '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174': { price: 1.0 },
+          },
         },
+        ...metaMaskState,
       },
-      marketData: {
-        '0x5': {
-          '0xdAC17F958D2ee523a2206206994597C13D831ec7': { price: 0.5 },
-          '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e': { price: 3.304588 },
-        },
-        '0x89': {
-          '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174': { price: 1.0 },
-        },
-      },
-      ...metaMaskState,
-    },
-  };
+    });
 
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const wrapper = ({ children }: any) => (
-    <MetaMaskTestReduxProvider store={configureStore(state)}>
-      {children}
-    </MetaMaskTestReduxProvider>
+  const queryClient = options?.queryClient ?? createQueryClient();
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <MetaMaskTestReduxProvider store={store}>
+        {children}
+      </MetaMaskTestReduxProvider>
+    </QueryClientProvider>
   );
 
-  return renderHook(() => useTokenExchangeRate(tokenAddress, overrideChainId), {
-    wrapper,
-  });
+  return {
+    ...renderHook(() => useTokenExchangeRate(tokenAddress, overrideChainId), {
+      wrapper,
+    }),
+    store,
+    queryClient,
+  };
 };
 
 jest.mock('../../../../helpers/utils/util', () => ({
   fetchTokenExchangeRates: jest.fn(),
 }));
 
-describe('useProcessNewDecimalValue', () => {
+describe('useTokenExchangeRate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('ERC-20: price is available', () => {
-    const {
-      result: { current: exchangeRate },
-    } = renderUseTokenExchangeRate(
+    const { result } = renderUseTokenExchangeRate(
       '0xdac17f958d2ee523a2206206994597c13d831ec7',
     );
 
-    expect(String(exchangeRate?.value)).toEqual('5.55');
+    expect(String(result.current?.value)).toEqual('5.55');
+    expect(fetchTokenExchangeRates).not.toHaveBeenCalled();
   });
 
   it('ERC-20: price is unavailable through state but available through API', async () => {
-    (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
-      Promise.resolve({
-        '0x0000000000000000000000000000000000000001': '2.34',
-      }),
-    );
+    (fetchTokenExchangeRates as jest.Mock).mockResolvedValue({
+      '0x0000000000000000000000000000000000000001': '2.34',
+    });
 
-    const {
-      result: { current: exchangeRate },
-    } = renderUseTokenExchangeRate(
+    const { result } = renderUseTokenExchangeRate(
       '0x0000000000000000000000000000000000000001',
     );
 
-    waitFor(() => {
-      expect(exchangeRate?.value).toBe('2.34');
+    await waitFor(() => {
+      // 2.34 * ETH conversion rate (11.1) = 25.974
+      expect(String(result.current?.value)).toEqual('25.974');
     });
-    expect(fetchTokenExchangeRates).toBeCalledTimes(1);
+    expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(1);
   });
 
   it('ERC-20: price is unavailable through state and through API', async () => {
-    (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
-      Promise.resolve({
-        'Not token': '2.34',
-      }),
-    );
+    (fetchTokenExchangeRates as jest.Mock).mockResolvedValue({
+      'Not token': '2.34',
+    });
 
-    const {
-      result: { current: exchangeRate },
-    } = renderUseTokenExchangeRate(
+    const { result } = renderUseTokenExchangeRate(
       '0x0000000000000000000000000000000000000001',
     );
 
-    waitFor(() => {
-      expect(exchangeRate?.value).toBe(undefined);
+    await waitFor(() => {
+      expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(1);
     });
-    expect(fetchTokenExchangeRates).toBeCalledTimes(1);
+    expect(result.current).toBeUndefined();
   });
 
   it('ERC-20: price is unavailable through state but API call fails', async () => {
-    (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
-      Promise.reject(new Error('error')),
+    (fetchTokenExchangeRates as jest.Mock).mockRejectedValue(
+      new Error('error'),
     );
 
-    const {
-      result: { current: exchangeRate },
-    } = renderUseTokenExchangeRate(
+    const { result } = renderUseTokenExchangeRate(
       '0x0000000000000000000000000000000000000001',
     );
 
-    waitFor(() => {
-      expect(exchangeRate?.value).toBe(undefined);
+    await waitFor(() => {
+      expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(1);
     });
-    expect(fetchTokenExchangeRates).toBeCalledTimes(1);
+    expect(result.current).toBeUndefined();
+  });
+
+  it('ERC-20: uses Redux market rate after a failed fetch once rates arrive', async () => {
+    const tokenAddress = '0x0000000000000000000000000000000000000001';
+    (fetchTokenExchangeRates as jest.Mock).mockRejectedValue(
+      new Error('error'),
+    );
+
+    const store = configureStore({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        currencyRates: {
+          ETH: {
+            conversionRate: 11.1,
+          },
+        },
+        marketData: {
+          '0x5': {},
+        },
+      },
+    });
+
+    const { result } = renderUseTokenExchangeRate(
+      tokenAddress,
+      undefined,
+      undefined,
+      { store },
+    );
+
+    await waitFor(() => {
+      expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(1);
+      expect(result.current).toBeUndefined();
+    });
+
+    await act(async () => {
+      store.dispatch({
+        type: UPDATE_METAMASK_STATE,
+        value: {
+          marketData: {
+            '0x5': {
+              [tokenAddress]: { price: 2 },
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      // price (2) * ETH conversion rate (11.1) = 22.2
+      expect(String(result.current?.value)).toEqual('22.2');
+    });
   });
 
   it('native: price is available', () => {
-    const {
-      result: { current: exchangeRate },
-    } = renderUseTokenExchangeRate(undefined);
+    const { result } = renderUseTokenExchangeRate(undefined);
 
-    expect(String(exchangeRate?.value)).toBe('11.1');
+    expect(String(result.current?.value)).toBe('11.1');
+    expect(fetchTokenExchangeRates).not.toHaveBeenCalled();
   });
 
   it('native: price is unavailable', () => {
-    const {
-      result: { current: exchangeRate },
-    } = renderUseTokenExchangeRate(undefined, { currencyRates: {} });
+    const { result } = renderUseTokenExchangeRate(undefined, {
+      currencyRates: {},
+    });
 
-    expect(exchangeRate?.value).toBe(undefined);
+    expect(result.current).toBe(undefined);
+    expect(fetchTokenExchangeRates).not.toHaveBeenCalled();
   });
 
   describe('with overrideChainId', () => {
     it('ERC-20: returns price from override chain market data', () => {
-      // Current chain is 0x5 (Goerli), but we request price for token on 0x89 (Polygon)
-      const {
-        result: { current: exchangeRate },
-      } = renderUseTokenExchangeRate(
+      const { result } = renderUseTokenExchangeRate(
         '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
         undefined,
         '0x89',
       );
 
       // price (1.0) * POL conversion rate (0.25) = 0.25
-      expect(String(exchangeRate?.value)).toEqual('0.25');
+      expect(String(result.current?.value)).toEqual('0.25');
+      expect(fetchTokenExchangeRates).not.toHaveBeenCalled();
     });
 
-    it('ERC-20: fetches from API when token not in override chain market data', () => {
-      // Token exists on 0x5 but not on 0x89
+    it('ERC-20: fetches from API when token not in override chain market data', async () => {
       renderUseTokenExchangeRate(
         '0xdAC17F958D2ee523a2206206994597C13D831ec7',
         undefined,
         '0x89',
       );
 
-      // Should trigger API fetch since token not in 0x89 market data
-      expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
-        'POL',
-        ['0xdAC17F958D2ee523a2206206994597C13D831ec7'],
-        '0x89',
-      );
+      await waitFor(() => {
+        expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
+          'POL',
+          ['0xdAC17F958D2ee523a2206206994597C13D831ec7'],
+          '0x89',
+        );
+      });
     });
 
     it('native: returns conversion rate for override chain', () => {
-      // Current chain is 0x5 (ETH), but we request native rate for 0x89 (POL)
-      const {
-        result: { current: exchangeRate },
-      } = renderUseTokenExchangeRate(undefined, undefined, '0x89');
+      const { result } = renderUseTokenExchangeRate(
+        undefined,
+        undefined,
+        '0x89',
+      );
 
-      expect(String(exchangeRate?.value)).toEqual('0.25');
+      expect(String(result.current?.value)).toEqual('0.25');
     });
 
     it('native: returns undefined when override chain has no conversion rate', () => {
-      const {
-        result: { current: exchangeRate },
-      } = renderUseTokenExchangeRate(
+      const { result } = renderUseTokenExchangeRate(
         undefined,
         {
           currencyRates: {
             ETH: { conversionRate: 11.1 },
-            // POL not included
           },
         },
         '0x89',
       );
 
-      expect(exchangeRate?.value).toBe(undefined);
+      expect(result.current).toBe(undefined);
     });
 
     it('ERC-20: fetches from API with override chainId when not in state', async () => {
-      (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
-        Promise.resolve({
-          '0x0000000000000000000000000000000000000002': 2.0,
-        }),
-      );
+      (fetchTokenExchangeRates as jest.Mock).mockResolvedValue({
+        '0x0000000000000000000000000000000000000002': 2.0,
+      });
 
-      renderUseTokenExchangeRate(
+      const { result } = renderUseTokenExchangeRate(
         '0x0000000000000000000000000000000000000002',
         undefined,
         '0x89',
       );
 
-      expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
-        'POL',
-        ['0x0000000000000000000000000000000000000002'],
-        '0x89',
-      );
+      await waitFor(() => {
+        expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
+          'POL',
+          ['0x0000000000000000000000000000000000000002'],
+          '0x89',
+        );
+      });
+
+      await waitFor(() => {
+        // 2.0 * POL conversion rate (0.25) = 0.5
+        expect(String(result.current?.value)).toEqual('0.5');
+      });
     });
 
     it('ERC-20: caches rates per chain to prevent cross-chain contamination', async () => {
       const tokenAddress = '0x0000000000000000000000000000000000000003';
-      (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
-        Promise.resolve({ [tokenAddress]: 1.5 }),
-      );
+      const queryClient = createQueryClient();
+      (fetchTokenExchangeRates as jest.Mock).mockResolvedValue({
+        [tokenAddress]: 1.5,
+      });
 
-      // First render on chain 0x5
-      renderUseTokenExchangeRate(tokenAddress, undefined, '0x5');
+      renderUseTokenExchangeRate(tokenAddress, undefined, '0x5', {
+        queryClient,
+      });
 
       await waitFor(() => {
         expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
@@ -234,8 +306,9 @@ describe('useProcessNewDecimalValue', () => {
         );
       });
 
-      // Second render on chain 0x89 - should trigger a new fetch, not use cached rate
-      renderUseTokenExchangeRate(tokenAddress, undefined, '0x89');
+      renderUseTokenExchangeRate(tokenAddress, undefined, '0x89', {
+        queryClient,
+      });
 
       await waitFor(() => {
         expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
@@ -246,6 +319,42 @@ describe('useProcessNewDecimalValue', () => {
       });
 
       expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(2);
+    });
+
+    it('ERC-20: shares an in-flight fetch for the same chain and token', async () => {
+      const tokenAddress = '0x0000000000000000000000000000000000000004';
+      const queryClient = createQueryClient();
+      let resolveFetch: (value: Record<string, number>) => void = () =>
+        undefined;
+      (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+      );
+
+      const firstRender = renderUseTokenExchangeRate(
+        tokenAddress,
+        undefined,
+        '0x5',
+        { queryClient },
+      );
+      const secondRender = renderUseTokenExchangeRate(
+        tokenAddress,
+        undefined,
+        '0x5',
+        { queryClient },
+      );
+
+      await waitFor(() => {
+        expect(fetchTokenExchangeRates).toHaveBeenCalledTimes(1);
+      });
+
+      resolveFetch({ [tokenAddress]: 1.5 });
+
+      await waitFor(() => {
+        expect(String(firstRender.result.current?.value)).toEqual('16.65');
+        expect(String(secondRender.result.current?.value)).toEqual('16.65');
+      });
     });
   });
 });

--- a/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
+++ b/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { shallowEqual, useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
@@ -14,11 +15,6 @@ import {
 import { Numeric } from '../../../../../shared/lib/Numeric';
 import { fetchTokenExchangeRates } from '../../../../helpers/utils/util';
 
-type ExchangeRate = number | typeof LOADING | typeof FAILED | undefined;
-
-const LOADING = 'loading';
-const FAILED = 'failed';
-
 /**
  * A hook that returns the exchange rate of the given token –– assumes native if no token address is passed.
  *
@@ -29,7 +25,7 @@ const FAILED = 'failed';
 export default function useTokenExchangeRate(
   uncheckedTokenAddress?: string,
   overrideChainId?: Hex,
-): Numeric | undefined {
+) {
   const tokenAddress = uncheckedTokenAddress
     ? toChecksumAddress(uncheckedTokenAddress)
     : undefined;
@@ -52,9 +48,29 @@ export default function useTokenExchangeRate(
     Record<string, number>
   > = useSelector(getCrossChainTokenExchangeRates, shallowEqual);
 
-  const [exchangeRates, setExchangeRates] = useState<
-    Record<string, ExchangeRate>
-  >({});
+  const reduxTokenRate = tokenAddress
+    ? crossChainTokenExchangeRates[chainId]?.[tokenAddress]
+    : undefined;
+
+  const { data: fetchedTokenRate } = useQuery({
+    queryKey: ['tokenExchangeRate', chainId, tokenAddress, nativeCurrency],
+    queryFn: async () => {
+      if (!tokenAddress || !nativeCurrency) {
+        return null;
+      }
+
+      const addressToExchangeRate = await fetchTokenExchangeRates(
+        nativeCurrency,
+        [tokenAddress],
+        chainId,
+      );
+      return addressToExchangeRate[tokenAddress] ?? null;
+    },
+    enabled: Boolean(
+      tokenAddress && nativeCurrency && reduxTokenRate === undefined,
+    ),
+    retry: false,
+  });
 
   return useMemo(() => {
     if (!selectedNativeConversionRate) {
@@ -70,53 +86,16 @@ export default function useTokenExchangeRate(
       return nativeConversionRate;
     }
 
-    // Cache key includes chainId to prevent cross-chain rate contamination
-    const cacheKey = `${chainId}-${tokenAddress}`;
-
-    const isLoadingOrUnavailable = tokenAddress
-      ? ([LOADING, FAILED] as ExchangeRate[]).includes(exchangeRates[cacheKey])
-      : false;
-
-    if (isLoadingOrUnavailable) {
+    const tokenRate = reduxTokenRate ?? fetchedTokenRate;
+    if (tokenRate === undefined || tokenRate === null) {
       return undefined;
     }
 
-    const contractExchangeRates = crossChainTokenExchangeRates[chainId] ?? {};
-    const contractExchangeRate =
-      contractExchangeRates[tokenAddress] || exchangeRates[cacheKey];
-
-    if (!contractExchangeRate) {
-      // TODO: Fix "Calling setState from useMemo may trigger an infinite loop"
-      // eslint-disable-next-line react-hooks/set-state-in-render
-      setExchangeRates((prev) => ({
-        ...prev,
-        [cacheKey]: LOADING,
-      }));
-      fetchTokenExchangeRates(nativeCurrency, [tokenAddress], chainId)
-        .then((addressToExchangeRate) => {
-          setExchangeRates((prev) => ({
-            ...prev,
-            [cacheKey]: addressToExchangeRate[tokenAddress] || FAILED,
-          }));
-        })
-        .catch(() => {
-          setExchangeRates((prev) => ({
-            ...prev,
-            [cacheKey]: FAILED,
-          }));
-        });
-      return undefined;
-    }
-
-    return new Numeric(String(contractExchangeRate), 10).times(
-      nativeConversionRate,
-    );
+    return new Numeric(String(tokenRate), 10).times(nativeConversionRate);
   }, [
-    exchangeRates,
-    chainId,
-    nativeCurrency,
-    tokenAddress,
     selectedNativeConversionRate,
-    crossChainTokenExchangeRates,
+    tokenAddress,
+    reduxTokenRate,
+    fetchedTokenRate,
   ]);
 }

--- a/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
+++ b/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
@@ -25,7 +25,7 @@ import { fetchTokenExchangeRates } from '../../../../helpers/utils/util';
 export default function useTokenExchangeRate(
   uncheckedTokenAddress?: string,
   overrideChainId?: Hex,
-) {
+): Numeric | undefined {
   const tokenAddress = uncheckedTokenAddress
     ? toChecksumAddress(uncheckedTokenAddress)
     : undefined;
@@ -52,24 +52,28 @@ export default function useTokenExchangeRate(
     ? crossChainTokenExchangeRates[chainId]?.[tokenAddress]
     : undefined;
 
+  // Cache key includes chainId to prevent cross-chain rate contamination
+  const cacheKey = ['tokenExchangeRate', chainId, tokenAddress, nativeCurrency];
+
   const { data: fetchedTokenRate } = useQuery({
-    queryKey: ['tokenExchangeRate', chainId, tokenAddress, nativeCurrency],
+    queryKey: cacheKey,
     queryFn: async () => {
       if (!tokenAddress || !nativeCurrency) {
         return null;
       }
 
-      const addressToExchangeRate = await fetchTokenExchangeRates(
+      const exchangeRates = await fetchTokenExchangeRates(
         nativeCurrency,
         [tokenAddress],
         chainId,
       );
-      return addressToExchangeRate[tokenAddress] ?? null;
+      return exchangeRates[tokenAddress] ?? null;
     },
     enabled: Boolean(
       tokenAddress && nativeCurrency && reduxTokenRate === undefined,
     ),
     retry: false,
+    staleTime: Infinity,
   });
 
   return useMemo(() => {


### PR DESCRIPTION
## **Description**

`useTokenExchangeRate` fetched the fallback rate during render (`setState` inside `useMemo`), which blocked the React Compiler and hid later TokenRatesController rates after a failed local fetch.

This PR uses TanStack Query for that fallback.

Benefits
- Removes the render-time fetch / React Compiler opt-out
- Dedupes in-flight requests 
- Native tokens still skip the network

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MetaMask/MetaMask-planning#6823

<!--
## **Manual testing steps**
-->

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)