### PR TITLE
chore: remove dead `trackMetaMetricsEvent` background API method

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3582,32 +3582,6 @@ export default class MetamaskController extends EventEmitter {
         ),
 
       // MetaMetrics
-      trackMetaMetricsEvent: (payload, options) => {
-        trackEvent(
-          createEventBuilder(payload.event)
-            .addProperties({
-              ...(payload.properties ?? {}),
-              ...(payload.category === undefined
-                ? {}
-                : { category: payload.category }),
-              ...(payload.revenue === undefined
-                ? {}
-                : { revenue: payload.revenue }),
-              ...(payload.value === undefined ? {} : { value: payload.value }),
-              ...(payload.currency === undefined
-                ? {}
-                : { currency: payload.currency }),
-            })
-            .addSensitiveProperties(payload.sensitiveProperties)
-            .build({
-              environmentType: payload.environmentType,
-              page: payload.page,
-              referrer: payload.referrer,
-              excludeMetaMetricsId: options?.excludeMetaMetricsId,
-              matomoEvent: options?.matomoEvent,
-            }),
-        );
-      },
       trackAnalyticsEvent: trackEvent,
       trackAnalyticsPage: trackPage,
       trackMetaMetricsPage: trackPage,

--- a/test/integration/helpers.tsx
+++ b/test/integration/helpers.tsx
@@ -32,7 +32,6 @@ export const createMockImplementation = <T,>(requests: Record<string, T>) => {
     }
     if (
       method === 'trackAnalyticsEvent' ||
-      method === 'trackMetaMetricsEvent' ||
       method === 'addEventBeforeMetricsOptIn'
     ) {
       return Promise.resolve(undefined);

--- a/ui/__mocks__/actions.js
+++ b/ui/__mocks__/actions.js
@@ -50,10 +50,6 @@ module.exports = {
     return Promise.resolve(TOKEN_DETAILS_MOCK[address]);
   },
 
-  trackMetaMetricsEvent: () => {
-    // Intentionally empty
-  },
-
   trackAnalyticsEvent: () => Promise.resolve(),
 
   decodeTransactionData: async (request) => {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -6274,17 +6274,6 @@ export async function attemptCloseNotificationPopup() {
   }
 }
 
-/**
- * @param payload - details of the event to track
- * @param options - options for routing/handling of event
- * @returns
- */
-export function trackMetaMetricsEvent(
-  payload: MetaMetricsEventPayload,
-  options?: MetaMetricsEventOptions,
-) {
-  return submitRequestToBackground('trackMetaMetricsEvent', [payload, options]);
-}
 
 export function trackAnalyticsEvent(
   payload: AnalyticsEvent,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -6274,18 +6274,6 @@ export async function attemptCloseNotificationPopup() {
   }
 }
 
-/**
- * @param payload - details of the event to track
- * @param options - options for routing/handling of event
- * @returns
- */
-export function trackMetaMetricsEvent(
-  payload: MetaMetricsEventPayload,
-  options?: MetaMetricsEventOptions,
-) {
-  return submitRequestToBackground('trackMetaMetricsEvent', [payload, options]);
-}
-
 export function trackAnalyticsEvent(
   payload: AnalyticsEvent,
   options: AnalyticsEventBuildOptions & {


### PR DESCRIPTION
## **Description**

Part of WPC-418. WPC-1212 was scoped to migrate `trackMetaMetricsEvent` into `LegacyBackgroundApiService`, but a usage check shows the method is **dead code**, so this removes it instead of migrating it.

`trackMetaMetricsEvent` was a `getApi()` method that built a MetaMetrics event server-side (`createEventBuilder(payload.event).addProperties(...).addSensitiveProperties(...).build(...)`) and forwarded it to `trackEvent`. Nothing in the client invokes it:

- The `trackMetaMetricsEvent` thunk in `ui/store/actions.ts` is imported by no component, hook, or page (only a mock referenced it).
- The MetaMetrics UI context (`ui/contexts/metametrics.tsx`) builds events **client-side** with the same `createEventBuilder(...).build(...)` logic and sends them through `trackAnalyticsEvent` (a direct getApi bind to `trackEvent`) — so the server-side `trackMetaMetricsEvent` only duplicated work that nothing calls.

Removed:
- the `getApi()` `trackMetaMetricsEvent` entry in `app/scripts/metamask-controller.js`
- the `trackMetaMetricsEvent` thunk in `ui/store/actions.ts`
- its mock in `ui/__mocks__/actions.js`
- its entry in the integration-test background-method allow-list (`test/integration/helpers.tsx`)

The identically named local callbacks in the smart-transactions and token-detection controller inits are unrelated (they bind to `MetaMetricsController:trackEvent`) and are left untouched.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: [WPC-1212](https://consensyssoftware.atlassian.net/browse/WPC-1212)

## **Manual testing steps**

1. Trigger any MetaMetrics-tracked action in the UI (e.g. a transaction or a settings toggle) and confirm events are still recorded — the UI path (`trackEvent` via the MetaMetrics context → `trackAnalyticsEvent`) is unchanged.

## **Screenshots/Recordings**

### **Before**

N/A — dead-code removal, no behavior change.

### **After**

N/A — dead-code removal, no behavior change.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability.
- [ ] I've included tests if applicable.
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[WPC-1212]: https://consensyssoftware.atlassian.net/browse/WPC-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; live MetaMetrics traffic still goes through `trackAnalyticsEvent`, which is untouched.
> 
> **Overview**
> Removes the unused **`trackMetaMetricsEvent`** background `getApi()` path and all UI/test wiring that called it, in favor of the existing **`trackAnalyticsEvent`** flow.
> 
> The controller no longer exposes a server-side wrapper that rebuilt MetaMetrics payloads with `createEventBuilder` before calling `trackEvent`. The **`trackMetaMetricsEvent`** Redux thunk in `ui/store/actions.ts` is deleted along with its action mock and integration-test background stub. Analytics in the UI continues to build events client-side and send them via **`trackAnalyticsEvent`** (unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23ce0a4aa3b4853661423d8d85d5c53889a0ca31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->