### PR TITLE
fix(sentry): Stop sending trace headers that point at no trace

### DIFF
--- a/app/scripts/lib/sentry-trace-propagation.test.ts
+++ b/app/scripts/lib/sentry-trace-propagation.test.ts
@@ -13,6 +13,7 @@ import {
   matchesBackendTarget,
   resetConsensysRequestIdProvider,
   setConsensysRequestIdProvider,
+  stripTraceHeaders,
 } from './sentry-trace-propagation';
 
 jest.mock('@sentry/core', () => ({
@@ -32,6 +33,12 @@ const SPAN_ID = '00f067aa0ba902b7';
 const TRACEPARENT = `00-${TRACE_ID}-${SPAN_ID}-01`;
 const BACKEND_URL = 'https://accounts.api.cx.metamask.io/v1/accounts';
 const CONSENSYS_BAGGAGE = `consensys-request-id=uuid-fixed,consensys-application=metamask-extension`;
+// What the SDK's fetch instrumentation attaches to a `tracePropagationTargets`
+// match while no span is active: the ids come from the scope propagation
+// context, so the advertised parent belongs to no span.
+const SDK_SENTRY_TRACE_NO_SPAN = `${TRACE_ID}-${SPAN_ID}-0`;
+const SDK_TRACEPARENT_NO_SPAN = `00-${TRACE_ID}-${SPAN_ID}-00`;
+const SDK_BAGGAGE_NO_SPAN = `sentry-trace_id=${TRACE_ID},sentry-sample_rate=0.005`;
 
 const getActiveSpanMock = jest.mocked(getActiveSpan);
 const getCurrentScopeMock = jest.mocked(getCurrentScope);
@@ -183,6 +190,62 @@ describe('buildAugmentedHeaders', () => {
   });
 });
 
+describe('stripTraceHeaders', () => {
+  it('removes sentry-trace, traceparent and the Sentry baggage entries', () => {
+    const headers = stripTraceHeaders([
+      BACKEND_URL,
+      {
+        headers: {
+          'sentry-trace': SDK_SENTRY_TRACE_NO_SPAN,
+          traceparent: SDK_TRACEPARENT_NO_SPAN,
+          baggage: SDK_BAGGAGE_NO_SPAN,
+          'x-caller': 'kept',
+        },
+      },
+    ]) as Headers;
+
+    expect(headers.get('sentry-trace')).toBeNull();
+    expect(headers.get('traceparent')).toBeNull();
+    expect(headers.get('baggage')).toBeNull();
+    expect(headers.get('x-caller')).toBe('kept');
+  });
+
+  it('keeps non-Sentry baggage entries', () => {
+    const headers = stripTraceHeaders([
+      BACKEND_URL,
+      {
+        headers: {
+          'sentry-trace': SDK_SENTRY_TRACE_NO_SPAN,
+          baggage: `${SDK_BAGGAGE_NO_SPAN},vendor-key=vendor-value`,
+        },
+      },
+    ]) as Headers;
+
+    expect(headers.get('baggage')).toBe('vendor-key=vendor-value');
+  });
+
+  it('strips headers seeded from a Request', () => {
+    const request = new Request(BACKEND_URL, {
+      headers: {
+        traceparent: SDK_TRACEPARENT_NO_SPAN,
+        'x-from-request': 'yes',
+      },
+    });
+
+    const headers = stripTraceHeaders([request]) as Headers;
+
+    expect(headers.get('traceparent')).toBeNull();
+    expect(headers.get('x-from-request')).toBe('yes');
+  });
+
+  it('returns undefined when the request carries no trace headers', () => {
+    expect(
+      stripTraceHeaders([BACKEND_URL, { headers: { 'x-caller': 'kept' } }]),
+    ).toBeUndefined();
+    expect(stripTraceHeaders([BACKEND_URL])).toBeUndefined();
+  });
+});
+
 describe('consensysTracePropagationIntegration', () => {
   const log = jest.fn();
 
@@ -207,6 +270,99 @@ describe('consensysTracePropagationIntegration', () => {
     expect(init.headers.get('traceparent')).toBeNull();
     expect(init.headers.get('baggage')).toBe(CONSENSYS_BAGGAGE);
     expect(getCurrentConsensysRequestId()).toBe('uuid-fixed');
+  });
+
+  describe('no active span (outbound invariant)', () => {
+    // `beforeEach` leaves `getActiveSpan` returning undefined, so these cases
+    // exercise a matched backend host with no span — the combination that must
+    // never emit a trace header.
+
+    it('attaches nothing to a matched backend request that carries no headers', () => {
+      const handler = getFetchHandler();
+      const handlerData = {
+        fetchData: { url: BACKEND_URL, method: 'GET' },
+        args: [BACKEND_URL, undefined],
+      } as unknown as Parameters<typeof handler>[0];
+
+      handler(handlerData);
+
+      expect(handlerData.args[1]).toBeUndefined();
+      expect(getCurrentConsensysRequestId()).toBeUndefined();
+    });
+
+    it('strips the SDK trace headers and withholds the Consensys baggage', () => {
+      const handler = getFetchHandler();
+      const handlerData = {
+        fetchData: { url: BACKEND_URL, method: 'GET' },
+        args: [
+          BACKEND_URL,
+          {
+            headers: {
+              'sentry-trace': SDK_SENTRY_TRACE_NO_SPAN,
+              traceparent: SDK_TRACEPARENT_NO_SPAN,
+              baggage: SDK_BAGGAGE_NO_SPAN,
+              'x-caller': 'kept',
+            },
+          },
+        ],
+      } as unknown as Parameters<typeof handler>[0];
+
+      handler(handlerData);
+
+      const init = handlerData.args[1] as { headers: Headers };
+      expect(init.headers.get('sentry-trace')).toBeNull();
+      expect(init.headers.get('traceparent')).toBeNull();
+      expect(init.headers.get('baggage')).toBeNull();
+      expect(init.headers.get('x-caller')).toBe('kept');
+      expect(getCurrentConsensysRequestId()).toBeUndefined();
+    });
+
+    it('leaves non-Sentry baggage on the stripped request', () => {
+      const handler = getFetchHandler();
+      const handlerData = {
+        fetchData: { url: BACKEND_URL, method: 'GET' },
+        args: [
+          BACKEND_URL,
+          {
+            headers: {
+              traceparent: SDK_TRACEPARENT_NO_SPAN,
+              baggage: `${SDK_BAGGAGE_NO_SPAN},vendor-key=vendor-value`,
+            },
+          },
+        ],
+      } as unknown as Parameters<typeof handler>[0];
+
+      handler(handlerData);
+
+      const init = handlerData.args[1] as { headers: Headers };
+      expect(init.headers.get('traceparent')).toBeNull();
+      expect(init.headers.get('baggage')).toBe('vendor-key=vendor-value');
+      expect(init.headers.get('baggage')).not.toContain(CONSENSYS_BAGGAGE);
+    });
+
+    it('records no request id for the trace, so events are not tagged', () => {
+      // A scope propagation context is present, so without the gate the handler
+      // would mint a request id and bind it to this trace id.
+      getCurrentScopeMock.mockReturnValue({
+        getPropagationContext: () => ({ traceId: TRACE_ID }),
+      } as unknown as ReturnType<typeof getCurrentScope>);
+      const handler = getFetchHandler();
+      handler({
+        fetchData: { url: BACKEND_URL, method: 'GET' },
+        args: [BACKEND_URL, undefined],
+      } as unknown as Parameters<typeof handler>[0]);
+
+      const integration = consensysTracePropagationIntegration({ log });
+      const event = integration.processEvent?.(
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- Sentry event-payload key.
+        { contexts: { trace: { trace_id: TRACE_ID } } } as SentryEvent,
+        {} as EventHint,
+        {} as Client,
+      ) as SentryEvent;
+
+      expect(event.tags?.otelTraceId).toBe(TRACE_ID);
+      expect(event.tags?.consensysRequestId).toBeUndefined();
+    });
   });
 
   it('does not touch requests to non-backend hosts', () => {

--- a/app/scripts/lib/sentry-trace-propagation.ts
+++ b/app/scripts/lib/sentry-trace-propagation.ts
@@ -154,6 +154,29 @@ function toHeaders(existing: unknown): Headers {
 }
 
 /**
+ * Merge a fetch call's `Request` headers with its `init` headers into a single
+ * `Headers`, with `init` winning on duplicate keys — the precedence the platform
+ * applies when `fetch` receives both.
+ *
+ * @param args - The fetch arguments (`[input, init]`).
+ * @returns A new `Headers` instance holding the request's effective headers.
+ */
+function mergeFetchHeaders(args: unknown[]): Headers {
+  const [request, options] = args as [
+    unknown,
+    { headers?: unknown } | undefined,
+  ];
+  const requestHeaders = isRequest(request) ? request.headers : undefined;
+  const headers = toHeaders(requestHeaders);
+  const initHeaders = toHeaders(options?.headers);
+
+  initHeaders.forEach((value, key) => {
+    headers.set(key, value);
+  });
+  return headers;
+}
+
+/**
  * Build a new `Headers` for an outbound fetch with the Consensys `baggage`
  * appended. Seeds from the existing request headers (the SDK's `sentry-trace` /
  * `baggage` / `traceparent` are already present when this runs after Sentry's
@@ -168,21 +191,63 @@ export function buildAugmentedHeaders(
   args: unknown[],
   { requestId }: { requestId: string },
 ): Headers {
-  const [request, options] = args as [
-    unknown,
-    { headers?: unknown } | undefined,
-  ];
-  const requestHeaders = isRequest(request) ? request.headers : undefined;
-  const headers = toHeaders(requestHeaders);
-  const initHeaders = toHeaders(options?.headers);
-
-  initHeaders.forEach((value, key) => {
-    headers.set(key, value);
-  });
+  const headers = mergeFetchHeaders(args);
   // `baggage` is appended (not set): repeated baggage headers are merged by the
   // browser, so this preserves the SDK's Sentry-prefixed entries.
   headers.append('baggage', buildConsensysBaggage(requestId));
   return headers;
+}
+
+/** Headers that advertise a trace parent on an outbound request. */
+const TRACE_PARENT_HEADERS = ['sentry-trace', 'traceparent'];
+
+/** Prefix of the `baggage` entries that carry Sentry's trace context. */
+const SENTRY_BAGGAGE_PREFIX = 'sentry-';
+
+/**
+ * Remove every trace header from an outbound request's effective headers:
+ * `sentry-trace`, `traceparent`, and the Sentry-prefixed `baggage` entries.
+ * Non-Sentry `baggage` entries and all other headers are preserved.
+ *
+ * Used to hold the outbound invariant when no span is active. The SDK's fetch
+ * instrumentation attaches these headers whenever the URL matches
+ * `tracePropagationTargets`, independently of whether a span exists; with no
+ * span it derives them from the scope propagation context, so the advertised
+ * parent is a freshly minted id belonging to no span.
+ *
+ * @param args - The fetch arguments (`[input, init]`).
+ * @returns A new `Headers` instance without trace headers, or `undefined` when
+ * the request carried none — so the caller can leave the fetch arguments as
+ * they are rather than rewriting them to an equivalent value.
+ */
+export function stripTraceHeaders(args: unknown[]): Headers | undefined {
+  const headers = mergeFetchHeaders(args);
+  let removed = false;
+
+  for (const name of TRACE_PARENT_HEADERS) {
+    if (headers.has(name)) {
+      headers.delete(name);
+      removed = true;
+    }
+  }
+
+  const baggage = headers.get('baggage');
+  if (baggage !== null) {
+    const entries = baggage.split(',').map((entry) => entry.trim());
+    const kept = entries.filter(
+      (entry) => entry && !entry.startsWith(SENTRY_BAGGAGE_PREFIX),
+    );
+    if (kept.length !== entries.length) {
+      removed = true;
+      if (kept.length > 0) {
+        headers.set('baggage', kept.join(','));
+      } else {
+        headers.delete('baggage');
+      }
+    }
+  }
+
+  return removed ? headers : undefined;
 }
 
 function setRequestIdForTraceId(traceId: string, requestId: string): void {
@@ -214,9 +279,14 @@ function setRequestIdForTraceId(traceId: string, requestId: string): void {
  * `consensysRequestId`). The W3C `traceparent` / `sentry-trace` headers are
  * injected natively by the SDK (`propagateTraceparent` + `tracePropagationTargets`).
  *
+ * Also enforces the outbound invariant: a matched request made while no span is
+ * active carries no trace headers at all — the SDK's `sentry-trace` /
+ * `traceparent` / Sentry `baggage` are stripped and the Consensys segment is
+ * withheld, rather than advertising a parent that points at no span.
+ *
  * Must be registered after `browserTracingIntegration` so the SDK's
  * `sentry-trace` / `baggage` headers are already attached when the fetch hook
- * augments them.
+ * augments or strips them.
  *
  * @param options - Options bag.
  * @param options.log - Function to log diagnostic messages.
@@ -241,6 +311,22 @@ export function consensysTracePropagationIntegration({
           return;
         }
         try {
+          // Outbound invariant: never advertise a trace parent that points at
+          // nothing. The SDK attaches `sentry-trace` / `traceparent` / Sentry
+          // `baggage` to every `tracePropagationTargets` match, including when
+          // no span is active — then the parent id comes from the scope
+          // propagation context and belongs to no span the backend can ever
+          // join. Strip what the SDK attached, and withhold the Consensys
+          // `baggage` segment, which has no trace to correlate against.
+          if (!getActiveSpan()) {
+            const strippedHeaders = stripTraceHeaders(handlerData.args);
+            if (strippedHeaders) {
+              handlerData.args[1] = handlerData.args[1] || {};
+              handlerData.args[1].headers = strippedHeaders;
+            }
+            return;
+          }
+
           const requestId = requestIdProvider();
           currentConsensysRequestId = requestId;
 


### PR DESCRIPTION
## What this fixes

The Sentry SDK decides whether to attach trace headers on the **URL alone**:

```js
// @sentry/core@10.38.0 build/cjs/fetch.js:67-88
if (shouldAttachHeaders(handlerData.fetchData.url)) { ... }
```

`hasParent` is computed at `:57` but used only to pick which span `getTraceData` derives from (`:80`). With no active span it still emits `sentry-trace`, `traceparent` and `baggage`, built from the scope's propagation context — a trace context naming a span that will never be sent to Sentry. The backend then parents its own spans onto something that does not exist, which is the orphaned-backend-span half of the parenting work.

`consensysTracePropagationIntegration` now strips those headers and withholds its own Consensys baggage segment when `getActiveSpan()` is nullish.

Closes MetaMask-planning#7486.

## Why this did not need an SDK config change

The obvious alternative was to disable `propagateTraceparent` in `app/scripts/lib/setupSentry.js` and inject manually. That was rejected, and the reason is worth recording because it is not obvious from the outside:

- The SDK writes its headers to `handlerData.args[1].headers` (`fetch.js:85-86`) — the same slot this handler already rewrites. They are not sealed inside a `Request`, so they are strippable from where we already stand.
- Ordering is guaranteed rather than lucky: `browserTracingIntegration` registers its fetch handler in `afterAllSetup`, this integration also registers in `afterAllSetup`, and `setupSentry.js` lists browserTracing first. `addFetchInstrumentationHandler` fires handlers in insertion order, so ours runs last and sees what the SDK wrote.
- The strip list is complete. `getTraceData` returns exactly `sentry-trace`, `baggage`, `traceparent` (`@sentry/core/build/cjs/utils/traceData.js:54-59`) — there is no `tracestate` to miss.
- The URL sets coincide: `setupSentry.js:136` passes the same `BACKEND_TRACE_PROPAGATION_TARGETS` array that `matchesBackendTarget` tests, so there is no URL the SDK decorates that this gate never sees.

Doing it this way also leaves `sentry-traceparent-semantics.test.ts` intact. That file pins "propagates trace-flags `00` when no span is active" as *intentional*, and its own docstring scopes itself out of this question: *"Header gating/scoping is covered by integration tests."* It governs what a header **contains** when sent, not **whether** it is sent.

## Residuals — not fixed here

**XHR has the identical defect and is not covered.** `@sentry/browser` `tracing/request.js:271-280` gates `addTracingHeadersToXhrRequest` on the URL the same way, `traceXHR` defaults to `true`, and this integration registers no XHR handler. It is not a mirror of this fix: `setRequestHeader` cannot unset a header, so enforcing the invariant there needs interception *before* the SDK's handler — an ordering inversion and a separate design decision.

Sizing it honestly: `grep -rn "XMLHttpRequest" --include=*.ts --include=*.js --include=*.tsx app/ shared/ ui/` returns only a global-forwarding key list and one comment. So first-party code does not call XHR directly. That grep cannot see XHR issued from inside dependencies or an `axios` XHR adapter, so this is not a claim that no backend-target XHR occurs.

**A negatively-sampled active span still passes the gate.** `getActiveSpan()` is truthy, so headers go out with flags `00`. That is the behaviour the semantics test pins as deliberate, so widening the gate to "recording span" would be a semantic change rather than a bug fix — flagging it rather than making that call here.

**If `getActiveSpan()` throws**, the existing `catch` logs and returns, leaving the SDK's headers in place. Preserving "header injection must never break the outbound request" was the higher priority.

## Verification

```
$ yarn jest app/scripts/lib/sentry-trace-propagation.test.ts
Tests:       26 passed, 26 total

$ yarn jest app/scripts/lib/sentry-traceparent-semantics.test.ts
Tests:       4 passed, 4 total       (unmodified — git diff --stat empty)

$ yarn jest app/scripts/lib/
Test Suites: 131 passed, 131 total
Tests:       2 skipped, 2177 passed, 2179 total
```

`yarn lint:tsc` exits 0; `oxfmt --check` reports both changed files correctly formatted.

**Positive control, and what it caught.** The gate was temporarily neutered to `if (false && !getActiveSpan())`. First run, only **3 of 4** new integration tests went red — `records no request id for the trace` passed either way, because with the default empty propagation-scope mocks no id is bound regardless of the gate. That test was true but not discriminating. It was strengthened to mock a propagation context carrying a trace id, so without the gate the handler *would* mint and bind a request id. Re-run of the control: **4 failed, 22 passed**. The control edit was then reverted. The gate is live in the reviewed diff rather than left neutered — read it at https://github.com/MetaMask/metamask-extension/blob/1ce28f384f2fbf85654c8f4d33ea05315eff87d2/app/scripts/lib/sentry-trace-propagation.ts

**ESLint could not be run.** `npx eslint -c ./.eslintrc.js` dies with `TypeError: Converting circular structure to JSON` under ESLint 9.39.4 in this worktree, whose `node_modules` is a shared install so `npx` resolves a binary from a different repo root. Negative control: the same invocation fails identically on untouched `setupSentry.js`. Pre-existing and environmental — but this is explicitly *not* a claim of a clean lint.

## For the reviewer to decide

`getCurrentTraceId()`'s scope-propagation-context fallback (`:93-97`) is now unreachable from this handler — the gate returns before it. The dead branch was left standing rather than pruned, since narrowing an exported-adjacent helper's contract with no test demanding it is a reviewer's call.

Unconditional stripping does not distinguish SDK-set from caller-set trace headers, because by the time this handler runs the SDK has merged both into one `Headers` and the original init object is gone. A grep of first-party source finds nothing setting these headers manually, so the case is currently moot — but the behaviour is that a hand-set trace header on a matched backend URL under no active span would also be dropped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed-tracing headers on outbound backend API traffic; mis-gating could drop legitimate trace correlation or leave bad parents, but scope is limited to matched backend URLs and the no-active-span path.
> 
> **Overview**
> Fixes outbound backend `fetch` calls made **without an active Sentry span** still advertising trace parents from the SDK’s scope propagation context (orphaned backend spans).
> 
> **`consensysTracePropagationIntegration`** now checks `getActiveSpan()` before augmenting. When there is no span, it **strips** `sentry-trace`, `traceparent`, and Sentry-prefixed `baggage` via new **`stripTraceHeaders`**, preserves other headers (including non-Sentry baggage), and **does not** append Consensys baggage or bind `consensysRequestId`. When a span is active, behavior is unchanged.
> 
> Header merging for augment/strip is refactored through shared **`mergeFetchHeaders`** (Request + init precedence). Tests cover `stripTraceHeaders` and the no-span fetch invariant, including that events are not tagged with `consensysRequestId` when the gate applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ce28f384f2fbf85654c8f4d33ea05315eff87d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Changelog

CHANGELOG entry: null
