### PR TITLE
fix: exclude internal-address and simpleSend calls from enforced-simulations trust check cp-13.45.0

### DIFF
--- a/app/scripts/lib/transaction/hooks/index.ts
+++ b/app/scripts/lib/transaction/hooks/index.ts
@@ -16,7 +16,10 @@ import { Hex } from '@metamask/utils';
 
 import { AccountOverviewTabKey } from '../../../../../shared/constants/app-state';
 import { getEip7702SupportedChains } from '../../../../../shared/lib/eip7702-support-utils';
-import { isEnforcedSimulationsEligible } from '../../../../../shared/lib/transaction/enforced-simulations';
+import {
+  getInternalEvmAddresses,
+  isEnforcedSimulationsEligible,
+} from '../../../../../shared/lib/transaction/enforced-simulations';
 import { TransactionMetricsRequest } from '../../../../../shared/types/metametrics';
 import { accountSupports7702 } from '../../account-supports-7702';
 import {
@@ -82,17 +85,31 @@ function beforePublishHook({ messenger }: TransactionControllerHookRequest) {
 }
 
 function beforeSignHook({ messenger }: TransactionControllerHookRequest) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const m = messenger as any;
   return new EnforceSimulationHook({
     messenger,
-    isEligible: (transactionMeta) =>
-      isEnforcedSimulationsEligible(transactionMeta, {
-        ...m.call('AppStateController:getState'),
-        eip7702SupportedChains: getEip7702SupportedChains(
-          m.call('RemoteFeatureFlagController:getState'),
-        ),
-      }),
+    isEligible: (transactionMeta) => {
+      const { addressSecurityAlertResponses } = messenger.call(
+        'AppStateController:getState',
+      );
+
+      const featureFlagState = messenger.call(
+        'RemoteFeatureFlagController:getState',
+      );
+
+      const {
+        internalAccounts: { accounts },
+      } = messenger.call('AccountsController:getState');
+
+      const internalAddresses = getInternalEvmAddresses(
+        Object.values(accounts),
+      );
+
+      return isEnforcedSimulationsEligible(transactionMeta, {
+        addressSecurityAlertResponses,
+        eip7702SupportedChains: getEip7702SupportedChains(featureFlagState),
+        internalAddresses,
+      });
+    },
   }).getBeforeSignHook();
 }
 

--- a/app/scripts/wallet-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/wallet-init/messengers/transaction-controller-messenger.ts
@@ -164,6 +164,7 @@ export function getTransactionControllerInitMessenger(
     ],
     actions: [
       'AccountTrackerController:getState',
+      'AccountsController:getState',
       'ApprovalController:acceptRequest',
       'ApprovalController:addRequest',
       'ApprovalController:endFlow',

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -3,6 +3,7 @@ import {
   SimulationTokenStandard,
   TransactionMeta,
   TransactionStatus,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import { Hex } from '@metamask/utils';
@@ -47,6 +48,7 @@ const BASE_TRANSACTION_META: TransactionMeta = {
   txParams: {
     from: '0x0000000000000000000000000000000000000000',
     to: TO_ADDRESS,
+    data: '0xabcd',
   },
 };
 
@@ -69,6 +71,7 @@ function buildState(
       [createCacheKey(chainId, TO_ADDRESS)]: buildCacheEntry(resultType),
     },
     eip7702SupportedChains,
+    internalAddresses: [],
   };
 }
 
@@ -87,6 +90,7 @@ function buildStateForAddresses(
   return {
     addressSecurityAlertResponses: responses,
     eip7702SupportedChains,
+    internalAddresses: [],
   };
 }
 
@@ -259,6 +263,315 @@ describe('enforced-simulations', () => {
       ).toBe(true);
     });
 
