### PR TITLE
feat(confirmations): scan EIP-712 address fields via phishing controller

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1495,6 +1495,17 @@
   "alertMessageSignInWrongAccount": {
     "message": "This site is asking you to sign in using the wrong account."
   },
+  "alertMessageSignatureAddressMalicious": {
+    "message": "The $1 address $2 has been identified as malicious. If you confirm this request, you will probably lose your assets to a scammer.",
+    "description": "$1 is the message field name and $2 is the shortened address flagged as malicious."
+  },
+  "alertMessageSignatureAddressScanIncomplete": {
+    "message": "Some addresses in this request couldn't be checked for known threats. Only continue if you trust this site."
+  },
+  "alertMessageSignatureAddressWarning": {
+    "message": "The $1 address $2 can't be verified. Only continue if you trust the source.",
+    "description": "$1 is the message field name and $2 is the shortened address that needs review."
+  },
   "alertMessageSuggestedGasFeeHigh": {
     "message": "This site is suggesting a higher network fee than necessary. Edit the network fee to pay less."
   },
@@ -1566,6 +1577,9 @@
   },
   "alertReasonSignIn": {
     "message": "Suspicious sign-in request"
+  },
+  "alertReasonSignatureAddressScanIncomplete": {
+    "message": "Addresses not fully checked"
   },
   "alertReasonSuggestedGasFeeHigh": {
     "message": "High site fee"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1495,6 +1495,17 @@
   "alertMessageSignInWrongAccount": {
     "message": "This site is asking you to sign in using the wrong account."
   },
+  "alertMessageSignatureAddressMalicious": {
+    "message": "The $1 address $2 has been identified as malicious. If you confirm this request, you will probably lose your assets to a scammer.",
+    "description": "$1 is the message field name and $2 is the shortened address flagged as malicious."
+  },
+  "alertMessageSignatureAddressScanIncomplete": {
+    "message": "Some addresses in this request couldn't be checked for known threats. Only continue if you trust this site."
+  },
+  "alertMessageSignatureAddressWarning": {
+    "message": "The $1 address $2 can't be verified. Only continue if you trust the source.",
+    "description": "$1 is the message field name and $2 is the shortened address that needs review."
+  },
   "alertMessageSuggestedGasFeeHigh": {
     "message": "This site is suggesting a higher network fee than necessary. Edit the network fee to pay less."
   },
@@ -1566,6 +1577,9 @@
   },
   "alertReasonSignIn": {
     "message": "Suspicious sign-in request"
+  },
+  "alertReasonSignatureAddressScanIncomplete": {
+    "message": "Addresses not fully checked"
   },
   "alertReasonSuggestedGasFeeHigh": {
     "message": "High site fee"

--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -18,7 +18,11 @@ import { SIGNING_METHODS } from '../../../../shared/constants/transaction';
 import { PreferencesController } from '../../controllers/preferences-controller';
 import { AppStateController } from '../../controllers/app-state-controller';
 import { trace, TraceContext, TraceName } from '../../../../shared/lib/trace';
-import { LOADING_SECURITY_ALERT_RESPONSE } from '../../../../shared/constants/security-provider';
+import {
+  BlockaidResultType,
+  LOADING_SECURITY_ALERT_RESPONSE,
+} from '../../../../shared/constants/security-provider';
+import { scanUnvalidatedSignatureAddresses } from '../trust-signals/scan-unvalidated-signature';
 import {
   generateSecurityAlertId,
   handlePPOMError,
@@ -117,7 +121,7 @@ export function createPPOMMiddleware<
 
       const securityAlertId = generateSecurityAlertId();
 
-      trace(
+      const validationPromise = trace(
         { name: TraceName.PPOMValidation, parentContext: req.traceContext },
         () =>
           validateRequestWithPPOM({
@@ -129,6 +133,26 @@ export function createPPOMMiddleware<
             getSecurityAlertsConfig,
           }),
       );
+
+      if (SIGNING_METHODS.includes(req.method)) {
+        Promise.resolve(validationPromise)
+          .then((securityAlertResponse) => {
+            const resultType = securityAlertResponse?.result_type;
+            const ppomFlagged =
+              resultType === BlockaidResultType.Malicious ||
+              resultType === BlockaidResultType.Warning;
+            if (!ppomFlagged) {
+              scanUnvalidatedSignatureAddresses({
+                request: req,
+                chainId: chainId as Hex,
+                appStateController,
+              });
+            }
+          })
+          .catch(() => {
+            // ignore — scan is fire-and-forget
+          });
+      }
 
       const securityAlertResponseLoading: SecurityAlertResponse = {
         ...LOADING_SECURITY_ALERT_RESPONSE,

--- a/app/scripts/lib/ppom/ppom-util.ts
+++ b/app/scripts/lib/ppom/ppom-util.ts
@@ -72,7 +72,7 @@ export async function validateRequestWithPPOM({
   chainId: Hex;
   updateSecurityAlertResponse: UpdateSecurityAlertResponse;
   getSecurityAlertsConfig?: GetSecurityAlertsConfig;
-}) {
+}): Promise<SecurityAlertResponse> {
   try {
     const controllerObject = await updateSecurityResponse(
       request.method,
@@ -98,14 +98,23 @@ export async function validateRequestWithPPOM({
         );
 
     await updateSecurityResponse(request.method, securityAlertId, ppomResponse);
+
+    return ppomResponse;
   } catch (error: unknown) {
     log('Error', error);
+
+    const errorResponse = handlePPOMError(
+      error,
+      'Error validating JSON RPC using PPOM: ',
+    );
 
     await updateSecurityResponse(
       request.method,
       securityAlertId,
-      handlePPOMError(error, 'Error validating JSON RPC using PPOM: '),
+      errorResponse,
     );
+
+    return errorResponse;
   }
 }
 

--- a/app/scripts/lib/trust-signals/scan-unvalidated-signature.test.ts
+++ b/app/scripts/lib/trust-signals/scan-unvalidated-signature.test.ts
@@ -1,0 +1,219 @@
+import { scanUnvalidatedSignatureAddresses } from './scan-unvalidated-signature';
+
+const MALICIOUS_ADDRESS = '0x0000000000000000000000000000000000000bad';
+const SIGNER_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const CHAIN_ID = '0x1';
+
+const TYPED_DATA_V4 = {
+  types: {
+    Transfer: [{ name: 'recipient', type: 'address' }],
+  },
+  primaryType: 'Transfer',
+  message: { recipient: MALICIOUS_ADDRESS },
+};
+
+const makeRequest = (
+  method: string,
+  signer: string,
+  data: unknown,
+): { method: string; params: unknown[] } => ({
+  method,
+  params: [signer, JSON.stringify(data)],
+});
+
+const makeCache = () => {
+  const cache: Record<string, unknown> = {};
+  return {
+    getAddressSecurityAlertResponse: (address: string) => cache[address],
+    addAddressSecurityAlertResponse: (address: string, response: unknown) => {
+      cache[address] = response;
+    },
+  };
+};
+
+jest.mock('../ppom/security-alerts-api', () => ({
+  isSecurityAlertsAPIEnabled: jest.fn(),
+}));
+
+jest.mock('../../../../shared/lib/trust-signals', () => ({
+  mapChainIdToSupportedEVMChain: jest.fn(),
+}));
+
+jest.mock('./security-alerts-api', () => ({
+  scanAddressAndAddToCache: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockIsSecurityAlertsAPIEnabled = jest.requireMock(
+  '../ppom/security-alerts-api',
+).isSecurityAlertsAPIEnabled;
+
+const mockMapChainIdToSupportedEVMChain = jest.requireMock(
+  '../../../../shared/lib/trust-signals',
+).mapChainIdToSupportedEVMChain;
+
+const mockScanAddressAndAddToCache = jest.requireMock(
+  './security-alerts-api',
+).scanAddressAndAddToCache;
+
+describe('scanUnvalidatedSignatureAddresses', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsSecurityAlertsAPIEnabled.mockReturnValue(true);
+    mockMapChainIdToSupportedEVMChain.mockReturnValue('ethereum');
+  });
+
+  it('scans extracted address fields after PPOM passes', () => {
+    const cache = makeCache();
+    scanUnvalidatedSignatureAddresses({
+      request: makeRequest(
+        'eth_signTypedData_v4',
+        SIGNER_ADDRESS,
+        TYPED_DATA_V4,
+      ),
+      chainId: CHAIN_ID as `0x${string}`,
+      appStateController: cache,
+    });
+
+    expect(mockScanAddressAndAddToCache).toHaveBeenCalledWith(
+      MALICIOUS_ADDRESS,
+      cache.getAddressSecurityAlertResponse,
+      cache.addAddressSecurityAlertResponse,
+      'ethereum',
+    );
+  });
+
+  it('does nothing for non-typed-data methods', () => {
+    scanUnvalidatedSignatureAddresses({
+      request: { method: 'personal_sign', params: [SIGNER_ADDRESS, '0xdeadbeef'] },
+      chainId: CHAIN_ID as `0x${string}`,
+      appStateController: makeCache(),
+    });
+
+    expect(mockScanAddressAndAddToCache).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for v1 typed data', () => {
+    scanUnvalidatedSignatureAddresses({
+      request: { method: 'eth_signTypedData', params: [SIGNER_ADDRESS, '{}'] },
+      chainId: CHAIN_ID as `0x${string}`,
+      appStateController: makeCache(),
+    });
+
+    expect(mockScanAddressAndAddToCache).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when security alerts API is disabled', () => {
+    mockIsSecurityAlertsAPIEnabled.mockReturnValue(false);
+
+    scanUnvalidatedSignatureAddresses({
+      request: makeRequest(
+        'eth_signTypedData_v4',
+        SIGNER_ADDRESS,
+        TYPED_DATA_V4,
+      ),
+      chainId: CHAIN_ID as `0x${string}`,
+      appStateController: makeCache(),
+    });
+
+    expect(mockScanAddressAndAddToCache).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on an unsupported chain', () => {
+    mockMapChainIdToSupportedEVMChain.mockReturnValue(null);
+
+    scanUnvalidatedSignatureAddresses({
+      request: makeRequest(
+        'eth_signTypedData_v4',
+        SIGNER_ADDRESS,
+        TYPED_DATA_V4,
+      ),
+      chainId: '0x999' as `0x${string}`,
+      appStateController: makeCache(),
+    });
+
+    expect(mockScanAddressAndAddToCache).not.toHaveBeenCalled();
+  });
+
+  it('excludes the signer address', () => {
+    const data = {
+      types: { T: [{ name: 'recipient', type: 'address' }] },
+      primaryType: 'T',
+      message: { recipient: SIGNER_ADDRESS },
+    };
+
+    scanUnvalidatedSignatureAddresses({
+      request: makeRequest('eth_signTypedData_v4', SIGNER_ADDRESS, data),
+      chainId: CHAIN_ID as `0x${string}`,
+      appStateController: makeCache(),
+    });
+
+    expect(mockScanAddressAndAddToCache).not.toHaveBeenCalled();
+  });
+
+  it('excludes permit spender when verifyingContract is present', () => {
+    const data = {
+      types: { Permit: [{ name: 'spender', type: 'address' }] },
+      primaryType: 'Permit',
+      domain: { verifyingContract: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' },
+      message: { spender: MALICIOUS_ADDRESS },
+    };
+
+    scanUnvalidatedSignatureAddresses({
+      request: makeRequest('eth_signTypedData_v4', SIGNER_ADDRESS, data),
+      chainId: CHAIN_ID as `0x${string}`,
+      appStateController: makeCache(),
+    });
+
+    expect(mockScanAddressAndAddToCache).not.toHaveBeenCalled();
+  });
+
+  it('does not exclude permit spender when verifyingContract is absent', () => {
+    const data = {
+      types: { Permit: [{ name: 'spender', type: 'address' }] },
+      primaryType: 'Permit',
+      domain: {},
+      message: { spender: MALICIOUS_ADDRESS },
+    };
+
+    scanUnvalidatedSignatureAddresses({
+      request: makeRequest('eth_signTypedData_v4', SIGNER_ADDRESS, data),
+      chainId: CHAIN_ID as `0x${string}`,
+      appStateController: makeCache(),
+    });
+
+    expect(mockScanAddressAndAddToCache).toHaveBeenCalledWith(
+      MALICIOUS_ADDRESS,
+      expect.any(Function),
+      expect.any(Function),
+      'ethereum',
+    );
+  });
+
+  it('handles malformed typed data without throwing', () => {
+    expect(() =>
+      scanUnvalidatedSignatureAddresses({
+        request: { method: 'eth_signTypedData_v4', params: [SIGNER_ADDRESS, 'not-json{'] },
+        chainId: CHAIN_ID as `0x${string}`,
+        appStateController: makeCache(),
+      }),
+    ).not.toThrow();
+
+    expect(mockScanAddressAndAddToCache).not.toHaveBeenCalled();
+  });
+
+  it('accepts typed data as an object in params[1]', () => {
+    const cache = makeCache();
+    scanUnvalidatedSignatureAddresses({
+      request: { method: 'eth_signTypedData_v4', params: [SIGNER_ADDRESS, TYPED_DATA_V4] },
+      chainId: CHAIN_ID as `0x${string}`,
+      appStateController: cache,
+    });
+
+    expect(mockScanAddressAndAddToCache).toHaveBeenCalledWith(
+      MALICIOUS_ADDRESS,
+      expect.any(Function),
+      expect.any(Function),
+      'ethereum',
+    );
+  });
+});

--- a/app/scripts/lib/trust-signals/scan-unvalidated-signature.ts
+++ b/app/scripts/lib/trust-signals/scan-unvalidated-signature.ts
@@ -1,0 +1,86 @@
+import type { Hex } from '@metamask/utils';
+import { extractSignatureAddresses } from '@metamask/phishing-controller';
+import type { AppStateController } from '../../controllers/app-state-controller';
+import { parseTypedDataMessage } from '../../../../shared/lib/transaction.utils';
+import { MESSAGE_TYPE } from '../../../../shared/constants/app';
+import { mapChainIdToSupportedEVMChain } from '../../../../shared/lib/trust-signals';
+import { PRIMARY_TYPES_PERMIT } from '../../../../shared/constants/signatures';
+import { isSecurityAlertsAPIEnabled } from '../ppom/security-alerts-api';
+import { scanAddressAndAddToCache } from './security-alerts-api';
+
+type AppStateCache = Pick<
+  AppStateController,
+  'getAddressSecurityAlertResponse' | 'addAddressSecurityAlertResponse'
+>;
+
+/**
+ * Scan the address fields of a typed-data signature request against the
+ * real-time security-alerts API. Called after PPOM when PPOM has not flagged
+ * the request, since PPOM's threat data is refreshed on a delay. Results are
+ * cached so addresses scanned elsewhere are not re-requested.
+ */
+export function scanUnvalidatedSignatureAddresses({
+  request,
+  chainId,
+  appStateController,
+}: {
+  request: { method: string; params?: unknown };
+  chainId: Hex;
+  appStateController: AppStateCache;
+}): void {
+  if (
+    request.method !== MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V3 &&
+    request.method !== MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4
+  ) {
+    return;
+  }
+
+  if (!isSecurityAlertsAPIEnabled()) {
+    return;
+  }
+
+  const { params } = request;
+  if (!Array.isArray(params) || params[1] === undefined || params[1] === null) {
+    return;
+  }
+
+  const supportedEVMChain = mapChainIdToSupportedEVMChain(chainId);
+  if (!supportedEVMChain) {
+    return;
+  }
+
+  let typedDataMessage;
+  try {
+    typedDataMessage = parseTypedDataMessage(
+      typeof params[1] === 'string' ? params[1] : JSON.stringify(params[1]),
+    );
+  } catch (error) {
+    console.error('Error parsing typed data for signature address scan', error);
+    return;
+  }
+
+  const signerAddress = typeof params[0] === 'string' ? params[0] : undefined;
+
+  const isPermit = PRIMARY_TYPES_PERMIT.some(
+    (type) => type === typedDataMessage.primaryType,
+  );
+  const hasVerifyingContract = Boolean(
+    typedDataMessage.domain?.verifyingContract,
+  );
+
+  const { addresses } = extractSignatureAddresses(typedDataMessage, {
+    exclude: signerAddress ? [signerAddress] : [],
+    excludeFields: isPermit && hasVerifyingContract ? ['spender'] : [],
+  });
+
+  for (const address of addresses) {
+    scanAddressAndAddToCache(
+      address,
+      appStateController.getAddressSecurityAlertResponse,
+      appStateController.addAddressSecurityAlertResponse,
+      supportedEVMChain,
+    ).catch((error) => {
+      console.error('Error scanning signature address', error);
+    });
+  }
+}

--- a/ui/pages/confirmations/hooks/alerts/useSignatureAddressAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useSignatureAddressAlerts.test.ts
@@ -1,0 +1,268 @@
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import { Severity } from '../../../../helpers/constants/design-system';
+import { RowAlertKey } from '../../../../components/app/confirm/info/row/constants';
+import { TrustSignalDisplayState } from '../../../../hooks/useTrustSignals';
+import {
+  getMockTypedSignConfirmState,
+  getMockTypedSignConfirmStateForRequest,
+} from '../../../../../test/data/confirmations/helper';
+import {
+  unapprovedTypedSignMsgV4,
+  rawMessageV4,
+} from '../../../../../test/data/confirmations/typed_sign';
+import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
+import { SignatureRequestType } from '../../types/confirm';
+import { useSignatureAddressAlerts } from './useSignatureAddressAlerts';
+
+jest.mock('../../../../hooks/useTrustSignals', () => ({
+  useTrustSignals: jest.fn(),
+  TrustSignalDisplayState: {
+    Malicious: 'malicious',
+    Warning: 'warning',
+    Unknown: 'unknown',
+  },
+}));
+
+jest.mock('../../../../../app/scripts/lib/ppom/security-alerts-api', () => ({
+  isSecurityAlertsAPIEnabled: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: jest.fn(() => (key: string) => key),
+}));
+
+const mockUseTrustSignals = jest.requireMock(
+  '../../../../hooks/useTrustSignals',
+).useTrustSignals;
+
+const mockIsSecurityAlertsAPIEnabled = jest.requireMock(
+  '../../../../../app/scripts/lib/ppom/security-alerts-api',
+).isSecurityAlertsAPIEnabled;
+
+const MALICIOUS_ADDRESS = '0x0000000000000000000000000000000000000bad';
+const WARNING_ADDRESS = '0x0000000000000000000000000000000000000001';
+const SIGNER_ADDRESS = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
+
+const makeTypedSignV4 = (messageOverrides: object) =>
+  ({
+    ...unapprovedTypedSignMsgV4,
+    msgParams: {
+      ...unapprovedTypedSignMsgV4.msgParams,
+      data: JSON.stringify({
+        ...rawMessageV4,
+        ...messageOverrides,
+      }),
+    },
+  }) as SignatureRequestType;
+
+describe('useSignatureAddressAlerts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsSecurityAlertsAPIEnabled.mockReturnValue(true);
+    mockUseTrustSignals.mockReturnValue([]);
+  });
+
+  it('returns empty array when security alerts API is disabled', () => {
+    mockIsSecurityAlertsAPIEnabled.mockReturnValue(false);
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useSignatureAddressAlerts(),
+      getMockTypedSignConfirmState(),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns empty array when no message fields contain addresses', () => {
+    const request = makeTypedSignV4({
+      types: { Greeting: [{ name: 'text', type: 'string' }] },
+      primaryType: 'Greeting',
+      message: { text: 'Hello world' },
+    });
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useSignatureAddressAlerts(),
+      getMockTypedSignConfirmStateForRequest(request),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns a danger alert for a malicious address field', () => {
+    const request = makeTypedSignV4({
+      types: {
+        Transfer: [{ name: 'recipient', type: 'address' }],
+      },
+      primaryType: 'Transfer',
+      message: { recipient: MALICIOUS_ADDRESS },
+    });
+
+    mockUseTrustSignals.mockReturnValue([
+      { state: TrustSignalDisplayState.Malicious },
+    ]);
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useSignatureAddressAlerts(),
+      getMockTypedSignConfirmStateForRequest(request),
+    );
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({
+      key: `signatureAddressTrustSignalMalicious_${MALICIOUS_ADDRESS}`,
+      severity: Severity.Danger,
+      field: RowAlertKey.InteractingWith,
+      isBlocking: false,
+    });
+  });
+
+  it('returns a warning alert for a flagged address field', () => {
+    const request = makeTypedSignV4({
+      types: {
+        Transfer: [{ name: 'recipient', type: 'address' }],
+      },
+      primaryType: 'Transfer',
+      message: { recipient: WARNING_ADDRESS },
+    });
+
+    mockUseTrustSignals.mockReturnValue([
+      { state: TrustSignalDisplayState.Warning },
+    ]);
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useSignatureAddressAlerts(),
+      getMockTypedSignConfirmStateForRequest(request),
+    );
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({
+      key: `signatureAddressTrustSignalWarning_${WARNING_ADDRESS}`,
+      severity: Severity.Warning,
+      field: RowAlertKey.InteractingWith,
+    });
+  });
+
+  it('excludes the signer address from alerts', () => {
+    const request = makeTypedSignV4({
+      types: { T: [{ name: 'addr', type: 'address' }] },
+      primaryType: 'T',
+      message: { addr: SIGNER_ADDRESS },
+    });
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useSignatureAddressAlerts(),
+      getMockTypedSignConfirmStateForRequest(request),
+    );
+
+    expect(mockUseTrustSignals).toHaveBeenCalledWith([]);
+    expect(result.current).toEqual([]);
+  });
+
+  it('excludes permit spender field from scan', () => {
+    const request = makeTypedSignV4({
+      types: {
+        Permit: [{ name: 'spender', type: 'address' }],
+      },
+      domain: {
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+      },
+      primaryType: 'Permit',
+      message: { spender: MALICIOUS_ADDRESS },
+    });
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useSignatureAddressAlerts(),
+      getMockTypedSignConfirmStateForRequest(request),
+    );
+
+    expect(mockUseTrustSignals).toHaveBeenCalledWith([]);
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns overflow caution alert when address cap is exceeded', () => {
+    const addresses: Record<string, string> = {};
+    const types: { name: string; type: string }[] = [];
+    for (let i = 0; i < 12; i += 1) {
+      const name = `addr${i}`;
+      const addr = `0x${String(i).padStart(40, '0')}`;
+      addresses[name] = addr;
+      types.push({ name, type: 'address' });
+    }
+
+    const request = makeTypedSignV4({
+      types: { Flood: types },
+      primaryType: 'Flood',
+      message: addresses,
+    });
+
+    mockUseTrustSignals.mockReturnValue(
+      new Array(10).fill({ state: TrustSignalDisplayState.Unknown }),
+    );
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useSignatureAddressAlerts(),
+      getMockTypedSignConfirmStateForRequest(request),
+    );
+
+    expect(result.current.some((a) => a.key === 'signatureAddressScanIncomplete')).toBe(true);
+    expect(
+      result.current.find((a) => a.key === 'signatureAddressScanIncomplete'),
+    ).toMatchObject({
+      severity: Severity.Warning,
+      field: RowAlertKey.InteractingWith,
+    });
+  });
+
+  it('handles malformed typed data without throwing', () => {
+    const request = {
+      ...unapprovedTypedSignMsgV4,
+      msgParams: {
+        ...unapprovedTypedSignMsgV4.msgParams,
+        data: 'not-valid-json{',
+      },
+    } as SignatureRequestType;
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useSignatureAddressAlerts(),
+      getMockTypedSignConfirmStateForRequest(request),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns no alerts for unknown trust signal state', () => {
+    const request = makeTypedSignV4({
+      types: {
+        Transfer: [{ name: 'recipient', type: 'address' }],
+      },
+      primaryType: 'Transfer',
+      message: { recipient: '0x0000000000000000000000000000000000000002' },
+    });
+
+    mockUseTrustSignals.mockReturnValue([
+      { state: TrustSignalDisplayState.Unknown },
+    ]);
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useSignatureAddressAlerts(),
+      getMockTypedSignConfirmStateForRequest(request),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('passes all extracted addresses to useTrustSignals', () => {
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useSignatureAddressAlerts(),
+      getMockTypedSignConfirmState(),
+    );
+
+    expect(mockUseTrustSignals).toHaveBeenCalled();
+    const calls = mockUseTrustSignals.mock.calls[0][0];
+    expect(calls.length).toBeGreaterThan(0);
+    calls.forEach((entry: { chainId: string }) => {
+      expect(entry.chainId).toBe(CHAIN_IDS.GOERLI);
+    });
+
+    expect(result.current).toEqual([]);
+  });
+});

