### PR TITLE
chore: migrate `exportSeedPhraseWithPasskey` to LegacyBackgroundApiService

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -98,6 +98,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'PreferencesController:setPasswordForgotten',
       'PasskeyController:unlockWithPasskey',
       'PasskeyController:changePasswordWithPasskeyVerification',
+      'PasskeyController:exportSeedPhraseWithPasskey',
       'OnboardingController:getState',
       'SeedlessOnboardingController:checkIsPasswordOutdated',
       'SeedlessOnboardingController:getState',

--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -18,7 +18,6 @@ import { CHAIN_IDS } from '../../shared/constants/network';
 import { toAssetId } from '../../shared/lib/asset-utils';
 import { getIsAssetsUnifiedStateIncludedInBuild } from '../../shared/lib/environment';
 import MetaMaskController from './metamask-controller';
-import { convertEnglishWordlistIndicesToCodepoints } from './lib/util';
 
 // Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
 // so unify-state tests can exercise real feature-flag gating via controller state.
@@ -759,60 +758,20 @@ describe('MetaMaskController', function () {
     });
 
     describe('#exportSeedPhraseWithPasskey', function () {
-      it('delegates to the passkey controller and re-encodes the result', async function () {
-        const mnemonic = new Uint8Array([0, 0, 0, 1]);
-        const exportSpy = jest
-          .spyOn(
-            metamaskController.passkeyController,
-            'exportSeedPhraseWithPasskey',
-          )
-          .mockResolvedValue(mnemonic);
+      it('delegates to the legacy background API service export action', async function () {
+        const callSpy = jest
+          .spyOn(metamaskController.controllerMessenger, 'call')
+          .mockResolvedValue(undefined);
 
-        const result = await metamaskController.exportSeedPhraseWithPasskey(
+        await metamaskController
+          .getApi()
+          .exportSeedPhraseWithPasskey(authenticationResponse, 'keyring-id');
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'LegacyBackgroundApiService:exportSeedPhraseWithPasskey',
           authenticationResponse,
           'keyring-id',
         );
-
-        expect(exportSpy).toHaveBeenCalledWith(
-          authenticationResponse,
-          'keyring-id',
-        );
-        expect(result).toStrictEqual(
-          convertEnglishWordlistIndicesToCodepoints(mnemonic),
-        );
-      });
-
-      it('defaults to the primary keyring when no keyring id is provided', async function () {
-        const exportSpy = jest
-          .spyOn(
-            metamaskController.passkeyController,
-            'exportSeedPhraseWithPasskey',
-          )
-          .mockResolvedValue(new Uint8Array([0, 0, 0, 1]));
-
-        await metamaskController.exportSeedPhraseWithPasskey(
-          authenticationResponse,
-        );
-
-        expect(exportSpy).toHaveBeenCalledWith(
-          authenticationResponse,
-          undefined,
-        );
-      });
-
-      it('propagates errors from the passkey controller', async function () {
-        jest
-          .spyOn(
-            metamaskController.passkeyController,
-            'exportSeedPhraseWithPasskey',
-          )
-          .mockRejectedValue(new Error('invalid assertion'));
-
-        await expect(
-          metamaskController.exportSeedPhraseWithPasskey(
-            authenticationResponse,
-          ),
-        ).rejects.toThrow('invalid assertion');
       });
     });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -224,7 +224,6 @@ import {
   initializeRpcProviderDomains,
   getPlatform,
   getBooleanFlag,
-  convertEnglishWordlistIndicesToCodepoints,
 } from './lib/util';
 import createMetamaskMiddleware from './lib/createMetamaskMiddleware';
 import { createDefiReferralMiddleware } from './lib/defi-referrals/createDefiReferralMiddleware';
@@ -3335,7 +3334,10 @@ export default class MetamaskController extends EventEmitter {
         this.controllerMessenger,
         'PasskeyController:exportAccountsWithPasskey',
       ),
-      exportSeedPhraseWithPasskey: this.exportSeedPhraseWithPasskey.bind(this),
+      exportSeedPhraseWithPasskey: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:exportSeedPhraseWithPasskey',
+      ),
 
       // txController
       updateTransaction: txController.updateTransaction.bind(txController),
@@ -3964,26 +3966,6 @@ export default class MetamaskController extends EventEmitter {
       deleteInterface,
       origin,
     });
