### PR TITLE
perf: optimize browser storage key enumeration

### DIFF
--- a/shared/lib/stores/browser-storage-adapter.test.ts
+++ b/shared/lib/stores/browser-storage-adapter.test.ts
@@ -9,6 +9,7 @@ jest.mock('webextension-polyfill', () => ({
   storage: {
     local: {
       get: jest.fn(),
+      getKeys: jest.fn(),
       set: jest.fn(),
       remove: jest.fn(),
     },
@@ -18,6 +19,7 @@ jest.mock('webextension-polyfill', () => ({
 describe('BrowserStorageAdapter', () => {
   let adapter: typeof BrowserStorageAdapter;
   const mockGet = jest.mocked(browser.storage.local.get);
+  const mockGetKeys = jest.mocked(browser.storage.local.getKeys);
   const mockSet = jest.mocked(browser.storage.local.set);
   const mockRemove = jest.mocked(browser.storage.local.remove);
 
@@ -97,12 +99,12 @@ describe('BrowserStorageAdapter', () => {
 
   describe('getAllKeys', () => {
     it('returns only keys for the namespace', async () => {
-      mockGet.mockResolvedValue({
-        [`${STORAGE_KEY_PREFIX}TestController:key1`]: 'value1',
-        [`${STORAGE_KEY_PREFIX}TestController:key2`]: 'value2',
-        [`${STORAGE_KEY_PREFIX}OtherController:key3`]: 'value3',
-        unrelatedKey: 'value4',
-      });
+      mockGetKeys.mockResolvedValue([
+        `${STORAGE_KEY_PREFIX}TestController:key1`,
+        `${STORAGE_KEY_PREFIX}TestController:key2`,
+        `${STORAGE_KEY_PREFIX}OtherController:key3`,
+        'unrelatedKey',
+      ]);
 
       const keys = await adapter.getAllKeys('TestController');
 
@@ -110,16 +112,39 @@ describe('BrowserStorageAdapter', () => {
     });
 
     it('returns empty array when no keys exist', async () => {
-      mockGet.mockResolvedValue({});
+      mockGetKeys.mockResolvedValue([]);
 
       const keys = await adapter.getAllKeys('TestController');
 
       expect(keys).toStrictEqual([]);
     });
 
+    it('falls back to reading all values when getKeys is unavailable', async () => {
+      const storageLocalWithoutGetKeys = browser.storage.local as {
+        get: typeof browser.storage.local.get;
+        getKeys?: typeof browser.storage.local.getKeys;
+      };
+      const originalGetKeys = storageLocalWithoutGetKeys.getKeys;
+      storageLocalWithoutGetKeys.getKeys = undefined;
+
+      try {
+        mockGet.mockResolvedValue({
+          [`${STORAGE_KEY_PREFIX}TestController:key1`]: 'value1',
+          [`${STORAGE_KEY_PREFIX}OtherController:key2`]: 'value2',
+        });
+
+        const keys = await adapter.getAllKeys('TestController');
+
+        expect(mockGet).toHaveBeenCalledWith(null);
+        expect(keys).toStrictEqual(['key1']);
+      } finally {
+        storageLocalWithoutGetKeys.getKeys = originalGetKeys;
+      }
+    });
+
     it('throws on failure', async () => {
       const error = new Error('Storage error');
-      mockGet.mockRejectedValue(error);
+      mockGetKeys.mockRejectedValue(error);
 
       await expect(adapter.getAllKeys('TestController')).rejects.toThrow(
         'Storage error',
@@ -129,10 +154,10 @@ describe('BrowserStorageAdapter', () => {
 
   describe('clear', () => {
     it('removes all keys for the namespace', async () => {
-      mockGet.mockResolvedValue({
-        [`${STORAGE_KEY_PREFIX}TestController:key1`]: 'value1',
-        [`${STORAGE_KEY_PREFIX}TestController:key2`]: 'value2',
-      });
+      mockGetKeys.mockResolvedValue([
+        `${STORAGE_KEY_PREFIX}TestController:key1`,
+        `${STORAGE_KEY_PREFIX}TestController:key2`,
+      ]);
       mockRemove.mockResolvedValue(undefined);
 
       await adapter.clear('TestController');
@@ -144,7 +169,7 @@ describe('BrowserStorageAdapter', () => {
     });
 
     it('does not call remove when no keys exist', async () => {
-      mockGet.mockResolvedValue({});
+      mockGetKeys.mockResolvedValue([]);
 
       await adapter.clear('TestController');
 
@@ -152,9 +177,9 @@ describe('BrowserStorageAdapter', () => {
     });
 
     it('throws on failure', async () => {
-      mockGet.mockResolvedValue({
-        [`${STORAGE_KEY_PREFIX}TestController:key1`]: 'value1',
-      });
+      mockGetKeys.mockResolvedValue([
+        `${STORAGE_KEY_PREFIX}TestController:key1`,
+      ]);
       const error = new Error('Storage error');
       mockRemove.mockRejectedValue(error);
 

--- a/shared/lib/stores/browser-storage-adapter.ts
+++ b/shared/lib/stores/browser-storage-adapter.ts
@@ -101,8 +101,16 @@ export class BrowserStorageAdapter implements StorageAdapter {
   async getAllKeys(namespace: string): Promise<string[]> {
     try {
       const prefix = `${STORAGE_KEY_PREFIX}${namespace}:`;
-      const all = await browser.storage.local.get(null);
 
+      // Avoid reading all browser.storage.local values when getKeys is
+      // available (Chrome 130+ and Firefox 143+).
+      if (typeof browser.storage.local.getKeys === 'function') {
+        return (await browser.storage.local.getKeys())
+          .filter((key) => key.startsWith(prefix))
+          .map((key) => key.slice(prefix.length));
+      }
+
+      const all = await browser.storage.local.get(null);
       return Object.keys(all)
         .filter((k) => k.startsWith(prefix))
         .map((k) => k.slice(prefix.length));


### PR DESCRIPTION
## **Description**

`BrowserStorageAdapter.getAllKeys` currently calls `browser.storage.local.get(null)`, which materializes every extension-storage value even though the adapter only needs key names.

This change uses `browser.storage.local.getKeys()` when the API is available, filters the returned keys by StorageService namespace, and retains the existing `get(null)` behavior as a compatibility fallback. This keeps the optimization independent from the IndexedDB StorageService rollout in #44010.

## **Changelog**

CHANGELOG entry: Improved extension storage efficiency when enumerating StorageService keys

<!--
## **Related issues**

No issue is closed by this performance optimization.
-->

<!--
## **Manual testing steps**

This internal key-enumeration optimization has no independently observable UI behavior.
-->

<!--
## **Screenshots/Recordings**

Not applicable; this change has no UI.
-->

## **Validation**

- `yarn lint:changed:fix`
- `yarn lint:changed`
- `yarn lint:tsc`
- `yarn test:unit shared/lib/stores/browser-storage-adapter.test.ts --runInBand`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized storage-adapter optimization with a compatibility fallback and updated unit tests; no auth or data-semantics changes.
> 
> **Overview**
> **`BrowserStorageAdapter.getAllKeys`** no longer calls `browser.storage.local.get(null)` when `getKeys` exists (Chrome 130+, Firefox 143+). It lists keys via **`getKeys()`**, filters by the StorageService namespace prefix, and strips the prefix—same result as before without loading every stored value.
> 
> When **`getKeys` is missing**, behavior is unchanged: full **`get(null)`** plus key filtering. Unit tests now mock **`getKeys`** for the happy path and add coverage for that fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e551081a36afb3ac89efe45fc7f03eb956a6373f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->