--- a/ui/pages/confirmations/hooks/alerts/useSignatureAddressAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useSignatureAddressAlerts.ts
@@ -1,0 +1,133 @@
+import { useMemo } from 'react';
+import { NameType } from '@metamask/name-controller';
+import { extractSignatureAddresses } from '@metamask/phishing-controller';
+
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { shortenAddress } from '../../../../helpers/utils/util';
+import { useConfirmContext } from '../../context/confirm';
+import { isSignatureTransactionType } from '../../utils';
+import { SignatureRequestType } from '../../types/confirm';
+import { parseTypedDataMessage } from '../../../../../shared/lib/transaction.utils';
+import { PRIMARY_TYPES_PERMIT } from '../../../../../shared/constants/signatures';
+import { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
+import { RowAlertKey } from '../../../../components/app/confirm/info/row/constants';
+import { Severity } from '../../../../helpers/constants/design-system';
+import {
+  useTrustSignals,
+  TrustSignalDisplayState,
+} from '../../../../hooks/useTrustSignals';
+// eslint-disable-next-line import-x/no-restricted-paths
+import { isSecurityAlertsAPIEnabled } from '../../../../../app/scripts/lib/ppom/security-alerts-api';
+
+/**
+ * Generate trust-signal alerts for the address fields of a typed-data
+ * signature. Every address-typed field is scanned; the top-level permit
+ * `spender` is left to `useSpenderAlerts` to avoid a duplicate alert.
+ */
+export function useSignatureAddressAlerts(): Alert[] {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext();
+
+  const {
+    addresses: signatureAddresses,
+    fields,
+    overflow,
+  } = useMemo(() => {
+    const empty = {
+      addresses: [] as string[],
+      fields: {} as Record<string, string>,
+      overflow: false,
+    };
+
+    if (
+      !currentConfirmation ||
+      !isSignatureTransactionType(currentConfirmation) ||
+      currentConfirmation.type !== 'eth_signTypedData' ||
+      !isSecurityAlertsAPIEnabled()
+    ) {
+      return empty;
+    }
+
+    const signatureRequest = currentConfirmation as SignatureRequestType;
+    const msgData = signatureRequest.msgParams?.data as string;
+    if (!msgData) {
+      return empty;
+    }
+
+    try {
+      const parsed = parseTypedDataMessage(msgData);
+      const signer = signatureRequest.msgParams?.from as string | undefined;
+      const isPermit = PRIMARY_TYPES_PERMIT.some(
+        (type) => type === parsed.primaryType,
+      );
+      return extractSignatureAddresses(parsed, {
+        exclude: signer ? [signer] : [],
+        excludeFields: isPermit ? ['spender'] : [],
+      });
+    } catch {
+      return empty;
+    }
+  }, [currentConfirmation]);
+
+  const trustSignals = useTrustSignals(
+    signatureAddresses.map((value) => ({
+      value,
+      type: NameType.ETHEREUM_ADDRESS,
+      chainId: currentConfirmation?.chainId,
+    })),
+  );
+
+  return useMemo(() => {
+    const alerts: Alert[] = [];
+
+    if (overflow) {
+      alerts.push({
+        actions: [],
+        field: RowAlertKey.InteractingWith,
+        isBlocking: false,
+        key: 'signatureAddressScanIncomplete',
+        message: t('alertMessageSignatureAddressScanIncomplete'),
+        reason: t('alertReasonSignatureAddressScanIncomplete'),
+        severity: Severity.Warning,
+      });
+    }
+
+    if (signatureAddresses.length === 0) {
+      return alerts;
+    }
+
+    trustSignals.forEach(({ state }, index) => {
+      const address = signatureAddresses[index];
+
+      if (state === TrustSignalDisplayState.Malicious) {
+        alerts.push({
+          actions: [],
+          field: RowAlertKey.InteractingWith,
+          isBlocking: false,
+          key: `signatureAddressTrustSignalMalicious_${address}`,
+          message: t('alertMessageSignatureAddressMalicious', [
+            fields[address],
+            shortenAddress(address),
+          ]),
+          reason: t('nameModalTitleMalicious'),
+          severity: Severity.Danger,
+        });
+      } else if (state === TrustSignalDisplayState.Warning) {
+        alerts.push({
+          actions: [],
+          field: RowAlertKey.InteractingWith,
+          isBlocking: false,
+          key: `signatureAddressTrustSignalWarning_${address}`,
+          message: t('alertMessageSignatureAddressWarning', [
+            fields[address],
+            shortenAddress(address),
+          ]),
+          reason: t('nameModalTitleWarning'),
+          severity: Severity.Warning,
+        });
+      }
+    });
+
+    return alerts;
+  }, [signatureAddresses, fields, overflow, trustSignals, t]);
+}

--- a/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
@@ -27,6 +27,7 @@ import { useNetworkAndOriginSwitchingAlerts } from './alerts/useNetworkAndOrigin
 import { useSelectedAccountAlerts } from './alerts/useSelectedAccountAlerts';
 import { useAddressTrustSignalAlerts } from './alerts/useAddressTrustSignalAlerts';
 import { useOriginTrustSignalAlerts } from './alerts/useOriginTrustSignalAlerts';
+import { useSignatureAddressAlerts } from './alerts/useSignatureAddressAlerts';
 import { useSpenderAlerts } from './alerts/useSpenderAlerts';
 import { useTokenTrustSignalAlerts } from './alerts/useTokenTrustSignalAlerts';
 import { useShieldCoverageAlert } from './alerts/useShieldCoverageAlert';
@@ -135,6 +136,7 @@ export default function useConfirmationAlerts(): Alert[] {
   const addressTrustSignalAlerts = useAddressTrustSignalAlerts();
   const originTrustSignalAlerts = useOriginTrustSignalAlerts();
   const spenderAlerts = useSpenderAlerts();
+  const signatureAddressAlerts = useSignatureAddressAlerts();
   const addEthereumChainAlerts = useAddEthereumChainAlerts();
 
   return useMemo(
@@ -148,6 +150,7 @@ export default function useConfirmationAlerts(): Alert[] {
       ...addressTrustSignalAlerts,
       ...originTrustSignalAlerts,
       ...spenderAlerts,
+      ...signatureAddressAlerts,
       ...addEthereumChainAlerts,
     ],
     [
@@ -160,6 +163,7 @@ export default function useConfirmationAlerts(): Alert[] {
       addressTrustSignalAlerts,
       originTrustSignalAlerts,
       spenderAlerts,
+      signatureAddressAlerts,
       addEthereumChainAlerts,
     ],
   );


### PR DESCRIPTION
## Summary
Ticket: [PSAFE-441](https://consensyssoftware.atlassian.net/browse/PSAFE-441)

MetaMask validates `eth_signTypedData_v3` and `eth_signTypedData_v4` requests with PPOM, which inspects the address fields of a signature. PPOM's threat data is refreshed on a delay, so an address that has been flagged recently can still be reported as benign, and it does not cover every chain or protocol.

Separately, the real-time per-address scan (`/address/evm/scan`) is only applied to a few fields today: the token `verifyingContract`, permit `spender`, and delegation `delegate`. Addresses carried in any other field — recipients, makers, tokens, custom protocol fields — receive no real-time scan at all.

This change wires a schema-driven extractor (added to `@metamask/phishing-controller` in MetaMask/core#9875) that returns up to 10 distinct `address`-typed values found in a typed-data message, including nested structs and arrays, matched by declared type rather than field name. When PPOM has not already flagged the request, those addresses are passed to the real-time address scan. Results reuse the existing address cache, so fields already scanned elsewhere are not requested again. A confirmation alert surfaces any flagged address using the existing alert template, naming the flagged field and address. If some addresses could not be checked because the cap, depth limit, or work budget was reached, a separate caution is shown.

## Changes

- **`app/scripts/lib/trust-signals/scan-unvalidated-signature.ts`** (new) — extracts up to 10 address-typed fields and scans each against the real-time API after PPOM; excludes the signer, zero address, and permit `spender` when `verifyingContract` is already scanned
- **`ui/pages/confirmations/hooks/alerts/useSignatureAddressAlerts.ts`** (new) — React hook that reads scan results and returns alerts for malicious/warning addresses (naming the field) plus a caution when the walk was incomplete
- **`app/scripts/lib/ppom/ppom-middleware.ts`** — calls `scanUnvalidatedSignatureAddresses` after PPOM resolves for signing methods when PPOM has not flagged the request
- **`app/scripts/lib/ppom/ppom-util.ts`** — updates `validateRequestWithPPOM` return type to `Promise<SecurityAlertResponse>` in all paths
- **`ui/pages/confirmations/hooks/useConfirmationAlerts.ts`** — wires `useSignatureAddressAlerts` into the confirmation alert pipeline
- **Locales** — adds `alertMessageSignatureAddressMalicious`, `alertMessageSignatureAddressWarning`, `alertMessageSignatureAddressScanIncomplete`, `alertReasonSignatureAddressScanIncomplete`

## Dependencies

**Blocked on MetaMask/core#9875.** The `package.json` dependency on `@metamask/phishing-controller` must be bumped to the version that exports `extractSignatureAddresses` before this can merge.

## References

- Core PR (extractor): MetaMask/core#9875
- Mobile (parallel client wiring): MetaMask/metamask-mobile#34786
- Prior implementation with local extractor copy (superseded): #45058

## Test plan

- [ ] Open a v3/v4 typed-data signature on a supported chain with a known-malicious address in a non-`from` field (e.g. `recipient`, `token`, `maker`) — confirm a Danger alert appears naming the field and shortened address
- [ ] Open a permit-type signature — confirm `spender` alert comes from `useSpenderAlerts`, not duplicated here
- [ ] Trigger a message with more than 10 distinct address fields — confirm the scan-incomplete caution appears
- [ ] Open a signature on an unsupported chain — confirm no scan fires
- [ ] Confirm no alert regression on standard transaction confirmations

## Screenshots/Recordings

Signing the same typed-data request on a build without this change and a build with it. The request carries a flagged address in a non-permit field.

**Before** (no scan of arbitrary address fields — the flagged address is not surfaced):

<!-- drop before recording here -->

https://github.com/user-attachments/assets/aadddc8f-00e2-4865-856f-fffb704414c2



**After** (the flagged address is scanned and the standard warning is shown):

<!-- drop after recording here -->

https://github.com/user-attachments/assets/78a83031-7f79-4e2e-bec0-1edde7fdec31




[PSAFE-441]: https://consensyssoftware.atlassian.net/browse/PSAFE-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