### PR TITLE
fix(analytics): exclude redirect deep links from tracking

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -63,7 +63,10 @@ import { getManifestFlags } from '../../shared/lib/manifestFlags';
 import { DISPLAY_GENERAL_STARTUP_ERROR } from '../../shared/constants/start-up-errors';
 import { getPartnerByOrigin } from '../../shared/constants/defi-referrals';
 import { getInstallAttribution } from '../../shared/lib/install-attribution';
-import { createEvent } from '../../shared/lib/deep-links/metrics';
+import {
+  createEvent,
+  shouldTrackDeepLinkNavigation,
+} from '../../shared/lib/deep-links/metrics';
 import {
   backedUpStateKeys,
   hasVault,
@@ -905,7 +908,7 @@ async function initialize(backup) {
   })
     .on('navigate', async ({ url, parsed }) => {
       // don't track deep links that are immediately redirected (like /buy)
-      if (!('redirectTo' in parsed)) {
+      if (shouldTrackDeepLinkNavigation(parsed)) {
         trackEvent(createEvent({ signature: parsed.signature, url }));
       }
     })

--- a/shared/lib/deep-links/metrics.test.ts
+++ b/shared/lib/deep-links/metrics.test.ts
@@ -3,7 +3,30 @@ import {
   MetaMetricsEventName,
 } from '../../constants/metametrics';
 import { MISSING, VALID, INVALID } from './verify';
-import { createEvent } from './metrics';
+import { createEvent, shouldTrackDeepLinkNavigation } from './metrics';
+
+describe('shouldTrackDeepLinkNavigation', () => {
+  it('returns false for an external redirect destination', () => {
+    const result = shouldTrackDeepLinkNavigation({
+      destination: {
+        redirectTo: new URL('https://portfolio.metamask.io/buy'),
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true for an extension route destination', () => {
+    const result = shouldTrackDeepLinkNavigation({
+      destination: {
+        path: '/perps',
+        query: new URLSearchParams(),
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+});
 
 describe('createEvent', () => {
   describe('basic functionality', () => {

--- a/shared/lib/deep-links/metrics.ts
+++ b/shared/lib/deep-links/metrics.ts
@@ -5,6 +5,7 @@ import {
   MetaMetricsEventName,
 } from '../../constants/metametrics';
 import { UTM_PARAMETERS, type UTMParameter } from '../../types/metametrics';
+import type { ParsedDeepLink } from './parse';
 import type { SignatureStatus } from './verify';
 
 export type Properties = {
@@ -19,6 +20,22 @@ export type EventDetails = {
   url: URL;
   signature: SignatureStatus;
 };
+
+/**
+ * Determines whether a parsed deep-link navigation should be tracked.
+ *
+ * Destinations that redirect outside the extension are excluded because the
+ * extension does not handle the resulting navigation.
+ *
+ * @param parsed - The parsed deep-link destination.
+ * @param parsed.destination
+ * @returns Whether the navigation should produce a deep-link analytics event.
+ */
+export function shouldTrackDeepLinkNavigation({
+  destination,
+}: Pick<ParsedDeepLink, 'destination'>): boolean {
+  return !('redirectTo' in destination);
+}
 
 /**
  * Creates a trackable analytics event representing deep link usage.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Context

Deep links whose destinations redirect outside the extension, such as `/buy`, are intentionally excluded from the `Deep Link Used` analytics event.

### Problem

The background listener checked for `redirectTo` on the parsed deep-link wrapper. The property actually belongs to `parsed.destination`, so the guard always allowed valid parsed links through and external redirect destinations were tracked despite the accompanying comment.

### Solution

This PR extracts the tracking decision into a typed `shouldTrackDeepLinkNavigation` predicate that checks the destination itself, then uses that predicate in the background listener. Regression coverage verifies that external redirect destinations are excluded while extension route destinations remain trackable.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run the Chrome MV3 extension with MetaMetrics enabled and analytics event capture configured.
2. Open `https://link.metamask.io/buy`, proceeding through the deep-link interstitial if it appears.
3. Verify that navigation reaches the Portfolio buy page and no `Deep Link Used` event is captured for `/buy`.
4. Open an extension route such as `https://link.metamask.io/perps`, proceeding through the interstitial if it appears.
5. Verify that the extension route opens and a `Deep Link Used` event is captured for `/perps`.

<!--
## **Screenshots/Recordings**

Not applicable; this change has no visual UI impact.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow analytics guard fix with unit tests; no auth, vault, or navigation behavior changes beyond which deep links emit metrics.
> 
> **Overview**
> Fixes a bug where **Deep Link Used** analytics fired for routes that only redirect outside the extension (e.g. `/buy`), because the background listener looked for `redirectTo` on the parsed link object instead of on **`parsed.destination`**.
> 
> Introduces **`shouldTrackDeepLinkNavigation`**, which skips tracking when the destination has `redirectTo` and still tracks in-extension routes. The deep-link navigate handler uses this helper instead of the broken inline check. Unit tests cover external redirect vs extension route destinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767cadf94c94626275136d1b064b71a96e2cb573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->