-  }
-
-  /**
-   * Exports the Secret Recovery Phrase after verifying a passkey assertion,
-   * used as a password-less alternative to {@link getSeedPhrase}.
-   *
-   * @param {import('@metamask/passkey-controller').PasskeyAuthenticationResponse} authenticationResponse - WebAuthn authentication response from the passkey ceremony.
-   * @param {string} [keyringId] - The id of the HD keyring to export. Defaults to the primary keyring.
-   * @returns {Promise<Buffer>} The seed phrase encoded as an array of UTF-8 bytes.
-   */
-  async exportSeedPhraseWithPasskey(authenticationResponse, keyringId) {
-    // Assertion verification + vault-key export live in `PasskeyController`,
-    // which returns the raw wordlist-index bytes from `KeyringController`. The
-    // extension re-encodes them as UTF-8 codepoints for the UI.
-    const mnemonic = await this.passkeyController.exportSeedPhraseWithPasskey(
-      authenticationResponse,
-      keyringId,
-    );
-
-    return convertEnglishWordlistIndicesToCodepoints(mnemonic);
   }
 
   //=============================================================================

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -554,6 +554,23 @@ export type LegacyBackgroundApiServiceUnlockWithPasskeyAction = {
 };
 
 /**
+ * Exports the Secret Recovery Phrase after verifying a passkey assertion,
+ * used as a password-less alternative to {@link getSeedPhrase}.
+ *
+ * Assertion verification + vault-key export live in `PasskeyController`, which
+ * returns the raw wordlist-index bytes from `KeyringController`. The extension
+ * re-encodes them as UTF-8 codepoints for the UI.
+ *
+ * @param authenticationResponse - WebAuthn authentication response from the passkey ceremony.
+ * @param keyringId - The id of the HD keyring to export. Defaults to the primary keyring.
+ * @returns The seed phrase encoded as an array of UTF-8 bytes.
+ */
+export type LegacyBackgroundApiServiceExportSeedPhraseWithPasskeyAction = {
+  type: `LegacyBackgroundApiService:exportSeedPhraseWithPasskey`;
+  handler: LegacyBackgroundApiService['exportSeedPhraseWithPasskey'];
+};
+
+/**
  * Locks MetaMask
  *
  * @param options - The options for setting the locked state.
@@ -1052,6 +1069,7 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceSubmitPasswordOrEncryptionKeyAction
   | LegacyBackgroundApiServiceChangePasswordWithPasskeyVerificationAction
   | LegacyBackgroundApiServiceUnlockWithPasskeyAction
+  | LegacyBackgroundApiServiceExportSeedPhraseWithPasskeyAction
   | LegacyBackgroundApiServiceSetLockedAction
   | LegacyBackgroundApiServiceSyncKeyringEncryptionKeyAction
   | LegacyBackgroundApiServiceExportAccountAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -2295,6 +2295,63 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
+  describe('exportSeedPhraseWithPasskey', () => {
+    const authenticationResponse =
+      'authentication-response' as unknown as Parameters<
+        LegacyBackgroundApiService['exportSeedPhraseWithPasskey']
+      >[0];
+
+    it('exports the seed phrase via the passkey controller and re-encodes it', async () => {
+      const mnemonic =
+        'test test test test test test test test test test test ball';
+
+      const mockSeedPhrase = new Uint8Array(
+        new Uint16Array(
+          mnemonic.split(' ').map((word) => wordlist.indexOf(word)),
+        ).buffer,
+      );
+
+      const encodedSeedPhrase = Buffer.from(mnemonic, 'utf8');
+
+      await withService(async ({ rootMessenger }) => {
+        const exportSpy = jest.fn().mockResolvedValue(mockSeedPhrase);
+        rootMessenger.registerActionHandler(
+          'PasskeyController:exportSeedPhraseWithPasskey',
+          exportSpy,
+        );
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:exportSeedPhraseWithPasskey',
+          authenticationResponse,
+          'keyring-id',
+        );
+
+        expect(exportSpy).toHaveBeenCalledWith(
+          authenticationResponse,
+          'keyring-id',
+        );
+        expect(result).toEqual(encodedSeedPhrase);
+      });
+    });
+
+    it('propagates errors from the passkey controller', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const error = new Error('invalid assertion');
+        rootMessenger.registerActionHandler(
+          'PasskeyController:exportSeedPhraseWithPasskey',
+          jest.fn().mockRejectedValue(error),
+        );
+
+        await expect(
+          rootMessenger.call(
+            'LegacyBackgroundApiService:exportSeedPhraseWithPasskey',
+            authenticationResponse,
+          ),
+        ).rejects.toThrow(error);
+      });
+    });
+  });
+
   describe('addTransaction', () => {
     const TRANSACTION_PARAMS = {
       from: '0xfromaddress',
@@ -7393,6 +7450,7 @@ function getMessenger(
       'PreferencesController:setPasswordForgotten',
       'PasskeyController:unlockWithPasskey',
       'PasskeyController:changePasswordWithPasskeyVerification',
+      'PasskeyController:exportSeedPhraseWithPasskey',
       'OnboardingController:getState',
       'SeedlessOnboardingController:checkIsPasswordOutdated',
       'SeedlessOnboardingController:getState',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -250,6 +250,7 @@ import type {
   PasskeyAuthenticationResponse,
   PasskeyControllerChangePasswordWithPasskeyVerificationAction,
   PasskeyControllerClearStateAction,
+  PasskeyControllerExportSeedPhraseWithPasskeyAction,
   PasskeyControllerUnlockWithPasskeyAction,
 } from '@metamask/passkey-controller';
 import { cloneDeep, merge } from 'lodash';
@@ -471,6 +472,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'discoverAndCreateAccounts',
   'estimateGas',
   'exportAccount',
+  'exportSeedPhraseWithPasskey',
   'forgetDevice',
   'getAccountsBySnapId',
   'getAppNameAndVersion',
@@ -641,6 +643,7 @@ type AllowedActions =
   | OnboardingControllerResetOnboardingAction
   | PasskeyControllerChangePasswordWithPasskeyVerificationAction
   | PasskeyControllerClearStateAction
+  | PasskeyControllerExportSeedPhraseWithPasskeyAction
   | PasskeyControllerUnlockWithPasskeyAction
   | PermissionControllerAcceptPermissionsRequestAction
   | PermissionControllerClearStateAction
@@ -2463,6 +2466,31 @@ export class LegacyBackgroundApiService {
     );
 
     await this.#initAccountsAfterUnlock();
+  }
+
+  /**
+   * Exports the Secret Recovery Phrase after verifying a passkey assertion,
+   * used as a password-less alternative to {@link getSeedPhrase}.
+   *
+   * Assertion verification + vault-key export live in `PasskeyController`, which
+   * returns the raw wordlist-index bytes from `KeyringController`. The extension
+   * re-encodes them as UTF-8 codepoints for the UI.
+   *
+   * @param authenticationResponse - WebAuthn authentication response from the passkey ceremony.
+   * @param keyringId - The id of the HD keyring to export. Defaults to the primary keyring.
+   * @returns The seed phrase encoded as an array of UTF-8 bytes.
+   */
+  async exportSeedPhraseWithPasskey(
+    authenticationResponse: PasskeyAuthenticationResponse,
+    keyringId?: string,
+  ): Promise<Buffer> {
+    const mnemonic = await this.#messenger.call(
+      'PasskeyController:exportSeedPhraseWithPasskey',
+      authenticationResponse,
+      keyringId,
+    );
+
+    return convertEnglishWordlistIndicesToCodepoints(mnemonic);
   }
 
   /**


### PR DESCRIPTION
## **Description**

Part of the WPC-418 effort to migrate `getApi()` methods off `MetamaskController` and into `LegacyBackgroundApiService`, where they are exposed through the controller messenger.

This PR migrates `exportSeedPhraseWithPasskey`. The new service method delegates to the `PasskeyController:exportSeedPhraseWithPasskey` messenger action, then re-encodes the returned wordlist-index bytes with `convertEnglishWordlistIndicesToCodepoints` (the same helper `getSeedPhrase` already uses). The `getApi()` entry now binds to `LegacyBackgroundApiService:exportSeedPhraseWithPasskey`, mirroring the already-migrated sibling passkey methods (`unlockWithPasskey`, `changePasswordWithPasskeyVerification`). The old controller method and its now-unused import are removed.

No behavior change for the client: the `exportSeedPhraseWithPasskey` background API keeps the same signature and return value.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1210

## **Manual testing steps**

1. Enroll a passkey for the wallet.
2. Reveal the Secret Recovery Phrase using the passkey (password-less) flow.
3. Confirm the SRP is displayed correctly, exactly as before this change.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
