### PR TITLE
fix(ci): average every baseline statistic over the same runs

### DIFF
--- a/development/metamaskbot-build-announce/historical-comparison.test.ts
+++ b/development/metamaskbot-build-announce/historical-comparison.test.ts
@@ -196,6 +196,96 @@ describe('aggregateHistoricalData', () => {
     );
   });
 
+  it('averages every statistic over the same runs when one run is missing p75', () => {
+    // Runs 1 and 3 are complete; run 2 records no p75. Only complete runs may
+    // contribute, so mean and p75 must both average 100 and 1000 -> 550.
+    // Before MetaMask-planning#7204, mean averaged all three runs (400) while
+    // p75 averaged the two that had it (550): two numbers, two populations.
+    const data = asHistoricalFile({
+      c1: {
+        timestamp: 1,
+        presets: {
+          pageLoad: {
+            entry: {
+              mean: { metric: 100 },
+              p75: { metric: 100 },
+              p95: { metric: 100 },
+            },
+          },
+        },
+      },
+      c2: {
+        timestamp: 2,
+        presets: {
+          pageLoad: {
+            entry: {
+              mean: { metric: 100 },
+              p95: { metric: 100 },
+            },
+          },
+        },
+      },
+      c3: {
+        timestamp: 3,
+        presets: {
+          pageLoad: {
+            entry: {
+              mean: { metric: 1000 },
+              p75: { metric: 1000 },
+              p95: { metric: 1000 },
+            },
+          },
+        },
+      },
+    });
+
+    const result = aggregateHistoricalData(data);
+    const baseline = result['pageLoad/entry']?.metric;
+
+    expect(baseline?.mean).toBe(550);
+    expect(baseline?.p75).toBe(550);
+    expect(baseline?.p75).toBe(baseline?.mean);
+  });
+
+  it('omits stdDev when only some contributing runs recorded it', () => {
+    // A stdDev averaged over a subset describes a different population than
+    // the mean beside it, which is how `stdDev ~ 0` could sit next to a p75
+    // far above the mean. Emitting nothing is correct.
+    const data = asHistoricalFile({
+      c1: {
+        timestamp: 1,
+        presets: {
+          pageLoad: {
+            entry: {
+              mean: { metric: 100 },
+              stdDev: { metric: 5 },
+              p75: { metric: 100 },
+              p95: { metric: 100 },
+            },
+          },
+        },
+      },
+      c2: {
+        timestamp: 2,
+        presets: {
+          pageLoad: {
+            entry: {
+              mean: { metric: 1000 },
+              p75: { metric: 1000 },
+              p95: { metric: 1000 },
+            },
+          },
+        },
+      },
+    });
+
+    const result = aggregateHistoricalData(data);
+    const baseline = result['pageLoad/entry']?.metric;
+
+    expect(baseline?.mean).toBe(550);
+    expect(baseline?.stdDev).toBeUndefined();
+  });
+
   it('includes stdDev in the baseline when stdDev data is present', () => {
     const data = asHistoricalFile({
       c1: {

--- a/development/metamaskbot-build-announce/historical-comparison.ts
+++ b/development/metamaskbot-build-announce/historical-comparison.ts
@@ -94,9 +94,17 @@ function collectMetrics(
         metricName
       ];
       const arr = bucket[statKey];
-      if (typeof raw === 'number' && !Number.isNaN(raw) && arr !== undefined) {
-        arr.push(raw);
+      if (arr === undefined) {
+        continue;
       }
+      // Push a placeholder for a missing statistic rather than skipping it, so
+      // index `i` is the same run in every series. Skipping shifted later
+      // entries and let `mean[i]`, `p75[i]` and `stdDev[i]` refer to different
+      // runs — which is what allowed the three published numbers to describe
+      // different populations (MetaMask-planning#7204).
+      arr.push(
+        typeof raw === 'number' && !Number.isNaN(raw) ? raw : Number.NaN,
+      );
     }
   }
 }
@@ -125,8 +133,25 @@ function collectCommitPresets(
 }
 
 /**
- * Converts averaged CollectedMetricValues for one benchmark key into
+ * Converts collected per-run values for one benchmark key into
  * HistoricalBaselineMetrics entries, skipping metrics with no valid data.
+ *
+ * Every published statistic is averaged over the **same** set of runs. The
+ * previous implementation averaged each independently — `mean` over every run,
+ * `stdDev` over only the runs that recorded one, `p75`/`p95` over only the runs
+ * that recorded those — so the three numbers need not have described the same
+ * population, or even the same runs. That is how a baseline could report
+ * `stdDev ≈ 0` alongside `p75` far above `mean` without anything being
+ * impossible (MetaMask-planning#7204).
+ *
+ * A run contributes only if it recorded `mean`, `p75` and `p95`. `stdDev`
+ * remains optional because older entries predate it, but when present it is
+ * averaged over exactly the contributing runs rather than over a wider set.
+ *
+ * Note what this `stdDev` is: the mean of each run's **within-run** scatter. It
+ * does not describe run-to-run variation, and is not interchangeable with the
+ * spread of the `mean` series. Consumers reasoning about between-run stability
+ * need a different quantity.
  *
  * @param name - Benchmark key (used only for warning messages).
  * @param metrics - Collected arrays of values per metric.
@@ -138,26 +163,69 @@ function buildMetricBaselines(
 ): Record<string, HistoricalBaselineMetrics> {
   const result: Record<string, HistoricalBaselineMetrics> = {};
   for (const [metric, values] of Object.entries(metrics)) {
-    if (values.mean.length === 0) {
+    // Runs are collected in parallel arrays, so a shared index is the same run.
+    // Only indices present in all three series describe a complete record.
+    const complete: number[] = [];
+    for (let i = 0; i < values.mean.length; i++) {
+      if (
+        Number.isFinite(values.mean[i]) &&
+        Number.isFinite(values.p75[i]) &&
+        Number.isFinite(values.p95[i])
+      ) {
+        complete.push(i);
+      }
+    }
+
+    const pick = (series: number[]): number[] => complete.map((i) => series[i]);
+
+    if (complete.length > 0) {
+      const meanVal = calculateMean(pick(values.mean));
+      if (Number.isNaN(meanVal)) {
+        continue;
+      }
+      const stdDevs = complete
+        .map((i) => values.stdDev?.[i])
+        .filter((v): v is number => Number.isFinite(v));
+
+      result[metric] = {
+        mean: meanVal,
+        // Emitted only when every contributing run recorded one. Averaging
+        // over a subset is what let `stdDev` describe a different population
+        // than `mean` and `p75`.
+        ...(stdDevs.length === complete.length
+          ? { stdDev: calculateMean(stdDevs) }
+          : {}),
+        p75: calculateMean(pick(values.p75)),
+        p95: calculateMean(pick(values.p95)),
+      };
       continue;
     }
-    const meanVal = calculateMean(values.mean);
+
+    // No run recorded all three. This is the pre-existing documented fallback:
+    // percentiles stand in as the mean. It is deliberately unchanged here —
+    // it is a separate question from this fix, which is about runs that
+    // recorded *some* statistics producing a baseline whose numbers came from
+    // different run sets.
+    const finiteMeans = values.mean.filter((v) => Number.isFinite(v));
+    if (finiteMeans.length === 0) {
+      continue;
+    }
+    const meanVal = calculateMean(finiteMeans);
     if (Number.isNaN(meanVal)) {
       continue;
     }
-    if (values.p75.length === 0) {
+    const finiteP75 = values.p75.filter((v) => Number.isFinite(v));
+    const finiteP95 = values.p95.filter((v) => Number.isFinite(v));
+    if (finiteP75.length === 0) {
       console.warn(`No p75 data for ${name}/${metric}, using mean as fallback`);
     }
-    if (values.p95.length === 0) {
+    if (finiteP95.length === 0) {
       console.warn(`No p95 data for ${name}/${metric}, using mean as fallback`);
     }
     result[metric] = {
       mean: meanVal,
-      ...(values.stdDev?.length
-        ? { stdDev: calculateMean(values.stdDev) }
-        : {}),
-      p75: values.p75.length > 0 ? calculateMean(values.p75) : meanVal,
-      p95: values.p95.length > 0 ? calculateMean(values.p95) : meanVal,
+      p75: finiteP75.length > 0 ? calculateMean(finiteP75) : meanVal,
+      p95: finiteP95.length > 0 ? calculateMean(finiteP95) : meanVal,
     };
   }
   return result;


### PR DESCRIPTION
CHANGELOG entry: null

## **Description**

`aggregateHistoricalData` published three statistics per metric that need not have described the same population.

`buildMetricBaselines` averaged each independently:

```js
mean:   calculateMean(values.mean)      // every run
stdDev: calculateMean(values.stdDev)    // only runs that recorded stdDev
p75:    calculateMean(values.p75)       // only runs that recorded p75
```

`collectMetrics` compounded it. It pushed a value only when present, so a run missing one statistic shifted every later index — `mean[i]`, `p75[i]` and `stdDev[i]` stopped referring to the same run.

Together these are how a baseline could report `stdDev` near zero beside a `p75` far above the `mean` without anything being impossible, which is the anomaly in MetaMask-planning#7204. That ticket's own analysis reaches the same place: the arithmetic inside a single run's `calculateTimerStatistics` is sound, and the defect is one layer up in aggregation.

Note what this `stdDev` is, since the name invites the wrong reading: the mean of each run's **within-run** scatter. It does not describe run-to-run variation and is not interchangeable with the spread of the `mean` series.

### What changed

- `collectMetrics` pushes a placeholder for an absent statistic, so the per-metric series stay index-aligned and a shared index is the same run.
- `buildMetricBaselines` contributes only runs that recorded `mean`, `p75` and `p95` together, and averages all statistics over exactly that set.
- `stdDev` is emitted only when every contributing run recorded one. Averaging it over a subset is the specific defect above.

### Deliberately not changed

When **no** run recorded a percentile, the pre-existing fallback substitutes the mean. That behaviour is asserted by three existing tests and is a separate question from this fix, which is about runs recording *some* statistics producing a baseline assembled from different run sets. Removing it would reverse a tested decision and belongs in its own change.

## **Test plan**

Two arms, same commit, only the source change reverted between them:

```
with the fix:            25 passed, 25 total
source reverted (base):   2 failed, 23 passed, 25 total
```

The two failures on base are exactly the two new cases, and no others:

```
● aggregateHistoricalData › averages every statistic over the same runs when one run is missing p75
● aggregateHistoricalData › omits stdDev when only some contributing runs recorded it
```

- [x] `yarn jest development/metamaskbot-build-announce/historical-comparison.test.ts` — 25/25
- [x] Both new tests fail with the source change reverted (red on base)
- [x] The 23 pre-existing tests pass unchanged in both arms, including the three asserting the mean fallback
- [x] `tsc --noEmit` clean on the changed file; prettier clean

## **Related issues**

- MetaMask-planning#7204 — [P2] Aggregated benchmark statistics average mean, stdDev and percentiles independently across runs
- #45205 — the related finding that a mean of p75s is not the p75 of the pooled distribution
- #45266 — the bimodality in `onboardingNewWallet`, which is a genuine within-run two-cluster mixture and survives any aggregation. Not this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CI benchmark baseline math in metamaskbot-build-announce; relative PR deltas may shift for incomplete historical runs but pass/fail thresholds are unaffected.
> 
> **Overview**
> Fixes **historical benchmark baseline aggregation** so `mean`, `p75`, `p95`, and optional `stdDev` in PR performance comments all describe the **same** CI runs (MetaMask-planning#7204).
> 
> **`collectMetrics`** now pushes `NaN` when a statistic is missing instead of omitting that run from one series, keeping per-run index alignment across stat arrays.
> 
> **`buildMetricBaselines`** only averages runs that have finite `mean`, `p75`, and `p95` together; **`stdDev`** is included only when every contributing run recorded it. The legacy path when no run has full percentiles (mean-as-fallback for missing p75/p95) is unchanged.
> 
> Two unit tests lock in aligned averaging when a run lacks p75 and omission of partial `stdDev`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2684bbadbb2f93b1a36f9c0a3f2fd571b1070d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->