### PR TITLE
refactor: replace deprecated Popover with Modal in SetApproveForAllWarning

### DIFF
--- a/ui/pages/confirmations/components/set-approval-for-all-warning/set-approval-for-all-warning.js
+++ b/ui/pages/confirmations/components/set-approval-for-all-warning/set-approval-for-all-warning.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
-import Popover from '../../../../components/ui/popover';
 import Box from '../../../../components/ui/box';
 
 import {
@@ -19,6 +18,12 @@ import {
   Button,
   BUTTON_VARIANT,
   Text,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
 } from '../../../../components/component-library';
 
 const SetApproveForAllWarning = ({
@@ -29,88 +34,98 @@ const SetApproveForAllWarning = ({
   isERC721,
   onSubmit,
   onCancel,
+  isOpen = true,
+  onClose,
 }) => {
   const t = useI18nContext();
-
-  const footer = (
-    <Box
-      display={DISPLAY.FLEX}
-      flexDirection={FLEX_DIRECTION.COLUMN}
-      justifyContent={JustifyContent.SPACE_BETWEEN}
-      className="set-approval-for-all-warning__footer"
-      gap={4}
-    >
-      <Button
-        className="set-approval-for-all-warning__footer__approve-button"
-        variant={BUTTON_VARIANT.PRIMARY}
-        danger
-        onClick={onSubmit}
-      >
-        {t('approveButtonText')}
-      </Button>
-      <Button
-        className="set-approval-for-all-warning__footer__cancel-button"
-        variant={BUTTON_VARIANT.SECONDARY}
-        onClick={onCancel}
-      >
-        {t('reject')}
-      </Button>
-    </Box>
-  );
+  const handleClose = onClose ?? onCancel;
 
   return (
-    <Popover className="set-approval-for-all-warning__content" footer={footer}>
-      <Box
-        display={DISPLAY.FLEX}
-        flexDirection={FLEX_DIRECTION.ROW}
-        padding={4}
-        className="set-approval-for-all-warning__content__header"
-      >
-        <Icon
-          name={IconName.Danger}
-          className="set-approval-for-all-warning__content__header__warning-icon"
-        />
-        <Text variant={TextVariant.headingSm} as="h4">
-          {t('yourNFTmayBeAtRisk')}
-        </Text>
-      </Box>
-      <Box
-        display={DISPLAY.FLEX}
-        padding={4}
-        justifyContent={JustifyContent.spaceBetween}
-        className="set-approval-for-all-warning__content__account"
-      >
-        <Box display={DISPLAY.FLEX}>
-          <PreferredAvatar address={senderAddress} />
-          <Text
-            variant={TextVariant.bodyMd}
-            as="h5"
-            marginLeft={2}
-            className="set-approval-for-all-warning__content__account-name"
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      className="set-approval-for-all-warning__content"
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader onClose={handleClose}>
+          <Box
+            display={DISPLAY.FLEX}
+            flexDirection={FLEX_DIRECTION.ROW}
+            className="set-approval-for-all-warning__content__header"
           >
-            <strong>{name}</strong> {` (${shortenAddress(senderAddress)})`}
-          </Text>
-        </Box>
-        {isERC721 && total && <Text>{`${t('total')}: ${total}`}</Text>}
-      </Box>
+            <Icon
+              name={IconName.Danger}
+              className="set-approval-for-all-warning__content__header__warning-icon"
+            />
+            <Text variant={TextVariant.headingSm} as="h4">
+              {t('yourNFTmayBeAtRisk')}
+            </Text>
+          </Box>
+        </ModalHeader>
+        <ModalBody>
+          <Box
+            display={DISPLAY.FLEX}
+            justifyContent={JustifyContent.spaceBetween}
+            className="set-approval-for-all-warning__content__account"
+          >
+            <Box display={DISPLAY.FLEX}>
+              <PreferredAvatar address={senderAddress} />
+              <Text
+                variant={TextVariant.bodyMd}
+                as="h5"
+                marginLeft={2}
+                className="set-approval-for-all-warning__content__account-name"
+              >
+                <strong>{name}</strong> {` (${shortenAddress(senderAddress)})`}
+              </Text>
+            </Box>
+            {isERC721 && total && <Text>{`${t('total')}: ${total}`}</Text>}
+          </Box>
 
-      <Text
-        margin={4}
-        marginTop={4}
-        marginBottom={4}
-        variant={TextVariant.bodySm}
-        as="h6"
-      >
-        {t('nftWarningContent', [
-          <strong key="non_custodial_bold">
-            {t('nftWarningContentBold', [collectionName || ''])}
-          </strong>,
-          <strong key="non_custodial_grey">
-            {t('nftWarningContentGrey')}
-          </strong>,
-        ])}
-      </Text>
-    </Popover>
+          <Text
+            marginTop={4}
+            marginBottom={4}
+            variant={TextVariant.bodySm}
+            as="h6"
+          >
+            {t('nftWarningContent', [
+              <strong key="non_custodial_bold">
+                {t('nftWarningContentBold', [collectionName || ''])}
+              </strong>,
+              <strong key="non_custodial_grey">
+                {t('nftWarningContentGrey')}
+              </strong>,
+            ])}
+          </Text>
+        </ModalBody>
+        <ModalFooter>
+          <Box
+            display={DISPLAY.FLEX}
+            flexDirection={FLEX_DIRECTION.COLUMN}
+            justifyContent={JustifyContent.SPACE_BETWEEN}
+            className="set-approval-for-all-warning__footer"
+            gap={4}
+          >
+            <Button
+              className="set-approval-for-all-warning__footer__approve-button"
+              variant={BUTTON_VARIANT.PRIMARY}
+              danger
+              onClick={onSubmit}
+            >
+              {t('approveButtonText')}
+            </Button>
+            <Button
+              className="set-approval-for-all-warning__footer__cancel-button"
+              variant={BUTTON_VARIANT.SECONDARY}
+              onClick={onCancel}
+            >
+              {t('reject')}
+            </Button>
+          </Box>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
   );
 };
 
@@ -143,6 +158,14 @@ SetApproveForAllWarning.propTypes = {
    * Function that rejects collection
    */
   onCancel: PropTypes.func,
+  /**
+   * Whether the modal is open
+   */
+  isOpen: PropTypes.bool,
+  /**
+   * Function called when the modal requests to close (defaults to onCancel)
+   */
+  onClose: PropTypes.func,
 };
 
 export default SetApproveForAllWarning;


### PR DESCRIPTION
## **Description**

Migrates `SetApproveForAllWarning` (the NFT set-approval-for-all security warning) from the deprecated `ui/components/ui/popover` `Popover` to the component-library `Modal` (`Modal`/`ModalOverlay`/`ModalContent`/`ModalHeader`/`ModalBody`/`ModalFooter`), matching the pattern already used by `bridge-alert-modal`.

- Adds `isOpen`/`onClose` props to drive the `Modal` (`onClose` defaults to `onCancel`).
- Existing BEM classNames are preserved, so styling is unchanged aside from the `Modal`'s own built-in behavior (adds a close button in the header, top-aligns the dialog instead of vertically centering it — same as other `Modal` call sites in the app).

Part of #19555.

## **Changelog**

CHANGELOG entry: Replace deprecated Popover with Modal from the component-library in the SetApproveForAllWarning confirmation dialog.

## **Related issues**

Fixes: part of #19555

## **Manual testing steps**

1. Open Storybook and load the `SetApproveForAllWarning` story.
2. Confirm the dialog renders correctly and the approve/reject actions behave exactly as before.
3. Compare against `main` (Popover): the only visible difference is the `Modal`'s standard chrome (close button, top alignment), consistent with `bridge-alert-modal`.

## **Screenshots/Recordings**

### **Before**

Popover-based dialog on `main`.

### **After**

Modal-based dialog on this branch — only difference is the standard Modal close button and top alignment.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only swap on a confirmation dialog; approve/reject behavior and warning content are unchanged.
> 
> **Overview**
> Migrates the NFT **set-approval-for-all** security warning from the deprecated `Popover` to the shared component-library **`Modal`** stack (`ModalOverlay`, `ModalHeader`, `ModalBody`, `ModalFooter`), aligned with patterns like `bridge-alert-modal`.
> 
> The warning copy, account/collection details, and approve/reject handlers are unchanged; existing BEM class names are kept for styling. New **`isOpen`** (defaults to open) and **`onClose`** props control visibility, with **`onClose`** falling back to **`onCancel`**.
> 
> Users may see standard Modal chrome—a header close control and top-aligned dialog—instead of the old Popover layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73bc45f0233fcd15a6d9d3b428ed5290e078bc81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->