### PR TITLE
fix(confirmations): route money account batches by nested type

### DIFF
--- a/app/scripts/lib/money/pay/create-deposit-transaction.test.ts
+++ b/app/scripts/lib/money/pay/create-deposit-transaction.test.ts
@@ -4,11 +4,11 @@ import { TransactionType } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { createMoneyAccountDepositTransaction } from './create-deposit-transaction';
 import {
-  createMoneyPayMessengerMock,
+  createPlaceholderBatchMessengerMock,
   MONEY_ACCOUNT_ADDRESS_MOCK,
   NETWORK_CLIENT_ID_MOCK,
   VAULT_CONFIG_MOCK,
-  type MessengerMockOptions,
+  type PlaceholderBatchMockOptions,
 } from './test-mocks';
 
 const BATCH_ID = '0xB47C41D0000000000000000000000000' as Hex;
@@ -16,29 +16,16 @@ const TRANSACTION_ID = 'transaction-id-mock';
 
 const MUSD_ADDRESS = MUSD_TOKEN_ADDRESS_BY_CHAIN[VAULT_CONFIG_MOCK.chainId];
 
-function setup(options: MessengerMockOptions = {}) {
-  const addTransactionBatch = jest
-    .fn()
-    .mockResolvedValue({ batchId: BATCH_ID });
-
-  const mock = createMoneyPayMessengerMock({
+function setup(options: Omit<PlaceholderBatchMockOptions, 'transactionId'> = {}) {
+  return createPlaceholderBatchMessengerMock({
+    transactionId: TRANSACTION_ID,
     ...options,
-    handlers: {
-      'TransactionController:addTransactionBatch': addTransactionBatch,
-      'TransactionController:getState': () => ({
-        transactions: [
-          { id: 'other-transaction', batchId: '0x1234' },
-          { id: TRANSACTION_ID, batchId: BATCH_ID.toLowerCase() },
-        ],
-      }),
-      ...options.handlers,
-    },
   });
-
-  return { ...mock, addTransactionBatch };
 }
 
 describe('createMoneyAccountDepositTransaction', () => {
+  // The batch mock never settles, matching the controller: resolving at all
+  // proves initiation does not wait for the confirmation to be approved.
   it('submits the placeholder batch from the money account and returns the transaction id', async () => {
     const { messenger, addTransactionBatch } = setup();
 
@@ -103,15 +90,14 @@ describe('createMoneyAccountDepositTransaction', () => {
     ).rejects.toThrow('Money account deposit is not available');
   });
 
-  it('throws when the created transaction cannot be found', async () => {
-    const { messenger } = setup({
-      handlers: {
-        'TransactionController:getState': () => ({ transactions: [] }),
-      },
+  it('throws when the batch fails before the transaction is added', async () => {
+    const { messenger, unsubscribe } = setup({
+      batchError: new Error('Account does not support EIP-7702'),
     });
 
     await expect(
       createMoneyAccountDepositTransaction(messenger, BATCH_ID),
-    ).rejects.toThrow('Deposit transaction not found after batch creation');
+    ).rejects.toThrow('Account does not support EIP-7702');
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/scripts/lib/money/pay/create-deposit-transaction.ts
+++ b/app/scripts/lib/money/pay/create-deposit-transaction.ts
@@ -3,10 +3,10 @@ import {
   buildMoneyAccountDepositPlaceholderBatch,
   getMoneyAccountDepositAssetAddress,
 } from '@metamask/money-account-utils';
-import type { TransactionControllerState } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { getMoneyPayContext, type MoneyPayMessenger } from './pay-context';
+import { submitPlaceholderBatch } from './submit-placeholder-batch';
 
 const LOG_TAG = '[Money Account]';
 
@@ -48,8 +48,7 @@ export async function createMoneyAccountDepositTransaction(
     tellerAddress,
   });
 
-  await messenger.call('TransactionController:addTransactionBatch', {
-    batchId,
+  const transactionId = await submitPlaceholderBatch(messenger, batchId, {
     disableHook: true,
     disableSequential: true,
     disableUpgrade: true,
@@ -70,22 +69,5 @@ export async function createMoneyAccountDepositTransaction(
     transactions: [approveTx, depositTx],
   });
 
-  // `addTransactionBatch` returns only the batch id; the confirmation
-  // navigation needs the transaction id, so resolve it from state. The cast
-  // mirrors `lib/transaction/hooks`: TS cannot narrow this action's return
-  // type out of the messenger union.
-  const { transactions } = messenger.call(
-    'TransactionController:getState',
-  ) as TransactionControllerState;
-  const transaction = transactions.find(
-    (tx) => tx.batchId?.toLowerCase() === batchId.toLowerCase(),
-  );
-
-  if (!transaction) {
-    throw new Error(
-      `${LOG_TAG} Deposit transaction not found after batch creation`,
-    );
-  }
-
-  return { transactionId: transaction.id, batchId };
+  return { transactionId, batchId };
 }

--- a/app/scripts/lib/money/pay/create-withdraw-transaction.test.ts
+++ b/app/scripts/lib/money/pay/create-withdraw-transaction.test.ts
@@ -1,38 +1,24 @@
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '@metamask/money-account-utils';
 import { TransactionType } from '@metamask/transaction-controller';
-import type { Hex } from '@metamask/utils';
 import { createMoneyAccountWithdrawTransaction } from './create-withdraw-transaction';
 import {
-  createMoneyPayMessengerMock,
+  createPlaceholderBatchMessengerMock,
   MONEY_ACCOUNT_ADDRESS_MOCK,
   NETWORK_CLIENT_ID_MOCK,
   VAULT_CONFIG_MOCK,
-  type MessengerMockOptions,
+  type PlaceholderBatchMockOptions,
 } from './test-mocks';
 
-const BATCH_ID = '0xW1'.replace('W', 'a') as Hex;
 const TRANSACTION_ID = 'transaction-id-mock';
 
 const MUSD_ADDRESS = MUSD_TOKEN_ADDRESS_BY_CHAIN[VAULT_CONFIG_MOCK.chainId];
 
-function setup(options: MessengerMockOptions = {}) {
-  const addTransactionBatch = jest
-    .fn()
-    .mockResolvedValue({ batchId: BATCH_ID });
-
-  const mock = createMoneyPayMessengerMock({
+function setup(options: Omit<PlaceholderBatchMockOptions, 'transactionId'> = {}) {
+  return createPlaceholderBatchMessengerMock({
+    transactionId: TRANSACTION_ID,
     ...options,
-    handlers: {
-      'TransactionController:addTransactionBatch': addTransactionBatch,
-      'TransactionController:getState': () => ({
-        transactions: [{ id: TRANSACTION_ID, batchId: BATCH_ID }],
-      }),
-      ...options.handlers,
-    },
   });
-
-  return { ...mock, addTransactionBatch };
 }
 
 describe('createMoneyAccountWithdrawTransaction', () => {
@@ -41,12 +27,12 @@ describe('createMoneyAccountWithdrawTransaction', () => {
 
     const result = await createMoneyAccountWithdrawTransaction(messenger);
 
+    const request = addTransactionBatch.mock.calls[0][0];
+
     expect(result).toStrictEqual({
       transactionId: TRANSACTION_ID,
-      batchId: BATCH_ID,
+      batchId: request.batchId,
     });
-
-    const request = addTransactionBatch.mock.calls[0][0];
     expect(request).toMatchObject({
       disableHook: true,
       disableSequential: true,
@@ -60,8 +46,9 @@ describe('createMoneyAccountWithdrawTransaction', () => {
     });
     // No requiredAssets: the withdrawal consumes the vault balance.
     expect(request.requiredAssets).toBeUndefined();
-    // No caller batch id: withdrawals have no deposit-intent map to key.
-    expect(request.batchId).toBeUndefined();
+    // The batch id is generated here, not by the controller, so the created
+    // transaction can be recognised as it is added.
+    expect(request.batchId).toMatch(/^0x[0-9a-f]{32}$/u);
 
     const [withdrawTx, transferTx] = request.transactions;
     expect(withdrawTx).toStrictEqual({
@@ -85,15 +72,14 @@ describe('createMoneyAccountWithdrawTransaction', () => {
     expect(addTransactionBatch).not.toHaveBeenCalled();
   });
 
-  it('throws when the created transaction cannot be found', async () => {
-    const { messenger } = setup({
-      handlers: {
-        'TransactionController:getState': () => ({ transactions: [] }),
-      },
+  it('throws when the batch fails before the transaction is added', async () => {
+    const { messenger, unsubscribe } = setup({
+      batchError: new Error('Account does not support EIP-7702'),
     });
 
     await expect(
       createMoneyAccountWithdrawTransaction(messenger),
-    ).rejects.toThrow('Withdrawal transaction not found after batch creation');
+    ).rejects.toThrow('Account does not support EIP-7702');
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/scripts/lib/money/pay/create-withdraw-transaction.ts
+++ b/app/scripts/lib/money/pay/create-withdraw-transaction.ts
@@ -1,9 +1,10 @@
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import { buildMoneyAccountWithdrawPlaceholderBatch } from '@metamask/money-account-utils';
-import type { TransactionControllerState } from '@metamask/transaction-controller';
-import type { Hex } from '@metamask/utils';
+import { bytesToHex, type Hex } from '@metamask/utils';
+import { parse as uuidParse, v4 as uuidv4 } from 'uuid';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { getMoneyPayContext, type MoneyPayMessenger } from './pay-context';
+import { submitPlaceholderBatch } from './submit-placeholder-batch';
 
 const LOG_TAG = '[Money Account]';
 
@@ -15,10 +16,11 @@ const LOG_TAG = '[Money Account]';
  * initiation needs neither the selected account nor a vault read.
  *
  * Mirrors `create-deposit-transaction.ts`, with two differences that follow
- * mobile: no `requiredAssets` (the withdrawal consumes the vault balance,
- * not a payment asset) and no caller-supplied batch id (withdrawals have no
- * deposit-intent map to key; the controller-generated id is used to resolve
- * the created transaction).
+ * mobile: no `requiredAssets` (the withdrawal consumes the vault balance, not
+ * a payment asset) and a locally generated batch id (withdrawals have no
+ * deposit-intent map for the caller to key, but the id must still be known
+ * before submission so `submitPlaceholderBatch` can recognise the
+ * transaction).
  *
  * @param messenger - The messenger to build and submit through.
  * @returns The id of the created transaction, for confirmation navigation.
@@ -39,37 +41,21 @@ export async function createMoneyAccountWithdrawTransaction(
     tellerAddress,
   });
 
-  const { batchId } = await messenger.call(
-    'TransactionController:addTransactionBatch',
-    {
-      disableHook: true,
-      disableSequential: true,
-      disableUpgrade: true,
-      from: moneyAccountAddress,
-      // The gas-station sponsorship exists on Monad mainnet only.
-      isGasFeeSponsored: chainId === CHAIN_IDS.MONAD,
-      isInternal: true,
-      networkClientId,
-      origin: ORIGIN_METAMASK,
-      skipInitialGasEstimate: true,
-      transactions: [withdrawTx, transferTx],
-    },
-  );
+  const batchId = bytesToHex(new Uint8Array(uuidParse(uuidv4())));
 
-  // The cast mirrors `lib/transaction/hooks`: TS cannot narrow this action's
-  // return type out of the messenger union.
-  const { transactions } = messenger.call(
-    'TransactionController:getState',
-  ) as TransactionControllerState;
-  const transaction = transactions.find(
-    (tx) => tx.batchId?.toLowerCase() === batchId.toLowerCase(),
-  );
+  const transactionId = await submitPlaceholderBatch(messenger, batchId, {
+    disableHook: true,
+    disableSequential: true,
+    disableUpgrade: true,
+    from: moneyAccountAddress,
+    // The gas-station sponsorship exists on Monad mainnet only.
+    isGasFeeSponsored: chainId === CHAIN_IDS.MONAD,
+    isInternal: true,
+    networkClientId,
+    origin: ORIGIN_METAMASK,
+    skipInitialGasEstimate: true,
+    transactions: [withdrawTx, transferTx],
+  });
 
-  if (!transaction) {
-    throw new Error(
-      `${LOG_TAG} Withdrawal transaction not found after batch creation`,
-    );
-  }
-
-  return { transactionId: transaction.id, batchId };
+  return { transactionId, batchId };
 }

--- a/app/scripts/lib/money/pay/pay-context.ts
+++ b/app/scripts/lib/money/pay/pay-context.ts
@@ -14,6 +14,7 @@ import type {
   TransactionControllerGetNonceLockAction,
   TransactionControllerGetStateAction,
   TransactionControllerIsAtomicBatchSupportedAction,
+  TransactionControllerUnapprovedTransactionAddedEvent,
   TransactionControllerUpdateTransactionMetadataAction,
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
@@ -47,10 +48,14 @@ type MoneyPayActions =
   // account (`update-withdraw-amount.ts`).
   | AccountsControllerGetSelectedAccountAction;
 
+// Initiation resolves the created transaction's id from the added transaction
+// rather than the batch result (`submit-placeholder-batch.ts`).
+type MoneyPayEvents = TransactionControllerUnapprovedTransactionAddedEvent;
+
 /**
  * The messenger surface the Money Pay callbacks need.
  */
-export type MoneyPayMessenger = Messenger<string, MoneyPayActions, never>;
+export type MoneyPayMessenger = Messenger<string, MoneyPayActions, MoneyPayEvents>;
 
 /**
  * Everything a Money Pay callback needs before it can build calldata. Resolved

--- a/app/scripts/lib/money/pay/submit-placeholder-batch.test.ts
+++ b/app/scripts/lib/money/pay/submit-placeholder-batch.test.ts
@@ -1,0 +1,91 @@
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import { submitPlaceholderBatch } from './submit-placeholder-batch';
+import {
+  createMoneyPayMessengerMock,
+  MONEY_ACCOUNT_ADDRESS_MOCK,
+  NETWORK_CLIENT_ID_MOCK,
+  type BatchRequestMock,
+} from './test-mocks';
+
+const BATCH_ID = '0xB47C41D0000000000000000000000000' as Hex;
+const TRANSACTION_ID = 'transaction-id-mock';
+
+const REQUEST = {
+  from: MONEY_ACCOUNT_ADDRESS_MOCK,
+  networkClientId: NETWORK_CLIENT_ID_MOCK,
+  transactions: [],
+};
+
+/**
+ * A messenger whose `addTransactionBatch` publishes the added transactions and
+ * then hands publication control back to the test, since the real batch
+ * settles only once the confirmation is approved or rejected.
+ *
+ * @param added - Transactions to publish as added, in order.
+ * @returns The messenger mock and the publication rejector.
+ */
+function setup(added: Partial<TransactionMeta>[]) {
+  const publication: { reject?: (error: Error) => void } = {};
+  const emitter: {
+    emit?: (transaction: Partial<TransactionMeta>) => void;
+  } = {};
+
+  const addTransactionBatch = async (): Promise<never> => {
+    added.forEach((transaction) => emitter.emit?.(transaction));
+
+    return await new Promise<never>((_resolve, reject) => {
+      publication.reject = reject;
+    });
+  };
+
+  const mock = createMoneyPayMessengerMock({
+    handlers: {
+      'TransactionController:addTransactionBatch':
+        addTransactionBatch as unknown as (...args: unknown[]) => unknown,
+    },
+  });
+
+  emitter.emit = mock.emitUnapprovedTransactionAdded;
+
+  return { ...mock, publication };
+}
+
+describe('submitPlaceholderBatch', () => {
+  it('resolves with the transaction created for the batch id', async () => {
+    const { messenger, call, unsubscribe } = setup([
+      { id: 'unrelated-transaction', batchId: '0xffff' },
+      { id: TRANSACTION_ID, batchId: BATCH_ID.toLowerCase() as Hex },
+    ]);
+
+    await expect(
+      submitPlaceholderBatch(messenger, BATCH_ID, REQUEST),
+    ).resolves.toBe(TRANSACTION_ID);
+
+    expect(call).toHaveBeenCalledWith(
+      'TransactionController:addTransactionBatch',
+      { ...REQUEST, batchId: BATCH_ID } as BatchRequestMock,
+    );
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a batch rejection once the transaction was added', async () => {
+    const { messenger, unsubscribe, publication } = setup([
+      { id: TRANSACTION_ID, batchId: BATCH_ID },
+    ]);
+
+    const transactionId = await submitPlaceholderBatch(
+      messenger,
+      BATCH_ID,
+      REQUEST,
+    );
+
+    // A user rejecting the confirmation surfaces here, long after initiation
+    // handed the transaction id back.
+    publication.reject?.(new Error('User rejected the request'));
+    await Promise.resolve();
+
+    expect(transactionId).toBe(TRANSACTION_ID);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/scripts/lib/money/pay/submit-placeholder-batch.ts
+++ b/app/scripts/lib/money/pay/submit-placeholder-batch.ts
@@ -1,0 +1,81 @@
+import type {
+  TransactionControllerAddTransactionBatchAction,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import type { MoneyPayMessenger } from './pay-context';
+
+const UNAPPROVED_TRANSACTION_ADDED =
+  'TransactionController:unapprovedTransactionAdded' as const;
+
+type AddTransactionBatchRequest = Parameters<
+  TransactionControllerAddTransactionBatchAction['handler']
+>[0];
+
+/**
+ * Submits a placeholder Money Account batch and resolves the id of the
+ * transaction it creates.
+ *
+ * `addTransactionBatch` does not settle when the transaction is added: with
+ * `disableHook` and `disableSequential` it takes the EIP-7702 path, which
+ * awaits publication — and publication only happens once the user approves the
+ * confirmation. Awaiting it during initiation therefore deadlocks the flow,
+ * because the id it would eventually yield is exactly what the UI needs to
+ * navigate to that confirmation. Mobile sidesteps this by navigating *before*
+ * creating the batch; the extension navigates after creation, so it waits for
+ * the unapproved transaction instead and leaves the batch promise running.
+ *
+ * @param messenger - The messenger to submit and subscribe through.
+ * @param batchId - Batch id to create under, which identifies the transaction.
+ * Always caller-supplied so the subscription is in place before submission.
+ * @param request - The rest of the `addTransactionBatch` request.
+ * @returns The created transaction's id.
+ */
+export async function submitPlaceholderBatch(
+  messenger: MoneyPayMessenger,
+  batchId: Hex,
+  request: Omit<AddTransactionBatchRequest, 'batchId'>,
+): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    let isSettled = false;
+
+    const handleTransactionAdded = (transaction: TransactionMeta) => {
+      if (
+        isSettled ||
+        transaction.batchId?.toLowerCase() !== batchId.toLowerCase()
+      ) {
+        return;
+      }
+
+      isSettled = true;
+      messenger.unsubscribe(
+        UNAPPROVED_TRANSACTION_ADDED,
+        handleTransactionAdded,
+      );
+      resolve(transaction.id);
+    };
+
+    messenger.subscribe(UNAPPROVED_TRANSACTION_ADDED, handleTransactionAdded);
+
+    messenger
+      .call('TransactionController:addTransactionBatch', {
+        ...request,
+        batchId,
+      })
+      .catch((error) => {
+        // Once the transaction exists, a rejection belongs to publication —
+        // most often the user rejecting the confirmation — which initiation no
+        // longer owns.
+        if (isSettled) {
+          return;
+        }
+
+        isSettled = true;
+        messenger.unsubscribe(
+          UNAPPROVED_TRANSACTION_ADDED,
+          handleTransactionAdded,
+        );
+        reject(error);
+      });
+  });
+}

--- a/app/scripts/lib/money/pay/test-mocks.ts
+++ b/app/scripts/lib/money/pay/test-mocks.ts
@@ -1,3 +1,7 @@
+import type {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import type { MoneyPayMessenger } from './pay-context';
 
@@ -112,9 +116,103 @@ export function createMoneyPayMessengerMock(
     return handler(...args);
   });
 
+  type TransactionAddedHandler = (transaction: TransactionMeta) => void;
+  const subscribers = new Set<TransactionAddedHandler>();
+
+  const subscribe = jest.fn(
+    (_eventType: string, handler: TransactionAddedHandler) => {
+      subscribers.add(handler);
+    },
+  );
+
+  const unsubscribe = jest.fn(
+    (_eventType: string, handler: TransactionAddedHandler) => {
+      subscribers.delete(handler);
+    },
+  );
+
   return {
-    messenger: { call } as unknown as MoneyPayMessenger,
+    messenger: { call, subscribe, unsubscribe } as unknown as MoneyPayMessenger,
     call,
+    subscribe,
+    unsubscribe,
     provider,
+    /**
+     * Publishes `TransactionController:unapprovedTransactionAdded`.
+     *
+     * @param transaction - The transaction that was added.
+     */
+    emitUnapprovedTransactionAdded: (transaction: Partial<TransactionMeta>) => {
+      for (const handler of [...subscribers]) {
+        handler(transaction as TransactionMeta);
+      }
+    },
   };
+}
+
+/** The `addTransactionBatch` request the placeholder batches submit. */
+export type BatchRequestMock = {
+  batchId: Hex;
+  requiredAssets?: { address: Hex; amount: Hex; standard: string }[];
+  transactions: { params: { to: Hex; value: Hex }; type: TransactionType }[];
+};
+
+export type PlaceholderBatchMockOptions = MessengerMockOptions & {
+  /** Id of the transaction the batch creates. */
+  transactionId: string;
+  /** Rejection from the batch, standing in for a failed submission. */
+  batchError?: Error;
+};
+
+/**
+ * A `MoneyPayMessenger` mock whose `addTransactionBatch` behaves like the
+ * controller's: it publishes `unapprovedTransactionAdded` for the created
+ * transaction and then stays **pending**, because the real batch settles only
+ * once the user approves the confirmation. An unrelated transaction is
+ * published first, so consumers must match on the batch id.
+ *
+ * @param options - The options bag, also accepting every
+ * `createMoneyPayMessengerMock` option.
+ * @param options.transactionId - Id of the transaction the batch creates.
+ * @param options.batchError - Rejection from the batch, standing in for a
+ * failed submission.
+ * @returns The messenger mock and the `addTransactionBatch` mock.
+ */
+export function createPlaceholderBatchMessengerMock({
+  transactionId,
+  batchError,
+  ...options
+}: PlaceholderBatchMockOptions) {
+  const emitter: {
+    emit?: (transaction: Partial<TransactionMeta>) => void;
+  } = {};
+
+  const addTransactionBatch = jest.fn(
+    async ({ batchId }: BatchRequestMock): Promise<never> => {
+      if (batchError) {
+        throw batchError;
+      }
+
+      emitter.emit?.({ id: 'unrelated-transaction', batchId: '0xffff' });
+      emitter.emit?.({
+        id: transactionId,
+        batchId: batchId.toLowerCase() as Hex,
+      });
+
+      return await new Promise<never>(() => undefined);
+    },
+  );
+
+  const mock = createMoneyPayMessengerMock({
+    ...options,
+    handlers: {
+      'TransactionController:addTransactionBatch':
+        addTransactionBatch as unknown as (...args: unknown[]) => unknown,
+      ...options.handlers,
+    },
+  });
+
+  emitter.emit = mock.emitUnapprovedTransactionAdded;
+
+  return { ...mock, addTransactionBatch };
 }

--- a/shared/lib/transactions.utils.test.ts
+++ b/shared/lib/transactions.utils.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   isBatchTransaction,
   hasTransactionType,
+  getMoneyAccountTransactionType,
   getPostQuoteWithdrawTransactionType,
   getTransactionType,
   isPostQuoteWithdrawTransaction,
@@ -236,6 +237,48 @@ describe('Transactions utils', () => {
 
     it('returns false when transactionMeta is undefined', () => {
       expect(isPerpsWithdrawTransaction(undefined)).toBe(false);
+    });
+  });
+
+  describe('getMoneyAccountTransactionType', () => {
+    it('returns moneyAccountDeposit when it is a nested transaction of a batch', () => {
+      const transactionMeta = {
+        type: TransactionType.batch,
+        nestedTransactions: [
+          { type: TransactionType.tokenMethodApprove },
+          { type: TransactionType.moneyAccountDeposit },
+        ],
+      } as unknown as TransactionMeta;
+
+      expect(getMoneyAccountTransactionType(transactionMeta)).toBe(
+        TransactionType.moneyAccountDeposit,
+      );
+    });
+
+    it('returns moneyAccountWithdraw when it is the top-level type', () => {
+      const transactionMeta = {
+        type: TransactionType.moneyAccountWithdraw,
+      } as TransactionMeta;
+
+      expect(getMoneyAccountTransactionType(transactionMeta)).toBe(
+        TransactionType.moneyAccountWithdraw,
+      );
+    });
+
+    it('returns undefined for unrelated batch transactions', () => {
+      const transactionMeta = {
+        type: TransactionType.batch,
+        nestedTransactions: [
+          { type: TransactionType.tokenMethodApprove },
+          { type: TransactionType.tokenMethodTransfer },
+        ],
+      } as unknown as TransactionMeta;
+
+      expect(getMoneyAccountTransactionType(transactionMeta)).toBeUndefined();
+    });
+
+    it('returns undefined when transactionMeta is undefined', () => {
+      expect(getMoneyAccountTransactionType(undefined)).toBeUndefined();
     });
   });
 

--- a/shared/lib/transactions.utils.ts
+++ b/shared/lib/transactions.utils.ts
@@ -75,6 +75,33 @@ export function getTransactionType(
   return type;
 }
 
+export const MONEY_ACCOUNT_TRANSACTION_TYPES = [
+  TransactionType.moneyAccountDeposit,
+  TransactionType.moneyAccountWithdraw,
+] as const;
+
+/**
+ * Resolves the money-account type of a transaction, including batches.
+ *
+ * Money-account deposits and withdrawals are created via
+ * `addTransactionBatch`, so the top-level `type` is `batch` and the
+ * meaningful type sits on a nested transaction — and not necessarily the
+ * first one: deposits are `[approve, deposit]`, so `getTransactionType`
+ * would resolve them to `tokenMethodApprove`. Mirrors mobile's `info-root`
+ * routing, which checks `hasTransactionType` before the generic batch map.
+ *
+ * @param transactionMeta - The transaction metadata to inspect.
+ * @returns The money-account type when present anywhere in the transaction,
+ * otherwise undefined.
+ */
+export function getMoneyAccountTransactionType(
+  transactionMeta: TransactionMeta | undefined,
+): TransactionType | undefined {
+  return MONEY_ACCOUNT_TRANSACTION_TYPES.find((transactionType) =>
+    hasTransactionType(transactionMeta, [transactionType]),
+  );
+}
+
 export const POST_QUOTE_WITHDRAW_TRANSACTION_TYPES = [
   TransactionType.moneyAccountWithdraw,
   TransactionType.perpsWithdraw,

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -7,6 +7,7 @@ import { PRODUCT_TYPES } from '@metamask/subscription-controller';
 import { useNavigate } from 'react-router-dom';
 import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
 import { isCorrectDeveloperTransactionType } from '../../../../../../shared/lib/confirmation.utils';
+import { getMoneyAccountTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import { ConfirmAlertModal } from '../../../../../components/app/alert-system/confirm-alert-modal';
 import {
   Box,
@@ -450,9 +451,15 @@ const Footer = () => {
     return null;
   }
 
+  // Money-account batches carry their meaningful type on a nested
+  // transaction, so resolve it before matching against the list.
+  const confirmationType =
+    getMoneyAccountTransactionType(currentConfirmation as TransactionMeta) ??
+    currentConfirmation.type;
+
   if (
-    currentConfirmation.type &&
-    SINGLE_ACTION_FOOTER_TYPES.includes(currentConfirmation.type)
+    confirmationType &&
+    SINGLE_ACTION_FOOTER_TYPES.includes(confirmationType)
   ) {
     return (
       <SingleActionFooter

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
@@ -3,6 +3,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import React, { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
 import { Button, ButtonSize } from '@metamask/design-system-react';
+import { getMoneyAccountTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import { Footer as PageFooter } from '../../../../../components/multichain/pages/page';
 import useAlerts from '../../../../../hooks/useAlerts';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
@@ -31,7 +32,11 @@ function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const transactionId = currentConfirmation?.id ?? '';
-  const transactionType = currentConfirmation?.type;
+  // Money-account batches carry their meaningful type on a nested
+  // transaction, so resolve it before the button-text lookup.
+  const transactionType =
+    getMoneyAccountTransactionType(currentConfirmation) ??
+    currentConfirmation?.type;
 
   const { alerts } = useAlerts(transactionId);
   const isPayLoading = useIsTransactionPayLoading();

--- a/ui/pages/confirmations/components/confirm/header/advanced-details-button.tsx
+++ b/ui/pages/confirmations/components/confirm/header/advanced-details-button.tsx
@@ -4,6 +4,7 @@ import {
 } from '@metamask/transaction-controller';
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { getMoneyAccountTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import {
   Box,
   ButtonIcon,
@@ -35,6 +36,12 @@ export const AdvancedDetailsButton = () => {
     dispatch(setConfirmationAdvancedDetailsOpen(value));
   };
 
+  // Money-account batches carry their meaningful type on a nested
+  // transaction, so resolve it before matching by type.
+  const confirmationType =
+    getMoneyAccountTransactionType(currentConfirmation) ??
+    currentConfirmation?.type;
+
   return (
     <Box
       backgroundColor={
@@ -46,12 +53,11 @@ export const AdvancedDetailsButton = () => {
       // hiding through visibility instead of rendering conditionally so the
       // header layout is not affected
       style={
-        currentConfirmation?.type ===
-          TransactionType.shieldSubscriptionApprove ||
-        currentConfirmation?.type === TransactionType.moneyAccountDeposit ||
-        currentConfirmation?.type === TransactionType.moneyAccountWithdraw ||
-        currentConfirmation?.type === TransactionType.perpsDeposit ||
-        currentConfirmation?.type === TransactionType.perpsWithdraw
+        confirmationType === TransactionType.shieldSubscriptionApprove ||
+        confirmationType === TransactionType.moneyAccountDeposit ||
+        confirmationType === TransactionType.moneyAccountWithdraw ||
+        confirmationType === TransactionType.perpsDeposit ||
+        confirmationType === TransactionType.perpsWithdraw
           ? { visibility: 'hidden' }
           : {}
       }

--- a/ui/pages/confirmations/components/confirm/header/header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/header.tsx
@@ -4,6 +4,7 @@ import {
 } from '@metamask/transaction-controller';
 import React from 'react';
 import { ORIGIN_METAMASK } from '../../../../../../shared/constants/app';
+import { getMoneyAccountTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import { Box, Text } from '../../../../../components/component-library';
 import { PreferredAvatar } from '../../../../../components/app/preferred-avatar';
 import {
@@ -92,15 +93,19 @@ const Header = () => {
   // back button if it's a wallet initiated confirmation. The default header is
   // the original header for the redesigns and includes the sender and recipient
   // addresses as well.
+  // Money-account batches carry their meaningful type on a nested
+  // transaction, so resolve it before matching against the type lists.
+  const confirmationType =
+    getMoneyAccountTransactionType(currentConfirmation as TransactionMeta) ??
+    currentConfirmation?.type;
+
   const isConfirmationWithNewHeader =
-    currentConfirmation?.type &&
-    CONFIRMATIONS_WITH_ALT_HEADER.includes(currentConfirmation.type);
+    confirmationType && CONFIRMATIONS_WITH_ALT_HEADER.includes(confirmationType);
   const isWalletInitiated =
     (currentConfirmation as TransactionMeta)?.origin === ORIGIN_METAMASK;
 
   const isSimpleHeader =
-    currentConfirmation?.type &&
-    SIMPLE_HEADER_TYPES.includes(currentConfirmation.type);
+    confirmationType && SIMPLE_HEADER_TYPES.includes(confirmationType);
 
   if (isSimpleHeader && isWalletInitiated) {
     return <SimpleConfirmationHeader />;

--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.test.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.test.tsx
@@ -25,6 +25,16 @@ const getPerpsDepositState = () => {
   } as TransactionMeta);
 };
 
+/** Build a confirm state for a moneyAccountWithdraw transaction. */
+const getMoneyAccountWithdrawState = () => {
+  const base = genUnapprovedContractInteractionConfirmation({ chainId: '0x1' });
+  return getMockConfirmStateForTransaction({
+    ...base,
+    type: TransactionType.moneyAccountWithdraw,
+    origin: 'metamask',
+  } as TransactionMeta);
+};
+
 /** Build a confirm state for a perpsWithdraw transaction. */
 const getPerpsWithdrawState = () => {
   const base = genUnapprovedContractInteractionConfirmation({ chainId: '0x1' });
@@ -147,6 +157,12 @@ describe('<WalletInitiatedHeader />', () => {
     const { getByText } = render(getPerpsWithdrawState());
 
     expect(getByText(tEn('perpsWithdrawFundsTitle'))).toBeInTheDocument();
+  });
+
+  it('shows send as the header title for moneyAccountWithdraw', () => {
+    const { getByText } = render(getMoneyAccountWithdrawState());
+
+    expect(getByText(tEn('send'))).toBeInTheDocument();
   });
 
   it('hides AdvancedDetailsButton visually for perpsWithdraw', () => {

--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
@@ -5,6 +5,7 @@ import {
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
+import { getMoneyAccountTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import {
   Box,
   ButtonIcon,
@@ -35,25 +36,28 @@ export const WalletInitiatedHeader = () => {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const navigate = useNavigate();
 
+  // Money-account batches carry their meaningful type on a nested
+  // transaction, so resolve it before matching by type.
+  const confirmationType =
+    getMoneyAccountTransactionType(currentConfirmation) ??
+    currentConfirmation?.type;
+
   const isSendTransaction =
-    currentConfirmation?.type &&
-    SEND_TRANSACTION_TYPES.includes(currentConfirmation.type);
+    confirmationType && SEND_TRANSACTION_TYPES.includes(confirmationType);
 
   const handleBackButtonClick = useCallback(() => {
-    if (
-      currentConfirmation.type === TransactionType.shieldSubscriptionApprove
-    ) {
+    if (confirmationType === TransactionType.shieldSubscriptionApprove) {
       onCancel({ location: MetaMetricsEventLocation.Confirmation });
       navigate(SHIELD_PLAN_ROUTE);
       return;
     }
 
     if (
-      currentConfirmation.type === TransactionType.moneyAccountDeposit ||
-      currentConfirmation.type === TransactionType.moneyAccountWithdraw ||
-      currentConfirmation.type === TransactionType.musdClaim ||
-      currentConfirmation.type === TransactionType.perpsDeposit ||
-      currentConfirmation.type === TransactionType.perpsWithdraw
+      confirmationType === TransactionType.moneyAccountDeposit ||
+      confirmationType === TransactionType.moneyAccountWithdraw ||
+      confirmationType === TransactionType.musdClaim ||
+      confirmationType === TransactionType.perpsDeposit ||
+      confirmationType === TransactionType.perpsWithdraw
     ) {
       onCancel({
         location: MetaMetricsEventLocation.Confirmation,
@@ -62,13 +66,12 @@ export const WalletInitiatedHeader = () => {
       return;
     }
 
-    const isNativeSend =
-      currentConfirmation.type === TransactionType.simpleSend;
+    const isNativeSend = confirmationType === TransactionType.simpleSend;
     const isERC20TokenSend =
-      currentConfirmation.type === TransactionType.tokenMethodTransfer;
+      confirmationType === TransactionType.tokenMethodTransfer;
     const isNFTTokenSend =
-      currentConfirmation.type === TransactionType.tokenMethodTransferFrom ||
-      currentConfirmation.type === TransactionType.tokenMethodSafeTransferFrom;
+      confirmationType === TransactionType.tokenMethodTransferFrom ||
+      confirmationType === TransactionType.tokenMethodSafeTransferFrom;
 
     if (isNativeSend || isERC20TokenSend || isNFTTokenSend) {
       onCancel({
@@ -76,30 +79,28 @@ export const WalletInitiatedHeader = () => {
         navigateBackForSend: true,
       });
     }
-  }, [currentConfirmation, navigate, onCancel]);
+  }, [confirmationType, navigate, onCancel]);
 
   const getHeaderTitle = () => {
     if (isSendTransaction) {
       return null;
     }
-    if (
-      currentConfirmation?.type === TransactionType.shieldSubscriptionApprove
-    ) {
+    if (confirmationType === TransactionType.shieldSubscriptionApprove) {
       return t('shieldConfirmMembership');
     }
-    if (currentConfirmation?.type === TransactionType.moneyAccountDeposit) {
+    if (confirmationType === TransactionType.moneyAccountDeposit) {
       return t('addFunds');
     }
-    if (currentConfirmation?.type === TransactionType.moneyAccountWithdraw) {
+    if (confirmationType === TransactionType.moneyAccountWithdraw) {
       return t('send');
     }
-    if (currentConfirmation?.type === TransactionType.musdClaim) {
+    if (confirmationType === TransactionType.musdClaim) {
       return null;
     }
-    if (currentConfirmation?.type === TransactionType.perpsDeposit) {
+    if (confirmationType === TransactionType.perpsDeposit) {
       return t('perpsDepositFundsTitle');
     }
-    if (currentConfirmation?.type === TransactionType.perpsWithdraw) {
+    if (confirmationType === TransactionType.perpsWithdraw) {
       return t('perpsWithdrawFundsTitle');
     }
     return t('review');

--- a/ui/pages/confirmations/components/confirm/info/info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.tsx
@@ -1,7 +1,11 @@
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { ApprovalType } from '@metamask/controller-utils';
 import React, { useMemo } from 'react';
 import { Skeleton } from '@metamask/design-system-react';
+import { getMoneyAccountTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import { useEnabledAdvancedPermissions } from '../../../../../hooks/gator-permissions/useEnabledAdvancedPermissions';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { useTrustSignalMetrics } from '../../../../trust-signals/hooks/useTrustSignalMetrics';
@@ -184,9 +188,16 @@ const Info = () => {
     );
   }
 
+  // Money-account deposits/withdrawals are batches: the top-level type is
+  // `batch` and the meaningful type sits on a nested transaction, so resolve
+  // it before the map lookup (mirrors mobile's info-root routing).
+  const confirmationType =
+    getMoneyAccountTransactionType(currentConfirmation as TransactionMeta) ??
+    currentConfirmation?.type;
+
   const InfoComponent =
     ConfirmationInfoComponentMap[
-      currentConfirmation?.type as keyof typeof ConfirmationInfoComponentMap
+      confirmationType as keyof typeof ConfirmationInfoComponentMap
     ]();
 
   return <InfoComponent />;

--- a/ui/pages/confirmations/components/confirm/title/title.test.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.test.tsx
@@ -18,6 +18,7 @@ import {
   permitNFTSignatureMsg,
   permitSignatureMsg,
 } from '../../../../../../test/data/confirmations/typed_sign';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { tEn } from '../../../../../../test/lib/i18n-helpers';
 import { upgradeAccountConfirmationOnly } from '../../../../../../test/data/confirmations/batch-transaction';
@@ -180,6 +181,30 @@ describe('ConfirmTitle', () => {
     );
 
     expect(getByText(tEn('confirmTitleTransaction'))).toBeInTheDocument();
+  });
+
+  it('does not render the generic batch title or nested transaction count for a money account deposit', () => {
+    const transaction = {
+      ...genUnapprovedContractInteractionConfirmation(),
+      type: TransactionType.batch,
+      nestedTransactions: [
+        { type: TransactionType.tokenMethodApprove },
+        { type: TransactionType.moneyAccountDeposit },
+      ],
+    } as Confirmation;
+    const mockStore = configureMockStore([])(
+      getMockConfirmStateForTransaction(transaction),
+    );
+
+    const { queryByText } = renderWithConfirmContextProvider(
+      <ConfirmTitle />,
+      mockStore,
+    );
+
+    expect(queryByText(tEn('confirmTitleTransaction'))).not.toBeInTheDocument();
+    expect(
+      queryByText(tEn('includesXTransactions', ['2'])),
+    ).not.toBeInTheDocument();
   });
 
   it('keeps the contract interaction title while spending-cap data is pending', () => {

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -6,6 +6,7 @@ import React, { memo, useMemo } from 'react';
 
 import { Skeleton } from '@metamask/design-system-react';
 import { TokenStandard } from '../../../../../../shared/constants/transaction';
+import { getMoneyAccountTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import GeneralAlert from '../../../../../components/app/alert-system/general-alert/general-alert';
 import { Box, Text } from '../../../../../components/component-library';
 import {
@@ -57,7 +58,11 @@ function ConfirmBannerAlert({ ownerId }: { ownerId: string }) {
   const { updateSignatureEventFragment } = useSignatureEventFragment();
   const { updateTransactionEventFragment } = useTransactionEventFragment();
 
-  const transactionType = currentConfirmation?.type;
+  // Money-account batches carry their meaningful type on a nested
+  // transaction, so resolve it before matching against the list.
+  const transactionType =
+    getMoneyAccountTransactionType(currentConfirmation) ??
+    currentConfirmation?.type;
   const shouldHideBanner =
     transactionType && TRANSACTION_TYPES_HIDE_BANNER.includes(transactionType);
 
@@ -278,6 +283,9 @@ const ConfirmTitle = memo(() => {
   const { currentConfirmation } = useConfirmContext();
   const { isUpgradeOnly } = useIsUpgradeTransaction();
   const { loader } = useConfirmationNavigationOptions();
+  const isMoneyAccountTransaction = Boolean(
+    getMoneyAccountTransactionType(currentConfirmation as TransactionMeta),
+  );
 
   const { isNFT } = useIsNFT(currentConfirmation as TransactionMeta);
 
@@ -361,7 +369,7 @@ const ConfirmTitle = memo(() => {
   return (
     <>
       <ConfirmBannerAlert ownerId={currentConfirmation.id} />
-      {title ? (
+      {!isMoneyAccountTransaction && title ? (
         <Text
           variant={TextVariant.headingLg}
           paddingTop={4}
@@ -372,10 +380,10 @@ const ConfirmTitle = memo(() => {
           {title}
         </Text>
       ) : (
-        showTitleSkeleton && <TitleSkeleton />
+        !isMoneyAccountTransaction && showTitleSkeleton && <TitleSkeleton />
       )}
-      <NestedTransactionTag />
-      {description !== '' && (
+      {!isMoneyAccountTransaction && <NestedTransactionTag />}
+      {!isMoneyAccountTransaction && description !== '' && (
         <Text
           paddingBottom={4}
           color={TextColor.textAlternative}

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -33,7 +33,10 @@ import {
   addToken,
   findNetworkClientIdByChainId,
 } from '../../../../../store/actions';
-import { isPostQuoteWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
+import {
+  getMoneyAccountTransactionType,
+  isPostQuoteWithdrawTransaction,
+} from '../../../../../../shared/lib/transactions.utils';
 import { useDispatch } from '../../../../../store/hooks';
 import { selectIsMoneyAccountTransactionEnabled } from '../../../selectors/feature-flags';
 import { usePayWithSections } from '../../../hooks/pay/usePayWithSections';
@@ -53,8 +56,14 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
   const blockedTokens = useTransactionPayBlockedTokens();
   const [showOtherAssets, setShowOtherAssets] = useState(false);
 
+  // Money-account batches carry their meaningful type on a nested
+  // transaction, so resolve it before matching by type.
+  const confirmationType =
+    getMoneyAccountTransactionType(currentConfirmation) ??
+    currentConfirmation?.type;
+
   const isMoneyAccountPayEnabled = useSelector((state) =>
-    selectIsMoneyAccountTransactionEnabled(state, currentConfirmation?.type),
+    selectIsMoneyAccountTransactionEnabled(state, confirmationType),
   );
 
   const { filterTokens: musdTokenFilter } = useMusdConversionTokens({
@@ -72,7 +81,7 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
   const isPostQuoteWithdraw =
     isPostQuoteWithdrawTransaction(currentConfirmation);
   const isMoneyAccountDeposit =
-    currentConfirmation?.type === TransactionType.moneyAccountDeposit;
+    confirmationType === TransactionType.moneyAccountDeposit;
   const { renderNoFeeTag } = usePayWithNoFeeToken();
   const tagRenderers = useMemo(
     () => (isMoneyAccountDeposit ? [renderNoFeeTag] : undefined),

--- a/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
+++ b/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
@@ -6,6 +6,7 @@ import {
   selectPaymentOverrideByTransactionId,
   type TransactionPayState,
 } from '../../../../../selectors/transactionPayController';
+import { getMoneyAccountTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import { selectIsMoneyAccountTransactionEnabled } from '../../../selectors/feature-flags';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../context/confirm';
@@ -29,7 +30,11 @@ export function usePayWithMoneyAccountSection({
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const transactionId = currentConfirmation?.id ?? '';
-  const transactionType = currentConfirmation?.type;
+  // Money-account batches carry their meaningful type on a nested
+  // transaction, so resolve it before the feature-flag check.
+  const transactionType =
+    getMoneyAccountTransactionType(currentConfirmation) ??
+    currentConfirmation?.type;
 
   const isEnabled = useSelector((state) =>
     selectIsMoneyAccountTransactionEnabled(state, transactionType),

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
@@ -829,7 +829,12 @@ describe('useAutomaticTransactionPayToken', () => {
         currentConfirmation: {
           id: TRANSACTION_ID_MOCK,
           type: TransactionType.batch,
-          nestedTransactions: [{ type: TransactionType.moneyAccountDeposit }],
+          // Real money-account deposits are `[approve, deposit]` — the
+          // meaningful type is not the first nested entry.
+          nestedTransactions: [
+            { type: TransactionType.tokenMethodApprove },
+            { type: TransactionType.moneyAccountDeposit },
+          ],
           txParams: { from: '0x123' },
         } as never,
         isScrollToBottomCompleted: true,

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -4,6 +4,7 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { getHardwareWalletType } from '../../../../../shared/lib/selectors/keyring';
 import {
+  getMoneyAccountTransactionType,
   getTransactionType,
   isPostQuoteWithdrawTransaction,
 } from '../../../../../shared/lib/transactions.utils';
@@ -53,8 +54,12 @@ export function useAutomaticTransactionPayToken({
 
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const transactionId = currentConfirmation?.id;
-  // Batch txs use top-level type `batch`; resolve nested type for flag lookups.
-  const transactionType = getTransactionType(currentConfirmation);
+  // Batch txs use top-level type `batch`. Prefer the money-account nested type
+  // when present — deposits are `[approve, deposit]`, so plain
+  // `getTransactionType` would resolve them to `tokenMethodApprove`.
+  const transactionType =
+    getMoneyAccountTransactionType(currentConfirmation) ??
+    getTransactionType(currentConfirmation);
   const from = currentConfirmation?.txParams?.from;
   const isPostQuoteWithdraw =
     isPostQuoteWithdrawTransaction(currentConfirmation);

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayBlockedTokens.test.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayBlockedTokens.test.ts
@@ -46,4 +46,22 @@ describe('useTransactionPayBlockedTokens', () => {
       TransactionType.moneyAccountDeposit,
     );
   });
+
+  it('resolves money-account type from nested batch transactions', () => {
+    mockUseTransactionMetadataRequestOptional.mockReturnValue({
+      type: TransactionType.batch,
+      nestedTransactions: [
+        { type: TransactionType.tokenMethodApprove },
+        { type: TransactionType.moneyAccountDeposit },
+      ],
+    } as never);
+    mockSelectBlockedPayTokens.mockReturnValue({ chainIds: [], tokens: [] });
+
+    renderHook(() => useTransactionPayBlockedTokens());
+
+    expect(mockSelectBlockedPayTokens).toHaveBeenCalledWith(
+      {},
+      TransactionType.moneyAccountDeposit,
+    );
+  });
 });

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayBlockedTokens.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayBlockedTokens.ts
@@ -1,6 +1,10 @@
 import { useSelector } from 'react-redux';
 
 import {
+  getMoneyAccountTransactionType,
+  getTransactionType,
+} from '../../../../../shared/lib/transactions.utils';
+import {
   selectBlockedPayTokens,
   type BlockedPayTokensListConfig,
 } from '../../selectors/feature-flags';
@@ -12,7 +16,12 @@ import { useTransactionMetadataRequestOptional } from '../transactions/useTransa
  */
 export function useTransactionPayBlockedTokens(): BlockedPayTokensListConfig {
   const transactionMeta = useTransactionMetadataRequestOptional();
-  const transactionType = transactionMeta?.type;
+  // Prefer money-account nested type when present — deposit batches are
+  // `[approve, deposit]`, so top-level `type` is `batch` and the first nested
+  // type is the approve.
+  const transactionType =
+    getMoneyAccountTransactionType(transactionMeta) ??
+    getTransactionType(transactionMeta);
 
   return useSelector((state) => selectBlockedPayTokens(state, transactionType));
 }


### PR DESCRIPTION
## **Description**

Fixes Money Account deposit/withdraw confirmation routing and initiation so those flows open the money-account UI instead of stalling or falling back to the generic batch screen.

Split from #45522. Stacked under a follow-up that adds APY / projected balance / available-balance UI.

- **Confirmation surfaces rendered the generic batch UI.** Deposits and withdrawals are created via `addTransactionBatch`, so the top-level type is `batch` and the money-account type sits on a nested transaction — for deposits `[approve, deposit]`, so it isn't even the first nested entry. Surfaces keyed off the top-level type fell back to the generic batch UI, showing "Transaction request" with a nested-transaction count and failing to resolve the nested approve's token standard. A shared `getMoneyAccountTransactionType` helper now resolves the type from anywhere in the batch, mirroring how mobile's `info-root` checks `hasTransactionType` before its generic type map.
- **Deposit initiation created the transaction but never navigated.** With `disableHook`/`disableSequential`, `addTransactionBatch` takes the EIP-7702 path, which awaits *publication* — it settles only once the user approves the confirmation. Awaiting it to learn the transaction id deadlocked initiation on the very confirmation it needed to open (mobile avoids this by navigating before creating the batch). The id is now resolved from `TransactionController:unapprovedTransactionAdded` while the batch promise keeps running, for withdrawals as well as deposits.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1743

## **Manual testing steps**

1. Build and load this branch (`yarn start`) with the Money Account feature flag enabled and a wallet that has a Money Account.
2. Open Settings → Developer Options → Money Account Deposit.
3. Verify the deposit confirmation opens (rather than the transaction being created with no navigation), and that it shows the Money Account deposit UI — no "Transaction request" title and no nested-transaction count.
4. Start a Money Account withdrawal (Send).
5. Verify the withdraw confirmation opens with the Money Account custom-amount UI, not the generic batch "Transaction request" screen.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.