### PR TITLE
fix(sentry): Stop the finished-transaction trace overwriting itself and emitting an orphan

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6745,15 +6745,14 @@ export default class MetamaskController extends EventEmitter {
     }
     const startTime = performance.now();
 
-    const traceContext = trace({
-      name: TraceName.OnFinishedTransaction,
-      startTime: performance.timeOrigin,
-    });
-
+    // Keyed by transaction id: `tracesByKey` keys on name + id and falls back to
+    // the literal 'default' when no id is given, so two transactions finishing
+    // during the awaits below would otherwise share one key and the first span
+    // would be silently dropped.
     trace({
       name: TraceName.OnFinishedTransaction,
+      id: transactionMeta.id,
       startTime: performance.timeOrigin,
-      parentContext: traceContext,
       data: {
         transactionMeta,
       },
@@ -6767,6 +6766,7 @@ export default class MetamaskController extends EventEmitter {
     });
     endTrace({
       name: TraceName.OnFinishedTransaction,
+      id: transactionMeta.id,
       timestamp: performance.timeOrigin + startTime,
     });
   }


### PR DESCRIPTION
## The defect

`_onFinishedTransaction` opened **two** traces under the same name, neither carrying an `id`:

```js
const traceContext = trace({ name: TraceName.OnFinishedTransaction, startTime });
trace({ name: TraceName.OnFinishedTransaction, parentContext: traceContext, data: { transactionMeta } });
```

`getTraceKey` keys on name + `getTraceId`, and `getTraceId` substitutes the literal `'default'` when no `id` is supplied (`shared/lib/trace.ts`). Both calls therefore wrote the key `OnFinishedTransaction:default`, and the second registration replaced the first in `tracesByKey` — before anything awaited.

Two consequences, both shipping today:

1. **The first span is never ended and never sent.** `endTrace` resolves the key to the second entry, so the outer span is dropped silently.
2. **What does ship is an orphan.** The surviving span named the dropped one as its `parentContext`, so the emitted span references a parent that was never transmitted.

There is a third case on top: `_onFinishedTransaction` runs per finished transaction and awaits four times. Two transactions confirming inside that window collided on the same key, dropping one of them.

## The change

One span per finished transaction, keyed by `transactionMeta.id`.

The outer trace is removed rather than given its own id. It carried no data, was never sent, and existed only to be the inner span's parent — a same-name self-parent that added a level without adding information. Collapsing to a single keyed span produces what the code was evidently reaching for, minus the orphan.

## Verification

```
$ yarn jest app/scripts/metamask-controller.test.js
Test Suites: 1 passed, 1 total
Tests:       5 skipped, 128 passed, 133 total
```

`oxfmt -c oxfmt.config.mts --check` reports the file correctly formatted, and the diff is confined to the trace block (6 insertions, 6 deletions).

No test previously covered this path — a search for `_onFinishedTransaction` and `OnFinishedTransaction` across `app/**/*.test.*` returns nothing. So the suite above (`app/scripts/metamask-controller.test.js`) covers the surrounding controller only — it does not pin the new behaviour, and this PR does not add a test: asserting it requires driving two concurrent `_onFinishedTransaction` calls through a real `tracesByKey`, which belongs with the collision work in MetaMask-planning#7523 rather than here.

## Scope

This is one confirmed instance, not the general fix. The audit behind it: of 41 `endTrace` call sites, 9 pass an explicit `id`; the remaining 32 are overwhelmingly singleton UI surfaces (modals, views) that cannot overlap, and several apparent risks are not real because `trace()` and `endTrace()` are synchronously adjacent with no await between them — `LazyLoadComponent` in `ui/helpers/utils/mm-lazy.ts` is the notable one, invoked for 88 components and still safe for exactly that reason.

A collision needs three things together: same name, no explicit `id`, and an async gap between start and end. This call site was the one place all three held **and** the same-name pair collided with itself in a single invocation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in transaction-finish tracing; no auth, transaction submission, or balance logic is altered beyond trace keys.
> 
> **Overview**
> Fixes **Sentry tracing** in `_onFinishedTransaction` so finished transactions no longer clobber each other or emit orphan spans.
> 
> The handler previously started **two** `OnFinishedTransaction` traces without an `id`, so both mapped to the same `tracesByKey` entry (`default`). The inner trace replaced the outer one before any `await`, so `endTrace` closed the wrong span and the emitted trace could reference a parent that was never sent. Concurrent finishes during the handler’s awaits hit the same key and could drop a span silently.
> 
> The change uses **one** span per finish, passing `transactionMeta.id` on both `trace` and `endTrace`, and removes the redundant outer/parent trace that added nesting without extra signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5181db91661c13fbe664fde933de29d283e65fdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Changelog

CHANGELOG entry: null
