### PR TITLE
test(perps): reduce flaky Perps E2E navigation and activity waits

### DIFF
--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -38,6 +38,9 @@ export async function assertPerpsActivityShowsCloseFill({
   const perpsTab = new PerpsTab(driver);
   await perpsTab.navigateToPerpsHome();
   await perpsTab.checkPageIsLoaded();
+  // See All only renders once userFills have populated the section (not on
+  // loading skeleton or empty state); wait to avoid flaky TimeoutError on click.
+  await perpsTab.waitForRecentActivitySection();
   await perpsTab.clickRecentActivitySeeAll();
 
   const activityPage = new PerpsActivityPage(driver);

--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -26,17 +26,29 @@ export async function assertPerpsActivityShowsCloseFill({
 }): Promise<void> {
   const marketDetailPage = new PerpsMarketDetailPage(driver);
   await marketDetailPage.clickBack();
-  try {
-    const marketListPage = new PerpsMarketListPage(driver);
+
+  const marketListPage = new PerpsMarketListPage(driver);
+  const onMarketList = await driver.isElementPresentAndVisible(
+    { testId: 'market-list-view' },
+    2000,
+  );
+  if (onMarketList) {
     await marketListPage.clickBack();
-  } catch (error) {
-    console.error('Market list not displayed, moving on', error);
   }
 
   const perpsTab = new PerpsTab(driver);
-  await perpsTab.navigateToPerpsHome();
+  const onPerpsHome = await driver.isElementPresentAndVisible(
+    { testId: 'perps-view' },
+    2000,
+  );
+  if (!onPerpsHome) {
+    await perpsTab.navigateToPerpsHome();
+  }
   await perpsTab.checkPageIsLoaded();
+  await perpsTab.waitForRecentActivityIdle();
+
   pushUserFills();
+
   await perpsTab.waitForRecentActivitySection();
   await perpsTab.clickRecentActivitySeeAll();
 

--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -5,13 +5,9 @@ import { PerpsMarketDetailPage } from '../pages/perps/perps-market-detail-page';
 import { PerpsMarketListPage } from '../pages/perps/perps-market-list-page';
 
 /**
- * After a simulated position change in E2E, navigates back to Perps home,
- * pushes a `userFills` snapshot via `pushUserFills`, then opens Perps Activity
- * and asserts a trade row appears with the expected title fragment.
- *
- * `pushUserFills` runs after Perps home is loaded: the default WS mock answers
- * `userFills` subscribe with an empty snapshot, so pushing earlier (on market
- * detail) is often wiped when home remounts and re-subscribes.
+ * After a simulated position change in E2E, pushes a `userFills` snapshot via
+ * `pushUserFills`, then opens Perps Activity and asserts a trade row appears
+ * with the expected title fragment (same navigation pattern as other lifecycle tests).
  *
  * @param options
  * @param options.driver
@@ -40,12 +36,7 @@ export async function assertPerpsActivityShowsCloseFill({
   const perpsTab = new PerpsTab(driver);
   await perpsTab.navigateToPerpsHome();
   await perpsTab.checkPageIsLoaded();
-
-  // After home mount/subscribe (empty default snapshot), push the close fill.
   pushUserFills();
-
-  // See All only renders once fills have populated the section (not on
-  // loading skeleton or empty state).
   await perpsTab.waitForRecentActivitySection();
   await perpsTab.clickRecentActivitySeeAll();
 

--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -5,9 +5,13 @@ import { PerpsMarketDetailPage } from '../pages/perps/perps-market-detail-page';
 import { PerpsMarketListPage } from '../pages/perps/perps-market-list-page';
 
 /**
- * After a simulated position change in E2E, pushes a `userFills` snapshot via
- * `pushUserFills`, then opens Perps Activity and asserts a trade row appears
- * with the expected title fragment (same navigation pattern as other lifecycle tests).
+ * After a simulated position change in E2E, navigates back to Perps home,
+ * pushes a `userFills` snapshot via `pushUserFills`, then opens Perps Activity
+ * and asserts a trade row appears with the expected title fragment.
+ *
+ * `pushUserFills` runs after Perps home is loaded: the default WS mock answers
+ * `userFills` subscribe with an empty snapshot, so pushing earlier (on market
+ * detail) is often wiped when home remounts and re-subscribes.
  *
  * @param options
  * @param options.driver
@@ -24,8 +28,6 @@ export async function assertPerpsActivityShowsCloseFill({
   /** Substring of the trade title, e.g. `Closed long` or `Closed short`. */
   expectedTitleContains: string;
 }): Promise<void> {
-  pushUserFills();
-
   const marketDetailPage = new PerpsMarketDetailPage(driver);
   await marketDetailPage.clickBack();
   try {
@@ -38,8 +40,12 @@ export async function assertPerpsActivityShowsCloseFill({
   const perpsTab = new PerpsTab(driver);
   await perpsTab.navigateToPerpsHome();
   await perpsTab.checkPageIsLoaded();
-  // See All only renders once userFills have populated the section (not on
-  // loading skeleton or empty state); wait to avoid flaky TimeoutError on click.
+
+  // After home mount/subscribe (empty default snapshot), push the close fill.
+  pushUserFills();
+
+  // See All only renders once fills have populated the section (not on
+  // loading skeleton or empty state).
   await perpsTab.waitForRecentActivitySection();
   await perpsTab.clickRecentActivitySeeAll();
 

--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -24,6 +24,8 @@ export async function assertPerpsActivityShowsCloseFill({
   /** Substring of the trade title, e.g. `Closed long` or `Closed short`. */
   expectedTitleContains: string;
 }): Promise<void> {
+  pushUserFills();
+
   const marketDetailPage = new PerpsMarketDetailPage(driver);
   await marketDetailPage.clickBack();
 
@@ -45,10 +47,6 @@ export async function assertPerpsActivityShowsCloseFill({
     await perpsTab.navigateToPerpsHome();
   }
   await perpsTab.checkPageIsLoaded();
-  await perpsTab.waitForRecentActivityIdle();
-
-  pushUserFills();
-
   await perpsTab.waitForRecentActivitySection();
   await perpsTab.clickRecentActivitySeeAll();
 

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -54,10 +54,6 @@ export class PerpsTab extends PerpsPositionsBase {
     testId: 'perps-recent-activity-empty',
   };
 
-  private readonly perpsRecentActivityLoading = {
-    testId: 'perps-recent-activity-loading',
-  };
-
   private readonly perpsRecentActivitySeeAll = {
     testId: 'perps-recent-activity-see-all',
   };
@@ -269,24 +265,6 @@ export class PerpsTab extends PerpsPositionsBase {
         return elements.length === expectedCount;
       },
       { timeout, interval: 500 },
-    );
-  }
-
-  /**
-   * Waits until the recent-activity loading skeleton is gone.
-   *
-   * @param timeout - Max wait time in ms (default 15 000).
-   */
-  async waitForRecentActivityIdle(timeout = 15000): Promise<void> {
-    await this.driver.waitUntil(
-      async () => {
-        const isLoading = await this.driver.isElementPresentAndVisible(
-          this.perpsRecentActivityLoading,
-          300,
-        );
-        return !isLoading;
-      },
-      { timeout, interval: 300 },
     );
   }
 

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -140,7 +140,8 @@ export class PerpsTab extends PerpsPositionsBase {
 
   /**
    * Clicks the "See All" link in the Recent Activity section (navigates to Perps Activity).
-   * Shown for both the populated list header and the empty-state header.
+   * Only rendered when the section has transactions; empty/loading states omit it.
+   * Prefer `waitForRecentActivitySection()` before calling this.
    */
   async clickRecentActivitySeeAll(): Promise<void> {
     await this.driver.clickElement(this.perpsRecentActivitySeeAll);
@@ -177,20 +178,38 @@ export class PerpsTab extends PerpsPositionsBase {
   }
 
   /**
-   * Navigates to Perps Home by clicking the Perps tab on the account overview.
-   * Requires the account overview to be visible (e.g. after login or driver.navigate()).
-   * Waits for the Perps tab to be present, clicks it, then waits for the Perps Home view to load.
+   * Navigates to Perps Home via bottom-nav Perps or the account-overview Perps tab.
+   * Requires the account overview / home chrome to be visible (e.g. after login).
+   * Waits until either entry point is present (avoids a short bottom-nav poll that
+   * false-negatives into waiting for an overview tab that never renders under
+   * bottom-nav treatment), clicks it, then waits for the Perps Home view to load.
    */
   async navigateToPerpsHome(): Promise<void> {
     console.log('Navigate to Perps home');
+    await this.driver.waitUntil(
+      async () => {
+        const isBottomNav = await this.driver.isElementPresentAndVisible(
+          this.bottomNavPerpsButton,
+          500,
+        );
+        if (isBottomNav) {
+          return true;
+        }
+        return await this.driver.isElementPresentAndVisible(
+          this.accountOverviewPerpsTab,
+          500,
+        );
+      },
+      { timeout: 20000, interval: 500 },
+    );
+
     const isBottomNav = await this.driver.isElementPresentAndVisible(
       this.bottomNavPerpsButton,
-      3000,
+      1000,
     );
     if (isBottomNav) {
       await this.driver.clickElement(this.bottomNavPerpsButton);
     } else {
-      await this.driver.waitForSelector(this.accountOverviewPerpsTab);
       await this.driver.clickElement(this.accountOverviewPerpsTab);
     }
     await this.checkPageIsLoaded();

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -140,8 +140,6 @@ export class PerpsTab extends PerpsPositionsBase {
 
   /**
    * Clicks the "See All" link in the Recent Activity section (navigates to Perps Activity).
-   * Only rendered when the section has transactions; empty/loading states omit it.
-   * Prefer `waitForRecentActivitySection()` before calling this.
    */
   async clickRecentActivitySeeAll(): Promise<void> {
     await this.driver.clickElement(this.perpsRecentActivitySeeAll);
@@ -178,11 +176,8 @@ export class PerpsTab extends PerpsPositionsBase {
   }
 
   /**
-   * Navigates to Perps Home via bottom-nav Perps or the account-overview Perps tab.
-   * Requires the account overview / home chrome to be visible (e.g. after login).
-   * Waits until either entry point is present (avoids a short bottom-nav poll that
-   * false-negatives into waiting for an overview tab that never renders under
-   * bottom-nav treatment), clicks it, then waits for the Perps Home view to load.
+   * Navigates to Perps Home by clicking the Perps tab on the account overview
+   * or the bottom-nav Perps button when present.
    */
   async navigateToPerpsHome(): Promise<void> {
     console.log('Navigate to Perps home');
@@ -277,7 +272,7 @@ export class PerpsTab extends PerpsPositionsBase {
    * Waits for the Recent Activity list (non-empty) to be visible.
    * When there is no history, the section uses `perps-recent-activity-empty` instead.
    *
-   * @param timeout - Max wait time in ms (default 20 000; Firefox CI is slower).
+   * @param timeout - Max wait time in ms (default 20 000).
    */
   async waitForRecentActivitySection(timeout = 20000): Promise<void> {
     await this.driver.waitForSelector(this.perpsRecentActivity, { timeout });

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -276,9 +276,11 @@ export class PerpsTab extends PerpsPositionsBase {
   /**
    * Waits for the Recent Activity list (non-empty) to be visible.
    * When there is no history, the section uses `perps-recent-activity-empty` instead.
+   *
+   * @param timeout - Max wait time in ms (default 20 000; Firefox CI is slower).
    */
-  async waitForRecentActivitySection(): Promise<void> {
-    await this.driver.waitForSelector(this.perpsRecentActivity);
+  async waitForRecentActivitySection(timeout = 20000): Promise<void> {
+    await this.driver.waitForSelector(this.perpsRecentActivity, { timeout });
   }
 
   /**

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -54,6 +54,10 @@ export class PerpsTab extends PerpsPositionsBase {
     testId: 'perps-recent-activity-empty',
   };
 
+  private readonly perpsRecentActivityLoading = {
+    testId: 'perps-recent-activity-loading',
+  };
+
   private readonly perpsRecentActivitySeeAll = {
     testId: 'perps-recent-activity-see-all',
   };
@@ -265,6 +269,24 @@ export class PerpsTab extends PerpsPositionsBase {
         return elements.length === expectedCount;
       },
       { timeout, interval: 500 },
+    );
+  }
+
+  /**
+   * Waits until the recent-activity loading skeleton is gone.
+   *
+   * @param timeout - Max wait time in ms (default 15 000).
+   */
+  async waitForRecentActivityIdle(timeout = 15000): Promise<void> {
+    await this.driver.waitUntil(
+      async () => {
+        const isLoading = await this.driver.isElementPresentAndVisible(
+          this.perpsRecentActivityLoading,
+          300,
+        );
+        return !isLoading;
+      },
+      { timeout, interval: 300 },
     );
   }
 

--- a/test/e2e/tests/perps/mocks/websocketDefaultMocks.ts
+++ b/test/e2e/tests/perps/mocks/websocketDefaultMocks.ts
@@ -14,6 +14,23 @@
 
 import type { WebSocketMessageMock } from '../../../websocket/types';
 
+const WS_MOCK_DEFAULT_USER = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1';
+
+/**
+ * Fills returned by the default `userFills` subscribe / POST mocks.
+ * `pushUserFillsClosePositionSnapshot` updates this so a home remount
+ * re-subscribe still delivers the close fill.
+ */
+let pendingUserFills: object[] = [];
+
+export function setPendingUserFills(fills: object[]): void {
+  pendingUserFills = fills;
+}
+
+export function clearPendingUserFills(): void {
+  pendingUserFills = [];
+}
+
 export function getResponsePayload(mock: WebSocketMessageMock): object | null {
   if (!mock.response) {
     return null;
@@ -448,6 +465,19 @@ export const DEFAULT_HYPERLIQUID_WS_MOCKS: WebSocketMessageMock[] = [
     logMessage: 'Hyperliquid WS candleSnapshot POST received',
   },
   {
+    // Prefer pending close-fill snapshots (set by pushUserFillsClosePositionSnapshot)
+    // over the generic POST catch-all that returns {}.
+    messageIncludes: ['"method":"post"', '"type":"userFills"'],
+    dynamicResponse: (message: string) => {
+      const req = parseWsPost(message);
+      return req
+        ? buildWsPostResponse(req.id, req.type, pendingUserFills)
+        : null;
+    },
+    delay: 50,
+    logMessage: 'Hyperliquid WS POST userFills',
+  },
+  {
     // Generic catch-all for any remaining WS POST (userFills, historicalOrders,
     // userFunding, userNonFundingLedgerUpdates, userFees, spotMeta, etc.).
     // Responds immediately with {} so the SDK promise resolves instead of timing out (10s).
@@ -491,7 +521,14 @@ export const DEFAULT_HYPERLIQUID_WS_MOCKS: WebSocketMessageMock[] = [
   {
     messageIncludes: ['"method":"subscribe"', '"type":"userFills"'],
     dynamicResponse: buildSubscribedConfirmation,
-    followUpResponse: { channel: 'userFills', data: [], time: 0 },
+    dynamicFollowUp: () => ({
+      channel: 'userFills',
+      data: {
+        user: WS_MOCK_DEFAULT_USER,
+        isSnapshot: true,
+        fills: pendingUserFills,
+      },
+    }),
     followUpDelay: 50,
     delay: 50,
     logMessage: 'Hyperliquid userFills subscribe message received',

--- a/test/e2e/tests/perps/mocks/websocketPositionMocks.ts
+++ b/test/e2e/tests/perps/mocks/websocketPositionMocks.ts
@@ -18,6 +18,7 @@ import {
   buildSubscribedConfirmation,
   buildWsPostResponse,
   parseWsPost,
+  setPendingUserFills,
 } from './websocketDefaultMocks';
 
 /**
@@ -612,12 +613,13 @@ export function pushUserFillsClosePositionSnapshot(
     twapId: null,
   };
 
+  setPendingUserFills([fill]);
   server.sendMessage(
     JSON.stringify({
       channel: 'userFills',
       data: {
         user,
-        isSnapshot: false,
+        isSnapshot: true,
         fills: [fill],
       },
     }),

--- a/test/e2e/tests/perps/mocks/websocketPositionMocks.ts
+++ b/test/e2e/tests/perps/mocks/websocketPositionMocks.ts
@@ -617,7 +617,7 @@ export function pushUserFillsClosePositionSnapshot(
       channel: 'userFills',
       data: {
         user,
-        isSnapshot: true,
+        isSnapshot: false,
         fills: [fill],
       },
     }),

--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -6,6 +6,7 @@ import {
   getProductionRemoteFlagApiResponse,
   getProductionRemoteFlagDefaults,
 } from '../../feature-flags/feature-flag-registry';
+import { BOTTOM_NAV_AB_TEST_KEY } from '../../../../shared/lib/ab-testing/configs/bottom-nav-bar';
 import { formatUnits } from '../../../../shared/lib/unit';
 import {
   MOCK_ETH_OPEN_LONG_FILL,
@@ -105,6 +106,10 @@ const PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS = {
   // is on in production (registry value), so it stays registered; tests that
   // need the slippage UI can opt in explicitly. Covered by unit tests + recipe.
   perpsSlippageConfig2: { enabled: false, minimumVersion: '0.0.0' },
+  // Pin bottom-nav AB test to control so Perps home is reached via
+  // account-overview__perps-tab (prod default is a multivariate threshold
+  // array that can resolve to treatment and hide that tab).
+  [BOTTOM_NAV_AB_TEST_KEY]: 'control',
 };
 
 /**
@@ -164,6 +169,8 @@ const PERPS_GEO_BLOCKED_REMOTE_FEATURE_FLAGS = {
     PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS.confirmations_pay_post_quote,
   perpsEnabledVersion: { enabled: true, minimumVersion: '0.0.0' },
   perpsPerpTradingGeoBlockedCountriesV2: { blockedRegions: ['US'] },
+  [BOTTOM_NAV_AB_TEST_KEY]:
+    PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS[BOTTOM_NAV_AB_TEST_KEY],
 };
 
 const PERPS_GEO_BLOCKED_FLAG = {
@@ -224,6 +231,8 @@ export function getPerpsGeoBlockConfig(title?: string) {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         confirmations_pay: { name: 'empty' },
         perpsPerpTradingGeoBlockedCountriesV2: { blockedRegions: ['US'] },
+        [BOTTOM_NAV_AB_TEST_KEY]:
+          PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS[BOTTOM_NAV_AB_TEST_KEY],
       });
       await server
         .forGet('https://client-config.api.cx.metamask.io/v1/flags')
@@ -284,6 +293,10 @@ async function mockEligibleFeatureFlags(
     // market submit disabled without order-book estimates.
     perpsSlippageConfig2:
       PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS.perpsSlippageConfig2,
+    // Keep bottom-nav pinned to control after the flags refetch (same reason
+    // as slippage above — prod default is a multivariate threshold array).
+    [BOTTOM_NAV_AB_TEST_KEY]:
+      PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS[BOTTOM_NAV_AB_TEST_KEY],
     ...overrides,
   });
   await server

--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -106,9 +106,6 @@ const PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS = {
   // is on in production (registry value), so it stays registered; tests that
   // need the slippage UI can opt in explicitly. Covered by unit tests + recipe.
   perpsSlippageConfig2: { enabled: false, minimumVersion: '0.0.0' },
-  // Pin bottom-nav AB test to control so Perps home is reached via
-  // account-overview__perps-tab (prod default is a multivariate threshold
-  // array that can resolve to treatment and hide that tab).
   [BOTTOM_NAV_AB_TEST_KEY]: 'control',
 };
 
@@ -293,8 +290,6 @@ async function mockEligibleFeatureFlags(
     // market submit disabled without order-book estimates.
     perpsSlippageConfig2:
       PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS.perpsSlippageConfig2,
-    // Keep bottom-nav pinned to control after the flags refetch (same reason
-    // as slippage above — prod default is a multivariate threshold array).
     [BOTTOM_NAV_AB_TEST_KEY]:
       PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS[BOTTOM_NAV_AB_TEST_KEY],
     ...overrides,

--- a/test/e2e/websocket/perps-mocks.ts
+++ b/test/e2e/websocket/perps-mocks.ts
@@ -2,6 +2,7 @@
 import { WebSocket } from 'ws';
 import {
   DEFAULT_HYPERLIQUID_WS_MOCKS,
+  clearPendingUserFills,
   getResponsePayload,
 } from '../tests/perps/mocks/websocketDefaultMocks';
 import type { WebSocketMessageMock } from './types';
@@ -34,6 +35,7 @@ async function setupPerpsWebsocketMocks(
   server: LocalWebSocketServer,
   mocks: WebSocketMessageMock[] = [],
 ): Promise<void> {
+  clearPendingUserFills();
   const wsServer = server.getServer();
 
   const mergedMocks = [...mocks, ...DEFAULT_HYPERLIQUID_WS_MOCKS];


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes intermittent Perps E2E flakes in CI.

### Recent Activity / close-fill assertion (`perps-tpsl`, lifecycle via shared flow)

- Wait for populated recent-activity section before clicking See All (See All only renders when transactions exist).
- Avoid 10s market-list back timeout when already on Perps home after market-detail back.
- Persist close fills across `userFills` resubscribe: `pushUserFillsClosePositionSnapshot` stores pending fills; default Hyperliquid WS mocks return those fills on `userFills` subscribe/POST (empty `[]` follow-up was wiping live pushes when home remounted). Cleared on each Perps WS mock setup.
- Verified locally: `yarn test:e2e:single test/e2e/tests/perps/perps-tpsl.spec.ts --browser=firefox` → 2 passing.

### Perps home navigation (`perps-position-lifecycle`, `perps-watchlist`)

- `navigateToPerpsHome()` waits until either bottom-nav Perps or `account-overview__perps-tab` is present, then clicks the available entry point (avoids short bottom-nav poll false-negative into a missing overview tab).

### Fixture determinism

- Pin bottom-nav AB test to `control` in Perps eligible fixtures (seeded RemoteFeatureFlagController + `/v1/flags` HTTP mock) so overview Perps tab remains the stable entry point.

**Commits on this branch** (`origin/main..HEAD`):

- `test(perps): persist close fills across userFills resubscribe`
- `test(perps): stabilize close-fill activity assertion timing`
- `test(perps): trim verbose comments from flakiness fixes`
- `test(perps): push userFills after Perps home mounts`
- `test(perps): reduce flaky Perps E2E navigation and activity waits`

**Files touched:** `perps-activity-close-fill.flow.ts`, `perps-tab.ts`, `websocketDefaultMocks.ts`, `websocketPositionMocks.ts`, `perps-fixture-config.ts`, `perps-mocks.ts` (6 files, +89 / −14).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Ensure `PERPS_ENABLED=true` and a firefox/chrome test build is available.
2. Run `yarn test:e2e:single test/e2e/tests/perps/perps-tpsl.spec.ts --browser=firefox`
3. Run `yarn test:e2e:single test/e2e/tests/perps/perps-position-lifecycle.spec.ts --browser=chrome`
4. Run `yarn test:e2e:single test/e2e/tests/perps/perps-watchlist.spec.ts --browser=chrome`
5. Confirm no timeouts on `perps-recent-activity-see-all`, `perps-recent-activity`, or `account-overview__perps-tab`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.