### PR TITLE
test: skip Home wait in goToActivityList when bottom nav is visible

### DIFF
--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -548,7 +548,6 @@ class HomePage {
 
   async goToActivityList(): Promise<void> {
     console.log(`Open activity tab on homepage`);
-    await this.checkPageIsLoaded();
     const isBottomNav = await this.driver.isElementPresentAndVisible(
       this.bottomNavActivityButton,
       3000,
@@ -559,6 +558,7 @@ class HomePage {
         url: `${this.driver.extensionUrl}/home.html#${ACTIVITY_ROUTE}`,
       });
     } else {
+      await this.checkPageIsLoaded();
       await this.driver.clickElement(this.activityTab);
     }
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Problem:**

- The test timed out waiting for the Home balance.
- After mint, the spec opens Activity and stays there.
- After approve confirm, the same window is still on the Activity tab (bottom-nav A/B, about 5% of runs).
- The second `goToActivityList()` (open Activity) wait needs Home-only balance and asset-tab UI.
- That UI is not on Activity when bottom nav is on. Classic tabs still have it.

**Solution:**

- Check for bottom nav first via `bottomNavActivityButton` (the Activity button in the bottom bar) — so we do not look for Home UI on Activity.
- If bottom nav is visible, click Activity and wait for the `#/activity` URL — so we know the tab switch finished without calling `checkPageIsLoaded()` (the Home-ready wait).
- Keep the Home wait, then click the activity tab, for classic tabs — those still show Home chrome first.

<!--
## **Related issues**

Fixes:
-->

## **Changelog**

CHANGELOG entry: null

## **Manual testing steps**

1. Start a test build: `yarn start:test`
2. Add `it.only` on `submits an ERC721 approve transaction` in `test/e2e/tests/confirmations/transactions/erc721-approve-redesign.spec.ts`.
3. Run:

```
SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/confirmations/transactions/erc721-approve-redesign.spec.ts --debug --leave-running
```

4. Confirm the second open-Activity call after approve does not time out on the Home balance when already on the Activity tab (bottom-nav treatment).
5. Remove `it.only` before committing or opening a PR.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->