+    describe('with simpleSend and internal-address exclusions', () => {
+      // A call is excluded from the trust check when its `type` is `simpleSend`
+      // (the controller only assigns this after `eth_getCode` finds no code at
+      // the recipient) or when its recipient is one of the user's own internal
+      // addresses. A base plain value transfer to the user's own account.
+      const SELF_SEND_META: TransactionMeta = {
+        ...BASE_TRANSACTION_META,
+        type: TransactionType.simpleSend,
+        txParams: {
+          ...BASE_TRANSACTION_META.txParams,
+          data: undefined,
+        },
+      };
+
+      const INTERNAL_STATE: EnforcedSimulationsState = {
+        ...buildState(ResultType.Benign, [ETHEREUM_CHAIN_ID]),
+        internalAddresses: [TO_ADDRESS],
+      };
+
+      it('is not eligible (trusted) for a no-calldata simpleSend to an internal address', () => {
+        expect(
+          isEnforcedSimulationsEligible(SELF_SEND_META, INTERNAL_STATE),
+        ).toBe(false);
+      });
+
+      it('is not eligible (trusted) when data is 0x for a simpleSend to an internal address', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              txParams: { ...SELF_SEND_META.txParams, data: '0x' },
+            },
+            INTERNAL_STATE,
+          ),
+        ).toBe(false);
+      });
+
+      it('is not eligible (trusted) when data is 0X (case-insensitive) for a simpleSend to an internal address', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              txParams: { ...SELF_SEND_META.txParams, data: '0X' },
+            },
+            INTERNAL_STATE,
+          ),
+        ).toBe(false);
+      });
+
+      it('is not eligible (trusted) for a simpleSend even when calldata is present', () => {
+        // `simpleSend` is only assigned after `eth_getCode` finds no code at the
+        // recipient, so the call is trusted regardless of any calldata.
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              txParams: { ...SELF_SEND_META.txParams, data: '0xabcd' },
+            },
+            buildState(ResultType.Benign, [ETHEREUM_CHAIN_ID]),
+          ),
+        ).toBe(false);
+      });
+
+      it('is not eligible (trusted) for a no-calldata simpleSend to an EXTERNAL EOA', () => {
+        // A calldata-free `simpleSend` carries no contract logic, so it is
+        // trusted regardless of whether the recipient is internal or external.
+        expect(
+          isEnforcedSimulationsEligible(
+            SELF_SEND_META,
+            buildState(ResultType.Benign, [ETHEREUM_CHAIN_ID]),
+          ),
+        ).toBe(false);
+      });
+
+      it('remains eligible for a no-calldata contractInteraction to an external address (payable receive/fallback executes logic)', () => {
+        // Empty calldata still invokes a contract payable `receive()`/`fallback()`,
+        // so a `contractInteraction` recipient must NOT be treated as trusted.
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              type: TransactionType.contractInteraction,
+            },
+            buildState(ResultType.Benign, [ETHEREUM_CHAIN_ID]),
+          ),
+        ).toBe(true);
+      });
+
+      it('remains eligible for a no-calldata transfer to an external address when type is undefined (fail closed)', () => {
+        // Before `eth_getCode` resolves, `type` is undefined; we must not skip.
+        expect(
+          isEnforcedSimulationsEligible(
+            { ...SELF_SEND_META, type: undefined },
+            buildState(ResultType.Benign, [ETHEREUM_CHAIN_ID]),
+          ),
+        ).toBe(true);
+      });
+
+      it('is not eligible (trusted) for a batch where every call is a calldata-free simpleSend to internal addresses', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              nestedTransactions: [
+                {
+                  to: NESTED_ADDRESS_A as `0x${string}`,
+                  type: TransactionType.simpleSend,
+                },
+                {
+                  to: NESTED_ADDRESS_B as `0x${string}`,
+                  type: TransactionType.simpleSend,
+                },
+              ],
+            },
+            {
+              ...buildStateForAddresses(
+                {
+                  [NESTED_ADDRESS_A]: ResultType.Benign,
+                  [NESTED_ADDRESS_B]: ResultType.Benign,
+                },
+                [ETHEREUM_CHAIN_ID],
+              ),
+              internalAddresses: [
+                TO_ADDRESS,
+                NESTED_ADDRESS_A,
+                NESTED_ADDRESS_B,
+              ],
+            },
+          ),
+        ).toBe(false);
+      });
+
+      it('remains eligible for a batch where a nested call is a contractInteraction', () => {
+        // Nested B is a payable contract (external, benign). It is not a
+        // calldata-free simpleSend and not internal, so it survives filtering
+        // and is trust-checked; being benign (not trusted) keeps the tx eligible.
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              nestedTransactions: [
+                {
+                  to: NESTED_ADDRESS_A as `0x${string}`,
+                  type: TransactionType.simpleSend,
+                },
+                {
+                  to: NESTED_ADDRESS_B as `0x${string}`,
+                  type: TransactionType.contractInteraction,
+                },
+              ],
+            },
+            {
+              ...buildStateForAddresses(
+                {
+                  [NESTED_ADDRESS_A]: ResultType.Benign,
+                  [NESTED_ADDRESS_B]: ResultType.Benign,
+                },
+                [ETHEREUM_CHAIN_ID],
+              ),
+              // A is internal (self); B is the external payable contract.
+              internalAddresses: [TO_ADDRESS, NESTED_ADDRESS_A],
+            },
+          ),
+        ).toBe(true);
+      });
+
+      it('is not eligible (trusted) for a batch where a nested simpleSend carries calldata', () => {
+        // Nested A is a simpleSend with calldata: `simpleSend` means no code at
+        // the recipient, so it is trusted regardless of calldata. The outer call
+        // targets an internal address, so the whole batch is trusted.
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              nestedTransactions: [
+                {
+                  to: NESTED_ADDRESS_A as `0x${string}`,
+                  type: TransactionType.simpleSend,
+                  data: '0xabcd',
+                },
+              ],
+            },
+            {
+              ...buildStateForAddresses(
+                { [NESTED_ADDRESS_A]: ResultType.Benign },
+                [ETHEREUM_CHAIN_ID],
+              ),
+              internalAddresses: [TO_ADDRESS],
+            },
+          ),
+        ).toBe(false);
+      });
+
+      it('remains eligible for a batch where a nested call type is undefined (fail closed)', () => {
+        // Nested A has an unknown type (external, benign). Only simpleSend is
+        // excluded, so an undefined type survives filtering and is trust-checked;
+        // being benign (not trusted) keeps the tx eligible.
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              nestedTransactions: [
+                { to: NESTED_ADDRESS_A as `0x${string}`, type: undefined },
+              ],
+            },
+            {
+              ...buildStateForAddresses(
+                { [NESTED_ADDRESS_A]: ResultType.Benign },
+                [ETHEREUM_CHAIN_ID],
+              ),
+              internalAddresses: [TO_ADDRESS],
+            },
+          ),
+        ).toBe(true);
+      });
+
+      it('is not eligible (trusted) for a batch of calldata-free simpleSends with an external nested recipient', () => {
+        // Every call is a calldata-free `simpleSend`, so the batch is trusted
+        // regardless of whether nested recipients are internal or external.
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              nestedTransactions: [
+                {
+                  to: NESTED_ADDRESS_A as `0x${string}`,
+                  type: TransactionType.simpleSend,
+                },
+              ],
+            },
+            {
+              ...buildStateForAddresses(
+                { [NESTED_ADDRESS_A]: ResultType.Benign },
+                [ETHEREUM_CHAIN_ID],
+              ),
+              // Outer recipient internal, nested recipient external.
+              internalAddresses: [TO_ADDRESS],
+            },
+          ),
+        ).toBe(false);
+      });
+
+      it('excludes a calldata-free simpleSend call from the trust check even when its recipient is malicious', () => {
+        // Mixed batch: a simpleSend to a malicious address (excluded) plus a
+        // contractInteraction to a trusted address (checked). Because the
+        // simpleSend is filtered out, only the trusted contract is checked, so
+        // the whole batch is trusted and not eligible.
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              nestedTransactions: [
+                {
+                  to: NESTED_ADDRESS_A as `0x${string}`,
+                  type: TransactionType.simpleSend,
+                },
+                {
+                  to: NESTED_ADDRESS_B as `0x${string}`,
+                  type: TransactionType.contractInteraction,
+                },
+              ],
+            },
+            {
+              ...buildStateForAddresses(
+                {
+                  [NESTED_ADDRESS_A]: ResultType.Malicious,
+                  [NESTED_ADDRESS_B]: ResultType.Trusted,
+                },
+                [ETHEREUM_CHAIN_ID],
+              ),
+              internalAddresses: [TO_ADDRESS],
+            },
+          ),
+        ).toBe(false);
+      });
+
+      it('remains eligible when a non-simpleSend call targets a malicious address', () => {
+        // The contractInteraction is not excluded, is malicious (not trusted),
+        // so the transaction stays eligible for enforced simulation.
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...SELF_SEND_META,
+              nestedTransactions: [
+                {
+                  to: NESTED_ADDRESS_A as `0x${string}`,
+                  type: TransactionType.simpleSend,
+                },
+                {
+                  to: NESTED_ADDRESS_B as `0x${string}`,
+                  type: TransactionType.contractInteraction,
+                },
+              ],
+            },
+            {
+              ...buildStateForAddresses(
+                {
+                  [NESTED_ADDRESS_A]: ResultType.Trusted,
+                  [NESTED_ADDRESS_B]: ResultType.Malicious,
+                },
+                [ETHEREUM_CHAIN_ID],
+              ),
+              internalAddresses: [TO_ADDRESS],
+            },
+          ),
+        ).toBe(true);
+      });
+    });
+
     describe('with trust signal state', () => {
       it('returns true when address is not trusted', () => {
         expect(
@@ -301,6 +614,7 @@ describe('enforced-simulations', () => {
           isEnforcedSimulationsEligible(BASE_TRANSACTION_META, {
             addressSecurityAlertResponses: {},
             eip7702SupportedChains: [ETHEREUM_CHAIN_ID],
+            internalAddresses: [],
           }),
         ).toBe(false);
       });
@@ -347,6 +661,7 @@ describe('enforced-simulations', () => {
             {
               addressSecurityAlertResponses: {},
               eip7702SupportedChains: [UNMAPPED_CHAIN_ID],
+              internalAddresses: [],
             },
           ),
         ).toBe(false);
@@ -383,6 +698,7 @@ describe('enforced-simulations', () => {
             {
               addressSecurityAlertResponses: {},
               eip7702SupportedChains: [UNMAPPED_CHAIN_ID],
+              internalAddresses: [],
             },
           ),
         ).toBe(false);
@@ -423,6 +739,7 @@ describe('enforced-simulations', () => {
                 [trustedCacheKey]: buildCacheEntry(ResultType.Trusted),
               },
               eip7702SupportedChains: [ETHEREUM_CHAIN_ID],
+              internalAddresses: [],
             },
           ),
         ).toBe(true);
@@ -442,13 +759,77 @@ describe('enforced-simulations', () => {
       });
     });
 
