### PR TITLE
fix(sentry): Stop spans silently attaching to whatever trace happens to be active

### DIFF
--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -384,8 +384,8 @@ describe('Trace', () => {
     });
   });
 
-  describe('explicit parenting only (no ambient active-span fallback)', () => {
-    it('does not inherit from the active span when no parentContext provided', () => {
+  describe('active-span fallback (opt-in via allowActiveSpanFallback)', () => {
+    it('does not inherit from the active span when the flag is absent', () => {
       const activeSpanMock = {
         spanContext: jest.fn().mockReturnValue({
           traceId: 'abc123',
@@ -397,7 +397,8 @@ describe('Trace', () => {
 
       trace({ name: NAME_MOCK }, () => true);
 
-      // The span must start as a root, not grafted onto the ambient span.
+      // The span must start as a root, not grafted onto the ambient span, and
+      // the ambient span must not even be looked up.
       expect(startSpanMock).toHaveBeenCalledWith(
         expect.objectContaining({
           parentSpan: null,
@@ -410,28 +411,75 @@ describe('Trace', () => {
         }),
         expect.any(Function),
       );
+      expect(getActiveSpanMock).not.toHaveBeenCalled();
+
+      const [spanOptions] = startSpanMock.mock.calls[0];
+      expect(spanOptions).not.toHaveProperty('forceTransaction');
     });
 
-    it('never consults getActiveSpan when starting a span, with or without parentContext', () => {
+    it('inherits the active span and forces a transaction only when the flag is set', () => {
       const activeSpanMock = {
         spanContext: jest.fn(),
       } as unknown as Sentry.Span;
 
       getActiveSpanMock.mockReturnValue(activeSpanMock);
 
-      trace({ name: NAME_MOCK }, () => true);
+      trace({ name: NAME_MOCK, allowActiveSpanFallback: true }, () => true);
+      trace({ name: NAME_MOCK, id: ID_MOCK }, () => true);
+
+      // Asserted as a pair: the flag, and nothing else, is what separates the
+      // inheriting call from the rooting one.
+      const [optedIn] = startSpanMock.mock.calls[0];
+      const [optedOut] = startSpanMock.mock.calls[1];
+
+      expect(optedIn).toEqual(
+        expect.objectContaining({
+          parentSpan: activeSpanMock,
+          forceTransaction: true,
+        }),
+      );
+      expect(optedOut).toEqual(
+        expect.objectContaining({
+          parentSpan: null,
+        }),
+      );
+      expect(optedOut).not.toHaveProperty('forceTransaction');
+    });
+
+    it('lets an explicit parentContext win over the flag, without consulting getActiveSpan', () => {
+      const activeSpanMock = {
+        spanContext: jest.fn(),
+      } as unknown as Sentry.Span;
+
+      getActiveSpanMock.mockReturnValue(activeSpanMock);
+
       trace(
-        { name: NAME_MOCK, id: ID_MOCK, parentContext: PARENT_CONTEXT_MOCK },
+        {
+          name: NAME_MOCK,
+          parentContext: PARENT_CONTEXT_MOCK,
+          allowActiveSpanFallback: true,
+        },
         () => true,
       );
 
+      expect(startSpanMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentSpan: PARENT_CONTEXT_MOCK,
+        }),
+        expect.any(Function),
+      );
       expect(getActiveSpanMock).not.toHaveBeenCalled();
+
+      const [spanOptions] = startSpanMock.mock.calls[0];
+      expect(spanOptions).not.toHaveProperty('forceTransaction');
     });
 
-    it('uses null parentSpan when no active span and no parentContext', () => {
+    it('roots the span when the flag is set but no active span exists', () => {
       getActiveSpanMock.mockReturnValue(undefined);
 
-      trace({ name: NAME_MOCK }, () => true);
+      expect(() => {
+        trace({ name: NAME_MOCK, allowActiveSpanFallback: true }, () => true);
+      }).not.toThrow();
 
       expect(startSpanMock).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -439,6 +487,9 @@ describe('Trace', () => {
         }),
         expect.any(Function),
       );
+
+      const [spanOptions] = startSpanMock.mock.calls[0];
+      expect(spanOptions).not.toHaveProperty('forceTransaction');
     });
 
     it('still honours an explicitly provided parentContext', () => {
@@ -457,7 +508,7 @@ describe('Trace', () => {
   });
 
   describe('forceTransaction', () => {
-    it('is not set when an active span exists and no parentContext is provided', () => {
+    it('is absent when an active span exists but the flag is not set', () => {
       const activeSpanMock = {
         spanContext: jest.fn(),
       } as unknown as Sentry.Span;
@@ -470,7 +521,7 @@ describe('Trace', () => {
       expect(spanOptions).not.toHaveProperty('forceTransaction');
     });
 
-    it('is not set when a parentContext is provided', () => {
+    it('is absent when a parentContext is provided', () => {
       trace(
         { name: NAME_MOCK, parentContext: PARENT_CONTEXT_MOCK },
         () => true,
@@ -480,13 +531,38 @@ describe('Trace', () => {
       expect(spanOptions).not.toHaveProperty('forceTransaction');
     });
 
-    it('is not set on the manually-ended (startSpanManual) path', () => {
-      getActiveSpanMock.mockReturnValue(undefined);
+    it('is absent on the manually-ended (startSpanManual) path when the flag is not set', () => {
+      const activeSpanMock = {
+        spanContext: jest.fn(),
+      } as unknown as Sentry.Span;
+
+      getActiveSpanMock.mockReturnValue(activeSpanMock);
 
       trace({ name: NAME_MOCK, id: ID_MOCK });
 
       const [spanOptions] = startSpanManualMock.mock.calls[0];
       expect(spanOptions).not.toHaveProperty('forceTransaction');
+      expect(spanOptions).toEqual(
+        expect.objectContaining({ parentSpan: null }),
+      );
+    });
+
+    it('is true on the manually-ended (startSpanManual) path when the flag is set', () => {
+      const activeSpanMock = {
+        spanContext: jest.fn(),
+      } as unknown as Sentry.Span;
+
+      getActiveSpanMock.mockReturnValue(activeSpanMock);
+
+      trace({ name: NAME_MOCK, id: ID_MOCK, allowActiveSpanFallback: true });
+
+      const [spanOptions] = startSpanManualMock.mock.calls[0];
+      expect(spanOptions).toEqual(
+        expect.objectContaining({
+          parentSpan: activeSpanMock,
+          forceTransaction: true,
+        }),
+      );
     });
   });
 

--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -384,8 +384,8 @@ describe('Trace', () => {
     });
   });
 
-  describe('getActiveSpan fallback', () => {
-    it('inherits from active span when no parentContext provided', () => {
+  describe('explicit parenting only (no ambient active-span fallback)', () => {
+    it('does not inherit from the active span when no parentContext provided', () => {
       const activeSpanMock = {
         spanContext: jest.fn().mockReturnValue({
           traceId: 'abc123',
@@ -397,8 +397,14 @@ describe('Trace', () => {
 
       trace({ name: NAME_MOCK }, () => true);
 
-      expect(getActiveSpanMock).toHaveBeenCalledTimes(1);
+      // The span must start as a root, not grafted onto the ambient span.
       expect(startSpanMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentSpan: null,
+        }),
+        expect.any(Function),
+      );
+      expect(startSpanMock).not.toHaveBeenCalledWith(
         expect.objectContaining({
           parentSpan: activeSpanMock,
         }),
@@ -406,9 +412,16 @@ describe('Trace', () => {
       );
     });
 
-    it('does not call getActiveSpan when parentContext is provided', () => {
+    it('never consults getActiveSpan when starting a span, with or without parentContext', () => {
+      const activeSpanMock = {
+        spanContext: jest.fn(),
+      } as unknown as Sentry.Span;
+
+      getActiveSpanMock.mockReturnValue(activeSpanMock);
+
+      trace({ name: NAME_MOCK }, () => true);
       trace(
-        { name: NAME_MOCK, parentContext: PARENT_CONTEXT_MOCK },
+        { name: NAME_MOCK, id: ID_MOCK, parentContext: PARENT_CONTEXT_MOCK },
         () => true,
       );
 
@@ -426,6 +439,54 @@ describe('Trace', () => {
         }),
         expect.any(Function),
       );
+    });
+
+    it('still honours an explicitly provided parentContext', () => {
+      trace(
+        { name: NAME_MOCK, parentContext: PARENT_CONTEXT_MOCK },
+        () => true,
+      );
+
+      expect(startSpanMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentSpan: PARENT_CONTEXT_MOCK,
+        }),
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('forceTransaction', () => {
+    it('is not set when an active span exists and no parentContext is provided', () => {
+      const activeSpanMock = {
+        spanContext: jest.fn(),
+      } as unknown as Sentry.Span;
+
+      getActiveSpanMock.mockReturnValue(activeSpanMock);
+
+      trace({ name: NAME_MOCK }, () => true);
+
+      const [spanOptions] = startSpanMock.mock.calls[0];
+      expect(spanOptions).not.toHaveProperty('forceTransaction');
+    });
+
+    it('is not set when a parentContext is provided', () => {
+      trace(
+        { name: NAME_MOCK, parentContext: PARENT_CONTEXT_MOCK },
+        () => true,
+      );
+
+      const [spanOptions] = startSpanMock.mock.calls[0];
+      expect(spanOptions).not.toHaveProperty('forceTransaction');
+    });
+
+    it('is not set on the manually-ended (startSpanManual) path', () => {
+      getActiveSpanMock.mockReturnValue(undefined);
+
+      trace({ name: NAME_MOCK, id: ID_MOCK });
+
+      const [spanOptions] = startSpanManualMock.mock.calls[0];
+      expect(spanOptions).not.toHaveProperty('forceTransaction');
     });
   });
 

--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -432,13 +432,13 @@ describe('Trace', () => {
       const [optedIn] = startSpanMock.mock.calls[0];
       const [optedOut] = startSpanMock.mock.calls[1];
 
-      expect(optedIn).toEqual(
+      expect(optedIn).toStrictEqual(
         expect.objectContaining({
           parentSpan: activeSpanMock,
           forceTransaction: true,
         }),
       );
-      expect(optedOut).toEqual(
+      expect(optedOut).toStrictEqual(
         expect.objectContaining({
           parentSpan: null,
         }),
@@ -542,7 +542,7 @@ describe('Trace', () => {
 
       const [spanOptions] = startSpanManualMock.mock.calls[0];
       expect(spanOptions).not.toHaveProperty('forceTransaction');
-      expect(spanOptions).toEqual(
+      expect(spanOptions).toStrictEqual(
         expect.objectContaining({ parentSpan: null }),
       );
     });
@@ -557,7 +557,7 @@ describe('Trace', () => {
       trace({ name: NAME_MOCK, id: ID_MOCK, allowActiveSpanFallback: true });
 
       const [spanOptions] = startSpanManualMock.mock.calls[0];
-      expect(spanOptions).toEqual(
+      expect(spanOptions).toStrictEqual(
         expect.objectContaining({
           parentSpan: activeSpanMock,
           forceTransaction: true,

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -527,21 +527,10 @@ function startSpan<T>(
   callback: (spanOptions: StartSpanOptions) => T,
 ) {
   const { data: attributes, name, parentContext, startTime, op } = request;
-  let parentSpan = resolveParentSpan(parentContext);
-
-  // Inherit from active span (e.g. browserTracingIntegration's pageload/navigation)
-  // when no explicit parent is provided. Must capture before withIsolationScope
-  // severs the active span context chain.
-  // forceTransaction preserves transaction-level visibility for monitoring while
-  // linking to the auto-instrumentation hierarchy.
-  let forceTransaction: boolean | undefined;
-  if (!parentSpan && !parentContext) {
-    const activeSpan = sentryGetActiveSpan();
-    if (activeSpan) {
-      parentSpan = activeSpan;
-      forceTransaction = true;
-    }
-  }
+  // Parenting is explicit only. A trace without a `parentContext` starts its own
+  // root span rather than grafting onto whatever span happens to be active, so
+  // unrelated operations are never nested under an ambient pageload/navigation.
+  const parentSpan = resolveParentSpan(parentContext);
 
   const spanOptions: StartSpanOptions = {
     attributes,
@@ -549,7 +538,6 @@ function startSpan<T>(
     op: op ?? OP_DEFAULT,
     parentSpan,
     startTime,
-    forceTransaction,
   };
 
   // Cross-process propagation via continueTrace when we have serialized

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -187,6 +187,32 @@ export type TraceRequest = {
   parentContext?: TraceContext;
 
   /**
+   * Opt in to inheriting the ambient active span when no `parentContext` is
+   * supplied. Defaults to `false`: a request without a `parentContext` starts
+   * its own root span.
+   *
+   * Parenting used to fall back to the active span implicitly, which made two
+   * different call sites indistinguishable. A call site that wants a real root
+   * trace and a call site that simply never threaded its parent through both
+   * reach this function as "no `parentContext`", and the implicit fallback
+   * grafted each of them onto whatever span happened to be active. Naming the
+   * behaviour forces every dependent call site to declare which of the two it
+   * is, instead of the resulting topology depending on what the runtime was
+   * doing at the time.
+   *
+   * Set this only where the ambient span is known to be the correct parent, for
+   * example an operation reached from inside another traced callback that
+   * cannot thread its `parentContext` through the intervening API.
+   *
+   * When the fallback applies, the span is also marked `forceTransaction`, so it
+   * stays a transaction rather than becoming a plain child span. The two are
+   * coupled deliberately: demoting an operation to a child removes it from
+   * transaction-level dashboards and alerting, which needs per-operation review
+   * rather than a blanket change. Tracked in MetaMask-planning#7549.
+   */
+  allowActiveSpanFallback?: boolean;
+
+  /**
    * Override the start time of the trace.
    */
   startTime?: number;
@@ -526,11 +552,38 @@ function startSpan<T>(
   request: TraceRequest,
   callback: (spanOptions: StartSpanOptions) => T,
 ) {
-  const { data: attributes, name, parentContext, startTime, op } = request;
-  // Parenting is explicit only. A trace without a `parentContext` starts its own
-  // root span rather than grafting onto whatever span happens to be active, so
-  // unrelated operations are never nested under an ambient pageload/navigation.
-  const parentSpan = resolveParentSpan(parentContext);
+  const {
+    data: attributes,
+    name,
+    parentContext,
+    startTime,
+    op,
+    allowActiveSpanFallback,
+  } = request;
+  let parentSpan = resolveParentSpan(parentContext);
+
+  // Parenting is explicit by default: without a `parentContext`, a trace starts
+  // its own root span rather than grafting onto whatever span happens to be
+  // active. Call sites that want the ambient span (e.g. an operation reached
+  // from inside another traced callback that cannot thread its parent through
+  // the intervening API) opt in via `allowActiveSpanFallback`, so "wants a root"
+  // and "forgot to pass a parent" are distinguishable at the call site.
+  //
+  // Must capture before withIsolationScope severs the active span context chain.
+  //
+  // `forceTransaction` stays coupled to the fallback deliberately: promoting the
+  // inherited child back to a transaction preserves transaction-level visibility
+  // for monitoring. Decoupling the two would demote these operations out of
+  // transaction-level dashboards and alerting, which needs per-operation review
+  // first (see MetaMask-planning#7549) and is therefore not done here.
+  let forceTransaction: boolean | undefined;
+  if (!parentSpan && !parentContext && allowActiveSpanFallback) {
+    const activeSpan = sentryGetActiveSpan();
+    if (activeSpan) {
+      parentSpan = activeSpan;
+      forceTransaction = true;
+    }
+  }
 
   const spanOptions: StartSpanOptions = {
     attributes,
@@ -538,6 +591,9 @@ function startSpan<T>(
     op: op ?? OP_DEFAULT,
     parentSpan,
     startTime,
+    // Omit the key entirely when the fallback did not apply, so an opted-out
+    // span carries no `forceTransaction` signal at all.
+    ...(forceTransaction === undefined ? {} : { forceTransaction }),
   };
 
   // Cross-process propagation via continueTrace when we have serialized


### PR DESCRIPTION
## What this fixes

`startSpan` treated "no `parentContext` supplied" as licence to inherit whatever span the runtime happened to have active, and to mark the result `forceTransaction`:

```ts
if (!parentSpan && !parentContext) {
  const activeSpan = sentryGetActiveSpan();
  if (activeSpan) {
    parentSpan = activeSpan;
    forceTransaction = true;
  }
}
```

The parent a span got therefore depended on scheduling rather than on intent — a background poll firing during a UI interaction became a child of that interaction. This is the single line behind the orphaned spans, stale-parent grafts and concurrent-context pollution tracked in the parenting sub-epic.

Parenting is now explicit by default. Absent a `parentContext`, a span roots itself — unless the call site opts in with the new `allowActiveSpanFallback` flag.

**Revised from outright deletion (2026-08-14).** Deleting the fallback fragmented the multichain account-creation trace: `Provider Create Accounts` and `Wallet Alignment` are reached from inside the `WalletCreateMultichainAccountGroup` callback, which also passes no `parentContext`, so the fallback was doing real grouping work there. An opt-in keeps that available while still forcing every dependent call site to say so. `forceTransaction` stays coupled to the fallback deliberately — decoupling it would demote those operations out of transaction-level dashboards and alerting, which needs per-operation review first.

**No call site opts in yet.** Establishing which ones genuinely need it is a separate audit; landing the flag with no adopters is the intended first step, so the fragmentation becomes an opt-in-able condition rather than a silent regression.

Closes MetaMask-planning#7549.

## This does not reduce billed volume — please read before citing it as a saving

The ticket carried a cost argument folded in from a duplicate: that `forceTransaction` manufactures roughly a fifth of billed transactions. That is true, and removing it here still saves nothing, because of what the spans become instead:

| Before | After | Billed |
|---|---|---|
| no `parentContext`, ambient span present → promoted child | root span | 1 → 1 |
| no `parentContext`, no ambient span → root | unchanged | 1 → 1 |
| `parentContext` supplied → plain child | unchanged | 0 → 0 |

A force-promoted child and a root span each bill as one transaction. The volume win would require keeping the parent link and dropping only `forceTransaction` — which is precisely the ambient parenting this change exists to remove. The two goals pull opposite ways, and the real reduction comes from threading a genuine `parentContext` through the call sites so these become ordinary child spans.

## Superseded: the multichain fragmentation is now opt-out-able

`Provider Create Accounts (v2 - batched)` and `Wallet Alignment` are reached from inside the `WalletCreateMultichainAccountGroup` callback, which also supplies no `parentContext`. The ambient fallback was doing real grouping work there, and after this change they become disconnected roots — same transaction count, worse trace tree.

This is why the change became an opt-in rather than a deletion. Setting `allowActiveSpanFallback: true` at those sites restores the grouping; threading a real `parentContext` through `@metamask/multichain-account-service` remains the durable fix, and is upstream of this repo.

`UI Startup` is unaffected — it is called before any span exists, and the adjacent `LoadScripts` call already passes `parentContext` explicitly.

## Known limitation: shape improvement is capped until the manual span is bound

Independent of this change, `startTrace` hands `sentryStartSpanManual` a callback that stores the pending trace and returns the span **synchronously** (`shared/lib/trace.ts:440-461`). The span is therefore active only for that callback, not for the `trace()` -> `endTrace()` window. So for the non-callback trace API there is no parent link to inherit *or* remove: an operation's own fetches were never nesting inside its span, and land on whatever is ambient — in the service worker, the `pageload`.

That is a second, independent producer of the same symptom this PR addresses, and it interacts with this change rather than being orthogonal to it. After this PR those operations become roots, which under the unbound-span defect means **an empty root span sitting beside its own fetches, which still hang off `pageload`**. In the trace UI that reads worse than the mis-parented version did, until the binding is fixed.

Raising it here rather than leaving it to be found after merge. The binding fix is a separate change with its own blast radius — making a span active for the whole window also causes *unrelated* in-window work (background polling) to nest inside long UI operations, which needs its own decision.

Corroborated independently outside this codebase by a repro harness that mirrors this file's structure, where the same two defects reproduce verbatim.

## Verification

Both suites green, and the new tests in `shared/lib/trace.test.ts` were run against the old implementation rather than trusted:

```
$ yarn jest shared/lib/trace.test.ts
Tests:       26 passed, 26 total

$ yarn jest shared/lib/
Test Suites: 137 passed, 137 total
Tests:       2284 passed, 2284 total
```

With the previous `trace.ts` restored and the new tests in place, **5 assertions fail** — `getActiveSpan` consulted, `parentSpan` resolving to the active span, and `forceTransaction` present on three paths. The tests pin the new contract rather than passing vacuously.

The three tests that asserted the deleted behaviour were rewritten to assert its absence rather than removed, so the guarantee is still held by the suite.

## Scope

`shared/lib/stores/utils/run-tracked-task.ts` also sets `forceTransaction: true`. It calls `sentry.startSpan` directly for a deliberate root-task span and never routes through `trace()`, so it is untouched and unreachable from this change.

`getSerializedTraceContext()` keeps its own `sentryGetActiveSpan()` call — same function, different job (cross-process propagation over RPC). Removing it would break distributed tracing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default trace topology for every `trace()` call without `parentContext`, which can fragment Sentry trees until call sites opt in or pass real parents; observability-only but broad blast radius.
> 
> **Overview**
> **Sentry span parenting in `trace()` is explicit by default.** When no `parentContext` is passed, spans start as roots (`parentSpan: null`) and **`getActiveSpan` is not called**. The old implicit “inherit whatever span is active” behavior is gated behind the new **`allowActiveSpanFallback`** option on the trace request.
> 
> **Opt-in fallback keeps the old grouping semantics.** With the flag set and an ambient span present, parenting uses that span and sets **`forceTransaction: true`** (still coupled to the fallback). Explicit `parentContext` wins and does not set `forceTransaction`. **`forceTransaction` is omitted from span options** when it does not apply, instead of passing `undefined`.
> 
> **Tests** replace the previous “always inherit active span” expectations with coverage for default roots, opt-in inheritance, manual `startSpanManual` paths, and when `forceTransaction` must be absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9d896eef3c43c139f3737915be9099bb8b07a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Changelog

CHANGELOG entry: null