+    describe('with internal address exclusion', () => {
+      it('returns false (trusted) when the only to address is an internal address', () => {
+        expect(
+          isEnforcedSimulationsEligible(BASE_TRANSACTION_META, {
+            ...buildState(ResultType.Benign),
+            internalAddresses: [TO_ADDRESS],
+          }),
+        ).toBe(false);
+      });
+
+      it('returns true when mix of internal and untrusted external addresses', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              nestedTransactions: [
+                { to: NESTED_ADDRESS_A as `0x${string}`, data: '0xabcd' },
+              ],
+            },
+            {
+              ...buildStateForAddresses({
+                [TO_ADDRESS]: ResultType.Benign,
+                [NESTED_ADDRESS_A]: ResultType.Benign,
+              }),
+              internalAddresses: [TO_ADDRESS],
+            },
+          ),
+        ).toBe(true);
+      });
+
+      it('matches internal addresses case-insensitively', () => {
+        expect(
+          isEnforcedSimulationsEligible(BASE_TRANSACTION_META, {
+            ...buildState(ResultType.Benign),
+            internalAddresses: [TO_ADDRESS.toUpperCase()],
+          }),
+        ).toBe(false);
+      });
+
+      it('internal address filtered out, remaining external malicious address is still eligible', () => {
+        // Proves the filter only removes internal addresses, not external ones.
+        // TO_ADDRESS is internal; NESTED_ADDRESS_A is external and malicious — tx is still eligible.
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              nestedTransactions: [
+                { to: NESTED_ADDRESS_A as `0x${string}`, data: '0xabcd' },
+              ],
+            },
+            {
+              ...buildStateForAddresses({
+                [TO_ADDRESS]: ResultType.Benign,
+                [NESTED_ADDRESS_A]: ResultType.Malicious,
+              }),
+              internalAddresses: [TO_ADDRESS],
+            },
+          ),
+        ).toBe(true);
+      });
+    });
+
     describe('with nested transactions', () => {
       it('returns true when primary is trusted but a nested address is not', () => {
         expect(
           isEnforcedSimulationsEligible(
             {
               ...BASE_TRANSACTION_META,
-              nestedTransactions: [{ to: NESTED_ADDRESS_A as `0x${string}` }],
+              nestedTransactions: [
+                { to: NESTED_ADDRESS_A as `0x${string}`, data: '0xabcd' },
+              ],
             },
             buildStateForAddresses({
               [TO_ADDRESS]: ResultType.Trusted,
@@ -464,7 +845,9 @@ describe('enforced-simulations', () => {
             {
               ...BASE_TRANSACTION_META,
               txParams: { ...BASE_TRANSACTION_META.txParams, to: undefined },
-              nestedTransactions: [{ to: NESTED_ADDRESS_A as `0x${string}` }],
+              nestedTransactions: [
+                { to: NESTED_ADDRESS_A as `0x${string}`, data: '0xabcd' },
+              ],
             },
             buildStateForAddresses({
               [NESTED_ADDRESS_A]: ResultType.Malicious,
@@ -479,8 +862,8 @@ describe('enforced-simulations', () => {
             {
               ...BASE_TRANSACTION_META,
               nestedTransactions: [
-                { to: NESTED_ADDRESS_A as `0x${string}` },
-                { to: NESTED_ADDRESS_B as `0x${string}` },
+                { to: NESTED_ADDRESS_A as `0x${string}`, data: '0xabcd' },
+                { to: NESTED_ADDRESS_B as `0x${string}`, data: '0xabcd' },
               ],
             },
             buildStateForAddresses({
@@ -499,8 +882,8 @@ describe('enforced-simulations', () => {
               ...BASE_TRANSACTION_META,
               txParams: { ...BASE_TRANSACTION_META.txParams, to: undefined },
               nestedTransactions: [
-                { to: NESTED_ADDRESS_A as `0x${string}` },
-                { to: NESTED_ADDRESS_B as `0x${string}` },
+                { to: NESTED_ADDRESS_A as `0x${string}`, data: '0xabcd' },
+                { to: NESTED_ADDRESS_B as `0x${string}`, data: '0xabcd' },
               ],
             },
             buildStateForAddresses({
@@ -517,8 +900,8 @@ describe('enforced-simulations', () => {
             {
               ...BASE_TRANSACTION_META,
               nestedTransactions: [
-                { to: NESTED_ADDRESS_A as `0x${string}` },
-                { to: NESTED_ADDRESS_B as `0x${string}` },
+                { to: NESTED_ADDRESS_A as `0x${string}`, data: '0xabcd' },
+                { to: NESTED_ADDRESS_B as `0x${string}`, data: '0xabcd' },
               ],
             },
             buildStateForAddresses({
@@ -551,8 +934,8 @@ describe('enforced-simulations', () => {
             {
               ...BASE_TRANSACTION_META,
               nestedTransactions: [
-                { to: NESTED_ADDRESS_A as `0x${string}` },
-                { to: NESTED_ADDRESS_B as `0x${string}` },
+                { to: NESTED_ADDRESS_A as `0x${string}`, data: '0xabcd' },
+                { to: NESTED_ADDRESS_B as `0x${string}`, data: '0xabcd' },
               ],
             },
             buildStateForAddresses({

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -1,9 +1,12 @@
 import {
   SimulationData,
   TransactionMeta,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
-import { Hex } from '@metamask/utils';
+import { isEvmAccountType } from '@metamask/keyring-api';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { Hex, createProjectLogger } from '@metamask/utils';
 import {
   CachedScanAddressResponse,
   createCacheKey,
@@ -21,6 +24,8 @@ const BASIS_POINTS_PER_PERCENT = 100;
 
 const ENFORCED_SIMULATIONS_FEATURE_FLAG = 'confirmations_enforced_simulations';
 
+const log = createProjectLogger('enforced-simulations-eligibility');
+
 /**
  * Shape of the `confirmations_enforced_simulations` remote feature flag
  * value. Both fields are optional; consumers fall back to safe defaults
@@ -37,6 +42,8 @@ export type EnforcedSimulationsFeatureFlag = {
 export type EnforcedSimulationsState = {
   addressSecurityAlertResponses: Record<string, CachedScanAddressResponse>;
   eip7702SupportedChains: Hex[];
+  /** Addresses of the user's own internal EVM accounts; excluded from trust evaluation. */
+  internalAddresses: string[];
 };
 
 type RemoteFlagsWithEnforcedSimulations = {
@@ -48,6 +55,24 @@ type FeatureFlagSource = Pick<
   RemoteFeatureFlagControllerState,
   'remoteFeatureFlags'
 >;
+
+function isInternalAddress(
+  address: string,
+  internalAddresses: string[],
+): boolean {
+  const normalized = address.toLowerCase();
+  return internalAddresses.some((a) => a.toLowerCase() === normalized);
+}
+
+/**
+ * Returns the EVM addresses of the given internal accounts.
+ *
+ * @param accounts - Array of internal accounts.
+ * @returns Array of EVM account addresses.
+ */
+export function getInternalEvmAddresses(accounts: InternalAccount[]): string[] {
+  return accounts.filter((a) => isEvmAccountType(a.type)).map((a) => a.address);
+}
 
 /**
  * Reads the `enabled` field from the `confirmations_enforced_simulations`
@@ -121,28 +146,36 @@ export function isEnforcedSimulationsEligible(
   transactionMeta: TransactionMeta,
   state: EnforcedSimulationsState,
 ): boolean {
-  const { chainId, simulationData } = transactionMeta;
+  const { chainId, simulationData, type } = transactionMeta;
 
   if (
     !state.eip7702SupportedChains?.some(
       (supported) => supported.toLowerCase() === chainId?.toLowerCase(),
     )
   ) {
+    log('Not eligible - chain does not support EIP-7702', {
+      chainId,
+      type,
+    });
     return false;
   }
 
   if (!hasBalanceChanges(simulationData)) {
+    log('Not eligible - no simulated balance changes', { type });
     return false;
   }
 
   if (isEnforcedSimulationsForceEnabled()) {
+    log('Eligible - force enabled', { type });
     return true;
   }
 
   if (isTrusted(transactionMeta, state)) {
+    log('Not eligible - transaction trusted', { type });
     return false;
   }
 
+  log('Eligible', { chainId, type });
   return true;
 }
 
@@ -158,7 +191,7 @@ function isTrusted(
   transactionMeta: TransactionMeta,
   state: EnforcedSimulationsState,
 ): boolean {
-  const { chainId, txParams, txParamsOriginal, nestedTransactions } =
+  const { chainId, type, txParams, txParamsOriginal, nestedTransactions } =
     transactionMeta;
 
   // Trust verdicts are cache-driven on every chain: only a cached non-Trusted
@@ -177,43 +210,56 @@ function isTrusted(
   // Use the original `to` address before any container wrapping,
   // since containers may redirect to a trusted delegation manager.
   const originalTo = txParamsOriginal?.to ?? txParams?.to;
-  const toAddresses = getToAddresses(originalTo, nestedTransactions);
+  const data = txParamsOriginal?.data ?? txParams?.data;
 
-  if (toAddresses.length === 0) {
-    return true;
-  }
+  // All calls the transaction performs: the outer call plus any nested (batch)
+  // calls, treated uniformly.
+  const calls = [{ to: originalTo, data, type }, ...(nestedTransactions ?? [])];
 
-  return !toAddresses.some((address) => {
-    const cacheKey = createCacheKey(chainId, address);
-    const cached = state.addressSecurityAlertResponses[cacheKey];
+  let trusted = true;
 
+  for (let index = 0; index < calls.length; index++) {
+    const { to, data: callData, type: callType } = calls[index];
+    const label = `Address ${index + 1}`;
+    const props = { address: to, type: callType, data: callData };
+
+    if (!to) {
+      log(`${label} - Trusted - No Recipient`, props);
+      continue;
+    }
+
+    if (isInternalAddress(to, state.internalAddresses)) {
+      log(`${label} - Trusted - Internal Address`, props);
+      continue;
+    }
+
+    if (callType === TransactionType.simpleSend) {
+      log(`${label} - Trusted - Simple Send`, props);
+      continue;
+    }
+
+    const cached =
+      state.addressSecurityAlertResponses[createCacheKey(chainId, to)];
+
+    // Unknown or still-loading signals don't make a call untrusted.
     if (!cached || cached.result_type === ResultType.Loading) {
-      return false;
+      log(`${label} - Trusted - Unknown Signal`, {
+        ...props,
+        resultType: cached?.result_type,
+      });
+      continue;
     }
 
-    return cached.result_type !== ResultType.Trusted;
-  });
-}
-
-function getToAddresses(
-  primaryTo: string | undefined,
-  nestedTransactions: TransactionMeta['nestedTransactions'],
-): string[] {
-  const addresses: string[] = [];
-
-  if (primaryTo) {
-    addresses.push(primaryTo);
-  }
-
-  if (nestedTransactions) {
-    for (const nested of nestedTransactions) {
-      if (nested.to) {
-        addresses.push(nested.to);
-      }
+    if (cached.result_type === ResultType.Trusted) {
+      log(`${label} - Trusted - Trusted Signal`, props);
+      continue;
     }
+
+    log(`${label} - Not Trusted - ${cached.result_type}`, props);
+    trusted = false;
   }
 
-  return addresses;
+  return trusted;
 }
 
 function hasBalanceChanges(simulationData?: SimulationData | null): boolean {

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
@@ -79,6 +79,7 @@ describe('useIsEnforcedSimulationsEligible', () => {
       {
         addressSecurityAlertResponses: alertResponses,
         eip7702SupportedChains: [],
+        internalAddresses: expect.any(Array),
       },
     );
   });

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
@@ -1,15 +1,18 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import {
   EnforcedSimulationsState,
+  getInternalEvmAddresses,
   isEnforcedSimulationsEligible,
   isEnforcedSimulationsForceEnabled,
 } from '../../../../shared/lib/transaction/enforced-simulations';
 import { getEip7702SupportedChains } from '../../../../shared/lib/eip7702-support-utils';
 import { useConfirmContext } from '../context/confirm';
 import { selectIsEnforcedSimulationsEnabled } from '../selectors/feature-flags';
+import { getInternalAccounts } from '../../../selectors/accounts';
 import { EMPTY_OBJECT } from '../../../selectors/shared';
 
 function selectEip7702SupportedChains(state: {
@@ -32,6 +35,12 @@ export function useIsEnforcedSimulationsEligible(): boolean {
     isEqual,
   );
 
+  const internalAccounts = useSelector(getInternalAccounts);
+  const internalAddresses = useMemo(
+    () => getInternalEvmAddresses(internalAccounts),
+    [internalAccounts],
+  );
+
   const enabled = useSelector(selectIsEnforcedSimulationsEnabled);
 
   if (
@@ -44,5 +53,6 @@ export function useIsEnforcedSimulationsEligible(): boolean {
   return isEnforcedSimulationsEligible(currentConfirmation, {
     addressSecurityAlertResponses,
     eip7702SupportedChains,
+    internalAddresses,
   });
 }


### PR DESCRIPTION
## **Description**

Enforced simulations wrap a transaction to guarantee the user gets the balance changes they were shown. This protection matters for untrusted external contracts, but was also being applied to transactions where the user is never at risk, adding overhead and friction for no benefit.

This PR skips enforcement for two additional cases:

- Transfers to one of the user's own accounts.
- Plain sends (`simpleSend`), where there is no code to execute at the destination.

Transactions interacting with untrusted external contracts still go through enforcement as before.

- The user's internal addresses are now supplied from both the background and UI entry points.
- Added debug logging for the per-call trust decision.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Send a plain value transfer to one of your own accounts — enforced simulation should not apply.
2. Send a plain value transfer to an external account — enforced simulation should not apply.
3. Send a transaction to an untrusted external contract — enforced simulation should still apply.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when enforced simulation wrapping runs before sign, which affects transaction protection for external contracts; logic is well-tested but misclassification could skip enforcement on risky txs.
> 
> **Overview**
> **Enforced simulations** no longer apply when every call in the transaction is considered trusted for reasons other than security-alert cache hits.
> 
> Eligibility trust evaluation now walks **outer + nested calls** individually and skips enforcement when a call targets one of the user’s **internal EVM accounts** or is typed **`simpleSend`** (plain transfer with no contract at the recipient). **`contractInteraction`** and **undefined** types still require trust-signal checks so empty-calldata contract calls and not-yet-classified txs stay **fail-closed**.
> 
> **`internalAddresses`** are built via **`getInternalEvmAddresses`** from **AccountsController** in the background **`beforeSign`** hook (messenger now allows **`AccountsController:getState`**) and from Redux **`getInternalAccounts`** in the confirmations UI hook. **Debug logging** was added for per-call trust decisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c489acffaae448caf499442ee650d7fd6e84fea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->