### PR TITLE
fix(confirmations): submit money account withdrawals on Monad

### DIFF
--- a/app/scripts/lib/account-supports-7702.test.ts
+++ b/app/scripts/lib/account-supports-7702.test.ts
@@ -1,0 +1,65 @@
+import { accountSupports7702 } from './account-supports-7702';
+
+const ADDRESS_MOCK = '0x1234567890123456789012345678901234567890';
+
+function keyringControllerWithType(type: string) {
+  return {
+    getKeyringForAccount: jest.fn().mockResolvedValue({ type }),
+  };
+}
+
+describe('accountSupports7702', () => {
+  it('returns true for HD keyring accounts', async () => {
+    expect(
+      await accountSupports7702(
+        ADDRESS_MOCK,
+        keyringControllerWithType('HD Key Tree'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for simple keyring accounts', async () => {
+    expect(
+      await accountSupports7702(
+        ADDRESS_MOCK,
+        keyringControllerWithType('Simple Key Pair'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for money keyring accounts', async () => {
+    // Sponsored Money Account transactions (e.g. Monad withdrawals) are
+    // externally signed and must publish via the EIP-7702 relay; treating the
+    // money keyring as unsupported skipped the relay hook and raw-sent an
+    // unsigned payload.
+    expect(
+      await accountSupports7702(
+        ADDRESS_MOCK,
+        keyringControllerWithType('Money Keyring'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for hardware keyring accounts', async () => {
+    expect(
+      await accountSupports7702(
+        ADDRESS_MOCK,
+        keyringControllerWithType('Ledger Hardware'),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true when the address is missing', async () => {
+    expect(
+      await accountSupports7702(undefined, keyringControllerWithType('any')),
+    ).toBe(true);
+  });
+
+  it('returns true when the keyring lookup fails', async () => {
+    expect(
+      await accountSupports7702(ADDRESS_MOCK, {
+        getKeyringForAccount: jest.fn().mockRejectedValue(new Error('nope')),
+      }),
+    ).toBe(true);
+  });
+});

--- a/app/scripts/lib/account-supports-7702.test.ts
+++ b/app/scripts/lib/account-supports-7702.test.ts
@@ -1,4 +1,7 @@
-import { accountSupports7702, accountSupports7702ForRelay } from './account-supports-7702';
+import {
+  accountSupports7702,
+  accountSupports7702ForRelay,
+} from './account-supports-7702';
 
 const ADDRESS_MOCK = '0x1234567890123456789012345678901234567890';
 

--- a/app/scripts/lib/account-supports-7702.test.ts
+++ b/app/scripts/lib/account-supports-7702.test.ts
@@ -1,4 +1,4 @@
-import { accountSupports7702 } from './account-supports-7702';
+import { accountSupports7702, accountSupports7702ForRelay } from './account-supports-7702';
 
 const ADDRESS_MOCK = '0x1234567890123456789012345678901234567890';
 
@@ -27,17 +27,15 @@ describe('accountSupports7702', () => {
     ).toBe(true);
   });
 
-  it('returns true for money keyring accounts', async () => {
-    // Sponsored Money Account transactions (e.g. Monad withdrawals) are
-    // externally signed and must publish via the EIP-7702 relay; treating the
-    // money keyring as unsupported skipped the relay hook and raw-sent an
-    // unsigned payload.
+  it('returns false for money keyring accounts', async () => {
+    // Money accounts are not general Smart Accounts; gas-fee-token / Tempo /
+    // bridge-batch paths must keep the narrower allowlist.
     expect(
       await accountSupports7702(
         ADDRESS_MOCK,
         keyringControllerWithType('Money Keyring'),
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('returns false for hardware keyring accounts', async () => {
@@ -61,5 +59,27 @@ describe('accountSupports7702', () => {
         getKeyringForAccount: jest.fn().mockRejectedValue(new Error('nope')),
       }),
     ).toBe(true);
+  });
+});
+
+describe('accountSupports7702ForRelay', () => {
+  it('returns true for money keyring accounts', async () => {
+    // Sponsored Money Account transactions are externally signed and must
+    // publish via the EIP-7702 relay.
+    expect(
+      await accountSupports7702ForRelay(
+        ADDRESS_MOCK,
+        keyringControllerWithType('Money Keyring'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for hardware keyring accounts', async () => {
+    expect(
+      await accountSupports7702ForRelay(
+        ADDRESS_MOCK,
+        keyringControllerWithType('Ledger Hardware'),
+      ),
+    ).toBe(false);
   });
 });

--- a/app/scripts/lib/account-supports-7702.ts
+++ b/app/scripts/lib/account-supports-7702.ts
@@ -1,5 +1,5 @@
 import { KeyringControllerGetKeyringForAccountAction } from '@metamask/keyring-controller';
-import { KEYRING_TYPES_SUPPORTING_7702 } from '../../../shared/constants/keyring';
+import { KEYRING_TYPES_SUPPORTING_7702_RELAY } from '../../../shared/constants/keyring';
 import { RootMessenger } from './messenger';
 
 /** Minimal shape; KeyringController.getKeyringForAccount is typed as Promise<unknown>. */
@@ -49,7 +49,7 @@ export async function accountSupports7702(
       typeof (keyring as { type: unknown }).type === 'string'
         ? (keyring as { type: string }).type
         : '';
-    return KEYRING_TYPES_SUPPORTING_7702.includes(keyringType as never);
+    return KEYRING_TYPES_SUPPORTING_7702_RELAY.includes(keyringType as never);
   } catch {
     return true;
   }

--- a/app/scripts/lib/account-supports-7702.ts
+++ b/app/scripts/lib/account-supports-7702.ts
@@ -1,5 +1,8 @@
 import { KeyringControllerGetKeyringForAccountAction } from '@metamask/keyring-controller';
-import { KEYRING_TYPES_SUPPORTING_7702_RELAY } from '../../../shared/constants/keyring';
+import {
+  KEYRING_TYPES_SUPPORTING_7702,
+  KEYRING_TYPES_SUPPORTING_7702_RELAY,
+} from '../../../shared/constants/keyring';
 import { RootMessenger } from './messenger';
 
 /** Minimal shape; KeyringController.getKeyringForAccount is typed as Promise<unknown>. */
@@ -13,24 +16,17 @@ type AccountSupports7702Messenger = RootMessenger<
   never
 >;
 
-/**
- * Returns whether the given account's keyring supports EIP-7702 gas fee tokens.
- * Used to avoid requesting 7702 from sentinel for hardware and other unsupported keyrings.
- *
- * @param address - Account address (e.g. request.from or transactionMeta.txParams?.from).
- * @param keyringSource - A KeyringController instance, a function that returns
- * it, or a messenger that can call `KeyringController:getKeyringForAccount`.
- * @returns True if the account supports 7702 (or address is missing / lookup fails; assume supported).
- */
-export async function accountSupports7702(
+type KeyringSource =
+  | KeyringControllerLike
+  | (() => KeyringControllerLike)
+  | AccountSupports7702Messenger;
+
+async function keyringTypeForAccount(
   address: string | undefined,
-  keyringSource:
-    | KeyringControllerLike
-    | (() => KeyringControllerLike)
-    | AccountSupports7702Messenger,
-): Promise<boolean> {
+  keyringSource: KeyringSource,
+): Promise<string | undefined> {
   if (!address) {
-    return true;
+    return undefined;
   }
   const resolved =
     typeof keyringSource === 'function' ? keyringSource() : keyringSource;
@@ -42,15 +38,60 @@ export async function accountSupports7702(
             'KeyringController:getKeyringForAccount',
             address,
           );
-    const keyringType =
-      keyring &&
+    return keyring &&
       typeof keyring === 'object' &&
       'type' in keyring &&
       typeof (keyring as { type: unknown }).type === 'string'
-        ? (keyring as { type: string }).type
-        : '';
-    return KEYRING_TYPES_SUPPORTING_7702_RELAY.includes(keyringType as never);
+      ? (keyring as { type: string }).type
+      : '';
   } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns whether the given account's keyring supports EIP-7702 Smart Account
+ * capabilities (gas fee tokens, Tempo, bridge-batch). Excludes Money keyring —
+ * those accounts are not general Smart Accounts.
+ *
+ * @param address - Account address (e.g. request.from or transactionMeta.txParams?.from).
+ * @param keyringSource - A KeyringController instance, a function that returns
+ * it, or a messenger that can call `KeyringController:getKeyringForAccount`.
+ * @returns True if the account supports 7702 (or address is missing / lookup fails; assume supported).
+ */
+export async function accountSupports7702(
+  address: string | undefined,
+  keyringSource: KeyringSource,
+): Promise<boolean> {
+  if (!address) {
     return true;
   }
+  const keyringType = await keyringTypeForAccount(address, keyringSource);
+  if (keyringType === undefined) {
+    return true;
+  }
+  return KEYRING_TYPES_SUPPORTING_7702.includes(keyringType as never);
+}
+
+/**
+ * Returns whether the account may publish via the EIP-7702 relay path.
+ * Broader than {@link accountSupports7702}: includes Money keyring accounts
+ * whose sponsored batches are externally signed and must use the relay.
+ *
+ * @param address - Account address.
+ * @param keyringSource - Keyring controller, factory, or messenger.
+ * @returns True if the account may use the 7702 relay publish hook.
+ */
+export async function accountSupports7702ForRelay(
+  address: string | undefined,
+  keyringSource: KeyringSource,
+): Promise<boolean> {
+  if (!address) {
+    return true;
+  }
+  const keyringType = await keyringTypeForAccount(address, keyringSource);
+  if (keyringType === undefined) {
+    return true;
+  }
+  return KEYRING_TYPES_SUPPORTING_7702_RELAY.includes(keyringType as never);
 }

--- a/app/scripts/lib/money/pay/update-withdraw-amount.test.ts
+++ b/app/scripts/lib/money/pay/update-withdraw-amount.test.ts
@@ -22,8 +22,10 @@ const buildWithdrawBatchMock = jest.mocked(buildMoneyAccountWithdrawBatch);
 const TRANSACTION_ID = 'withdraw-amount-tx';
 const ACCOUNT_OVERRIDE = '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
 const SELECTED_ACCOUNT = '0x1111111111111111111111111111111111111111' as Hex;
-const WITHDRAW_DATA = '0xwithdraw' as Hex;
-const TRANSFER_DATA = '0xtransfer' as Hex;
+const WITHDRAW_DATA = '0xaaa1' as Hex;
+const TRANSFER_DATA = '0xbbb2' as Hex;
+const WITHDRAW_DATA_2 = '0xccc3' as Hex;
+const TRANSFER_DATA_2 = '0xddd4' as Hex;
 
 function createWithdrawTransaction(): TransactionMeta {
   return {
@@ -98,8 +100,8 @@ describe('updateMoneyAccountWithdrawAmount', () => {
     );
 
     expect(result).toStrictEqual({
-      didCommit: true,
-      recipient: ACCOUNT_OVERRIDE,
+      withdrawData: WITHDRAW_DATA,
+      transferData: TRANSFER_DATA,
     });
     expect(buildWithdrawBatchMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -127,15 +129,15 @@ describe('updateMoneyAccountWithdrawAmount', () => {
     );
 
     expect(result).toStrictEqual({
-      didCommit: true,
-      recipient: SELECTED_ACCOUNT,
+      withdrawData: WITHDRAW_DATA,
+      transferData: TRANSFER_DATA,
     });
     expect(buildWithdrawBatchMock).toHaveBeenCalledWith(
       expect.objectContaining({ recipient: SELECTED_ACCOUNT }),
     );
   });
 
-  it('returns didCommit false for a zero amount without encoding', async () => {
+  it('returns false for a zero amount without encoding', async () => {
     const { messenger, updateTransaction } = setup();
 
     const result = await updateMoneyAccountWithdrawAmount(
@@ -144,7 +146,7 @@ describe('updateMoneyAccountWithdrawAmount', () => {
       '0',
     );
 
-    expect(result).toStrictEqual({ didCommit: false });
+    expect(result).toBe(false);
     expect(buildWithdrawBatchMock).not.toHaveBeenCalled();
     expect(updateTransaction).not.toHaveBeenCalled();
   });
@@ -172,7 +174,7 @@ describe('updateMoneyAccountWithdrawAmount', () => {
         withdrawTx: {
           params: {
             to: VAULT_CONFIG_MOCK.tellerAddress,
-            data: '0xwithdraw2' as Hex,
+            data: WITHDRAW_DATA_2,
             value: '0x0',
           },
           type: TransactionType.moneyAccountWithdraw,
@@ -180,7 +182,7 @@ describe('updateMoneyAccountWithdrawAmount', () => {
         transferTx: {
           params: {
             to: VAULT_CONFIG_MOCK.underlyingToken,
-            data: '0xtransfer2' as Hex,
+            data: TRANSFER_DATA_2,
             value: '0x0',
           },
           type: TransactionType.tokenMethodTransfer,
@@ -201,8 +203,8 @@ describe('updateMoneyAccountWithdrawAmount', () => {
     );
 
     await expect(second).resolves.toStrictEqual({
-      didCommit: true,
-      recipient: ACCOUNT_OVERRIDE,
+      withdrawData: WITHDRAW_DATA_2,
+      transferData: TRANSFER_DATA_2,
     });
     resolveFirst({
       withdrawTx: {
@@ -222,7 +224,7 @@ describe('updateMoneyAccountWithdrawAmount', () => {
         type: TransactionType.tokenMethodTransfer,
       },
     });
-    await expect(first).resolves.toStrictEqual({ didCommit: false });
+    await expect(first).resolves.toBe(false);
     expect(updateTransaction).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/scripts/lib/money/pay/update-withdraw-amount.test.ts
+++ b/app/scripts/lib/money/pay/update-withdraw-amount.test.ts
@@ -95,8 +95,12 @@ describe('updateMoneyAccountWithdrawAmount', () => {
       AMOUNT_HUMAN,
     );
 
-    expect(result).toBe(true);
     const meta = committed.meta as TransactionMeta;
+    expect(result).toEqual({
+      withdrawData: meta.nestedTransactions?.[0].data,
+      transferData: meta.nestedTransactions?.[1].data,
+      transactionData: meta.txParams.data,
+    });
 
     const withdraw = TELLER_INTERFACE.decodeFunctionData(
       'withdraw',
@@ -105,7 +109,6 @@ describe('updateMoneyAccountWithdrawAmount', () => {
     expect(withdraw.withdrawAsset.toLowerCase()).toBe(
       MUSD_ADDRESS.toLowerCase(),
     );
-    // Shares are ceil(amount * ONE_SHARE / rate) at the mocked vault rate.
     expect(withdraw.shareAmount.toBigInt()).toBe(
       (AMOUNT_ROUNDED_DOWN * 1_000_000n + VAULT_RATE_MOCK - 1n) /
         VAULT_RATE_MOCK,
@@ -119,6 +122,7 @@ describe('updateMoneyAccountWithdrawAmount', () => {
     expect(transfer.recipient.toLowerCase()).toBe(RECIPIENT_MOCK);
     expect(transfer.amount.toBigInt()).toBe(AMOUNT_ROUNDED_DOWN);
 
+    expect(meta.type).toBe(TransactionType.moneyAccountWithdraw);
     expect(meta.txParams.gas).toBeUndefined();
     expect(meta.simulationData).toBeUndefined();
   });
@@ -150,6 +154,22 @@ describe('updateMoneyAccountWithdrawAmount', () => {
     ).rejects.toThrow(
       'Update Amount: Money Account Withdrawal: missing withdraw/transfer transaction template',
     );
+  });
+
+  it('encodes when nested slots exist without money-account types', async () => {
+    const transaction = buildTemplateTransaction();
+    delete transaction.nestedTransactions?.[0].type;
+    delete transaction.nestedTransactions?.[1].type;
+    const { messenger, committed } = setup(transaction);
+
+    const result = await updateMoneyAccountWithdrawAmount(
+      messenger,
+      transaction.id,
+      AMOUNT_HUMAN,
+    );
+
+    expect(result).not.toBe(false);
+    expect(committed.meta?.nestedTransactions?.[1].data).toBeDefined();
   });
 
   it('rejects when no recipient account resolves', async () => {
@@ -233,6 +253,63 @@ describe('updateMoneyAccountWithdrawAmount', () => {
     );
 
     expect(second).toBe(first);
-    await expect(first).resolves.toBe(true);
+    await expect(first).resolves.toEqual(
+      expect.objectContaining({
+        transferData: expect.any(String),
+        withdrawData: expect.any(String),
+      }),
+    );
+  });
+
+  it('forwards mUSD to the recipient override instead of the selected account', async () => {
+    const transaction = buildTemplateTransaction();
+    const { messenger, committed } = setup(transaction);
+    const recipientOverride =
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Hex;
+
+    await updateMoneyAccountWithdrawAmount(
+      messenger,
+      transaction.id,
+      AMOUNT_HUMAN,
+      recipientOverride,
+    );
+
+    const meta = committed.meta as TransactionMeta;
+    const transfer = ERC20_INTERFACE.decodeFunctionData(
+      'transfer',
+      meta.nestedTransactions?.[1].data as string,
+    );
+    expect(transfer.recipient.toLowerCase()).toBe(
+      recipientOverride.toLowerCase(),
+    );
+  });
+
+  it('does not share the promise when the recipient override differs', async () => {
+    const transaction = buildTemplateTransaction();
+    const { messenger } = setup(transaction);
+    const firstRecipient = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Hex;
+    const secondRecipient = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Hex;
+
+    const first = updateMoneyAccountWithdrawAmount(
+      messenger,
+      transaction.id,
+      AMOUNT_HUMAN,
+      firstRecipient,
+    );
+    const second = updateMoneyAccountWithdrawAmount(
+      messenger,
+      transaction.id,
+      AMOUNT_HUMAN,
+      secondRecipient,
+    );
+
+    expect(second).not.toBe(first);
+    await expect(first).resolves.toBe(false);
+    await expect(second).resolves.toEqual(
+      expect.objectContaining({
+        transferData: expect.any(String),
+        withdrawData: expect.any(String),
+      }),
+    );
   });
 });

--- a/app/scripts/lib/money/pay/update-withdraw-amount.ts
+++ b/app/scripts/lib/money/pay/update-withdraw-amount.ts
@@ -1,6 +1,6 @@
 import { buildMoneyAccountWithdrawBatch } from '@metamask/money-account-utils';
 import { isStrictHexString, type Hex } from '@metamask/utils';
-import type { MoneyAccountWithdrawAmountUpdate } from '../../../../shared/lib/money/withdraw-amount-commit';
+import type { MoneyAccountWithdrawAmountUpdate } from '../../../../../shared/lib/money/withdraw-amount-commit';
 import {
   beginAmountCommit,
   clearAmountCommitIfCurrent,

--- a/app/scripts/lib/money/pay/update-withdraw-amount.ts
+++ b/app/scripts/lib/money/pay/update-withdraw-amount.ts
@@ -1,5 +1,6 @@
 import { buildMoneyAccountWithdrawBatch } from '@metamask/money-account-utils';
 import { isStrictHexString, type Hex } from '@metamask/utils';
+import type { MoneyAccountWithdrawAmountUpdate } from '../../../../shared/lib/money/withdraw-amount-commit';
 import {
   beginAmountCommit,
   clearAmountCommitIfCurrent,
@@ -10,19 +11,15 @@ import {
 } from './amount-commit';
 import { getMoneyPayContext, type MoneyPayMessenger } from './pay-context';
 
-const LOG_TAG = '[Money Account]';
+export type { MoneyAccountWithdrawAmountUpdate };
 
-export type MoneyAccountWithdrawAmountUpdate = {
-  transactionData?: Hex;
-  transferData: Hex;
-  withdrawData: Hex;
-};
+const LOG_TAG = '[Money Account]';
 
 /**
  * Re-encodes the nested withdraw + transfer calls for a new human amount and
- * writes them onto the transaction. The recipient is the Pay account override
- * (the account shown on the confirmation) or, when unset, the currently
- * selected EVM account. Superseded intents resolve `false`.
+ * writes them onto the transaction. The recipient is the address that receives
+ * the redeemed mUSD (typically the Pay account override or, when unset, the
+ * currently selected EVM account). Superseded intents resolve `false`.
  *
  * Confirm patches the returned hexes onto the approval clone because the UI
  * bridge can strip nested calldata from the store copy.
@@ -30,14 +27,14 @@ export type MoneyAccountWithdrawAmountUpdate = {
  * @param messenger - Messenger used to encode and commit.
  * @param transactionId - Id of the Money Account withdrawal transaction.
  * @param amountHuman - Exact human-readable mUSD amount.
- * @param accountOverride - Pay funding/destination account, if set.
+ * @param recipientOverride - Address that receives the redeemed mUSD, if set.
  * @returns Encoded nested calldata, or `false` when this intent did not commit.
  */
 export async function updateMoneyAccountWithdrawAmount(
   messenger: MoneyPayMessenger,
   transactionId: string,
   amountHuman: string,
-  accountOverride?: Hex,
+  recipientOverride?: Hex,
 ): Promise<MoneyAccountWithdrawAmountUpdate | false> {
   pruneStaleAmountCommits(messenger);
 
@@ -54,7 +51,7 @@ export async function updateMoneyAccountWithdrawAmount(
   const isCurrent = beginAmountCommit(transactionId);
 
   try {
-    const recipient = resolveWithdrawRecipient(messenger, accountOverride);
+    const recipient = resolveWithdrawRecipient(messenger, recipientOverride);
     const updates = await encodeWithdrawCalldata(
       messenger,
       amountRaw,
@@ -90,19 +87,19 @@ export async function updateMoneyAccountWithdrawAmount(
 }
 
 /**
- * Resolves who receives the redeemed mUSD: Pay's account override, otherwise
- * the currently selected EVM account.
+ * Resolves who receives the redeemed mUSD: the explicit recipient override,
+ * otherwise the currently selected EVM account.
  *
  * @param messenger - Messenger used to read the selected account.
- * @param accountOverride - Pay destination account, if set.
+ * @param recipientOverride - Address that receives the redeemed mUSD, if set.
  * @returns The recipient address.
  */
 function resolveWithdrawRecipient(
   messenger: MoneyPayMessenger,
-  accountOverride?: Hex,
+  recipientOverride?: Hex,
 ): Hex {
-  if (accountOverride && isStrictHexString(accountOverride)) {
-    return accountOverride;
+  if (recipientOverride && isStrictHexString(recipientOverride)) {
+    return recipientOverride;
   }
 
   const selectedAddress = messenger.call(

--- a/app/scripts/lib/money/pay/update-withdraw-amount.ts
+++ b/app/scripts/lib/money/pay/update-withdraw-amount.ts
@@ -1,6 +1,5 @@
 import { buildMoneyAccountWithdrawBatch } from '@metamask/money-account-utils';
 import { isStrictHexString, type Hex } from '@metamask/utils';
-import type { WithdrawAmountCommitResult } from '../../../../../shared/lib/money/withdraw-amount-commit';
 import {
   beginAmountCommit,
   clearAmountCommitIfCurrent,
@@ -13,34 +12,43 @@ import { getMoneyPayContext, type MoneyPayMessenger } from './pay-context';
 
 const LOG_TAG = '[Money Account]';
 
+export type MoneyAccountWithdrawAmountUpdate = {
+  transactionData?: Hex;
+  transferData: Hex;
+  withdrawData: Hex;
+};
+
 /**
  * Re-encodes the nested withdraw + transfer calls for a new human amount and
  * writes them onto the transaction. The recipient is the Pay account override
  * (the account shown on the confirmation) or, when unset, the currently
- * selected EVM account. Superseded intents resolve `{ didCommit: false }`.
+ * selected EVM account. Superseded intents resolve `false`.
+ *
+ * Confirm patches the returned hexes onto the approval clone because the UI
+ * bridge can strip nested calldata from the store copy.
  *
  * @param messenger - Messenger used to encode and commit.
  * @param transactionId - Id of the Money Account withdrawal transaction.
  * @param amountHuman - Exact human-readable mUSD amount.
  * @param accountOverride - Pay funding/destination account, if set.
- * @returns Whether this intent committed, and the recipient it encoded if so.
+ * @returns Encoded nested calldata, or `false` when this intent did not commit.
  */
 export async function updateMoneyAccountWithdrawAmount(
   messenger: MoneyPayMessenger,
   transactionId: string,
   amountHuman: string,
   accountOverride?: Hex,
-): Promise<WithdrawAmountCommitResult> {
+): Promise<MoneyAccountWithdrawAmountUpdate | false> {
   pruneStaleAmountCommits(messenger);
 
   const amountRaw = parseMusdHumanAmount(amountHuman);
   if (amountRaw === undefined) {
-    return { didCommit: false };
+    return false;
   }
 
   const transaction = getTransactionMeta(messenger, transactionId);
   if (!transaction) {
-    return { didCommit: false };
+    return false;
   }
 
   const isCurrent = beginAmountCommit(transactionId);
@@ -54,7 +62,7 @@ export async function updateMoneyAccountWithdrawAmount(
     );
 
     if (!isCurrent()) {
-      return { didCommit: false };
+      return false;
     }
 
     commitTransactionPayUpdates(
@@ -63,10 +71,17 @@ export async function updateMoneyAccountWithdrawAmount(
       updates,
       'Money Account withdraw: update amount',
     );
-    return { didCommit: true, recipient };
+
+    const committed = getTransactionMeta(messenger, transactionId);
+    const transactionData = committed?.txParams?.data as Hex | undefined;
+    return {
+      withdrawData: updates[0].data,
+      transferData: updates[1].data,
+      ...(transactionData ? { transactionData } : {}),
+    };
   } catch (error) {
     if (!isCurrent()) {
-      return { didCommit: false };
+      return false;
     }
     throw error;
   } finally {

--- a/app/scripts/lib/money/pay/update-withdraw-amount.ts
+++ b/app/scripts/lib/money/pay/update-withdraw-amount.ts
@@ -24,7 +24,16 @@ import {
 
 const UPDATE_ERROR_PREFIX = 'Update Amount: Money Account Withdrawal: ';
 
-const amountUpdates = new Map<string, AmountUpdateIntent<boolean>>();
+export type MoneyAccountWithdrawAmountUpdate = {
+  transactionData?: Hex;
+  transferData: Hex;
+  withdrawData: Hex;
+};
+
+const amountUpdates = new Map<
+  string,
+  AmountUpdateIntent<MoneyAccountWithdrawAmountUpdate | false>
+>();
 
 function failUpdate(message: string): never {
   throw new Error(`${UPDATE_ERROR_PREFIX}${message}`);
@@ -37,11 +46,12 @@ function failUpdate(message: string): never {
  * @param transaction - The transaction to validate.
  */
 function validateTransactionTemplate(transaction: TransactionMeta): void {
+  // Require the two nested slots only. `addTransactionBatch` can drop nested
+  // types on the unapproved parent, and a type check here made every encode
+  // throw — Send then no-op'd because confirm swallowed that error.
   if (
-    transaction.nestedTransactions?.[0]?.type !==
-      TransactionType.moneyAccountWithdraw ||
-    transaction.nestedTransactions[1]?.type !==
-      TransactionType.tokenMethodTransfer
+    !transaction.nestedTransactions?.[0] ||
+    !transaction.nestedTransactions[1]
   ) {
     failUpdate('missing withdraw/transfer transaction template');
   }
@@ -52,7 +62,8 @@ async function updateMoneyAccountWithdrawAmountInternal(
   transaction: TransactionMeta,
   amountHuman: string,
   isCurrentIntent: () => boolean,
-): Promise<boolean> {
+  recipientOverride?: Hex,
+): Promise<MoneyAccountWithdrawAmountUpdate | false> {
   validateTransactionTemplate(transaction);
 
   const chainId = transaction.chainId as Hex;
@@ -79,19 +90,26 @@ async function updateMoneyAccountWithdrawAmountInternal(
     return false;
   }
 
-  // The redeemed mUSD is forwarded to the user's currently selected account,
-  // resolved at commit time — the same rule as mobile's `selectEvmAddress`
-  // default. Validated rather than cast: the selected account is global
-  // state the user can change mid-flow, including to a non-EVM account whose
-  // address would otherwise reach the ABI encoder as a bogus recipient.
-  const selectedAccount = getSelectedAccount(messenger);
-  if (!selectedAccount) {
-    failUpdate('missing recipient account');
+  // Mobile: `recipientOverride ?? selectEvmAddress`. The From-row override is
+  // the user's EVM account; `txParams.from` is the money account and must not
+  // receive the redeemed mUSD. Fall back to the selected account when no
+  // override is set, resolved at commit time.
+  //
+  // The fallback is validated rather than cast: the selected account is
+  // global state the user can change mid-flow, including to a non-EVM
+  // account whose address would otherwise reach the ABI encoder as a bogus
+  // recipient.
+  let recipient: string | undefined = recipientOverride;
+  if (!recipient) {
+    const selectedAccount = getSelectedAccount(messenger);
+    if (!selectedAccount) {
+      failUpdate('missing recipient account');
+    }
+    if (!isEvmAccountType(selectedAccount.type)) {
+      failUpdate('selected account is not an EVM account');
+    }
+    recipient = selectedAccount.address;
   }
-  if (!isEvmAccountType(selectedAccount.type)) {
-    failUpdate('selected account is not an EVM account');
-  }
-  const recipient = selectedAccount.address;
   if (!isStrictHexString(recipient)) {
     failUpdate('invalid recipient address');
   }
@@ -116,6 +134,7 @@ async function updateMoneyAccountWithdrawAmountInternal(
     failUpdate('incomplete withdraw/transfer updates');
   }
 
+  let transactionData: Hex | undefined;
   messenger.call('TransactionController:updateTransactionMetadata', {
     transactionId: transaction.id,
     skipResimulate: true,
@@ -133,7 +152,7 @@ async function updateMoneyAccountWithdrawAmountInternal(
         failUpdate('transaction chain changed during preparation');
       }
 
-      const { nestedTransactions, transactionData } = updateEIP7702BatchData({
+      const updated = updateEIP7702BatchData({
         from: transactionMeta.txParams.from as Hex,
         transactions: transactionMeta.nestedTransactions ?? [],
         updates: [
@@ -141,37 +160,49 @@ async function updateMoneyAccountWithdrawAmountInternal(
           { transactionIndex: 1, transactionData: transferData },
         ],
       });
+      transactionData = updated.transactionData;
 
-      transactionMeta.nestedTransactions = nestedTransactions;
-      transactionMeta.txParams.data = transactionData;
+      transactionMeta.type = TransactionType.moneyAccountWithdraw;
+      transactionMeta.nestedTransactions = updated.nestedTransactions;
+      transactionMeta.txParams.data = updated.transactionData;
       resetTransactionEstimates(transactionMeta);
     },
   });
 
-  return true;
+  const committed = findTransaction(
+    messenger,
+    ({ id }) => id === transaction.id,
+  );
+  if (!committed) {
+    failUpdate('transaction missing after commit');
+  }
+
+  // Return the hexes, not the full TransactionMeta. The UI background bridge
+  // often strips nested calldata, which made Send treat a successful encode
+  // as "not funded" and no-op.
+  return { withdrawData, transferData, transactionData };
 }
 
 /**
  * Prepares and atomically commits a Money Account withdrawal amount:
- * re-encodes the withdraw + transfer calldata for the new amount (which needs
- * the vault rate for the share conversion) and writes it into the transaction
- * in one `updateTransactionMetadata` call.
- *
- * The concurrency contract mirrors `updateMoneyAccountDepositAmount`:
- * identical in-flight intents share a promise, and a newer intent for the
- * same transaction prevents an older preparation from committing stale
- * calldata — the superseded call resolves `false`.
+ * re-encodes the withdraw + transfer calldata and writes both nested calls
+ * in one `updateTransactionMetadata` so confirm can approve the returned
+ * transaction instead of the empty placeholder.
  *
  * @param messenger - The messenger to resolve and commit through.
  * @param transactionId - Id of the Money Account withdrawal transaction.
  * @param amountHuman - Exact human-readable amount.
- * @returns Whether this intent committed transaction metadata.
+ * @param recipientOverride - Optional EVM address to receive the redeemed mUSD.
+ * When omitted, defaults to the currently selected account.
+ * @returns The encoded nested calldata, or `false` if this intent did not
+ * commit (zero amount or superseded).
  */
 export function updateMoneyAccountWithdrawAmount(
   messenger: MoneyPayMessenger,
   transactionId: string,
   amountHuman: string,
-): Promise<boolean> {
+  recipientOverride?: Hex,
+): Promise<MoneyAccountWithdrawAmountUpdate | false> {
   const transaction = findTransaction(
     messenger,
     ({ id }) => id === transactionId,
@@ -180,7 +211,11 @@ export function updateMoneyAccountWithdrawAmount(
     failUpdate('transaction not found');
   }
 
-  const intentKey = JSON.stringify({ amountHuman, transactionId });
+  const intentKey = JSON.stringify({
+    amountHuman,
+    recipientOverride: recipientOverride?.toLowerCase() ?? null,
+    transactionId,
+  });
 
   return runSingleFlightAmountUpdate(
     amountUpdates,
@@ -192,6 +227,7 @@ export function updateMoneyAccountWithdrawAmount(
         transaction,
         amountHuman,
         isCurrentIntent,
+        recipientOverride,
       ),
   );
 }

--- a/app/scripts/lib/transaction/delegation.test.ts
+++ b/app/scripts/lib/transaction/delegation.test.ts
@@ -291,6 +291,56 @@ describe('delegation', () => {
       );
     });
 
+    it('uses the parent txParams execution when useParentExecution is set, even with nestedTransactions', async () => {
+      // Mirrors the mobile publish hook: sponsored Money Account withdrawals
+      // must relay the parent `execute()` as a single execution — redeeming
+      // the nested calls directly mined on Monad without moving funds.
+      const transaction = {
+        ...TRANSACTION_META_MOCK,
+        nestedTransactions: [
+          {
+            to: '0x1111111111111111111111111111111111111111',
+            value: '0x2',
+            data: '0xaaaa',
+          },
+          {
+            to: '0x2222222222222222222222222222222222222222',
+            value: '0x3',
+            data: '0xbbbb',
+          },
+        ],
+      } as unknown as TransactionMeta;
+
+      await convertTransactionToRedeemDelegations({
+        transaction,
+        messenger,
+        useParentExecution: true,
+      });
+
+      expect(createExactExecutionTermsMock).toHaveBeenCalledWith({
+        execution: {
+          target: TRANSACTION_META_MOCK.txParams.to,
+          value: 256n,
+          callData: '0xdeadbeef',
+        },
+      });
+      expect(createExactExecutionBatchTermsMock).not.toHaveBeenCalled();
+
+      expect(encodeRedeemDelegationsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executions: [
+            [
+              {
+                target: TRANSACTION_META_MOCK.txParams.to,
+                value: 256n,
+                callData: '0xdeadbeef',
+              },
+            ],
+          ],
+        }),
+      );
+    });
+
     it('normalizes nestedTransactions callData', async () => {
       const transaction = {
         ...TRANSACTION_META_MOCK,

--- a/app/scripts/lib/transaction/delegation.ts
+++ b/app/scripts/lib/transaction/delegation.ts
@@ -124,6 +124,16 @@ type ConvertTransactionToRedeemDelegationsRequest = {
    * of the 7702 batch and caveats that leave the order-id placeholder free.
    */
   isSubsidized?: boolean;
+
+  /**
+   * When true, build a single execution from the parent `txParams` (`to` /
+   * `data`) even when `nestedTransactions` exist. Matches the mobile publish
+   * hook: for 7702 batches the parent `execute()` calldata is the canonical
+   * payload — redeeming the nested calls directly is a shape mobile never
+   * publishes and it does not move funds on-chain (e.g. sponsored Money
+   * Account withdrawals on Monad).
+   */
+  useParentExecution?: boolean;
 };
 
 type ConvertTransactionToRedeemDelegationsResult = {
@@ -173,7 +183,7 @@ export async function convertTransactionToRedeemDelegations(
 
   const defaultExecutions = isSubsidized
     ? buildSubsidizedExecutions(transaction)
-    : getDefaultTransactionExecutions(transaction);
+    : getDefaultTransactionExecutions(transaction, request.useParentExecution);
 
   const additionalExecutions = isSubsidized
     ? []
@@ -278,10 +288,12 @@ function hasExecutableNestedTransactions(
 
 function getDefaultTransactionExecutions(
   transactionMeta: TransactionMeta,
+  useParentExecution = false,
 ): ExecutionStruct[] {
   const { nestedTransactions, txParams } = transactionMeta;
 
   if (
+    !useParentExecution &&
     nestedTransactions?.length &&
     hasExecutableNestedTransactions(transactionMeta)
   ) {

--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.test.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.test.ts
@@ -222,6 +222,31 @@ describe('Delegation 7702 Publish Hook', () => {
       });
     });
 
+    it('throws for a sponsored transaction when EIP-7702 is not supported', async () => {
+      // Sponsored transactions skip local signing; a silent skip here would
+      // raw-send an unsigned payload ("Transaction decoding error").
+      const upgradedElsewhere = '0x12345678901234567890123456789012345678ff';
+      isAtomicBatchSupportedMock.mockResolvedValueOnce([
+        {
+          chainId: TRANSACTION_META_MOCK.chainId,
+          delegationAddress: upgradedElsewhere as never,
+          isSupported: false,
+        },
+      ]);
+
+      await expect(
+        hookClass.getHook()(
+          {
+            ...TRANSACTION_META_MOCK,
+            isGasFeeSponsored: true,
+          },
+          SIGNED_TX_MOCK,
+        ),
+      ).rejects.toThrow(
+        'Chain must support EIP-7702 for sponsored or gas included transaction',
+      );
+    });
+
     it('no gas fee tokens', async () => {
       isAtomicBatchSupportedMock.mockResolvedValueOnce([
         {
@@ -505,6 +530,59 @@ describe('Delegation 7702 Publish Hook', () => {
     expect(signDelegationControllerMock).toHaveBeenCalledTimes(1);
     const signArgs = signDelegationControllerMock.mock.calls[0][0];
     expect(signArgs.delegation.caveats).toHaveLength(2);
+  });
+
+  it('relays the parent execute as a single execution for sponsored batches with nested calls', async () => {
+    // Money Account withdrawals are `[withdraw, transfer]` batches sponsored
+    // on Monad. Same as mobile: the delegation must enforce the parent
+    // `execute()` (single ExactExecution), not a batch of the nested calls —
+    // the batch shape mined on-chain without moving funds.
+    isAtomicBatchSupportedMock.mockResolvedValueOnce([
+      {
+        chainId: TRANSACTION_META_MOCK.chainId,
+        delegationAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        isSupported: true,
+        upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+      },
+    ]);
+
+    await hookClass.getHook()(
+      {
+        ...TRANSACTION_META_MOCK,
+        type: TransactionType.batch,
+        isGasFeeSponsored: true,
+        txParams: {
+          ...TRANSACTION_META_MOCK.txParams,
+          data: '0xdeadbeef',
+        },
+        nestedTransactions: [
+          {
+            to: '0x1111111111111111111111111111111111111111',
+            data: '0xaaaa',
+          },
+          {
+            to: '0x2222222222222222222222222222222222222222',
+            data: '0xbbbb',
+          },
+        ],
+      } as unknown as TransactionMeta,
+      SIGNED_TX_MOCK,
+    );
+
+    expect(submitRelayTransactionMock).toHaveBeenCalledTimes(1);
+    expect(signDelegationControllerMock).toHaveBeenCalledTimes(1);
+
+    const { caveatEnforcers } = getDeleGatorEnvironment(
+      parseInt(TRANSACTION_META_MOCK.chainId, 16),
+    );
+    const signArgs = signDelegationControllerMock.mock.calls[0][0];
+    const enforcers = signArgs.delegation.caveats.map(
+      (caveat: { enforcer: string }) => caveat.enforcer,
+    );
+    expect(enforcers).toContain(caveatEnforcers.ExactExecutionEnforcer);
+    expect(enforcers).not.toContain(
+      caveatEnforcers.ExactExecutionBatchEnforcer,
+    );
   });
 
   it('signs delegation for gasless 7702 swap without gas fee tokens', async () => {

--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
@@ -99,14 +99,28 @@ export class Delegation7702PublishHook {
     const { isSupported, delegationAddress, upgradeContractAddress } =
       checkEip7702Support(atomicBatchChainSupport);
 
-    if (!isSupported) {
-      log('Skipping as EIP-7702 is not supported', { from, chainId });
-      return EMPTY_RESULT;
-    }
-
     const isGaslessSwap = transactionMeta.isGasFeeIncluded;
 
     const isSponsored = Boolean(transactionMeta.isGasFeeSponsored);
+
+    if (!isSupported) {
+      log('Skipping as EIP-7702 is not supported', { from, chainId });
+
+      if (isGaslessSwap || isSponsored) {
+        // Same as mobile: sponsored and gas-included transactions skip local
+        // signing, so falling through to the default publish would raw-send
+        // an unsigned payload ("Transaction decoding error"). Fail loudly.
+        throw new Error(
+          `Chain must support EIP-7702 for sponsored or gas included transaction. chainId: ${chainId}, delegationAddress: ${
+            atomicBatchChainSupport?.delegationAddress ?? 'none'
+          }, upgradeContractAddress: ${
+            atomicBatchChainSupport?.upgradeContractAddress ?? 'none'
+          }, entryFound: ${Boolean(atomicBatchChainSupport)}`,
+        );
+      }
+
+      return EMPTY_RESULT;
+    }
 
     if (
       (!selectedGasFeeToken || !gasFeeTokens?.length) &&
@@ -163,6 +177,11 @@ export class Delegation7702PublishHook {
               upgradeContractAddress:
                 (upgradeContractAddress as Hex) ?? undefined,
             },
+        // Same as mobile's publish hook: relay the parent `execute()` as a
+        // single execution. Expanding `nestedTransactions` into a batch
+        // redeem is a shape mobile never publishes — on Monad it mined
+        // without moving funds for Money Account withdrawals.
+        useParentExecution: true,
       });
 
     const relayRequest: RelaySubmitRequest = {

--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
@@ -99,7 +99,7 @@ export class Delegation7702PublishHook {
     const { isSupported, delegationAddress, upgradeContractAddress } =
       checkEip7702Support(atomicBatchChainSupport);
 
-    const {isGasFeeIncluded} = transactionMeta;
+    const { isGasFeeIncluded } = transactionMeta;
 
     const isSponsored = Boolean(transactionMeta.isGasFeeSponsored);
 

--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
@@ -99,14 +99,14 @@ export class Delegation7702PublishHook {
     const { isSupported, delegationAddress, upgradeContractAddress } =
       checkEip7702Support(atomicBatchChainSupport);
 
-    const isGaslessSwap = transactionMeta.isGasFeeIncluded;
+    const {isGasFeeIncluded} = transactionMeta;
 
     const isSponsored = Boolean(transactionMeta.isGasFeeSponsored);
 
     if (!isSupported) {
       log('Skipping as EIP-7702 is not supported', { from, chainId });
 
-      if (isGaslessSwap || isSponsored) {
+      if (isGasFeeIncluded || isSponsored) {
         // Same as mobile: sponsored and gas-included transactions skip local
         // signing, so falling through to the default publish would raw-send
         // an unsigned payload ("Transaction decoding error"). Fail loudly.
@@ -124,7 +124,7 @@ export class Delegation7702PublishHook {
 
     if (
       (!selectedGasFeeToken || !gasFeeTokens?.length) &&
-      !isGaslessSwap &&
+      !isGasFeeIncluded &&
       !isSponsored
     ) {
       log('Skipping as no selected gas fee token');
@@ -132,7 +132,7 @@ export class Delegation7702PublishHook {
     }
 
     const gasFeeToken =
-      isGaslessSwap || isSponsored
+      isGasFeeIncluded || isSponsored
         ? undefined
         : gasFeeTokens?.find(
             (token) =>
@@ -140,12 +140,12 @@ export class Delegation7702PublishHook {
               selectedGasFeeToken?.toLowerCase(),
           );
 
-    if (!gasFeeToken && !isGaslessSwap && !isSponsored) {
+    if (!gasFeeToken && !isGasFeeIncluded && !isSponsored) {
       throw new Error('Selected gas fee token not found');
     }
 
     const includeTransfer =
-      !isGaslessSwap && !transactionMeta.isGasFeeSponsored;
+      !isGasFeeIncluded && !transactionMeta.isGasFeeSponsored;
 
     const { nonce, ...txParamsWithoutNonce } = transactionMeta.txParams;
     const finalTransactionMeta: TransactionMeta = {

--- a/app/scripts/lib/transaction/hooks/index.ts
+++ b/app/scripts/lib/transaction/hooks/index.ts
@@ -21,7 +21,7 @@ import {
   isEnforcedSimulationsEligible,
 } from '../../../../../shared/lib/transaction/enforced-simulations';
 import { TransactionMetricsRequest } from '../../../../../shared/types/metametrics';
-import { accountSupports7702 } from '../../account-supports-7702';
+import { accountSupports7702ForRelay } from '../../account-supports-7702';
 import {
   getSmartTransactionCommonParams,
   SmartTransactionHookMessenger,
@@ -152,7 +152,7 @@ function publishHook({
 
     const { isExternalSign } = transactionMeta;
 
-    const keyringSupports7702 = await accountSupports7702(
+    const keyringSupports7702 = await accountSupports7702ForRelay(
       transactionMeta.txParams?.from,
       getKeyringController(messenger),
     );

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
@@ -463,21 +463,58 @@ describe('TransactionPayControllerInit', () => {
         transactionData: { 'tx-1': { accountOverride } },
       };
       updateWithdrawAmountMock.mockResolvedValue({
-        didCommit: true,
-        recipient: accountOverride,
+        withdrawData: '0xaaa1',
+        transferData: '0xbbb2',
       });
 
       const result = await api.updateMoneyAccountWithdrawAmount('tx-1', '10');
 
       expect(result).toStrictEqual({
-        didCommit: true,
-        recipient: accountOverride,
+        withdrawData: '0xaaa1',
+        transferData: '0xbbb2',
       });
       expect(updateWithdrawAmountMock).toHaveBeenCalledWith(
         expect.anything(),
         'tx-1',
         '10',
         accountOverride,
+      );
+    });
+
+    it('prefers the recipient override over the Pay account override', async () => {
+      const { api, messengerClient } =
+        TransactionPayControllerInit(getInitRequestMock());
+      if (!api) {
+        throw new Error('Expected init result to expose an api');
+      }
+      const payOverride = '0xabcdef1234567890abcdef1234567890abcdef12' as const;
+      const recipientOverride =
+        '0x1111111111111111111111111111111111111111' as const;
+      (
+        messengerClient as {
+          state: {
+            transactionData: Record<string, { accountOverride?: string }>;
+          };
+        }
+      ).state = {
+        transactionData: { 'tx-1': { accountOverride: payOverride } },
+      };
+      updateWithdrawAmountMock.mockResolvedValue({
+        withdrawData: '0xaaa1',
+        transferData: '0xbbb2',
+      });
+
+      await api.updateMoneyAccountWithdrawAmount(
+        'tx-1',
+        '10',
+        recipientOverride,
+      );
+
+      expect(updateWithdrawAmountMock).toHaveBeenCalledWith(
+        expect.anything(),
+        'tx-1',
+        '10',
+        recipientOverride,
       );
     });
   });

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
@@ -139,8 +139,10 @@ function getApi(
     updateMoneyAccountWithdrawAmount: (
       transactionId: string,
       amountHuman: string,
+      recipientOverride?: Hex,
     ) => {
       const accountOverride =
+        recipientOverride ??
         messengerClient.state?.transactionData?.[transactionId]
           ?.accountOverride;
       return updateMoneyAccountWithdrawAmount(

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
@@ -141,7 +141,7 @@ function getApi(
       amountHuman: string,
       recipientOverride?: Hex,
     ) => {
-      const accountOverride =
+      const resolvedRecipient =
         recipientOverride ??
         messengerClient.state?.transactionData?.[transactionId]
           ?.accountOverride;
@@ -149,7 +149,7 @@ function getApi(
         moneyPayMessenger,
         transactionId,
         amountHuman,
-        accountOverride,
+        resolvedRecipient,
       );
     },
     setTransactionPayPaymentOverride: (

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
@@ -90,11 +90,13 @@ function getApi(
     updateMoneyAccountWithdrawAmount: (
       transactionId: string,
       amountHuman: string,
+      recipientOverride?: Hex,
     ) =>
       updateMoneyAccountWithdrawAmount(
         moneyPayMessenger,
         transactionId,
         amountHuman,
+        recipientOverride,
       ),
     updateMoneyAccountDepositAmount: (
       transactionId: string,

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -928,11 +928,6 @@
       "count": 1
     }
   },
-  "ui/pages/confirmations/components/rows/from-account-row/from-account-row.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
   "ui/pages/confirmations/components/send/amount/amount.tsx": {
     "react-hooks/exhaustive-deps": {
       "count": 1

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1031,11 +1031,6 @@
       "count": 1
     }
   },
-  "ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts": {
-    "react-hooks/immutability": {
-      "count": 4
-    }
-  },
   "ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts": {
     "react-hooks/set-state-in-effect": {
       "count": 1

--- a/shared/constants/keyring.ts
+++ b/shared/constants/keyring.ts
@@ -37,3 +37,19 @@ export const KEYRING_TYPES_SUPPORTING_7702 = [
   KeyringTypes.hd,
   KeyringTypes.simple,
 ];
+
+/**
+ * Keyring types whose transactions can publish via the EIP-7702 relay
+ * (sentinel). Extends the Smart Account list with the Money keyring: sponsored
+ * Money Account transactions (e.g. withdrawals on Monad) are marked
+ * externally-signed and must publish through the relay — without the money
+ * keyring here the relay hook is skipped and an unsigned payload reaches
+ * `eth_sendRawTransaction` ("Transaction decoding error"). Mirrors mobile's
+ * `KEYRING_TYPES_SUPPORTING_7702`, which includes `ExtendedKeyringTypes.money`
+ * for its transaction publish gate only.
+ */
+export const KEYRING_TYPES_SUPPORTING_7702_RELAY = [
+  KeyringTypes.hd,
+  KeyringTypes.simple,
+  KeyringTypes.money,
+];

--- a/shared/lib/money/withdraw-amount-commit.ts
+++ b/shared/lib/money/withdraw-amount-commit.ts
@@ -1,11 +1,12 @@
 import type { Hex } from '@metamask/utils';
 
 /**
- * Result of committing a Money Account withdrawal amount. Crosses the
- * background→UI bridge, so it carries the recipient the commit actually
- * encoded: the UI's Confirm gate compares it against the recipient currently
- * displayed, which can change between commits.
+ * Encoded nested withdraw + transfer calldata returned by a Money Account
+ * amount commit. Shared across the background encoder and the UI confirm
+ * bridge so the contract cannot drift.
  */
-export type WithdrawAmountCommitResult =
-  | { didCommit: true; recipient: Hex }
-  | { didCommit: false };
+export type MoneyAccountWithdrawAmountUpdate = {
+  transactionData?: Hex;
+  transferData: Hex;
+  withdrawData: Hex;
+};

--- a/ui/pages/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { TransactionStatus } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetailsHero } from './transaction-details-hero';
@@ -16,24 +19,48 @@ const mockState = {
   },
 };
 
-function createMockTransactionMeta(targetFiat?: string) {
+function createMockTransactionMeta({
+  targetFiat,
+  type,
+  nestedTransactions,
+}: {
+  targetFiat?: string;
+  type?: TransactionType;
+  nestedTransactions?: { data?: string; type?: TransactionType }[];
+} = {}) {
   return {
     id: 'test-id',
     chainId: '0x1',
     status: TransactionStatus.confirmed,
     time: Date.now(),
+    type,
     txParams: {
       from: '0x123',
       to: '0x456',
     },
+    nestedTransactions,
     metamaskPay: targetFiat ? { targetFiat } : undefined,
   };
 }
 
-function render(targetFiat?: string) {
+function render({
+  targetFiat,
+  type,
+  nestedTransactions,
+}: {
+  targetFiat?: string;
+  type?: TransactionType;
+  nestedTransactions?: { data?: string; type?: TransactionType }[];
+} = {}) {
   return renderWithProvider(
     <TransactionDetailsProvider
-      transactionMeta={createMockTransactionMeta(targetFiat) as never}
+      transactionMeta={
+        createMockTransactionMeta({
+          targetFiat,
+          type,
+          nestedTransactions,
+        }) as never
+      }
     >
       <TransactionDetailsHero />
     </TransactionDetailsProvider>,
@@ -43,7 +70,7 @@ function render(targetFiat?: string) {
 
 describe('TransactionDetailsHero', () => {
   it('renders formatted fiat amount when targetFiat is provided', () => {
-    const { getByTestId, getByText } = render('100.50');
+    const { getByTestId, getByText } = render({ targetFiat: '100.50' });
     expect(getByTestId('transaction-details-hero')).toBeInTheDocument();
     // metamaskPay fiat values are USD; override currency so BRL preference does not show R$
     expect(getByText(/\$100[.,]50/u)).toBeInTheDocument();
@@ -55,7 +82,38 @@ describe('TransactionDetailsHero', () => {
   });
 
   it('returns null when targetFiat is zero', () => {
-    const { container } = render('0');
+    const { container } = render({ targetFiat: '0' });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the nested transfer amount for a money account withdraw when targetFiat is missing', () => {
+    const { getByTestId, getByText } = render({
+      type: TransactionType.moneyAccountWithdraw,
+      nestedTransactions: [
+        { type: TransactionType.moneyAccountWithdraw, data: '0xwithdraw' },
+        {
+          type: TransactionType.tokenMethodTransfer,
+          data: '0xa9059cbb0000000000000000000000002222222222222222222222222222222222222222000000000000000000000000000000000000000000000000000000000000c350',
+        },
+      ],
+    });
+
+    expect(getByTestId('transaction-details-hero')).toBeInTheDocument();
+    expect(getByText('0.05 mUSD')).toBeInTheDocument();
+  });
+
+  it('returns null for a money account withdraw whose nested transfer amount is zero', () => {
+    const { container } = render({
+      type: TransactionType.moneyAccountWithdraw,
+      nestedTransactions: [
+        { type: TransactionType.moneyAccountWithdraw, data: '0xwithdraw' },
+        {
+          type: TransactionType.tokenMethodTransfer,
+          data: '0xa9059cbb00000000000000000000000022222222222222222222222222222222222222220000000000000000000000000000000000000000000000000000000000000000',
+        },
+      ],
+    });
+
     expect(container.firstChild).toBeNull();
   });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -1,4 +1,7 @@
 import React, { useMemo } from 'react';
+import { TransactionType } from '@metamask/transaction-controller';
+import { MUSD_DECIMALS, MUSD_TOKEN } from '@metamask/money-account-utils';
+import { BigNumber } from 'bignumber.js';
 import { Text, Box } from '../../../../../components/component-library';
 import {
   Display,
@@ -6,7 +9,32 @@ import {
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
+import { parseStandardTokenTransactionData } from '../../../../../../shared/lib/transaction.utils';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import { useTransactionDetails } from '../transaction-details-context';
+
+function getWithdrawTransferAmountHuman(transactionMeta: {
+  nestedTransactions?: { data?: string; type?: string }[];
+}): string | undefined {
+  const transfer = transactionMeta.nestedTransactions?.find(
+    (nested) => nested.type === TransactionType.tokenMethodTransfer,
+  );
+  if (!transfer?.data) {
+    return undefined;
+  }
+  const parsed = parseStandardTokenTransactionData(transfer.data);
+  const value = parsed?.args?._value ?? parsed?.args?.value;
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const amount = new BigNumber(value.toString()).dividedBy(
+    new BigNumber(10).pow(MUSD_DECIMALS),
+  );
+  if (amount.isZero()) {
+    return undefined;
+  }
+  return `${amount.toFixed()} ${MUSD_TOKEN.symbol}`;
+}
 
 export function TransactionDetailsHero() {
   const { transactionMeta } = useTransactionDetails();
@@ -14,13 +42,21 @@ export function TransactionDetailsHero() {
 
   const { metamaskPay } = transactionMeta;
   const { targetFiat } = metamaskPay || {};
+  const isMoneyAccountWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountWithdraw,
+  ]);
 
   const formattedAmount = useMemo(() => {
-    if (!targetFiat || targetFiat === '0') {
-      return null;
+    if (targetFiat && targetFiat !== '0') {
+      return fiatFormatter(Number(targetFiat));
     }
-    return fiatFormatter(Number(targetFiat));
-  }, [fiatFormatter, targetFiat]);
+    // Direct withdraws have no quotes, so targetFiat stays 0. Show the
+    // nested transfer amount instead of an empty / $0 hero.
+    if (isMoneyAccountWithdraw) {
+      return getWithdrawTransferAmountHuman(transactionMeta);
+    }
+    return null;
+  }, [fiatFormatter, isMoneyAccountWithdraw, targetFiat, transactionMeta]);
 
   if (!formattedAmount) {
     return null;

--- a/ui/pages/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -9,25 +9,26 @@ import {
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
-import { parseStandardTokenTransactionData } from '../../../../../../shared/lib/transaction.utils';
 import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
+import { getMoneyAccountWithdrawTransferDetails } from '../../../utils/money-account-withdraw';
 import { useTransactionDetails } from '../transaction-details-context';
 
-function getWithdrawTransferAmountHuman(transactionMeta: {
+/**
+ * Amount-plus-symbol label for the activity hero (e.g. `1.5 mUSD`).
+ *
+ * @param transactionMeta - Withdraw transaction with nested transfer calldata.
+ * @param transactionMeta.nestedTransactions
+ * @returns Display label, or `undefined` when the transfer amount is missing
+ * or zero.
+ */
+function getWithdrawTransferAmountDisplay(transactionMeta: {
   nestedTransactions?: { data?: string; type?: string }[];
 }): string | undefined {
-  const transfer = transactionMeta.nestedTransactions?.find(
-    (nested) => nested.type === TransactionType.tokenMethodTransfer,
-  );
-  if (!transfer?.data) {
+  const { amountRaw } = getMoneyAccountWithdrawTransferDetails(transactionMeta);
+  if (!amountRaw) {
     return undefined;
   }
-  const parsed = parseStandardTokenTransactionData(transfer.data);
-  const value = parsed?.args?._value ?? parsed?.args?.value;
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  const amount = new BigNumber(value.toString()).dividedBy(
+  const amount = new BigNumber(amountRaw).dividedBy(
     new BigNumber(10).pow(MUSD_DECIMALS),
   );
   if (amount.isZero()) {
@@ -53,7 +54,7 @@ export function TransactionDetailsHero() {
     // Direct withdraws have no quotes, so targetFiat stays 0. Show the
     // nested transfer amount instead of an empty / $0 hero.
     if (isMoneyAccountWithdraw) {
-      return getWithdrawTransferAmountHuman(transactionMeta);
+      return getWithdrawTransferAmountDisplay(transactionMeta);
     }
     return null;
   }, [fiatFormatter, isMoneyAccountWithdraw, targetFiat, transactionMeta]);

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -77,6 +77,7 @@ jest.mock('../../../hooks/pay/useTransactionPayData', () => ({
   useTransactionPayPrimaryRequiredToken: jest.fn(() => undefined),
   useTransactionPayQuotes: jest.fn(() => undefined),
   useTransactionPayRequiredTokens: jest.fn(() => []),
+  useTransactionPayTotals: jest.fn(() => undefined),
 }));
 jest.mock(
   '../../../../../components/app/product-safety/scam-questionnaire/useScamQuestionnaireMetrics',

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 import { TransactionType } from '@metamask/transaction-controller';
 import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
@@ -11,10 +11,13 @@ import {
   useIsTransactionPayQuotePending,
   useTransactionPayHasExecutableQuote,
   useTransactionPayPrimaryRequiredToken,
+  useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
+import { useLastMoneyAccountWithdrawAmount } from '../../../hooks/transactions/useLastMoneyAccountWithdrawAmount';
 import { SingleActionFooter } from './single-action-footer';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../hooks/transactions/useLastMoneyAccountWithdrawAmount');
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -120,6 +123,8 @@ describe('<SingleActionFooter />', () => {
     jest.resetAllMocks();
     jest.mocked(useIsTransactionPayQuotePending).mockReturnValue(false);
     jest.mocked(useTransactionPayHasExecutableQuote).mockReturnValue(true);
+    jest.mocked(useTransactionPayTotals).mockReturnValue(undefined);
+    jest.mocked(useLastMoneyAccountWithdrawAmount).mockReturnValue(undefined);
     jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
       amountUsd: '10.00',
       skipIfBalance: false,
@@ -132,10 +137,12 @@ describe('<SingleActionFooter />', () => {
     expect(getByTestId('confirm-footer-button')).toBeInTheDocument();
   });
 
-  it('calls onSubmit when button is clicked', () => {
+  it('calls onSubmit when button is clicked', async () => {
     const { getByTestId } = render();
 
-    fireEvent.click(getByTestId('confirm-footer-button'));
+    await act(async () => {
+      fireEvent.click(getByTestId('confirm-footer-button'));
+    });
 
     expect(MOCK_ON_SUBMIT).toHaveBeenCalledTimes(1);
   });
@@ -144,6 +151,22 @@ describe('<SingleActionFooter />', () => {
     const { getByTestId } = render({ isGaslessLoading: true });
 
     expect(getByTestId('confirm-footer-button')).toBeDisabled();
+  });
+
+  it('does not keep Send loading for a withdraw when gasless tokens never arrive', () => {
+    jest.mocked(useLastMoneyAccountWithdrawAmount).mockReturnValue('0.05');
+    jest
+      .mocked(useTransactionPayPrimaryRequiredToken)
+      .mockReturnValue(undefined);
+
+    const { getByTestId } = render({
+      confirmation: genMoneyAccountWithdraw(),
+      isGaslessLoading: true,
+    });
+
+    const button = getByTestId('confirm-footer-button');
+    expect(button).toBeEnabled();
+    expect(button).not.toHaveAttribute('aria-busy', 'true');
   });
 
   it('disables the button when pay token data is loading', () => {
@@ -236,6 +259,49 @@ describe('<SingleActionFooter />', () => {
     const { getByTestId } = render();
 
     expect(getByTestId('confirm-footer-button')).toBeDisabled();
+  });
+
+  it('enables button when amountUsd is zero but amountHuman is committed', () => {
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      amountHuman: '0.05',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('confirm-footer-button')).toBeEnabled();
+  });
+
+  it('disables button when amount is zero even if totals exist at zero', () => {
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      amountHuman: '0',
+      amountRaw: '0',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+    jest.mocked(useTransactionPayTotals).mockReturnValue({
+      targetAmount: { usd: '0' },
+      sourceAmount: { usd: '0' },
+    } as ReturnType<typeof useTransactionPayTotals>);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('confirm-footer-button')).toBeDisabled();
+  });
+
+  it('enables button when amountUsd is zero but quote totals are positive', () => {
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+    jest.mocked(useTransactionPayTotals).mockReturnValue({
+      targetAmount: { usd: '0.05' },
+    } as ReturnType<typeof useTransactionPayTotals>);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('confirm-footer-button')).toBeEnabled();
   });
 
   it('shows disabled loading when primary required token is not yet resolved', () => {
@@ -368,11 +434,62 @@ describe('<SingleActionFooter />', () => {
     expect(getByTestId('confirm-footer-button')).toBeDisabled();
   });
 
-  it('submits perps withdrawal when an executable quote is ready', () => {
+  it('submits perps withdrawal when an executable quote is ready', async () => {
     const { getByTestId } = render({ confirmation: genPerpsWithdraw() });
 
-    fireEvent.click(getByTestId('confirm-footer-button'));
+    // `handleSubmit` is async: it flips `isSubmitting` back in a `finally`
+    // that lands a microtask after the click, so the click must be awaited
+    // inside `act` for that update to be covered.
+    await act(async () => {
+      fireEvent.click(getByTestId('confirm-footer-button'));
+    });
 
     expect(MOCK_ON_SUBMIT).toHaveBeenCalledTimes(1);
+  });
+
+  it('enables Send for a withdraw when a positive amount was typed', () => {
+    jest.mocked(useLastMoneyAccountWithdrawAmount).mockReturnValue('0.05');
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { getByTestId } = render({
+      confirmation: genMoneyAccountWithdraw(),
+    });
+
+    expect(getByTestId('confirm-footer-button')).toBeEnabled();
+    expect(getByTestId('confirm-footer-button')).toHaveTextContent(
+      messages.send.message,
+    );
+  });
+
+  it('disables Send for a withdraw when the typed amount is zero', () => {
+    jest.mocked(useLastMoneyAccountWithdrawAmount).mockReturnValue('0');
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { getByTestId } = render({
+      confirmation: genMoneyAccountWithdraw(),
+    });
+
+    expect(getByTestId('confirm-footer-button')).toBeDisabled();
+  });
+
+  it('enables Send for a withdraw without a required token once an amount is typed', () => {
+    jest.mocked(useLastMoneyAccountWithdrawAmount).mockReturnValue('0.05');
+    jest
+      .mocked(useTransactionPayPrimaryRequiredToken)
+      .mockReturnValue(undefined);
+
+    const { getByTestId } = render({
+      confirmation: genMoneyAccountWithdraw(),
+    });
+
+    const button = getByTestId('confirm-footer-button');
+    expect(button).toBeEnabled();
+    expect(button).not.toHaveAttribute('aria-busy', 'true');
   });
 });

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 import { TransactionType } from '@metamask/transaction-controller';
 import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
@@ -11,11 +11,14 @@ import {
   useIsTransactionPayQuotePending,
   useTransactionPayHasExecutableQuote,
   useTransactionPayPrimaryRequiredToken,
+  useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
 import * as confirmContext from '../../../context/confirm';
+import { useLastMoneyAccountWithdrawAmount } from '../../../hooks/transactions/useLastMoneyAccountWithdrawAmount';
 import { SingleActionFooter } from './single-action-footer';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../hooks/transactions/useLastMoneyAccountWithdrawAmount');
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -112,6 +115,8 @@ describe('<SingleActionFooter />', () => {
     jest.resetAllMocks();
     jest.mocked(useIsTransactionPayQuotePending).mockReturnValue(false);
     jest.mocked(useTransactionPayHasExecutableQuote).mockReturnValue(true);
+    jest.mocked(useTransactionPayTotals).mockReturnValue(undefined);
+    jest.mocked(useLastMoneyAccountWithdrawAmount).mockReturnValue(undefined);
     jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
       amountUsd: '10.00',
       skipIfBalance: false,
@@ -124,10 +129,12 @@ describe('<SingleActionFooter />', () => {
     expect(getByTestId('confirm-footer-button')).toBeInTheDocument();
   });
 
-  it('calls onSubmit when button is clicked', () => {
+  it('calls onSubmit when button is clicked', async () => {
     const { getByTestId } = render();
 
-    fireEvent.click(getByTestId('confirm-footer-button'));
+    await act(async () => {
+      fireEvent.click(getByTestId('confirm-footer-button'));
+    });
 
     expect(MOCK_ON_SUBMIT).toHaveBeenCalledTimes(1);
   });
@@ -136,6 +143,22 @@ describe('<SingleActionFooter />', () => {
     const { getByTestId } = render({ isGaslessLoading: true });
 
     expect(getByTestId('confirm-footer-button')).toBeDisabled();
+  });
+
+  it('does not keep Send loading for a withdraw when gasless tokens never arrive', () => {
+    jest.mocked(useLastMoneyAccountWithdrawAmount).mockReturnValue('0.05');
+    jest
+      .mocked(useTransactionPayPrimaryRequiredToken)
+      .mockReturnValue(undefined);
+
+    const { getByTestId } = render({
+      confirmation: genMoneyAccountWithdraw(),
+      isGaslessLoading: true,
+    });
+
+    const button = getByTestId('confirm-footer-button');
+    expect(button).toBeEnabled();
+    expect(button).not.toHaveAttribute('aria-busy', 'true');
   });
 
   it('disables the button when pay token data is loading', () => {
@@ -230,6 +253,49 @@ describe('<SingleActionFooter />', () => {
     expect(getByTestId('confirm-footer-button')).toBeDisabled();
   });
 
+  it('enables button when amountUsd is zero but amountHuman is committed', () => {
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      amountHuman: '0.05',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('confirm-footer-button')).toBeEnabled();
+  });
+
+  it('disables button when amount is zero even if totals exist at zero', () => {
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      amountHuman: '0',
+      amountRaw: '0',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+    jest.mocked(useTransactionPayTotals).mockReturnValue({
+      targetAmount: { usd: '0' },
+      sourceAmount: { usd: '0' },
+    } as ReturnType<typeof useTransactionPayTotals>);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('confirm-footer-button')).toBeDisabled();
+  });
+
+  it('enables button when amountUsd is zero but quote totals are positive', () => {
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+    jest.mocked(useTransactionPayTotals).mockReturnValue({
+      targetAmount: { usd: '0.05' },
+    } as ReturnType<typeof useTransactionPayTotals>);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('confirm-footer-button')).toBeEnabled();
+  });
+
   it('shows disabled loading when primary required token is not yet resolved', () => {
     jest
       .mocked(useTransactionPayPrimaryRequiredToken)
@@ -310,10 +376,15 @@ describe('<SingleActionFooter />', () => {
     expect(getByTestId('confirm-footer-button')).toBeDisabled();
   });
 
-  it('submits perps withdrawal when an executable quote is ready', () => {
+  it('submits perps withdrawal when an executable quote is ready', async () => {
     const { getByTestId } = render({ confirmation: genPerpsWithdraw() });
 
-    fireEvent.click(getByTestId('confirm-footer-button'));
+    // `handleSubmit` is async: it flips `isSubmitting` back in a `finally`
+    // that lands a microtask after the click, so the click must be awaited
+    // inside `act` for that update to be covered.
+    await act(async () => {
+      fireEvent.click(getByTestId('confirm-footer-button'));
+    });
 
     expect(MOCK_ON_SUBMIT).toHaveBeenCalledTimes(1);
   });
@@ -326,6 +397,37 @@ describe('<SingleActionFooter />', () => {
     );
   });
 
+  it('enables Send for a withdraw when a positive amount was typed', () => {
+    jest.mocked(useLastMoneyAccountWithdrawAmount).mockReturnValue('0.05');
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { getByTestId } = render({
+      confirmation: genMoneyAccountWithdraw(),
+    });
+
+    expect(getByTestId('confirm-footer-button')).toBeEnabled();
+    expect(getByTestId('confirm-footer-button')).toHaveTextContent(
+      messages.perpsWithdraw.message,
+    );
+  });
+
+  it('disables Send for a withdraw when the typed amount is zero', () => {
+    jest.mocked(useLastMoneyAccountWithdrawAmount).mockReturnValue('0');
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { getByTestId } = render({
+      confirmation: genMoneyAccountWithdraw(),
+    });
+
+    expect(getByTestId('confirm-footer-button')).toBeDisabled();
+  });
+
   it('disables the button while a money account amount commit is pending', () => {
     const confirmation = genMoneyAccountDeposit();
     jest.spyOn(confirmContext, 'useConfirmContext').mockReturnValue({
@@ -336,6 +438,21 @@ describe('<SingleActionFooter />', () => {
     const { getByTestId } = render({ confirmation });
 
     expect(getByTestId('confirm-footer-button')).toBeDisabled();
+  });
+
+  it('enables Send for a withdraw without a required token once an amount is typed', () => {
+    jest.mocked(useLastMoneyAccountWithdrawAmount).mockReturnValue('0.05');
+    jest
+      .mocked(useTransactionPayPrimaryRequiredToken)
+      .mockReturnValue(undefined);
+
+    const { getByTestId } = render({
+      confirmation: genMoneyAccountWithdraw(),
+    });
+
+    const button = getByTestId('confirm-footer-button');
+    expect(button).toBeEnabled();
+    expect(button).not.toHaveAttribute('aria-busy', 'true');
   });
 
   it('re-enables the button once the money account amount commit resolves', () => {

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
@@ -1,6 +1,6 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionType } from '@metamask/transaction-controller';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { BigNumber } from 'bignumber.js';
 import { Button, ButtonSize } from '@metamask/design-system-react';
 import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
@@ -12,7 +12,9 @@ import {
   useIsTransactionPayQuotePending,
   useTransactionPayHasExecutableQuote,
   useTransactionPayPrimaryRequiredToken,
+  useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
+import { useLastMoneyAccountWithdrawAmount } from '../../../hooks/transactions/useLastMoneyAccountWithdrawAmount';
 import { getConfirmationTransactionType } from '../../../utils/confirm';
 import { FlexDirection } from '../../../../../helpers/constants/design-system';
 
@@ -50,6 +52,8 @@ function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {
   const requiresExecutableQuote =
     isPerpsWithdrawTransaction(currentConfirmation) || isMoneyAccountDeposit;
   const isPayReady = !requiresExecutableQuote || hasExecutableQuote;
+  const totals = useTransactionPayTotals();
+  const lastWithdrawAmount = useLastMoneyAccountWithdrawAmount(transactionId);
 
   const blockingAlerts = useMemo(
     () => alerts.filter((a) => a.isBlocking),
@@ -71,19 +75,11 @@ function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {
     const alertText =
       firstAlert?.reason ?? (firstAlert?.message as string | undefined);
 
-    const hasAmountFromPay = primaryRequiredToken
-      ? new BigNumber(primaryRequiredToken.amountUsd ?? 0).gt(0)
-      : false;
-    const hasAmountFromWithdrawCalldata = Boolean(
-      isMoneyAccountWithdraw &&
-      currentConfirmation.nestedTransactions?.some(
-        (nestedTransaction) =>
-          nestedTransaction.type === TransactionType.moneyAccountWithdraw &&
-          nestedTransaction.data &&
-          nestedTransaction.data !== '0x',
-      ),
-    );
-    const hasAmount = hasAmountFromPay || hasAmountFromWithdrawCalldata;
+    // Withdrawals have no `requiredAssets` and often no quote totals (same-
+    // token mUSD). Enable from the last typed amount; $0 stays disabled.
+    const hasAmount = isMoneyAccountWithdraw
+      ? isPositiveAmount(lastWithdrawAmount)
+      : hasCommittedPayAmount(primaryRequiredToken, totals);
 
     const buttonText =
       !isAwaitingRequiredToken && hasBlockingAlerts && alertText
@@ -93,25 +89,66 @@ function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {
     const isDisabled =
       isAwaitingRequiredToken || hasBlockingAlerts || !hasAmount || !isPayReady;
 
+    // Direct withdraws do not fetch quotes and skip initial gas estimate.
+    // Stuck pay/gasless loading flags would keep Send spinning after the
+    // amount is already typed.
     const isLoading =
-      isAwaitingRequiredToken || isGaslessLoading || isPayLoading;
+      isAwaitingRequiredToken ||
+      (isGaslessLoading && !isMoneyAccountWithdraw) ||
+      (isPayLoading && !(isMoneyAccountWithdraw && !primaryRequiredToken));
 
     return { buttonText, isDisabled, isLoading };
   }, [
     blockingAlerts,
-    currentConfirmation,
     isGaslessLoading,
     isMoneyAccountWithdraw,
     isPayReady,
     isPayLoading,
+    lastWithdrawAmount,
     primaryRequiredToken,
+    totals,
     transactionType,
     t,
   ]);
 }
 
+function isPositiveAmount(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  return new BigNumber(value).gt(0);
+}
+
+function hasCommittedPayAmount(
+  primaryRequiredToken: ReturnType<
+    typeof useTransactionPayPrimaryRequiredToken
+  >,
+  totals: ReturnType<typeof useTransactionPayTotals>,
+): boolean {
+  if (!primaryRequiredToken) {
+    return false;
+  }
+
+  if (isPositiveAmount(primaryRequiredToken.amountUsd)) {
+    return true;
+  }
+
+  if (isPositiveAmount(primaryRequiredToken.amountHuman)) {
+    return true;
+  }
+
+  if (isPositiveAmount(primaryRequiredToken.amountRaw)) {
+    return true;
+  }
+
+  return (
+    isPositiveAmount(totals?.targetAmount?.usd) ||
+    isPositiveAmount(totals?.sourceAmount?.usd)
+  );
+}
+
 type SingleActionFooterProps = {
-  onSubmit: () => void;
+  onSubmit: () => void | Promise<void>;
   isGaslessLoading: boolean;
 };
 
@@ -121,6 +158,23 @@ export const SingleActionFooter = ({
 }: SingleActionFooterProps) => {
   const { buttonText, isDisabled, isLoading } =
     useSingleActionButtonState(isGaslessLoading);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (isDisabled || isLoading || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit();
+    } catch (error) {
+      console.error('Confirmation submit failed', error);
+      throw error;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <PageFooter
@@ -130,9 +184,9 @@ export const SingleActionFooter = ({
       <Button
         className="w-full"
         data-testid="confirm-footer-button"
-        disabled={isDisabled || isLoading}
-        isLoading={isLoading}
-        onClick={onSubmit}
+        disabled={isDisabled || isLoading || isSubmitting}
+        isLoading={isLoading || isSubmitting}
+        onClick={handleSubmit}
         size={ButtonSize.Lg}
       >
         {buttonText}

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
@@ -1,6 +1,6 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionType } from '@metamask/transaction-controller';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { BigNumber } from 'bignumber.js';
 import { Button, ButtonSize } from '@metamask/design-system-react';
 import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
@@ -13,7 +13,9 @@ import {
   useIsTransactionPayQuotePending,
   useTransactionPayHasExecutableQuote,
   useTransactionPayPrimaryRequiredToken,
+  useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
+import { useLastMoneyAccountWithdrawAmount } from '../../../hooks/transactions/useLastMoneyAccountWithdrawAmount';
 import { FlexDirection } from '../../../../../helpers/constants/design-system';
 
 type ButtonState = {
@@ -43,6 +45,10 @@ function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {
   const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
   const isPayReady =
     !isPerpsWithdrawTransaction(currentConfirmation) || hasExecutableQuote;
+  const totals = useTransactionPayTotals();
+  const lastWithdrawAmount = useLastMoneyAccountWithdrawAmount(transactionId);
+  const isMoneyAccountWithdraw =
+    transactionType === TransactionType.moneyAccountWithdraw;
 
   const blockingAlerts = useMemo(
     () => alerts.filter((a) => a.isBlocking),
@@ -54,16 +60,21 @@ function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {
       (transactionType && BUTTON_TEXT_BY_TYPE[transactionType]) ?? 'confirm';
     const defaultButtonText = t(i18nKey);
 
-    const isAwaitingRequiredToken = !primaryRequiredToken;
+    // Direct withdraws set `disablePay` and have no `requiredAssets`, so TPC
+    // never resolves a primary required token. Do not treat that as loading.
+    const isAwaitingRequiredToken =
+      !isMoneyAccountWithdraw && !primaryRequiredToken;
 
     const hasBlockingAlerts = blockingAlerts.length > 0;
     const firstAlert = blockingAlerts[0];
     const alertText =
       firstAlert?.reason ?? (firstAlert?.message as string | undefined);
 
-    const hasAmount = primaryRequiredToken
-      ? new BigNumber(primaryRequiredToken.amountUsd ?? 0).gt(0)
-      : false;
+    // Withdrawals have no `requiredAssets` and often no quote totals (same-
+    // token mUSD). Enable from the last typed amount; $0 stays disabled.
+    const hasAmount = isMoneyAccountWithdraw
+      ? isPositiveAmount(lastWithdrawAmount)
+      : hasCommittedPayAmount(primaryRequiredToken, totals);
 
     const buttonText =
       !isAwaitingRequiredToken && hasBlockingAlerts && alertText
@@ -77,24 +88,67 @@ function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {
       !isPayReady ||
       isMoneyAccountAmountCommitPending;
 
+    // Direct withdraws do not fetch quotes and skip initial gas estimate.
+    // Stuck pay/gasless loading flags would keep Send spinning after the
+    // amount is already typed.
     const isLoading =
-      isAwaitingRequiredToken || isGaslessLoading || isPayLoading;
+      isAwaitingRequiredToken ||
+      (isGaslessLoading && !isMoneyAccountWithdraw) ||
+      (isPayLoading && !(isMoneyAccountWithdraw && !primaryRequiredToken));
 
     return { buttonText, isDisabled, isLoading };
   }, [
     blockingAlerts,
     isGaslessLoading,
     isMoneyAccountAmountCommitPending,
+    isMoneyAccountWithdraw,
     isPayReady,
     isPayLoading,
+    lastWithdrawAmount,
     primaryRequiredToken,
+    totals,
     transactionType,
     t,
   ]);
 }
 
+function isPositiveAmount(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  return new BigNumber(value).gt(0);
+}
+
+function hasCommittedPayAmount(
+  primaryRequiredToken: ReturnType<
+    typeof useTransactionPayPrimaryRequiredToken
+  >,
+  totals: ReturnType<typeof useTransactionPayTotals>,
+): boolean {
+  if (!primaryRequiredToken) {
+    return false;
+  }
+
+  if (isPositiveAmount(primaryRequiredToken.amountUsd)) {
+    return true;
+  }
+
+  if (isPositiveAmount(primaryRequiredToken.amountHuman)) {
+    return true;
+  }
+
+  if (isPositiveAmount(primaryRequiredToken.amountRaw)) {
+    return true;
+  }
+
+  return (
+    isPositiveAmount(totals?.targetAmount?.usd) ||
+    isPositiveAmount(totals?.sourceAmount?.usd)
+  );
+}
+
 type SingleActionFooterProps = {
-  onSubmit: () => void;
+  onSubmit: () => void | Promise<void>;
   isGaslessLoading: boolean;
 };
 
@@ -104,6 +158,23 @@ export const SingleActionFooter = ({
 }: SingleActionFooterProps) => {
   const { buttonText, isDisabled, isLoading } =
     useSingleActionButtonState(isGaslessLoading);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (isDisabled || isLoading || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit();
+    } catch (error) {
+      console.error('Confirmation submit failed', error);
+      throw error;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <PageFooter
@@ -113,9 +184,9 @@ export const SingleActionFooter = ({
       <Button
         className="w-full"
         data-testid="confirm-footer-button"
-        disabled={isDisabled || isLoading}
-        isLoading={isLoading}
-        onClick={onSubmit}
+        disabled={isDisabled || isLoading || isSubmitting}
+        isLoading={isLoading || isSubmitting}
+        onClick={handleSubmit}
         size={ButtonSize.Lg}
       >
         {buttonText}

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
@@ -79,7 +79,7 @@ function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {
     // token mUSD). Enable from the last typed amount; $0 stays disabled.
     const hasAmount = isMoneyAccountWithdraw
       ? isPositiveAmount(lastWithdrawAmount)
-      : hasCommittedPayAmount(primaryRequiredToken, totals);
+      : hasPositivePayAmount(primaryRequiredToken, totals);
 
     const buttonText =
       !isAwaitingRequiredToken && hasBlockingAlerts && alertText
@@ -119,7 +119,17 @@ function isPositiveAmount(value: string | undefined): boolean {
   return new BigNumber(value).gt(0);
 }
 
-function hasCommittedPayAmount(
+/**
+ * Whether Pay already has a positive amount to enable Confirm.
+ * Checks human / raw / USD on the primary required token, then quote totals —
+ * deposits and other Pay flows can populate any one of these before the rest.
+ * Does not mean an amount was committed or persisted.
+ *
+ * @param primaryRequiredToken - Primary required token from Pay, if any.
+ * @param totals - Pay quote totals, if any.
+ * @returns Whether any positive amount field is present.
+ */
+function hasPositivePayAmount(
   primaryRequiredToken: ReturnType<
     typeof useTransactionPayPrimaryRequiredToken
   >,

--- a/ui/pages/confirmations/components/developer/money-account-withdraw-button/messenger.ts
+++ b/ui/pages/confirmations/components/developer/money-account-withdraw-button/messenger.ts
@@ -1,0 +1,13 @@
+import { defineAllowedRouteCapabilities } from '../../../../../helpers/route-messenger-helpers';
+import type { RouteMessengerFromCapabilities } from '../../../../../messengers/route-messenger';
+
+export const MONEY_ACCOUNT_WITHDRAW_BUTTON_ALLOWED_CAPABILITIES =
+  defineAllowedRouteCapabilities({
+    actions: ['MoneyAccountAvailabilityService:getAvailability'],
+    events: [],
+  });
+
+export type MoneyAccountWithdrawButtonMessenger =
+  RouteMessengerFromCapabilities<
+    typeof MONEY_ACCOUNT_WITHDRAW_BUTTON_ALLOWED_CAPABILITIES
+  >;

--- a/ui/pages/confirmations/components/developer/money-account-withdraw-button/money-account-withdraw-button.test.tsx
+++ b/ui/pages/confirmations/components/developer/money-account-withdraw-button/money-account-withdraw-button.test.tsx
@@ -1,63 +1,78 @@
+import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { TransactionType } from '@metamask/transaction-controller';
-import { CHAIN_IDS } from '../../../../../../shared/constants/network';
-import { MUSD_TOKEN, MUSD_TOKEN_ADDRESS } from '../../../constants/musd';
-import { useDeveloperTransferTransaction } from '../utils';
+import configureMockStore from 'redux-mock-store';
+import mockState from '../../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import { useMoneyAccountInfo } from '../../../../../hooks/money/useMoneyAccountInfo';
+import { useMoneyAccountWithdrawal } from '../../../../../hooks/money/useMoneyAccountWithdrawal';
 import { MoneyAccountWithdrawButton } from './money-account-withdraw-button';
 
-jest.mock('../utils', () => ({
-  useDeveloperTransferTransaction: jest.fn(),
+const render = () =>
+  renderWithProvider(
+    <MoneyAccountWithdrawButton />,
+    configureMockStore()(mockState),
+  );
+
+jest.mock('../../../../../hooks/money/useMoneyAccountWithdrawal', () => ({
+  useMoneyAccountWithdrawal: jest.fn(),
 }));
 
-const useDeveloperTransferTransactionMock = jest.mocked(
-  useDeveloperTransferTransaction,
-);
+jest.mock('../../../../../hooks/money/useMoneyAccountInfo', () => ({
+  useMoneyAccountInfo: jest.fn(),
+}));
+
+const useMoneyAccountWithdrawalMock = jest.mocked(useMoneyAccountWithdrawal);
+const useMoneyAccountInfoMock = jest.mocked(useMoneyAccountInfo);
 
 describe('MoneyAccountWithdrawButton', () => {
-  const handleTriggerMock = jest.fn();
+  const initiateWithdrawalMock = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    useDeveloperTransferTransactionMock.mockReturnValue({
+    initiateWithdrawalMock.mockResolvedValue(undefined);
+    useMoneyAccountWithdrawalMock.mockReturnValue({
+      initiateWithdrawal: initiateWithdrawalMock,
       isLoading: false,
-      handleTrigger: handleTriggerMock,
     });
+    useMoneyAccountInfoMock.mockReturnValue({
+      isMoneyAccountFeatureEnabled: true,
+      hasMoneyAccount: true,
+      primaryMoneyAccount: { address: '0xd5fe' },
+    } as unknown as ReturnType<typeof useMoneyAccountInfo>);
   });
 
-  it('configures the transfer hook for a Monad mUSD money account withdraw', () => {
-    render(<MoneyAccountWithdrawButton />);
-
-    expect(useDeveloperTransferTransactionMock).toHaveBeenCalledWith({
-      chainId: CHAIN_IDS.MONAD,
-      tokenAddress: MUSD_TOKEN_ADDRESS,
-      decimals: MUSD_TOKEN.decimals,
-      type: TransactionType.moneyAccountWithdraw,
-      errorMessage: 'Failed to create money account withdraw transaction',
-    });
-  });
-
-  it('renders the developer button and triggers the transaction on click', () => {
-    render(<MoneyAccountWithdrawButton />);
+  it('initiates the withdrawal on click', () => {
+    render();
 
     const button = screen.getByRole('button', {
       name: 'Money Account Withdraw',
     });
-    expect(button).toBeInTheDocument();
     expect(button).not.toBeDisabled();
 
     fireEvent.click(button);
-    expect(handleTriggerMock).toHaveBeenCalledTimes(1);
+    expect(initiateWithdrawalMock).toHaveBeenCalledTimes(1);
   });
 
-  it('disables the button while loading', () => {
-    useDeveloperTransferTransactionMock.mockReturnValue({
+  it('renders nothing at all when the money account is unavailable', () => {
+    useMoneyAccountInfoMock.mockReturnValue({
+      isMoneyAccountFeatureEnabled: false,
+      hasMoneyAccount: false,
+      primaryMoneyAccount: undefined,
+    } as unknown as ReturnType<typeof useMoneyAccountInfo>);
+
+    const { container } = render();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('disables the button while initiating', () => {
+    useMoneyAccountWithdrawalMock.mockReturnValue({
+      initiateWithdrawal: initiateWithdrawalMock,
       isLoading: true,
-      handleTrigger: handleTriggerMock,
     });
 
-    render(<MoneyAccountWithdrawButton />);
+    render();
 
     expect(
       screen.getByRole('button', { name: 'Money Account Withdraw' }),

--- a/ui/pages/confirmations/components/developer/money-account-withdraw-button/money-account-withdraw-button.tsx
+++ b/ui/pages/confirmations/components/developer/money-account-withdraw-button/money-account-withdraw-button.tsx
@@ -1,25 +1,49 @@
 import React from 'react';
-import { TransactionType } from '@metamask/transaction-controller';
-import { CHAIN_IDS } from '../../../../../../shared/constants/network';
 
+import { useMoneyAccountInfo } from '../../../../../hooks/money/useMoneyAccountInfo';
+import { useMoneyAccountWithdrawal } from '../../../../../hooks/money/useMoneyAccountWithdrawal';
+import { RouteWithMessenger } from '../../../../../layouts/route-with-messenger';
 import { DeveloperButton } from '../developer-button';
-import { MUSD_TOKEN, MUSD_TOKEN_ADDRESS } from '../../../constants/musd';
-import { useDeveloperTransferTransaction } from '../utils';
+import { MONEY_ACCOUNT_WITHDRAW_BUTTON_ALLOWED_CAPABILITIES } from './messenger';
 
-export const MoneyAccountWithdrawButton = () => {
-  const { isLoading, handleTrigger } = useDeveloperTransferTransaction({
-    chainId: CHAIN_IDS.MONAD,
-    tokenAddress: MUSD_TOKEN_ADDRESS,
-    decimals: MUSD_TOKEN.decimals,
-    type: TransactionType.moneyAccountWithdraw,
-    errorMessage: 'Failed to create money account withdraw transaction',
-  });
+/**
+ * Developer trigger for the real Money Account withdraw flow: the placeholder
+ * withdraw + transfer batch from the money account, re-encoded once an amount
+ * is chosen. Hidden entirely — not disabled — when the money account is
+ * unavailable, the same rule every production entry point follows.
+ */
+const MoneyAccountWithdrawButtonContent = () => {
+  const { hasMoneyAccount } = useMoneyAccountInfo();
+  const { initiateWithdrawal, isLoading } = useMoneyAccountWithdrawal();
+
+  if (!hasMoneyAccount) {
+    return null;
+  }
 
   return (
     <DeveloperButton
       title="Money Account Withdraw"
-      onPress={handleTrigger}
+      onPress={() =>
+        initiateWithdrawal().catch((error) =>
+          console.error('Failed to initiate money account withdrawal', error),
+        )
+      }
       disabled={isLoading}
     />
   );
 };
+
+/**
+ * {@link MoneyAccountWithdrawButtonContent}, wrapped in the route messenger it
+ * needs to call `MoneyAccountAvailabilityService:getAvailability` via
+ * `useMoneyAccountInfo`. This settings panel isn't behind a router route with
+ * its own messenger, so it carries its own.
+ */
+export const MoneyAccountWithdrawButton = () => (
+  <RouteWithMessenger
+    path="money-account-withdraw-button"
+    capabilities={MONEY_ACCOUNT_WITHDRAW_BUTTON_ALLOWED_CAPABILITIES}
+  >
+    <MoneyAccountWithdrawButtonContent />
+  </RouteWithMessenger>
+);

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -83,6 +83,16 @@ jest.mock('../../rows/total-row/total-row', () => ({
 const MOCK_TRANSACTION_META =
   genUnapprovedContractInteractionConfirmation() as TransactionMeta;
 
+// Withdraws are batches, so the money-account type sits on a nested transaction.
+const MOCK_MONEY_ACCOUNT_WITHDRAW_TRANSACTION_META = {
+  ...MOCK_TRANSACTION_META,
+  type: TransactionType.batch,
+  nestedTransactions: [
+    { type: TransactionType.moneyAccountWithdraw },
+    { type: TransactionType.tokenMethodTransfer },
+  ],
+} as TransactionMeta;
+
 const mockStore = configureMockStore([]);
 
 const DEFAULT_CUSTOM_AMOUNT_HOOK_RETURN = {
@@ -471,6 +481,19 @@ describe('CustomAmountInfo', () => {
         queryByTestId('custom-amount-info-skeleton'),
       ).not.toBeInTheDocument();
     });
+
+    it('does not render the skeleton for a money-account withdraw without a required token', () => {
+      const { getByTestId, queryByTestId } = render({
+        disablePay: false,
+        primaryRequiredToken: undefined,
+        transactionMeta: MOCK_MONEY_ACCOUNT_WITHDRAW_TRANSACTION_META,
+      });
+
+      expect(getByTestId('custom-amount-info')).toBeInTheDocument();
+      expect(
+        queryByTestId('custom-amount-info-skeleton'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('renders the pay with selector when tokens available and disablePay is false', () => {
@@ -611,6 +634,17 @@ describe('CustomAmountInfo', () => {
         isQuotesLoading: false,
       });
 
+      expect(queryByTestId('bridge-fee-row')).not.toBeInTheDocument();
+    });
+
+    it('renders the total without a fee row for disablePay withdraws', () => {
+      const { getByTestId, queryByTestId } = render({
+        disablePay: true,
+        hasQuotes: false,
+        isQuotesLoading: false,
+      });
+
+      expect(getByTestId('total-row')).toBeInTheDocument();
       expect(queryByTestId('bridge-fee-row')).not.toBeInTheDocument();
     });
 

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -83,6 +83,16 @@ jest.mock('../../rows/total-row/total-row', () => ({
 const MOCK_TRANSACTION_META =
   genUnapprovedContractInteractionConfirmation() as TransactionMeta;
 
+// Withdraws are batches, so the money-account type sits on a nested transaction.
+const MOCK_MONEY_ACCOUNT_WITHDRAW_TRANSACTION_META = {
+  ...MOCK_TRANSACTION_META,
+  type: TransactionType.batch,
+  nestedTransactions: [
+    { type: TransactionType.moneyAccountWithdraw },
+    { type: TransactionType.tokenMethodTransfer },
+  ],
+} as TransactionMeta;
+
 const mockStore = configureMockStore([]);
 
 const DEFAULT_CUSTOM_AMOUNT_HOOK_RETURN = {
@@ -487,6 +497,20 @@ describe('CustomAmountInfo', () => {
         queryByTestId('custom-amount-info-skeleton'),
       ).not.toBeInTheDocument();
     });
+
+    it('does not render the skeleton for a money-account withdraw without a required token', () => {
+      const { getByTestId, queryByTestId } = render({
+        disablePay: false,
+        primaryRequiredToken: undefined,
+        transactionMeta: MOCK_MONEY_ACCOUNT_WITHDRAW_TRANSACTION_META,
+        withdraw: { isWithdraw: true, canSelectWithdrawToken: false },
+      });
+
+      expect(getByTestId('custom-amount-info')).toBeInTheDocument();
+      expect(
+        queryByTestId('custom-amount-info-skeleton'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('renders the pay with selector when tokens available and disablePay is false', () => {
@@ -642,6 +666,17 @@ describe('CustomAmountInfo', () => {
         isQuotesLoading: false,
       });
 
+      expect(queryByTestId('bridge-fee-row')).not.toBeInTheDocument();
+    });
+
+    it('renders the total without a fee row for disablePay withdraws', () => {
+      const { getByTestId, queryByTestId } = render({
+        disablePay: true,
+        hasQuotes: false,
+        isQuotesLoading: false,
+      });
+
+      expect(getByTestId('total-row')).toBeInTheDocument();
       expect(queryByTestId('bridge-fee-row')).not.toBeInTheDocument();
     });
 

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -1,5 +1,8 @@
 import React, { ReactNode, useCallback } from 'react';
-import type { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
 import { Box, Text } from '../../../../../components/component-library';
 import {
   Display,
@@ -29,7 +32,10 @@ import {
   PercentageButtons,
   PercentageButtonsSkeleton,
 } from '../../percentage-buttons';
-import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
+import {
+  hasTransactionType,
+  isPerpsWithdrawTransaction,
+} from '../../../../../../shared/lib/transactions.utils';
 import { useTransactionCustomAmount } from '../../../hooks/transactions/useTransactionCustomAmount';
 import { useTransactionCustomAmountAlerts } from '../../../hooks/transactions/useTransactionCustomAmountAlerts';
 import { useAutomaticTransactionPayToken } from '../../../hooks/pay/useAutomaticTransactionPayToken';
@@ -138,7 +144,14 @@ export const CustomAmountInfo = React.memo(
     const { isWithdraw } = useTransactionPayWithdraw();
     const hasTokens = availableTokens.length > 0 || isWithdraw;
     const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
-    const isAwaitingRequiredToken = !disablePay && !primaryRequiredToken;
+    // Direct and post-quote money-account withdraws have no `requiredAssets`,
+    // so TPC never resolves a primary required token. Waiting on it keeps the
+    // amount skeleton up forever after the placeholder batch is created.
+    const isMoneyAccountWithdraw = hasTransactionType(currentConfirmation, [
+      TransactionType.moneyAccountWithdraw,
+    ]);
+    const isAwaitingRequiredToken =
+      !disablePay && !isMoneyAccountWithdraw && !primaryRequiredToken;
 
     const { disableUpdate } = useTransactionCustomAmountAlerts();
 
@@ -352,7 +365,7 @@ function BottomContainer({
   hasAmount: boolean;
 }) {
   const t = useI18nContext();
-  const isResultReady = useIsResultReady(hasAmount);
+  const isResultReady = useIsResultReady(hasAmount, disablePay);
   const { hideResults } = useTransactionCustomAmountAlerts();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
@@ -376,14 +389,18 @@ function BottomContainer({
       {disablePay !== true && <PayWithRow />}
       {isResultReady && !hideResults && (
         <>
-          <BridgeFeeRow
-            variant={ConfirmInfoRowSize.Small}
-            tooltipDescription={
-              isPerpsWithdraw ? t('perpsWithdrawTooltip') : undefined
-            }
-          />
-          <BridgeTimeRow rowVariant={ConfirmInfoRowSize.Small} />
-          {canSelectWithdrawToken ? (
+          {disablePay !== true && (
+            <>
+              <BridgeFeeRow
+                variant={ConfirmInfoRowSize.Small}
+                tooltipDescription={
+                  isPerpsWithdraw ? t('perpsWithdrawTooltip') : undefined
+                }
+              />
+              <BridgeTimeRow rowVariant={ConfirmInfoRowSize.Small} />
+            </>
+          )}
+          {canSelectWithdrawToken && disablePay !== true ? (
             <ReceiveRow
               inputAmountUsd={amountFiat}
               variant={ConfirmInfoRowSize.Small}
@@ -408,8 +425,10 @@ function BottomContainer({
  * numbers on screen until a new quote resolves.
  *
  * @param hasAmount - Whether the amount field holds a value greater than zero.
+ * @param disablePay - Whether the confirmation skips the pay/quote pipeline
+ * (direct withdraws), in which case no quote will ever arrive.
  */
-function useIsResultReady(hasAmount: boolean) {
+function useIsResultReady(hasAmount: boolean, disablePay?: boolean) {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const quotes = useTransactionPayQuotes();
   const isQuotePending = useIsTransactionPayQuotePending();
@@ -417,6 +436,8 @@ function useIsResultReady(hasAmount: boolean) {
   const hasPositiveRequiredAmount =
     useTransactionPayHasPositiveRequiredAmount();
 
+  // Selecting a destination token still stores a no-op quote and gas totals.
+  // A $0 withdraw must not show those as a real quote.
   if (!hasAmount) {
     return false;
   }
@@ -425,7 +446,9 @@ function useIsResultReady(hasAmount: boolean) {
     return hasPositiveRequiredAmount && (isQuotePending || hasExecutableQuote);
   }
 
-  return isQuotePending || Boolean(quotes?.length);
+  // Direct withdraws never fetch quotes. Show the total once an amount is
+  // typed; do not wait on a quote that will never arrive.
+  return Boolean(disablePay) || isQuotePending || Boolean(quotes?.length);
 }
 
 function AlertMessage() {

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback } from 'react';
-import type { TransactionMeta } from '@metamask/transaction-controller';
+import { type TransactionMeta } from '@metamask/transaction-controller';
 import { Box, Text } from '../../../../../components/component-library';
 import {
   Display,
@@ -364,7 +364,7 @@ function BottomContainer({
   hasAmount: boolean;
 }) {
   const t = useI18nContext();
-  const isResultReady = useIsResultReady(hasAmount);
+  const isResultReady = useIsResultReady(hasAmount, disablePay);
   const { hideResults } = useTransactionCustomAmountAlerts();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
@@ -388,14 +388,18 @@ function BottomContainer({
       {disablePay !== true && <PayWithRow />}
       {isResultReady && !hideResults && (
         <>
-          <BridgeFeeRow
-            variant={ConfirmInfoRowSize.Small}
-            tooltipDescription={
-              isPerpsWithdraw ? t('perpsWithdrawTooltip') : undefined
-            }
-          />
-          <BridgeTimeRow rowVariant={ConfirmInfoRowSize.Small} />
-          {canSelectWithdrawToken ? (
+          {disablePay !== true && (
+            <>
+              <BridgeFeeRow
+                variant={ConfirmInfoRowSize.Small}
+                tooltipDescription={
+                  isPerpsWithdraw ? t('perpsWithdrawTooltip') : undefined
+                }
+              />
+              <BridgeTimeRow rowVariant={ConfirmInfoRowSize.Small} />
+            </>
+          )}
+          {canSelectWithdrawToken && disablePay !== true ? (
             <ReceiveRow
               inputAmountUsd={amountFiat}
               variant={ConfirmInfoRowSize.Small}
@@ -420,8 +424,10 @@ function BottomContainer({
  * numbers on screen until a new quote resolves.
  *
  * @param hasAmount - Whether the amount field holds a value greater than zero.
+ * @param disablePay - Whether the confirmation skips the pay/quote pipeline
+ * (direct withdraws), in which case no quote will ever arrive.
  */
-function useIsResultReady(hasAmount: boolean) {
+function useIsResultReady(hasAmount: boolean, disablePay?: boolean) {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const quotes = useTransactionPayQuotes();
   const isQuotePending = useIsTransactionPayQuotePending();
@@ -429,6 +435,8 @@ function useIsResultReady(hasAmount: boolean) {
   const hasPositiveRequiredAmount =
     useTransactionPayHasPositiveRequiredAmount();
 
+  // Selecting a destination token still stores a no-op quote and gas totals.
+  // A $0 withdraw must not show those as a real quote.
   if (!hasAmount) {
     return false;
   }
@@ -437,7 +445,9 @@ function useIsResultReady(hasAmount: boolean) {
     return hasPositiveRequiredAmount && (isQuotePending || hasExecutableQuote);
   }
 
-  return isQuotePending || Boolean(quotes?.length);
+  // Direct withdraws never fetch quotes. Show the total once an amount is
+  // typed; do not wait on a quote that will never arrive.
+  return Boolean(disablePay) || isQuotePending || Boolean(quotes?.length);
 }
 
 function AlertMessage() {

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -252,6 +252,18 @@ describe('PayWithModal', () => {
     expect(screen.getByTestId('has-tag-renderers')).toHaveTextContent('true');
   });
 
+  it('passes no-fee tag renderers for money account withdraws', () => {
+    useConfirmContextMock.mockReturnValue({
+      currentConfirmation: {
+        type: TransactionType.moneyAccountWithdraw,
+      },
+    } as ReturnType<typeof useConfirmContext>);
+
+    renderModal({ isOpen: true, onClose: onCloseMock });
+
+    expect(screen.getByTestId('has-tag-renderers')).toHaveTextContent('true');
+  });
+
   it('calls onClose when close button is clicked', () => {
     renderModal({ isOpen: true, onClose: onCloseMock });
 

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -78,8 +78,11 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
     confirmationType === TransactionType.moneyAccountDeposit;
   const { renderNoFeeTag } = usePayWithNoFeeToken();
   const tagRenderers = useMemo(
-    () => (isMoneyAccountDeposit ? [renderNoFeeTag] : undefined),
-    [isMoneyAccountDeposit, renderNoFeeTag],
+    () =>
+      isMoneyAccountDeposit || isPostQuoteWithdraw
+        ? [renderNoFeeTag]
+        : undefined,
+    [isMoneyAccountDeposit, isPostQuoteWithdraw, renderNoFeeTag],
   );
 
   const handleClose = useCallback(() => {

--- a/ui/pages/confirmations/components/rows/from-account-row/from-account-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/from-account-row/from-account-row.test.tsx
@@ -6,6 +6,7 @@ import { renderWithProvider } from '../../../../../../test/lib/render-helpers-na
 import { useConfirmContext } from '../../../context/confirm';
 import { useDisplayName } from '../../../../../hooks/useDisplayName';
 import { setAccountOverride } from '../../../../../store/controller-actions/transaction-pay-controller';
+import { replaceAccountInNestedTransactions } from '../../../utils/transaction-pay';
 import { FromAccountRow } from './from-account-row';
 
 jest.mock('../../../context/confirm');
@@ -16,6 +17,9 @@ jest.mock(
     setAccountOverride: jest.fn(),
   }),
 );
+jest.mock('../../../utils/transaction-pay', () => ({
+  replaceAccountInNestedTransactions: jest.fn(),
+}));
 
 jest.mock('../../account-select-modal', () => ({
   AccountSelectModal: ({
@@ -105,6 +109,9 @@ describe('FromAccountRow', () => {
   const useConfirmContextMock = jest.mocked(useConfirmContext);
   const useDisplayNameMock = jest.mocked(useDisplayName);
   const setAccountOverrideMock = jest.mocked(setAccountOverride);
+  const replaceAccountInNestedTransactionsMock = jest.mocked(
+    replaceAccountInNestedTransactions,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -196,9 +203,44 @@ describe('FromAccountRow', () => {
     fireEvent.click(screen.getByTestId('from-account-pill'));
     fireEvent.click(screen.getByTestId('select-other'));
 
+    expect(replaceAccountInNestedTransactionsMock).toHaveBeenCalledWith({
+      transactionId: TX_ID_MOCK,
+      nestedTransactions: undefined,
+      oldAddress: FROM_ADDRESS_MOCK,
+      newAddress: OTHER_ADDRESS_MOCK,
+    });
     expect(setAccountOverrideMock).toHaveBeenCalledWith(
       TX_ID_MOCK,
       OTHER_ADDRESS_MOCK,
+    );
+  });
+
+  it('rewrites nested calldata using the previous override as the old address', () => {
+    const nestedTransactions = [{ data: '0xabc', to: '0x1' }];
+    useConfirmContextMock.mockReturnValue({
+      currentConfirmation: {
+        id: TX_ID_MOCK,
+        chainId: CHAIN_ID_MOCK,
+        txParams: { from: FROM_ADDRESS_MOCK },
+        nestedTransactions,
+      },
+    } as never);
+
+    const store = createStore({ accountOverride: OTHER_ADDRESS_MOCK });
+    renderWithProvider(<FromAccountRow />, store);
+
+    fireEvent.click(screen.getByTestId('from-account-pill'));
+    fireEvent.click(screen.getByTestId('select-same'));
+
+    expect(replaceAccountInNestedTransactionsMock).toHaveBeenCalledWith({
+      transactionId: TX_ID_MOCK,
+      nestedTransactions,
+      oldAddress: OTHER_ADDRESS_MOCK,
+      newAddress: FROM_ADDRESS_MOCK,
+    });
+    expect(setAccountOverrideMock).toHaveBeenCalledWith(
+      TX_ID_MOCK,
+      FROM_ADDRESS_MOCK,
     );
   });
 
@@ -209,6 +251,7 @@ describe('FromAccountRow', () => {
     fireEvent.click(screen.getByTestId('from-account-pill'));
     fireEvent.click(screen.getByTestId('select-same'));
 
+    expect(replaceAccountInNestedTransactionsMock).not.toHaveBeenCalled();
     expect(setAccountOverrideMock).not.toHaveBeenCalled();
   });
 
@@ -219,6 +262,7 @@ describe('FromAccountRow', () => {
     fireEvent.click(screen.getByTestId('from-account-pill'));
     fireEvent.click(screen.getByTestId('select-override'));
 
+    expect(replaceAccountInNestedTransactionsMock).not.toHaveBeenCalled();
     expect(setAccountOverrideMock).not.toHaveBeenCalled();
   });
 

--- a/ui/pages/confirmations/components/rows/from-account-row/from-account-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/from-account-row/from-account-row.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
@@ -130,6 +130,7 @@ describe('FromAccountRow', () => {
     } as never);
 
     setAccountOverrideMock.mockResolvedValue(undefined);
+    replaceAccountInNestedTransactionsMock.mockResolvedValue(undefined);
   });
 
   it('renders the from account row with the wallet label and account name', () => {
@@ -196,7 +197,7 @@ describe('FromAccountRow', () => {
     );
   });
 
-  it('sets the pay account override with the chosen address', () => {
+  it('sets the pay account override with the chosen address', async () => {
     const store = createStore();
     renderWithProvider(<FromAccountRow />, store);
 
@@ -209,13 +210,15 @@ describe('FromAccountRow', () => {
       oldAddress: FROM_ADDRESS_MOCK,
       newAddress: OTHER_ADDRESS_MOCK,
     });
-    expect(setAccountOverrideMock).toHaveBeenCalledWith(
-      TX_ID_MOCK,
-      OTHER_ADDRESS_MOCK,
-    );
+    await waitFor(() => {
+      expect(setAccountOverrideMock).toHaveBeenCalledWith(
+        TX_ID_MOCK,
+        OTHER_ADDRESS_MOCK,
+      );
+    });
   });
 
-  it('rewrites nested calldata using the previous override as the old address', () => {
+  it('rewrites nested calldata using the previous override as the old address', async () => {
     const nestedTransactions = [{ data: '0xabc', to: '0x1' }];
     useConfirmContextMock.mockReturnValue({
       currentConfirmation: {
@@ -238,10 +241,12 @@ describe('FromAccountRow', () => {
       oldAddress: OTHER_ADDRESS_MOCK,
       newAddress: FROM_ADDRESS_MOCK,
     });
-    expect(setAccountOverrideMock).toHaveBeenCalledWith(
-      TX_ID_MOCK,
-      FROM_ADDRESS_MOCK,
-    );
+    await waitFor(() => {
+      expect(setAccountOverrideMock).toHaveBeenCalledWith(
+        TX_ID_MOCK,
+        FROM_ADDRESS_MOCK,
+      );
+    });
   });
 
   it('does not set the account override when the current account is chosen', () => {

--- a/ui/pages/confirmations/components/rows/from-account-row/from-account-row.tsx
+++ b/ui/pages/confirmations/components/rows/from-account-row/from-account-row.tsx
@@ -27,6 +27,7 @@ import {
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useDisplayName } from '../../../../../hooks/useDisplayName';
 import { useConfirmContext } from '../../../context/confirm';
+import { replaceAccountInNestedTransactions } from '../../../utils/transaction-pay';
 import { AccountSelectModal } from '../../account-select-modal';
 
 export { ConfirmInfoRowSize };
@@ -91,6 +92,16 @@ export function FromAccountRow({
         currentConfirmation?.id &&
         address.toLowerCase() !== from.toLowerCase()
       ) {
+        // Mobile PayAccountSelector rewrites encoded nested calldata first so
+        // the withdraw transfer recipient (or any other encoded account word)
+        // matches the new selection, then seeds accountOverride.
+        replaceAccountInNestedTransactions({
+          transactionId: currentConfirmation.id,
+          nestedTransactions: currentConfirmation.nestedTransactions,
+          oldAddress: accountOverride ?? txFrom,
+          newAddress: address,
+        });
+
         // The TransactionPayController resolves the funding account (and gas)
         // from `accountOverride ?? txParams.from`, so keep it in sync with the
         // newly selected account.
@@ -101,7 +112,7 @@ export function FromAccountRow({
         );
       }
     },
-    [closeModal, currentConfirmation?.id, from],
+    [accountOverride, closeModal, currentConfirmation, from, txFrom],
   );
 
   if (!currentConfirmation || !from) {

--- a/ui/pages/confirmations/components/rows/from-account-row/from-account-row.tsx
+++ b/ui/pages/confirmations/components/rows/from-account-row/from-account-row.tsx
@@ -85,31 +85,29 @@ export function FromAccountRow({
   const closeModal = useCallback(() => setIsModalOpen(false), []);
 
   const handleSelect = useCallback(
-    (address: string) => {
+    async (address: string) => {
       closeModal();
 
       if (
-        currentConfirmation?.id &&
-        address.toLowerCase() !== from.toLowerCase()
+        !currentConfirmation?.id ||
+        address.toLowerCase() === from.toLowerCase()
       ) {
-        // Mobile PayAccountSelector rewrites encoded nested calldata first so
-        // the withdraw transfer recipient (or any other encoded account word)
-        // matches the new selection, then seeds accountOverride.
-        replaceAccountInNestedTransactions({
+        return;
+      }
+
+      // Rewrite nested calldata first and await persistence so confirm cannot
+      // approve a previously funded batch that still transfers to the old
+      // recipient, then seed accountOverride.
+      try {
+        await replaceAccountInNestedTransactions({
           transactionId: currentConfirmation.id,
           nestedTransactions: currentConfirmation.nestedTransactions,
           oldAddress: accountOverride ?? txFrom,
           newAddress: address,
         });
-
-        // The TransactionPayController resolves the funding account (and gas)
-        // from `accountOverride ?? txParams.from`, so keep it in sync with the
-        // newly selected account.
-        setAccountOverride(currentConfirmation.id, address as Hex).catch(
-          (error) => {
-            console.error('Failed to set pay account override', error);
-          },
-        );
+        await setAccountOverride(currentConfirmation.id, address as Hex);
+      } catch (error) {
+        console.error('Failed to update pay account override', error);
       }
     },
     [accountOverride, closeModal, currentConfirmation, from, txFrom],

--- a/ui/pages/confirmations/components/rows/receive-row/receive-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/receive-row/receive-row.test.tsx
@@ -12,11 +12,13 @@ import {
   useTransactionPayQuotes,
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
+import { useIsPaidByMetaMask } from '../../../hooks/pay/useIsPaidByMetaMask';
 import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
 import { ConfirmInfoRowSize } from '../../../../../components/app/confirm/info/row/row';
 import { ReceiveRow, ReceiveRowProps } from './receive-row';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../hooks/pay/useIsPaidByMetaMask');
 
 const mockStore = configureMockStore([]);
 
@@ -36,9 +38,12 @@ describe('ReceiveRow', () => {
   const useIsTransactionPayQuotePendingMock = jest.mocked(
     useIsTransactionPayQuotePending,
   );
+  const useIsPaidByMetaMaskMock = jest.mocked(useIsPaidByMetaMask);
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    useIsPaidByMetaMaskMock.mockReturnValue(false);
 
     useTransactionPayTotalsMock.mockReturnValue({
       fees: {
@@ -98,6 +103,14 @@ describe('ReceiveRow', () => {
     const { getByTestId } = render({ inputAmountUsd: '0.10' });
 
     expect(getByTestId('receive-value')).toHaveTextContent('$0.00');
+  });
+
+  it('does not subtract sponsored network gas from the receive amount', () => {
+    useIsPaidByMetaMaskMock.mockReturnValue(true);
+
+    const { getByTestId } = render({ inputAmountUsd: '0.05' });
+
+    expect(getByTestId('receive-value')).toHaveTextContent('$0.05');
   });
 
   it('renders an empty value when there are no quotes', () => {

--- a/ui/pages/confirmations/components/rows/receive-row/receive-row.tsx
+++ b/ui/pages/confirmations/components/rows/receive-row/receive-row.tsx
@@ -16,6 +16,7 @@ import {
   useTransactionPayQuotes,
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
+import { useIsPaidByMetaMask } from '../../../hooks/pay/useIsPaidByMetaMask';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
 
@@ -51,6 +52,7 @@ export function ReceiveRow({
   const isLoading = useIsTransactionPayQuotePending();
   const totals = useTransactionPayTotals();
   const quotes = useTransactionPayQuotes();
+  const isPaidByMetaMask = useIsPaidByMetaMask();
 
   const hasQuotes = Boolean(quotes?.length);
 
@@ -65,6 +67,14 @@ export function ReceiveRow({
     }
 
     const inputUsd = new BigNumber(inputAmountUsd || '0');
+    // Same-token Money Account withdraws quote estimated network gas that
+    // Monad sponsors. Subtracting it would show $0 received on a tiny send.
+    if (isPaidByMetaMask) {
+      return formatFiat(
+        (inputUsd.gte(0) ? inputUsd : new BigNumber(0)).toNumber(),
+      );
+    }
+
     const providerFee = new BigNumber(totals.fees?.provider?.usd ?? 0);
     const sourceNetworkFee = new BigNumber(
       totals.fees?.sourceNetwork?.estimate?.usd ?? 0,
@@ -83,7 +93,7 @@ export function ReceiveRow({
     return formatFiat(
       (youReceive.gte(0) ? youReceive : new BigNumber(0)).toNumber(),
     );
-  }, [hasQuotes, inputAmountUsd, totals, formatFiat]);
+  }, [hasQuotes, inputAmountUsd, isPaidByMetaMask, totals, formatFiat]);
 
   const isSmall = variant === ConfirmInfoRowSize.Small;
   const textVariant = isSmall ? TextVariant.bodyMd : TextVariant.bodyMdMedium;

--- a/ui/pages/confirmations/hooks/alerts/constants.ts
+++ b/ui/pages/confirmations/hooks/alerts/constants.ts
@@ -11,6 +11,7 @@ export enum AlertsName {
   InsufficientPayTokenBalance = 'insufficientPayTokenBalance',
   InsufficientPayTokenNative = 'insufficientPayTokenNative',
   InsufficientPayTokenFees = 'insufficientPayTokenFees',
+  InsufficientMoneyAccountBalance = 'insufficientMoneyAccountBalance',
   NetworkBusy = 'networkBusy',
   NoGasPrice = 'noGasPrice',
   NoPayTokenQuotes = 'noPayTokenQuotes',

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
@@ -424,7 +424,7 @@ describe('useInsufficientBalanceAlerts', () => {
       expect(alerts).toEqual([]);
     });
 
-    it('returns alert when post-quote is disabled for the type, since the direct transfer spends native balance', () => {
+    it('returns no alerts for a direct money-account withdraw, which is sponsored from the money account', () => {
       const alerts = runHook({
         balance: 7,
         currentConfirmation: WITHDRAW_TRANSACTION_MOCK,
@@ -432,7 +432,7 @@ describe('useInsufficientBalanceAlerts', () => {
         remoteFeatureFlags: buildPostQuoteFlags(false),
       });
 
-      expect(alerts).toEqual(ALERT);
+      expect(alerts).toEqual([]);
     });
   });
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
@@ -428,7 +428,7 @@ describe('useInsufficientBalanceAlerts', () => {
       expect(alerts).toEqual([]);
     });
 
-    it('returns alert when post-quote is disabled for the type, since the direct transfer spends native balance', () => {
+    it('returns no alerts for a direct money-account withdraw, which is sponsored from the money account', () => {
       const alerts = runHook({
         balance: 7,
         currentConfirmation: WITHDRAW_TRANSACTION_MOCK,
@@ -436,7 +436,7 @@ describe('useInsufficientBalanceAlerts', () => {
         remoteFeatureFlags: buildPostQuoteFlags(false),
       });
 
-      expect(alerts).toEqual(ALERT);
+      expect(alerts).toEqual([]);
     });
   });
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -53,10 +53,13 @@ export function useInsufficientBalanceAlerts({
   const isPayPendingInput =
     Boolean(payToken) && primaryRequiredToken?.amountRaw === '0';
 
-  // Deposit batches execute from the money account, which has no native MON.
-  // Gas is sponsored, so the EOA native-balance check is wrong.
-  const isMoneyAccountDeposit = hasTransactionType(currentConfirmation, [
+  // Money-account batches execute from the money account, which has no native
+  // MON. Gas is sponsored, so the EOA native-balance check is wrong. Direct
+  // withdraws also skip initial gas estimate, so this alert otherwise blocks
+  // Send after the user types an amount.
+  const isMoneyAccountTransaction = hasTransactionType(currentConfirmation, [
     TransactionType.moneyAccountDeposit,
+    TransactionType.moneyAccountWithdraw,
   ]);
 
   const isGasFeeTokensEmpty = gasFeeTokens?.length === 0;
@@ -100,7 +103,7 @@ export function useInsufficientBalanceAlerts({
     shouldCheckGaslessConditions &&
     !isSponsoredTransaction &&
     !isPostQuoteWithdraw &&
-    !isMoneyAccountDeposit;
+    !isMoneyAccountTransaction;
 
   return useMemo(() => {
     if (!showAlert) {

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
@@ -1,0 +1,205 @@
+import { BigNumber } from 'bignumber.js';
+import { useQuery } from '@metamask/react-data-query';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-account-balance-service';
+import { DATA_SERVICES } from '../../../../../../shared/constants/data-services';
+import { MoneyAccountBalanceServiceQueryKeys } from '../../../../../../shared/lib/money/query-keys';
+import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
+import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
+import { AlertsName } from '../constants';
+import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
+import { Severity } from '../../../../../helpers/constants/design-system';
+import { useInsufficientMoneyAccountBalanceAlert } from './useInsufficientMoneyAccountBalanceAlert';
+
+jest.mock('@metamask/react-data-query', () => ({
+  useQuery: jest.fn(),
+}));
+jest.mock('../../pay/useTransactionPayData');
+
+const useQueryMock = jest.mocked(useQuery);
+const usePrimaryRequiredTokenMock = jest.mocked(
+  useTransactionPayPrimaryRequiredToken,
+);
+
+const EXPECTED_ALERT = {
+  field: RowAlertKey.Amount,
+  isBlocking: true,
+  key: AlertsName.InsufficientMoneyAccountBalance,
+  message: 'Insufficient funds',
+  reason: 'Insufficient funds',
+  severity: Severity.Danger,
+};
+
+const MONEY_ACCOUNT_ADDRESS = '0xabc0000000000000000000000000000000000001';
+
+function musdUnits(human: string): string {
+  return new BigNumber(human).times(1e6).toFixed(0);
+}
+
+function mockBalance({
+  vmusdHuman,
+  isLoading = false,
+  isError = false,
+}: {
+  vmusdHuman?: string;
+  isLoading?: boolean;
+  isError?: boolean;
+}) {
+  useQueryMock.mockReturnValue({
+    data:
+      vmusdHuman === undefined
+        ? undefined
+        : ({
+            vmusdValueInMusd: musdUnits(vmusdHuman),
+          } as CanonicalMoneyAccountBalanceResponse),
+    isLoading,
+    isError,
+  } as ReturnType<typeof useQuery>);
+}
+
+function runHook({
+  pendingAmount,
+  type = TransactionType.moneyAccountWithdraw,
+}: {
+  pendingAmount?: string;
+  type?: TransactionType;
+} = {}) {
+  const transaction = {
+    ...genUnapprovedContractInteractionConfirmation(),
+    type,
+    txParams: {
+      from: MONEY_ACCOUNT_ADDRESS,
+    },
+  } as TransactionMeta;
+
+  return renderHookWithConfirmContextProvider(
+    () => useInsufficientMoneyAccountBalanceAlert({ pendingAmount }),
+    getMockConfirmStateForTransaction(transaction),
+  );
+}
+
+describe('useInsufficientMoneyAccountBalanceAlert', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockBalance({ vmusdHuman: '100' });
+    usePrimaryRequiredTokenMock.mockReturnValue(
+      undefined as unknown as ReturnType<
+        typeof useTransactionPayPrimaryRequiredToken
+      >,
+    );
+  });
+
+  it('returns alert when pending amount exceeds available balance', () => {
+    const { result } = runHook({ pendingAmount: '150' });
+
+    expect(result.current).toEqual([EXPECTED_ALERT]);
+  });
+
+  it('returns no alert when pending amount equals available balance', () => {
+    const { result } = runHook({ pendingAmount: '100' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert when pending amount is less than available balance', () => {
+    const { result } = runHook({ pendingAmount: '50' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert when withdrawableMusd is undefined', () => {
+    mockBalance({});
+
+    const { result } = runHook({ pendingAmount: '150' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert while the balance is loading', () => {
+    mockBalance({ isLoading: true });
+
+    const { result } = runHook({ pendingAmount: '150' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert when the balance query failed', () => {
+    mockBalance({ isError: true });
+
+    const { result } = runHook({ pendingAmount: '150' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert when transaction type is not moneyAccountWithdraw', () => {
+    const { result } = runHook({
+      pendingAmount: '150',
+      type: TransactionType.simpleSend,
+    });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('queries the money account balance service for a withdraw', () => {
+    runHook({ pendingAmount: '150' });
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [
+          MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+          MONEY_ACCOUNT_ADDRESS,
+        ],
+      }),
+    );
+  });
+
+  it('does not use a data service query key for a non-withdraw confirmation', () => {
+    // This hook runs for every confirmation via `useConfirmationAlerts`. The
+    // query client opens a background `messengerSubscribe` on the first
+    // observer of any data service key, so a money-account key here would
+    // fire that subscription for unrelated confirmations.
+    runHook({ pendingAmount: '150', type: TransactionType.simpleSend });
+
+    const queryKey = useQueryMock.mock.calls[0][0].queryKey ?? [];
+
+    expect(queryKey).not.toContain(
+      MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+    );
+    expect(
+      DATA_SERVICES.some((service) =>
+        String(queryKey[0]).startsWith(`${service}:`),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns no alert when no pendingAmount is provided and defaults to zero', () => {
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns alert using required token amount when no pendingAmount provided', () => {
+    usePrimaryRequiredTokenMock.mockReturnValue({
+      amountHuman: '150',
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([EXPECTED_ALERT]);
+  });
+
+  it('returns no alert when required token amount is within balance', () => {
+    usePrimaryRequiredTokenMock.mockReturnValue({
+      amountHuman: '50',
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+});

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
@@ -175,7 +175,11 @@ describe('useInsufficientMoneyAccountBalanceAlert', () => {
         String(queryKey[0]).startsWith(`${service}:`),
       ),
     ).toBe(false);
-    expect(typeof useQueryMock.mock.calls[0][0].queryFn).toBe('function');
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryFn: expect.any(Function),
+      }),
+    );
   });
 
   it('returns no alert when no pendingAmount is provided and defaults to zero', () => {

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
@@ -1,0 +1,206 @@
+import { BigNumber } from 'bignumber.js';
+import { useQuery } from '@metamask/react-data-query';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-account-balance-service';
+import { DATA_SERVICES } from '../../../../../../shared/constants/data-services';
+import { MoneyAccountBalanceServiceQueryKeys } from '../../../../../../shared/lib/money/query-keys';
+import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
+import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
+import { AlertsName } from '../constants';
+import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
+import { Severity } from '../../../../../helpers/constants/design-system';
+import { useInsufficientMoneyAccountBalanceAlert } from './useInsufficientMoneyAccountBalanceAlert';
+
+jest.mock('@metamask/react-data-query', () => ({
+  useQuery: jest.fn(),
+}));
+jest.mock('../../pay/useTransactionPayData');
+
+const useQueryMock = jest.mocked(useQuery);
+const usePrimaryRequiredTokenMock = jest.mocked(
+  useTransactionPayPrimaryRequiredToken,
+);
+
+const EXPECTED_ALERT = {
+  field: RowAlertKey.Amount,
+  isBlocking: true,
+  key: AlertsName.InsufficientMoneyAccountBalance,
+  message: 'Insufficient funds',
+  reason: 'Insufficient funds',
+  severity: Severity.Danger,
+};
+
+const MONEY_ACCOUNT_ADDRESS = '0xabc0000000000000000000000000000000000001';
+
+function musdUnits(human: string): string {
+  return new BigNumber(human).times(1e6).toFixed(0);
+}
+
+function mockBalance({
+  vmusdHuman,
+  isLoading = false,
+  isError = false,
+}: {
+  vmusdHuman?: string;
+  isLoading?: boolean;
+  isError?: boolean;
+}) {
+  useQueryMock.mockReturnValue({
+    data:
+      vmusdHuman === undefined
+        ? undefined
+        : ({
+            vmusdValueInMusd: musdUnits(vmusdHuman),
+          } as CanonicalMoneyAccountBalanceResponse),
+    isLoading,
+    isError,
+  } as ReturnType<typeof useQuery>);
+}
+
+function runHook({
+  pendingAmount,
+  type = TransactionType.moneyAccountWithdraw,
+}: {
+  pendingAmount?: string;
+  type?: TransactionType;
+} = {}) {
+  const transaction = {
+    ...genUnapprovedContractInteractionConfirmation(),
+    type,
+    txParams: {
+      from: MONEY_ACCOUNT_ADDRESS,
+    },
+  } as TransactionMeta;
+
+  return renderHookWithConfirmContextProvider(
+    () => useInsufficientMoneyAccountBalanceAlert({ pendingAmount }),
+    getMockConfirmStateForTransaction(transaction),
+  );
+}
+
+describe('useInsufficientMoneyAccountBalanceAlert', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockBalance({ vmusdHuman: '100' });
+    usePrimaryRequiredTokenMock.mockReturnValue(
+      undefined as unknown as ReturnType<
+        typeof useTransactionPayPrimaryRequiredToken
+      >,
+    );
+  });
+
+  it('returns alert when pending amount exceeds available balance', () => {
+    const { result } = runHook({ pendingAmount: '150' });
+
+    expect(result.current).toEqual([EXPECTED_ALERT]);
+  });
+
+  it('returns no alert when pending amount equals available balance', () => {
+    const { result } = runHook({ pendingAmount: '100' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert when pending amount is less than available balance', () => {
+    const { result } = runHook({ pendingAmount: '50' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert when withdrawableMusd is undefined', () => {
+    mockBalance({});
+
+    const { result } = runHook({ pendingAmount: '150' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert while the balance is loading', () => {
+    mockBalance({ isLoading: true });
+
+    const { result } = runHook({ pendingAmount: '150' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert when the balance query failed', () => {
+    mockBalance({ isError: true });
+
+    const { result } = runHook({ pendingAmount: '150' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert when transaction type is not moneyAccountWithdraw', () => {
+    const { result } = runHook({
+      pendingAmount: '150',
+      type: TransactionType.simpleSend,
+    });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('queries the money account balance service for a withdraw', () => {
+    runHook({ pendingAmount: '150' });
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [
+          MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+          MONEY_ACCOUNT_ADDRESS,
+        ],
+      }),
+    );
+  });
+
+  it('does not use a data service query key for a non-withdraw confirmation', () => {
+    // This hook runs for every confirmation via `useConfirmationAlerts`. The
+    // query client opens a background `messengerSubscribe` on the first
+    // observer of any data service key, so a money-account key here would
+    // fire that subscription for unrelated confirmations.
+    runHook({ pendingAmount: '150', type: TransactionType.simpleSend });
+
+    const queryKey = useQueryMock.mock.calls[0][0].queryKey ?? [];
+
+    expect(queryKey).not.toContain(
+      MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+    );
+    expect(
+      DATA_SERVICES.some((service) =>
+        String(queryKey[0]).startsWith(`${service}:`),
+      ),
+    ).toBe(false);
+    expect(typeof useQueryMock.mock.calls[0][0].queryFn).toBe('function');
+  });
+
+  it('returns no alert when no pendingAmount is provided and defaults to zero', () => {
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns alert using required token amount when no pendingAmount provided', () => {
+    usePrimaryRequiredTokenMock.mockReturnValue({
+      amountHuman: '150',
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([EXPECTED_ALERT]);
+  });
+
+  it('returns no alert when required token amount is within balance', () => {
+    usePrimaryRequiredTokenMock.mockReturnValue({
+      amountHuman: '50',
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+});

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
@@ -11,6 +11,7 @@ import { getMockConfirmStateForTransaction } from '../../../../../../test/data/c
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
+import { useLastMoneyAccountWithdrawAmount } from '../../transactions/useLastMoneyAccountWithdrawAmount';
 import { AlertsName } from '../constants';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../helpers/constants/design-system';
@@ -20,10 +21,14 @@ jest.mock('@metamask/react-data-query', () => ({
   useQuery: jest.fn(),
 }));
 jest.mock('../../pay/useTransactionPayData');
+jest.mock('../../transactions/useLastMoneyAccountWithdrawAmount');
 
 const useQueryMock = jest.mocked(useQuery);
 const usePrimaryRequiredTokenMock = jest.mocked(
   useTransactionPayPrimaryRequiredToken,
+);
+const useLastWithdrawAmountMock = jest.mocked(
+  useLastMoneyAccountWithdrawAmount,
 );
 
 const EXPECTED_ALERT = {
@@ -87,6 +92,7 @@ describe('useInsufficientMoneyAccountBalanceAlert', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockBalance({ vmusdHuman: '100' });
+    useLastWithdrawAmountMock.mockReturnValue(undefined);
     usePrimaryRequiredTokenMock.mockReturnValue(
       undefined as unknown as ReturnType<
         typeof useTransactionPayPrimaryRequiredToken
@@ -188,7 +194,15 @@ describe('useInsufficientMoneyAccountBalanceAlert', () => {
     expect(result.current).toStrictEqual([]);
   });
 
-  it('returns alert using required token amount when no pendingAmount provided', () => {
+  it('returns alert using the last typed withdraw amount when no pendingAmount provided', () => {
+    useLastWithdrawAmountMock.mockReturnValue('150');
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([EXPECTED_ALERT]);
+  });
+
+  it('returns alert using required token amount when no pendingAmount or typed amount provided', () => {
     usePrimaryRequiredTokenMock.mockReturnValue({
       amountHuman: '150',
     } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.ts
@@ -1,0 +1,117 @@
+'use no memo';
+
+import { useMemo } from 'react';
+import { BigNumber } from 'bignumber.js';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { MUSD_DECIMALS } from '@metamask/money-account-utils';
+import { useQuery } from '@metamask/react-data-query';
+import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-account-balance-service';
+import type { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
+import { Severity } from '../../../../../helpers/constants/design-system';
+import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
+import { MoneyAccountBalanceServiceQueryKeys } from '../../../../../../shared/lib/money/query-keys';
+import { useConfirmContext } from '../../../context/confirm';
+import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
+import { AlertsName } from '../constants';
+
+const MUSD_UNIT = 10 ** MUSD_DECIMALS;
+
+/**
+ * Inert query key used when the confirmation is not a money-account withdraw.
+ * Deliberately not a `DATA_SERVICES` name so the query client does not open a
+ * background messenger subscription for it.
+ */
+const NON_WITHDRAW_QUERY_KEY = 'money-account-withdraw-alert:disabled';
+
+/**
+ * Blocking alert when a money-account withdraw exceeds withdrawable vmUSD.
+ *
+ * Reads the same react-query cache `useMoneyAccountBalance` writes (from the
+ * withdraw info messenger) so this can run in `useConfirmationAlerts` without
+ * requiring a money-account route messenger.
+ *
+ * Mirrors mobile `useInsufficientMoneyAccountBalanceAlert`.
+ *
+ * @param options
+ * @param options.pendingAmount - Optional in-progress human mUSD amount.
+ */
+export function useInsufficientMoneyAccountBalanceAlert({
+  pendingAmount,
+}: {
+  pendingAmount?: string;
+} = {}): Alert[] {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
+
+  const isMoneyAccountWithdraw = hasTransactionType(currentConfirmation, [
+    TransactionType.moneyAccountWithdraw,
+  ]);
+  const moneyAccountAddress = currentConfirmation?.txParams?.from;
+
+  // This hook runs from `useConfirmationAlerts` for every confirmation, but
+  // only withdrawals can produce this alert. `useQuery` registers a cache
+  // observer even when `enabled` is false, and the query client subscribes to
+  // the owning data service on the first observer — so a money-account key
+  // here would open a `messengerSubscribe` for unrelated confirmations. Use a
+  // key outside `DATA_SERVICES` unless this really is a withdraw, which leaves
+  // the query inert and skips the subscription entirely.
+  const moneyBalanceQuery = useQuery<CanonicalMoneyAccountBalanceResponse>({
+    queryKey: isMoneyAccountWithdraw
+      ? [
+          MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+          moneyAccountAddress ?? '',
+        ]
+      : [NON_WITHDRAW_QUERY_KEY],
+    enabled: false,
+  });
+
+  const amountHuman = pendingAmount ?? primaryRequiredToken?.amountHuman ?? '0';
+
+  const withdrawableMusd = useMemo(() => {
+    if (
+      !isMoneyAccountWithdraw ||
+      moneyBalanceQuery.isLoading ||
+      moneyBalanceQuery.isError ||
+      !moneyBalanceQuery.data
+    ) {
+      return undefined;
+    }
+
+    return new BigNumber(
+      moneyBalanceQuery.data.vmusdValueInMusd ?? 0,
+    ).dividedBy(MUSD_UNIT);
+  }, [
+    isMoneyAccountWithdraw,
+    moneyBalanceQuery.data,
+    moneyBalanceQuery.isError,
+    moneyBalanceQuery.isLoading,
+  ]);
+
+  const isInsufficient =
+    isMoneyAccountWithdraw &&
+    withdrawableMusd !== undefined &&
+    withdrawableMusd.lt(amountHuman);
+
+  return useMemo(() => {
+    if (!isInsufficient) {
+      return [];
+    }
+
+    return [
+      {
+        field: RowAlertKey.Amount,
+        isBlocking: true,
+        key: AlertsName.InsufficientMoneyAccountBalance,
+        message: t('alertInsufficientPayTokenBalance'),
+        reason: t('alertInsufficientPayTokenBalance'),
+        severity: Severity.Danger,
+      },
+    ];
+  }, [isInsufficient, t]);
+}

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.ts
@@ -17,6 +17,7 @@ import { hasTransactionType } from '../../../../../../shared/lib/transactions.ut
 import { MoneyAccountBalanceServiceQueryKeys } from '../../../../../../shared/lib/money/query-keys';
 import { useConfirmContext } from '../../../context/confirm';
 import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
+import { useLastMoneyAccountWithdrawAmount } from '../../transactions/useLastMoneyAccountWithdrawAmount';
 import { AlertsName } from '../constants';
 
 const MUSD_UNIT = 10 ** MUSD_DECIMALS;
@@ -34,11 +35,14 @@ const NON_WITHDRAW_QUERY_KEY = 'money-account-withdraw-alert:disabled';
  * false — and this hook runs for every confirmation via `useConfirmationAlerts`.
  */
 function disabledWithdrawAlertQueryFn(): never {
-  throw new Error('money-account-withdraw-alert is cache-only');
+  throw new Error('money-account-withdraw-alert is disabled for non-withdraws');
 }
 
 /**
- * Blocking alert when a money-account withdraw exceeds withdrawable vmUSD.
+ * Blocking alert when a money-account withdraw exceeds withdrawable vault
+ * balance (`vmusdValueInMusd` only — free mUSD is not withdrawable via this
+ * path). Matches the Max / available-balance source used by
+ * `useTransactionCustomAmount` for money-account withdraws.
  *
  * Reads the same react-query cache `useMoneyAccountBalance` writes (from the
  * withdraw info messenger) so this can run in `useConfirmationAlerts` without
@@ -57,6 +61,9 @@ export function useInsufficientMoneyAccountBalanceAlert({
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
+  const lastWithdrawAmount = useLastMoneyAccountWithdrawAmount(
+    currentConfirmation?.id ?? '',
+  );
 
   const isMoneyAccountWithdraw = hasTransactionType(currentConfirmation, [
     TransactionType.moneyAccountWithdraw,
@@ -85,7 +92,13 @@ export function useInsufficientMoneyAccountBalanceAlert({
       : { queryFn: disabledWithdrawAlertQueryFn }),
   });
 
-  const amountHuman = pendingAmount ?? primaryRequiredToken?.amountHuman ?? '0';
+  // Direct withdraws have no primary required token; the typed amount is
+  // recorded synchronously for the footer / confirm path.
+  const amountHuman =
+    pendingAmount ??
+    lastWithdrawAmount ??
+    primaryRequiredToken?.amountHuman ??
+    '0';
 
   const withdrawableMusd = useMemo(() => {
     if (

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.ts
@@ -1,0 +1,131 @@
+'use no memo';
+
+import { useMemo } from 'react';
+import { BigNumber } from 'bignumber.js';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { MUSD_DECIMALS } from '@metamask/money-account-utils';
+import { useQuery } from '@metamask/react-data-query';
+import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-account-balance-service';
+import type { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
+import { Severity } from '../../../../../helpers/constants/design-system';
+import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
+import { MoneyAccountBalanceServiceQueryKeys } from '../../../../../../shared/lib/money/query-keys';
+import { useConfirmContext } from '../../../context/confirm';
+import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
+import { AlertsName } from '../constants';
+
+const MUSD_UNIT = 10 ** MUSD_DECIMALS;
+
+/**
+ * Inert query key used when the confirmation is not a money-account withdraw.
+ * Deliberately not a `DATA_SERVICES` name so the query client does not open a
+ * background messenger subscription for it.
+ */
+const NON_WITHDRAW_QUERY_KEY = 'money-account-withdraw-alert:disabled';
+
+/**
+ * Never-run `queryFn` for {@link NON_WITHDRAW_QUERY_KEY}. TanStack Query logs
+ * "No queryFn was found" for observers that omit one, even when `enabled` is
+ * false — and this hook runs for every confirmation via `useConfirmationAlerts`.
+ */
+function disabledWithdrawAlertQueryFn(): never {
+  throw new Error('money-account-withdraw-alert is cache-only');
+}
+
+/**
+ * Blocking alert when a money-account withdraw exceeds withdrawable vmUSD.
+ *
+ * Reads the same react-query cache `useMoneyAccountBalance` writes (from the
+ * withdraw info messenger) so this can run in `useConfirmationAlerts` without
+ * requiring a money-account route messenger.
+ *
+ * Mirrors mobile `useInsufficientMoneyAccountBalanceAlert`.
+ *
+ * @param options
+ * @param options.pendingAmount - Optional in-progress human mUSD amount.
+ */
+export function useInsufficientMoneyAccountBalanceAlert({
+  pendingAmount,
+}: {
+  pendingAmount?: string;
+} = {}): Alert[] {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
+
+  const isMoneyAccountWithdraw = hasTransactionType(currentConfirmation, [
+    TransactionType.moneyAccountWithdraw,
+  ]);
+  const moneyAccountAddress = currentConfirmation?.txParams?.from;
+
+  // This hook runs from `useConfirmationAlerts` for every confirmation, but
+  // only withdrawals can produce this alert. `useQuery` registers a cache
+  // observer even when `enabled` is false, and the query client subscribes to
+  // the owning data service on the first observer — so a money-account key
+  // here would open a `messengerSubscribe` for unrelated confirmations. Use a
+  // key outside `DATA_SERVICES` unless this really is a withdraw, which leaves
+  // the query inert and skips the subscription entirely.
+  const moneyBalanceQuery = useQuery<CanonicalMoneyAccountBalanceResponse>({
+    queryKey: isMoneyAccountWithdraw
+      ? [
+          MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+          moneyAccountAddress ?? '',
+        ]
+      : [NON_WITHDRAW_QUERY_KEY],
+    enabled: false,
+    // Only the dummy key needs a queryFn. The withdraw key is owned by
+    // DATA_SERVICES; attaching a local queryFn would overwrite that handler.
+    ...(isMoneyAccountWithdraw
+      ? {}
+      : { queryFn: disabledWithdrawAlertQueryFn }),
+  });
+
+  const amountHuman = pendingAmount ?? primaryRequiredToken?.amountHuman ?? '0';
+
+  const withdrawableMusd = useMemo(() => {
+    if (
+      !isMoneyAccountWithdraw ||
+      moneyBalanceQuery.isLoading ||
+      moneyBalanceQuery.isError ||
+      !moneyBalanceQuery.data
+    ) {
+      return undefined;
+    }
+
+    return new BigNumber(
+      moneyBalanceQuery.data.vmusdValueInMusd ?? 0,
+    ).dividedBy(MUSD_UNIT);
+  }, [
+    isMoneyAccountWithdraw,
+    moneyBalanceQuery.data,
+    moneyBalanceQuery.isError,
+    moneyBalanceQuery.isLoading,
+  ]);
+
+  const isInsufficient =
+    isMoneyAccountWithdraw &&
+    withdrawableMusd !== undefined &&
+    withdrawableMusd.lt(amountHuman);
+
+  return useMemo(() => {
+    if (!isInsufficient) {
+      return [];
+    }
+
+    return [
+      {
+        field: RowAlertKey.Amount,
+        isBlocking: true,
+        key: AlertsName.InsufficientMoneyAccountBalance,
+        message: t('alertInsufficientPayTokenBalance'),
+        reason: t('alertInsufficientPayTokenBalance'),
+        severity: Severity.Danger,
+      },
+    ];
+  }, [isInsufficient, t]);
+}

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.test.ts
@@ -1,4 +1,4 @@
-import { GasFeeToken } from '@metamask/transaction-controller';
+import { GasFeeToken, TransactionType } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 
 import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
@@ -23,6 +23,7 @@ async function runHook({
   selectedGasFeeToken,
   excludeNativeTokenForFee,
   isGasFeeSponsored,
+  type,
 }: {
   simulationEnabled: boolean;
   gaslessSupported: boolean;
@@ -32,6 +33,7 @@ async function runHook({
   selectedGasFeeToken?: Hex;
   excludeNativeTokenForFee?: boolean;
   isGasFeeSponsored?: boolean;
+  type?: TransactionType;
 }) {
   mockedUseIsGaslessSupported.mockReturnValue({
     isSupported: gaslessSupported,
@@ -44,17 +46,21 @@ async function runHook({
     nativeCurrency: 'USD',
   });
 
+  const confirmation = genUnapprovedContractInteractionConfirmation({
+    gasFeeTokens,
+    selectedGasFeeToken,
+    excludeNativeTokenForFee,
+    isGasFeeSponsored,
+  });
+  if (type) {
+    confirmation.type = type;
+  }
+
   const { result } = renderHookWithConfirmContextProvider(
     useIsGaslessLoading,
-    getMockConfirmStateForTransaction(
-      genUnapprovedContractInteractionConfirmation({
-        gasFeeTokens,
-        selectedGasFeeToken,
-        excludeNativeTokenForFee,
-        isGasFeeSponsored,
-      }),
-      { metamask: { useTransactionSimulations: simulationEnabled } },
-    ),
+    getMockConfirmStateForTransaction(confirmation, {
+      metamask: { useTransactionSimulations: simulationEnabled },
+    }),
   );
 
   return result.current;
@@ -106,6 +112,18 @@ describe('useIsGaslessLoading', () => {
     expect(result.isGaslessLoading).toBe(false);
   });
 
+  it('returns false for a money account withdraw even when gas fee tokens are still loading', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: undefined,
+      type: TransactionType.moneyAccountWithdraw,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
   it('returns true if gas fee tokens are undefined (still loading)', async () => {
     const result = await runHook({
       simulationEnabled: true,
@@ -124,6 +142,18 @@ describe('useIsGaslessLoading', () => {
       insufficientBalance: true,
       gasFeeTokens: undefined,
       isGasFeeSponsored: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false for a money-account deposit even if gas fee tokens are missing', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: undefined,
+      type: TransactionType.moneyAccountDeposit,
     });
 
     expect(result.isGaslessLoading).toBe(false);

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.test.ts
@@ -1,4 +1,4 @@
-import { GasFeeToken } from '@metamask/transaction-controller';
+import { GasFeeToken, TransactionType } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 
 import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
@@ -22,6 +22,7 @@ async function runHook({
   gasFeeTokens,
   selectedGasFeeToken,
   excludeNativeTokenForFee,
+  type,
 }: {
   simulationEnabled: boolean;
   gaslessSupported: boolean;
@@ -30,6 +31,7 @@ async function runHook({
   gasFeeTokens?: GasFeeToken[];
   selectedGasFeeToken?: Hex;
   excludeNativeTokenForFee?: boolean;
+  type?: TransactionType;
 }) {
   mockedUseIsGaslessSupported.mockReturnValue({
     isSupported: gaslessSupported,
@@ -45,11 +47,14 @@ async function runHook({
   const { result } = renderHookWithConfirmContextProvider(
     useIsGaslessLoading,
     getMockConfirmStateForTransaction(
-      genUnapprovedContractInteractionConfirmation({
-        gasFeeTokens,
-        selectedGasFeeToken,
-        excludeNativeTokenForFee,
-      }),
+      {
+        ...genUnapprovedContractInteractionConfirmation({
+          gasFeeTokens,
+          selectedGasFeeToken,
+          excludeNativeTokenForFee,
+        }),
+        ...(type ? { type } : {}),
+      },
       { metamask: { useTransactionSimulations: simulationEnabled } },
     ),
   );
@@ -98,6 +103,18 @@ describe('useIsGaslessLoading', () => {
       simulationEnabled: true,
       gaslessSupported: true,
       insufficientBalance: false,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false for a money account withdraw even when gas fee tokens are still loading', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: undefined,
+      type: TransactionType.moneyAccountWithdraw,
     });
 
     expect(result.isGaslessLoading).toBe(false);

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.ts
@@ -1,6 +1,11 @@
 import { useSelector } from 'react-redux';
-import { GasFeeToken, TransactionMeta } from '@metamask/transaction-controller';
+import {
+  GasFeeToken,
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
+import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
 import { useConfirmContext } from '../../context/confirm';
 import { getUseTransactionSimulations } from '../../../../selectors';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
@@ -49,7 +54,15 @@ export function useIsGaslessLoading() {
   const hasNoNativeTokenAvailable =
     excludeNativeTokenForFee || hasInsufficientBalance;
 
+  // Money-account batches skip initial gas estimate and sponsor Monad gas.
+  // Waiting on `gasFeeTokens` keeps Send spinning forever.
+  const isMoneyAccountTransaction = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountDeposit,
+    TransactionType.moneyAccountWithdraw,
+  ]);
+
   const isGaslessLoading = Boolean(
+    !isMoneyAccountTransaction &&
     isSimulationEnabled &&
     hasNoNativeTokenAvailable &&
     (isGaslessSupportedPending || isGaslessSupportedFinished) &&

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 import { GasFeeToken, TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
+import { getMoneyAccountFlow } from '../../../../../shared/lib/money/money-account-flow';
 import { useConfirmContext } from '../../context/confirm';
 import { getUseTransactionSimulations } from '../../../../selectors';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
@@ -49,10 +50,12 @@ export function useIsGaslessLoading() {
   const hasNoNativeTokenAvailable =
     excludeNativeTokenForFee || hasInsufficientBalance;
 
-  // Money Account batches skip the initial gas estimate and set
-  // `isGasFeeSponsored` at creation on Monad, so `gasFeeTokens` never arrives.
-  // Waiting on them leaves the confirm button spinning after quotes are ready.
-  const skipsGaslessTokenWait = Boolean(transactionMeta?.isGasFeeSponsored);
+  // Money Account batches skip the initial gas estimate and are often
+  // sponsored, so `gasFeeTokens` never arrives. Waiting on them leaves the
+  // confirm button spinning after quotes (and "Paid by MetaMask") are ready.
+  const skipsGaslessTokenWait =
+    Boolean(transactionMeta?.isGasFeeSponsored) ||
+    Boolean(getMoneyAccountFlow(transactionMeta));
 
   const isGaslessLoading = Boolean(
     !skipsGaslessTokenWait &&

--- a/ui/pages/confirmations/hooks/pay/useIsPaidByMetaMask.test.ts
+++ b/ui/pages/confirmations/hooks/pay/useIsPaidByMetaMask.test.ts
@@ -7,6 +7,7 @@ import type { TransactionPayTotals } from '@metamask/transaction-pay-controller'
 import { useTransactionMetadataRequestOptional } from '../transactions/useTransactionMetadataRequest';
 import {
   useTransactionPayHasPositiveRequiredAmount,
+  useTransactionPayQuotes,
   useTransactionPaySourceAmounts,
   useTransactionPayTotals,
 } from './useTransactionPayData';
@@ -22,6 +23,7 @@ const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
 const useTransactionPayHasPositiveRequiredAmountMock = jest.mocked(
   useTransactionPayHasPositiveRequiredAmount,
 );
+const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
 const useTransactionPaySourceAmountsMock = jest.mocked(
   useTransactionPaySourceAmounts,
 );
@@ -54,6 +56,7 @@ describe('useIsPaidByMetaMask', () => {
     mockConfirmation(TransactionType.musdConversion);
     mockTotals();
     useTransactionPayHasPositiveRequiredAmountMock.mockReturnValue(true);
+    useTransactionPayQuotesMock.mockReturnValue([{}] as never);
     useTransactionPaySourceAmountsMock.mockReturnValue(undefined);
   });
 
@@ -107,6 +110,64 @@ describe('useIsPaidByMetaMask', () => {
 
   it('returns true when all fees are zero for moneyAccountDeposit', () => {
     mockConfirmation(TransactionType.moneyAccountDeposit);
+
+    const { result } = renderHook(() => useIsPaidByMetaMask());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true when all fees are zero for moneyAccountWithdraw', () => {
+    mockConfirmation(TransactionType.moneyAccountWithdraw);
+
+    const { result } = renderHook(() => useIsPaidByMetaMask());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true for a sponsored withdraw with no quotes', () => {
+    mockConfirmation(TransactionType.moneyAccountWithdraw, {
+      isGasFeeSponsored: true,
+    });
+    useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayTotalsMock.mockReturnValue(undefined);
+    useTransactionPaySourceAmountsMock.mockReturnValue([]);
+
+    const { result } = renderHook(() => useIsPaidByMetaMask());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true for a sponsored withdraw whose quote only has network gas', () => {
+    mockConfirmation(TransactionType.moneyAccountWithdraw, {
+      isGasFeeSponsored: true,
+    });
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      {},
+    ] as unknown as ReturnType<typeof useTransactionPaySourceAmounts>);
+    mockTotals({
+      sourceNetwork: { estimate: { usd: '0.15' } },
+    } as TransactionPayTotals['fees']);
+
+    const { result } = renderHook(() => useIsPaidByMetaMask());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false for a sponsored withdraw with a provider fee', () => {
+    mockConfirmation(TransactionType.moneyAccountWithdraw, {
+      isGasFeeSponsored: true,
+    });
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      {},
+    ] as unknown as ReturnType<typeof useTransactionPaySourceAmounts>);
+    mockTotals({
+      sourceNetwork: { estimate: { usd: '0.15' } },
+      provider: { usd: '1.00' },
+    } as TransactionPayTotals['fees']);
+
+    const { result } = renderHook(() => useIsPaidByMetaMask());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true for a money-account withdraw with no required amount', () => {
+    mockConfirmation(TransactionType.moneyAccountWithdraw);
+    useTransactionPayHasPositiveRequiredAmountMock.mockReturnValue(false);
 
     const { result } = renderHook(() => useIsPaidByMetaMask());
     expect(result.current).toBe(true);

--- a/ui/pages/confirmations/hooks/pay/useIsPaidByMetaMask.test.ts
+++ b/ui/pages/confirmations/hooks/pay/useIsPaidByMetaMask.test.ts
@@ -7,6 +7,7 @@ import type { TransactionPayTotals } from '@metamask/transaction-pay-controller'
 import { useTransactionMetadataRequestOptional } from '../transactions/useTransactionMetadataRequest';
 import {
   useTransactionPayHasPositiveRequiredAmount,
+  useTransactionPayQuotes,
   useTransactionPaySourceAmounts,
   useTransactionPayTotals,
 } from './useTransactionPayData';
@@ -22,6 +23,7 @@ const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
 const useTransactionPayHasPositiveRequiredAmountMock = jest.mocked(
   useTransactionPayHasPositiveRequiredAmount,
 );
+const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
 const useTransactionPaySourceAmountsMock = jest.mocked(
   useTransactionPaySourceAmounts,
 );
@@ -54,6 +56,7 @@ describe('useIsPaidByMetaMask', () => {
     mockConfirmation(TransactionType.musdConversion);
     mockTotals();
     useTransactionPayHasPositiveRequiredAmountMock.mockReturnValue(true);
+    useTransactionPayQuotesMock.mockReturnValue([{}] as never);
     useTransactionPaySourceAmountsMock.mockReturnValue(undefined);
   });
 
@@ -110,6 +113,25 @@ describe('useIsPaidByMetaMask', () => {
 
     const { result } = renderHook(() => useIsPaidByMetaMask());
     expect(result.current).toBe(true);
+  });
+
+  it('returns true when all fees are zero for moneyAccountWithdraw', () => {
+    mockConfirmation(TransactionType.moneyAccountWithdraw);
+
+    const { result } = renderHook(() => useIsPaidByMetaMask());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false for a sponsored withdraw with no quotes', () => {
+    mockConfirmation(TransactionType.moneyAccountWithdraw, {
+      isGasFeeSponsored: true,
+    });
+    useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayTotalsMock.mockReturnValue(undefined);
+    useTransactionPaySourceAmountsMock.mockReturnValue([]);
+
+    const { result } = renderHook(() => useIsPaidByMetaMask());
+    expect(result.current).toBe(false);
   });
 
   it('returns true when gas is sponsored and there are no source amounts yet', () => {

--- a/ui/pages/confirmations/hooks/pay/useIsPaidByMetaMask.ts
+++ b/ui/pages/confirmations/hooks/pay/useIsPaidByMetaMask.ts
@@ -4,6 +4,7 @@ import { hasTransactionType } from '../../../../../shared/lib/transactions.utils
 import { useTransactionMetadataRequestOptional } from '../transactions/useTransactionMetadataRequest';
 import {
   useTransactionPayHasPositiveRequiredAmount,
+  useTransactionPayQuotes,
   useTransactionPaySourceAmounts,
   useTransactionPayTotals,
 } from './useTransactionPayData';
@@ -11,6 +12,7 @@ import {
 const SUPPORTED_TYPES: TransactionType[] = [
   TransactionType.musdConversion,
   TransactionType.moneyAccountDeposit,
+  TransactionType.moneyAccountWithdraw,
 ];
 
 /**
@@ -29,11 +31,14 @@ const SUPPORTED_TYPES: TransactionType[] = [
  *
  * Money-account deposits on Monad are gas-sponsored, and fixed-spread /
  * same-token (Monad mUSD) routes have $0 provider fee, so they show as paid
- * by MetaMask the same way mUSD conversion does.
+ * by MetaMask the same way mUSD conversion does. Same-token Money Account
+ * withdraws store a Pay no-op quote whose totals still include estimated
+ * network gas; that gas is also sponsored on Monad.
  */
 export function useIsPaidByMetaMask(): boolean {
   const transactionMeta = useTransactionMetadataRequestOptional();
   const totals = useTransactionPayTotals();
+  const quotes = useTransactionPayQuotes();
   const sourceAmounts = useTransactionPaySourceAmounts();
   const hasPositiveRequiredAmount =
     useTransactionPayHasPositiveRequiredAmount();
@@ -42,19 +47,26 @@ export function useIsPaidByMetaMask(): boolean {
     return false;
   }
 
+  const isMoneyAccountWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountWithdraw,
+  ]);
   const isGasSponsored = Boolean(transactionMeta?.isGasFeeSponsored);
 
-  // Pre-quote gasless deposits: sponsorship is known from the transaction
+  // Pre-quote / same-token no-op: sponsorship is known from the transaction
   // flag before conversion quotes exist.
   if (isGasSponsored && !sourceAmounts?.length) {
     return true;
   }
 
   // Every fee is zero before an amount is entered, which is indistinguishable
-  // from genuine sponsorship. Requiring a positive amount stops the empty state
-  // from claiming the transaction is "Paid by MetaMask" and then contradicting
-  // itself with real fees once the user types.
-  if (!totals?.fees || !hasPositiveRequiredAmount) {
+  // from genuine sponsorship. Requiring a positive amount stops the empty
+  // deposit state from claiming "Paid by MetaMask". Withdrawals have no
+  // `requiredAssets`, so that gate would never pass.
+  if (
+    !quotes?.length ||
+    !totals?.fees ||
+    (!isMoneyAccountWithdraw && !hasPositiveRequiredAmount)
+  ) {
     return false;
   }
 

--- a/ui/pages/confirmations/hooks/pay/useIsPaidByMetaMask.ts
+++ b/ui/pages/confirmations/hooks/pay/useIsPaidByMetaMask.ts
@@ -4,6 +4,7 @@ import { hasTransactionType } from '../../../../../shared/lib/transactions.utils
 import { useTransactionMetadataRequestOptional } from '../transactions/useTransactionMetadataRequest';
 import {
   useTransactionPayHasPositiveRequiredAmount,
+  useTransactionPayQuotes,
   useTransactionPaySourceAmounts,
   useTransactionPayTotals,
 } from './useTransactionPayData';
@@ -11,19 +12,22 @@ import {
 const SUPPORTED_TYPES: TransactionType[] = [
   TransactionType.musdConversion,
   TransactionType.moneyAccountDeposit,
+  TransactionType.moneyAccountWithdraw,
 ];
 
 /**
  * Determines whether the current transaction is fully sponsored by MetaMask
  * (zero gas, zero provider fee, zero MetaMask fee).
  *
- * Money-account deposits on Monad are gas-sponsored, and fixed-spread / same-
- * token (Monad mUSD) routes have $0 provider fee, so they show as paid by
- * MetaMask the same way mUSD conversion does.
+ * The pre-quote sponsored short-circuit is deposit-only. Direct withdrawals
+ * set `isGasFeeSponsored` on Monad and never have source amounts, so that
+ * check would always show "Paid by MetaMask". Withdrawals only qualify once
+ * a quote reports $0 fees.
  */
 export function useIsPaidByMetaMask(): boolean {
   const transactionMeta = useTransactionMetadataRequestOptional();
   const totals = useTransactionPayTotals();
+  const quotes = useTransactionPayQuotes();
   const sourceAmounts = useTransactionPaySourceAmounts();
   const hasPositiveRequiredAmount =
     useTransactionPayHasPositiveRequiredAmount();
@@ -32,8 +36,16 @@ export function useIsPaidByMetaMask(): boolean {
     return false;
   }
 
+  const isMoneyAccountWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountWithdraw,
+  ]);
+
   // Pre-quote gasless deposits: no conversion yet, gas is sponsored.
-  if (transactionMeta?.isGasFeeSponsored && !sourceAmounts?.length) {
+  if (
+    !isMoneyAccountWithdraw &&
+    transactionMeta?.isGasFeeSponsored &&
+    !sourceAmounts?.length
+  ) {
     return true;
   }
 
@@ -41,7 +53,7 @@ export function useIsPaidByMetaMask(): boolean {
   // from genuine sponsorship. Requiring a positive amount stops the empty state
   // from claiming the transaction is "Paid by MetaMask" and then contradicting
   // itself with real fees once the user types.
-  if (!totals?.fees || !hasPositiveRequiredAmount) {
+  if (!quotes?.length || !totals?.fees || !hasPositiveRequiredAmount) {
     return false;
   }
 

--- a/ui/pages/confirmations/hooks/pay/usePayWithNoFeeToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePayWithNoFeeToken.test.tsx
@@ -2,15 +2,25 @@ import React from 'react';
 import { renderHook } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { type Asset } from '../../types/send';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { MUSD_TOKEN_ADDRESS } from '../../constants/musd';
+import { useTransactionMetadataRequestOptional } from '../transactions/useTransactionMetadataRequest';
 import { usePayWithNoFeeToken } from './usePayWithNoFeeToken';
+
+jest.mock('../transactions/useTransactionMetadataRequest');
 
 const ETH_USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 const ETH_MUSD = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
 
 const mockStore = configureMockStore();
+const useTransactionMetadataRequestOptionalMock = jest.mocked(
+  useTransactionMetadataRequestOptional,
+);
 
 function renderUsePayWithNoFeeToken(
   remoteFeatureFlags: Record<string, unknown>,
@@ -29,6 +39,10 @@ function renderUsePayWithNoFeeToken(
 }
 
 describe('usePayWithNoFeeToken', () => {
+  beforeEach(() => {
+    useTransactionMetadataRequestOptionalMock.mockReturnValue(undefined);
+  });
+
   it('returns false when the relay fixed-spread flag is empty', () => {
     const { result } = renderUsePayWithNoFeeToken({});
 
@@ -95,5 +109,51 @@ describe('usePayWithNoFeeToken', () => {
     } as Asset);
 
     expect(tagged).not.toBeNull();
+  });
+
+  describe('Money Account withdrawal — directional no-fee', () => {
+    const ethDest = '0xdddddddddddddddddddddddddddddddddddddddd';
+
+    beforeEach(() => {
+      useTransactionMetadataRequestOptionalMock.mockReturnValue({
+        type: TransactionType.moneyAccountWithdraw,
+      } as TransactionMeta);
+    });
+
+    it('tags a token that is the destination of a Monad mUSD route', () => {
+      const { result } = renderUsePayWithNoFeeToken({
+        /* eslint-disable @typescript-eslint/naming-convention */
+        confirmations_relay_fixed_spread: {
+          chains: { eth: '0x1', monad: CHAIN_IDS.MONAD },
+          tokens: { eth_dest: ethDest, musd: MUSD_TOKEN_ADDRESS },
+          routes: [['monad', 'musd', 'eth', 'eth_dest']],
+        },
+        /* eslint-enable @typescript-eslint/naming-convention */
+      });
+
+      expect(result.current.isNoFeeToken(ethDest, '0x1')).toBe(true);
+    });
+
+    it('does not tag a deposit-only subsidised source', () => {
+      const { result } = renderUsePayWithNoFeeToken({
+        /* eslint-disable @typescript-eslint/naming-convention */
+        confirmations_relay_fixed_spread: {
+          chains: { eth: '0x1', monad: CHAIN_IDS.MONAD },
+          tokens: { eth_usdc: ETH_USDC, musd: MUSD_TOKEN_ADDRESS },
+          routes: [['eth', 'eth_usdc', 'monad', 'musd']],
+        },
+        /* eslint-enable @typescript-eslint/naming-convention */
+      });
+
+      expect(result.current.isNoFeeToken(ETH_USDC, '0x1')).toBe(false);
+    });
+
+    it('tags Monad mUSD itself even though the flag omits the same-token route', () => {
+      const { result } = renderUsePayWithNoFeeToken({});
+
+      expect(
+        result.current.isNoFeeToken(MUSD_TOKEN_ADDRESS, CHAIN_IDS.MONAD),
+      ).toBe(true);
+    });
   });
 });

--- a/ui/pages/confirmations/hooks/pay/usePayWithNoFeeToken.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePayWithNoFeeToken.tsx
@@ -1,16 +1,30 @@
 import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { isSubsidizedSource } from '../../utils/relay-fixed-spread';
+import { TransactionType } from '@metamask/transaction-controller';
+import {
+  isSubsidizedRoute,
+  isSubsidizedSource,
+} from '../../utils/relay-fixed-spread';
 import { selectRelayFixedSpread } from '../../selectors/feature-flags';
 import { NoFeeTag } from '../../components/UI/no-fee-tag';
 import { type TokenTagRenderer } from '../../components/UI/asset';
 import { type Asset } from '../../types/send';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
 import { MUSD_TOKEN_ADDRESS } from '../../constants/musd';
+import { useTransactionMetadataRequestOptional } from '../transactions/useTransactionMetadataRequest';
+
+/** The Money Account vault token; withdrawals always convert FROM this. */
+const MONAD_MUSD_SOURCE = {
+  address: MUSD_TOKEN_ADDRESS,
+  chainId: CHAIN_IDS.MONAD,
+};
 
 /**
  * Monad mUSD → Monad mUSD needs no swap or bridge, so the fixed-spread flag
- * omits that same-token route. Depositing it still incurs no Relay fee.
+ * omits that same-token route. Depositing or withdrawing it still incurs no
+ * Relay fee.
+ *
  * @param address
  * @param chainId
  */
@@ -19,21 +33,38 @@ const isMonadMusd = (address: string, chainId: string) =>
   address.toLowerCase() === MUSD_TOKEN_ADDRESS.toLowerCase();
 
 /**
- * Identifies payment tokens that incur no Relay fixed-spread fee for
- * Money Account deposits. A token is no-fee when it is a subsidised source
- * in the `confirmations_relay_fixed_spread` remote feature flag, or when it
- * is Monad mUSD itself.
+ * Identifies tokens that incur no Relay fixed-spread fee.
+ *
+ * For deposits the picker token is the source, so a token is no-fee when it
+ * is a subsidised source (or Monad mUSD itself). For a Money Account
+ * withdrawal the picker token is the destination and the source is always
+ * Monad mUSD, so the match is directional: a subsidised route FROM Monad
+ * mUSD INTO the token, or Monad mUSD itself.
  */
 export function usePayWithNoFeeToken(): {
   isNoFeeToken: (address: string, chainId: string) => boolean;
   renderNoFeeTag: TokenTagRenderer;
 } {
   const relayFixedSpread = useSelector(selectRelayFixedSpread);
+  const transactionMeta = useTransactionMetadataRequestOptional();
+  const isMoneyWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountWithdraw,
+  ]);
 
   const isNoFeeToken = useCallback(
     (address: string, chainId: string): boolean => {
       if (!address || !chainId) {
         return false;
+      }
+
+      if (isMoneyWithdraw) {
+        return (
+          isMonadMusd(address, chainId) ||
+          isSubsidizedRoute(relayFixedSpread, MONAD_MUSD_SOURCE, {
+            address,
+            chainId: String(chainId),
+          })
+        );
       }
 
       return (
@@ -44,7 +75,7 @@ export function usePayWithNoFeeToken(): {
         })
       );
     },
-    [relayFixedSpread],
+    [isMoneyWithdraw, relayFixedSpread],
   );
 
   const renderNoFeeTag: TokenTagRenderer = useCallback(

--- a/ui/pages/confirmations/hooks/pay/usePayWithNoFeeToken.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePayWithNoFeeToken.tsx
@@ -1,17 +1,30 @@
 import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { isSubsidizedSource } from '../../utils/relay-fixed-spread';
+import { TransactionType } from '@metamask/transaction-controller';
+import {
+  isSubsidizedRoute,
+  isSubsidizedSource,
+} from '../../utils/relay-fixed-spread';
 import type { RelayFixedSpreadConfig } from '../../utils/relay-fixed-spread';
 import { selectRelayFixedSpread } from '../../selectors/feature-flags';
 import { NoFeeTag } from '../../components/UI/no-fee-tag';
 import { type TokenTagRenderer } from '../../components/UI/asset';
 import { type Asset } from '../../types/send';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
 import { MUSD_TOKEN_ADDRESS } from '../../constants/musd';
+import { useTransactionMetadataRequestOptional } from '../transactions/useTransactionMetadataRequest';
+
+/** The Money Account vault token; withdrawals always convert FROM this. */
+const MONAD_MUSD_SOURCE = {
+  address: MUSD_TOKEN_ADDRESS,
+  chainId: CHAIN_IDS.MONAD,
+};
 
 /**
  * Monad mUSD → Monad mUSD needs no swap or bridge, so the fixed-spread flag
- * omits that same-token route. Depositing it still incurs no Relay fee.
+ * omits that same-token route. Depositing or withdrawing it still incurs no
+ * Relay fee.
  *
  * @param address - Token contract address.
  * @param chainId - Token chain ID.
@@ -53,21 +66,43 @@ export function isNoFeePayToken(
 }
 
 /**
- * Identifies payment tokens that incur no Relay fixed-spread fee for
- * Money Account deposits. A token is no-fee when it is a subsidised source
- * in the `confirmations_relay_fixed_spread` remote feature flag, or when it
- * is Monad mUSD itself.
+ * Identifies tokens that incur no Relay fixed-spread fee.
+ *
+ * For deposits the picker token is the source, so a token is no-fee when it
+ * is a subsidised source (or Monad mUSD itself). For a Money Account
+ * withdrawal the picker token is the destination and the source is always
+ * Monad mUSD, so the match is directional: a subsidised route FROM Monad
+ * mUSD INTO the token, or Monad mUSD itself.
  */
 export function usePayWithNoFeeToken(): {
   isNoFeeToken: (address: string, chainId: string) => boolean;
   renderNoFeeTag: TokenTagRenderer;
 } {
   const relayFixedSpread = useSelector(selectRelayFixedSpread);
+  const transactionMeta = useTransactionMetadataRequestOptional();
+  const isMoneyWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountWithdraw,
+  ]);
 
   const isNoFeeToken = useCallback(
-    (address: string, chainId: string): boolean =>
-      isNoFeePayToken(relayFixedSpread, address, chainId),
-    [relayFixedSpread],
+    (address: string, chainId: string): boolean => {
+      if (isMoneyWithdraw) {
+        if (!address || !chainId) {
+          return false;
+        }
+
+        return (
+          isMonadMusd(address, chainId) ||
+          isSubsidizedRoute(relayFixedSpread, MONAD_MUSD_SOURCE, {
+            address,
+            chainId: String(chainId),
+          })
+        );
+      }
+
+      return isNoFeePayToken(relayFixedSpread, address, chainId);
+    },
+    [isMoneyWithdraw, relayFixedSpread],
   );
 
   const renderNoFeeTag: TokenTagRenderer = useCallback(

--- a/ui/pages/confirmations/hooks/transactions/useLastMoneyAccountWithdrawAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useLastMoneyAccountWithdrawAmount.test.ts
@@ -1,0 +1,46 @@
+import { renderHook, act } from '@testing-library/react';
+import {
+  getLastMoneyAccountWithdrawAmount,
+  setLastMoneyAccountWithdrawAmount,
+  updateMoneyAccountWithdrawAmount,
+} from '../../../../store/controller-actions/transaction-pay-controller';
+import { useLastMoneyAccountWithdrawAmount } from './useLastMoneyAccountWithdrawAmount';
+
+jest.mock('../../../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn(() => Promise.resolve(false)),
+}));
+
+describe('useLastMoneyAccountWithdrawAmount', () => {
+  it('returns undefined before an amount is dispatched', () => {
+    const { result } = renderHook(() =>
+      useLastMoneyAccountWithdrawAmount('tx-none'),
+    );
+
+    expect(result.current).toBeUndefined();
+    expect(getLastMoneyAccountWithdrawAmount('tx-none')).toBeUndefined();
+  });
+
+  it('updates when the typed amount is recorded', () => {
+    const { result } = renderHook(() =>
+      useLastMoneyAccountWithdrawAmount('tx-typed-amount'),
+    );
+
+    act(() => {
+      setLastMoneyAccountWithdrawAmount('tx-typed-amount', '0.05');
+    });
+
+    expect(result.current).toBe('0.05');
+  });
+
+  it('updates when a withdraw amount is dispatched', async () => {
+    const { result } = renderHook(() =>
+      useLastMoneyAccountWithdrawAmount('tx-withdraw-amount'),
+    );
+
+    await act(async () => {
+      await updateMoneyAccountWithdrawAmount('tx-withdraw-amount', '0.05');
+    });
+
+    expect(result.current).toBe('0.05');
+  });
+});

--- a/ui/pages/confirmations/hooks/transactions/useLastMoneyAccountWithdrawAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useLastMoneyAccountWithdrawAmount.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../../../store/background-connection', () => ({
 }));
 
 describe('useLastMoneyAccountWithdrawAmount', () => {
-  it('returns undefined before an amount is dispatched', () => {
+  it('returns undefined before an amount is recorded', () => {
     const { result } = renderHook(() =>
       useLastMoneyAccountWithdrawAmount('tx-none'),
     );
@@ -32,7 +32,7 @@ describe('useLastMoneyAccountWithdrawAmount', () => {
     expect(result.current).toBe('0.05');
   });
 
-  it('updates when a withdraw amount is dispatched', async () => {
+  it('updates when a withdraw amount is recorded via update', async () => {
     const { result } = renderHook(() =>
       useLastMoneyAccountWithdrawAmount('tx-withdraw-amount'),
     );

--- a/ui/pages/confirmations/hooks/transactions/useLastMoneyAccountWithdrawAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useLastMoneyAccountWithdrawAmount.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from 'react';
+import {
+  getLastMoneyAccountWithdrawAmount,
+  subscribeLastMoneyAccountWithdrawAmount,
+} from '../../../../store/controller-actions/transaction-pay-controller';
+
+/**
+ * Last human-readable withdraw amount dispatched for this confirmation.
+ * Reactive so the footer can enable Send without waiting on TPC required
+ * tokens or quote totals.
+ *
+ * @param transactionId - Id of the Money Account withdrawal transaction.
+ * @returns The last amount, if any update has been dispatched.
+ */
+export function useLastMoneyAccountWithdrawAmount(
+  transactionId: string,
+): string | undefined {
+  return useSyncExternalStore(subscribeLastMoneyAccountWithdrawAmount, () =>
+    getLastMoneyAccountWithdrawAmount(transactionId),
+  );
+}

--- a/ui/pages/confirmations/hooks/transactions/useLastMoneyAccountWithdrawAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useLastMoneyAccountWithdrawAmount.ts
@@ -5,12 +5,12 @@ import {
 } from '../../../../store/controller-actions/transaction-pay-controller';
 
 /**
- * Last human-readable withdraw amount dispatched for this confirmation.
+ * Last human-readable withdraw amount recorded for this confirmation.
  * Reactive so the footer can enable Send without waiting on TPC required
  * tokens or quote totals.
  *
  * @param transactionId - Id of the Money Account withdrawal transaction.
- * @returns The last amount, if any update has been dispatched.
+ * @returns The last amount, if any update has been recorded.
  */
 export function useLastMoneyAccountWithdrawAmount(
   transactionId: string,

--- a/ui/pages/confirmations/hooks/transactions/useMoneyAccountWithdrawConfirm.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useMoneyAccountWithdrawConfirm.test.ts
@@ -1,0 +1,291 @@
+import {
+  generateEIP7702BatchTransaction,
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import { renderHook } from '@testing-library/react';
+
+import { submitRequestToBackground } from '../../../../store/background-connection';
+import {
+  getLastMoneyAccountWithdrawAmount,
+  updateMoneyAccountWithdrawAmount,
+} from '../../../../store/controller-actions/transaction-pay-controller';
+import { useDispatch } from '../../../../store/hooks';
+import { useMoneyAccountWithdrawConfirm } from './useMoneyAccountWithdrawConfirm';
+import { useTransactionAccountOverride } from './useTransactionAccountOverride';
+
+jest.mock('../../../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn(() => Promise.resolve()),
+}));
+jest.mock(
+  '../../../../store/controller-actions/transaction-pay-controller',
+  () => ({
+    getLastMoneyAccountWithdrawAmount: jest.fn(),
+    updateMoneyAccountWithdrawAmount: jest.fn(),
+  }),
+);
+jest.mock('../../../../store/hooks', () => ({ useDispatch: jest.fn() }));
+jest.mock('./useTransactionAccountOverride');
+
+const FROM = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc' as Hex;
+const TELLER_ADDRESS = '0x1111111111111111111111111111111111111111' as Hex;
+const MUSD_ADDRESS = '0x3333333333333333333333333333333333333333' as Hex;
+const OVERRIDE_ADDRESS = '0x4444444444444444444444444444444444444444' as Hex;
+const WITHDRAW_DATA = '0x1234567890abcdef1234567890abcdef12345678' as Hex;
+const PLACEHOLDER_DATA = '0xemptyexecute';
+const FUNDED_TRANSFER_DATA =
+  '0xa9059cbb0000000000000000000000002222222222222222222222222222222222222222000000000000000000000000000000000000000000000000000000000000c350' as Hex;
+const ZERO_TRANSFER_DATA =
+  '0xa9059cbb00000000000000000000000022222222222222222222222222222222222222220000000000000000000000000000000000000000000000000000000000000000' as Hex;
+const TRANSACTION_ID = 'tx-1';
+
+const PLACEHOLDER_NESTED = [
+  { to: TELLER_ADDRESS, data: '0x' as Hex },
+  { to: MUSD_ADDRESS, data: '0x' as Hex },
+] as TransactionMeta['nestedTransactions'];
+
+const FUNDED_NESTED = [
+  { to: TELLER_ADDRESS, data: WITHDRAW_DATA },
+  { to: MUSD_ADDRESS, data: FUNDED_TRANSFER_DATA },
+] as TransactionMeta['nestedTransactions'];
+
+const FUNDED_UPDATE = {
+  withdrawData: WITHDRAW_DATA,
+  transferData: FUNDED_TRANSFER_DATA,
+};
+
+function buildTransaction(
+  nestedTransactions?: TransactionMeta['nestedTransactions'],
+): TransactionMeta {
+  return {
+    id: TRANSACTION_ID,
+    type: TransactionType.batch,
+    txParams: { from: FROM, to: FROM, data: PLACEHOLDER_DATA },
+    nestedTransactions,
+  } as unknown as TransactionMeta;
+}
+
+const mockUseDispatch = jest.mocked(useDispatch);
+const mockUseTransactionAccountOverride = jest.mocked(
+  useTransactionAccountOverride,
+);
+const mockGetLastMoneyAccountWithdrawAmount = jest.mocked(
+  getLastMoneyAccountWithdrawAmount,
+);
+const mockUpdateMoneyAccountWithdrawAmount = jest.mocked(
+  updateMoneyAccountWithdrawAmount,
+);
+const mockSubmitRequestToBackground = jest.mocked(submitRequestToBackground);
+
+/**
+ * Builds a dispatch that resolves thunks against a fake transaction
+ * controller state.
+ *
+ * @param storeTransactions - Transactions the store should hold, in order.
+ * Each call to the thunk reads the next entry, so later reads can observe a
+ * background write.
+ * @returns A jest mock behaving like `useDispatch()`'s return value.
+ */
+function buildDispatch(storeTransactions: (TransactionMeta | undefined)[]) {
+  let callIndex = 0;
+  return jest.fn((thunk: unknown) => {
+    if (typeof thunk !== 'function') {
+      return thunk;
+    }
+    const transactions = [
+      storeTransactions[Math.min(callIndex, storeTransactions.length - 1)],
+    ].filter(Boolean);
+    callIndex += 1;
+    return (thunk as (dispatch: unknown, getState: () => unknown) => unknown)(
+      jest.fn(),
+      () => ({ metamask: { transactions } }),
+    );
+  });
+}
+
+function runHook() {
+  const { result } = renderHook(() => useMoneyAccountWithdrawConfirm());
+  return result.current;
+}
+
+describe('useMoneyAccountWithdrawConfirm', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {
+      // Suppress the expected refusal logs.
+    });
+    mockUseDispatch.mockReturnValue(buildDispatch([undefined]) as never);
+    mockUseTransactionAccountOverride.mockReturnValue(undefined);
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue(undefined);
+    mockUpdateMoneyAccountWithdrawAmount.mockResolvedValue(false);
+    mockSubmitRequestToBackground.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('rebuilds the parent execute from funded nested calls without re-encoding', async () => {
+    const transaction = buildTransaction(FUNDED_NESTED);
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(transaction);
+
+    const expected = generateEIP7702BatchTransaction(FROM, FUNDED_NESTED ?? []);
+    expect(result?.type).toBe(TransactionType.moneyAccountWithdraw);
+    expect(result?.txParams.data).toBe(expected.data);
+    expect(result?.txParams.to).toBe(expected.to ?? FROM);
+    expect(mockUpdateMoneyAccountWithdrawAmount).not.toHaveBeenCalled();
+  });
+
+  it('persists the rebuilt transaction before approve', async () => {
+    const { prepareWithdrawTransaction } = runHook();
+
+    await prepareWithdrawTransaction(buildTransaction(FUNDED_NESTED));
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'updateTransaction',
+      [expect.objectContaining({ id: TRANSACTION_ID })],
+    );
+  });
+
+  it('prefers the funded transaction held in the store', async () => {
+    mockUseDispatch.mockReturnValue(
+      buildDispatch([buildTransaction(FUNDED_NESTED)]) as never,
+    );
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(
+      buildTransaction(PLACEHOLDER_NESTED),
+    );
+
+    expect(result?.nestedTransactions?.[1].data).toBe(FUNDED_TRANSFER_DATA);
+    expect(mockUpdateMoneyAccountWithdrawAmount).not.toHaveBeenCalled();
+  });
+
+  it('encodes the committed amount and patches the nested calldata', async () => {
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.05');
+    mockUpdateMoneyAccountWithdrawAmount.mockResolvedValue(FUNDED_UPDATE);
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(
+      buildTransaction(PLACEHOLDER_NESTED),
+    );
+
+    expect(mockUpdateMoneyAccountWithdrawAmount).toHaveBeenCalledWith(
+      TRANSACTION_ID,
+      '0.05',
+      undefined,
+    );
+    expect(result?.nestedTransactions?.[0].data).toBe(WITHDRAW_DATA);
+    expect(result?.nestedTransactions?.[1].data).toBe(FUNDED_TRANSFER_DATA);
+    expect(result?.txParams.data).not.toBe(PLACEHOLDER_DATA);
+  });
+
+  it('passes the account override as the withdraw recipient', async () => {
+    mockUseTransactionAccountOverride.mockReturnValue(OVERRIDE_ADDRESS);
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.05');
+    mockUpdateMoneyAccountWithdrawAmount.mockResolvedValue(FUNDED_UPDATE);
+    const { prepareWithdrawTransaction } = runHook();
+
+    await prepareWithdrawTransaction(buildTransaction(PLACEHOLDER_NESTED));
+
+    expect(mockUpdateMoneyAccountWithdrawAmount).toHaveBeenCalledWith(
+      TRANSACTION_ID,
+      '0.05',
+      OVERRIDE_ADDRESS,
+    );
+  });
+
+  it('falls back to the store when the encoder result cannot be patched', async () => {
+    mockUseDispatch.mockReturnValue(
+      buildDispatch([undefined, buildTransaction(FUNDED_NESTED)]) as never,
+    );
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.05');
+    mockUpdateMoneyAccountWithdrawAmount.mockResolvedValue(false);
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(buildTransaction());
+
+    expect(result?.nestedTransactions?.[1].data).toBe(FUNDED_TRANSFER_DATA);
+  });
+
+  it('returns null when no amount has been committed', async () => {
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(buildTransaction());
+
+    expect(result).toBeNull();
+    expect(mockUpdateMoneyAccountWithdrawAmount).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the committed amount is zero', async () => {
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0');
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(buildTransaction());
+
+    expect(result).toBeNull();
+    expect(mockUpdateMoneyAccountWithdrawAmount).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the encoder does not commit', async () => {
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.05');
+    mockUpdateMoneyAccountWithdrawAmount.mockResolvedValue(false);
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(buildTransaction());
+
+    expect(result).toBeNull();
+    expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a zero-amount transfer even when the calldata is encoded', async () => {
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.05');
+    mockUpdateMoneyAccountWithdrawAmount.mockResolvedValue({
+      withdrawData: WITHDRAW_DATA,
+      transferData: ZERO_TRANSFER_DATA,
+    });
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(
+      buildTransaction([
+        { to: TELLER_ADDRESS, data: WITHDRAW_DATA },
+        { to: MUSD_ADDRESS, data: ZERO_TRANSFER_DATA },
+      ] as TransactionMeta['nestedTransactions']),
+    );
+
+    expect(result).toBeNull();
+    expect(mockUpdateMoneyAccountWithdrawAmount).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when the encoder returns unencoded nested calldata', async () => {
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.05');
+    mockUpdateMoneyAccountWithdrawAmount.mockResolvedValue({
+      withdrawData: '0x',
+      transferData: '0x',
+    });
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(
+      buildTransaction(PLACEHOLDER_NESTED),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('rethrows when the encoder fails', async () => {
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.05');
+    mockUpdateMoneyAccountWithdrawAmount.mockRejectedValue(
+      new Error('Update Amount: Money Account Withdrawal: missing vault'),
+    );
+    const { prepareWithdrawTransaction } = runHook();
+
+    await expect(
+      prepareWithdrawTransaction(buildTransaction(PLACEHOLDER_NESTED)),
+    ).rejects.toThrow('Update Amount: Money Account Withdrawal: missing vault');
+  });
+});

--- a/ui/pages/confirmations/hooks/transactions/useMoneyAccountWithdrawConfirm.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useMoneyAccountWithdrawConfirm.test.ts
@@ -8,6 +8,7 @@ import { renderHook } from '@testing-library/react';
 
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import {
+  clearLastMoneyAccountWithdrawAmount,
   getLastMoneyAccountWithdrawAmount,
   updateMoneyAccountWithdrawAmount,
 } from '../../../../store/controller-actions/transaction-pay-controller';
@@ -21,6 +22,7 @@ jest.mock('../../../../store/background-connection', () => ({
 jest.mock(
   '../../../../store/controller-actions/transaction-pay-controller',
   () => ({
+    clearLastMoneyAccountWithdrawAmount: jest.fn(),
     getLastMoneyAccountWithdrawAmount: jest.fn(),
     updateMoneyAccountWithdrawAmount: jest.fn(),
   }),
@@ -128,7 +130,9 @@ describe('useMoneyAccountWithdrawConfirm', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it('rebuilds the parent execute from funded nested calls without re-encoding', async () => {
+  it('rebuilds the parent execute from funded nested calls without re-encoding when the amount matches', async () => {
+    // FUNDED_TRANSFER_DATA encodes 50000 raw = 0.05 mUSD.
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.05');
     const transaction = buildTransaction(FUNDED_NESTED);
     const { prepareWithdrawTransaction } = runHook();
 
@@ -142,6 +146,7 @@ describe('useMoneyAccountWithdrawConfirm', () => {
   });
 
   it('persists the rebuilt transaction before approve', async () => {
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.05');
     const { prepareWithdrawTransaction } = runHook();
 
     await prepareWithdrawTransaction(buildTransaction(FUNDED_NESTED));
@@ -152,7 +157,8 @@ describe('useMoneyAccountWithdrawConfirm', () => {
     );
   });
 
-  it('prefers the funded transaction held in the store', async () => {
+  it('prefers the funded transaction held in the store when the amount matches', async () => {
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.05');
     mockUseDispatch.mockReturnValue(
       buildDispatch([buildTransaction(FUNDED_NESTED)]) as never,
     );
@@ -164,6 +170,38 @@ describe('useMoneyAccountWithdrawConfirm', () => {
 
     expect(result?.nestedTransactions?.[1].data).toBe(FUNDED_TRANSFER_DATA);
     expect(mockUpdateMoneyAccountWithdrawAmount).not.toHaveBeenCalled();
+  });
+
+  it('re-encodes when funded nested calldata does not match the typed amount', async () => {
+    // Store still holds 0.05 while the footer enabled Send for 0.10.
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.10');
+    mockUpdateMoneyAccountWithdrawAmount.mockResolvedValue(FUNDED_UPDATE);
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(
+      buildTransaction(FUNDED_NESTED),
+    );
+
+    expect(mockUpdateMoneyAccountWithdrawAmount).toHaveBeenCalledWith(
+      TRANSACTION_ID,
+      '0.10',
+      undefined,
+    );
+    expect(result?.nestedTransactions?.[1].data).toBe(FUNDED_TRANSFER_DATA);
+  });
+
+  it('does not approve a stale funded store batch after a mismatched encode', async () => {
+    mockUseDispatch.mockReturnValue(
+      buildDispatch([undefined, buildTransaction(FUNDED_NESTED)]) as never,
+    );
+    mockGetLastMoneyAccountWithdrawAmount.mockReturnValue('0.10');
+    mockUpdateMoneyAccountWithdrawAmount.mockResolvedValue(false);
+    const { prepareWithdrawTransaction } = runHook();
+
+    const result = await prepareWithdrawTransaction(buildTransaction());
+
+    expect(result).toBeNull();
+    expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
   });
 
   it('encodes the committed amount and patches the nested calldata', async () => {
@@ -200,7 +238,7 @@ describe('useMoneyAccountWithdrawConfirm', () => {
     );
   });
 
-  it('falls back to the store when the encoder result cannot be patched', async () => {
+  it('falls back to the store when the encoder result cannot be patched but amounts match', async () => {
     mockUseDispatch.mockReturnValue(
       buildDispatch([undefined, buildTransaction(FUNDED_NESTED)]) as never,
     );

--- a/ui/pages/confirmations/hooks/transactions/useMoneyAccountWithdrawConfirm.ts
+++ b/ui/pages/confirmations/hooks/transactions/useMoneyAccountWithdrawConfirm.ts
@@ -1,0 +1,136 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { BigNumber } from 'bignumber.js';
+import { useCallback } from 'react';
+
+import {
+  selectTransactionById,
+  type TransactionState,
+} from '../../../../selectors/transactionController';
+import { submitRequestToBackground } from '../../../../store/background-connection';
+import {
+  getLastMoneyAccountWithdrawAmount,
+  updateMoneyAccountWithdrawAmount,
+} from '../../../../store/controller-actions/transaction-pay-controller';
+import { useDispatch } from '../../../../store/hooks';
+import type { MetaMaskReduxDispatch } from '../../../../store/types';
+import {
+  applyWithdrawCalldata,
+  asFundedWithdrawUpdate,
+  withFundedBatchCalldata,
+} from '../../utils/money-account-withdraw';
+import { useTransactionAccountOverride } from './useTransactionAccountOverride';
+
+async function persistWithdrawTransaction(
+  transaction: TransactionMeta,
+): Promise<void> {
+  await submitRequestToBackground('updateTransaction', [transaction]);
+}
+
+function readTransactionFromStore(
+  dispatch: MetaMaskReduxDispatch,
+  transactionId: string,
+): TransactionMeta | undefined {
+  return dispatch((_, getState) =>
+    selectTransactionById(getState() as TransactionState, transactionId),
+  );
+}
+
+/**
+ * Prepares a Money Account withdrawal for approval.
+ *
+ * Withdraw placeholders have no calldata. Await the amount commit and approve
+ * only a funded withdraw (nested transfer amount > 0). Never approve the
+ * empty placeholder or `transfer(recipient, 0)` — both mine successfully
+ * and move no funds.
+ *
+ * Nested calls can look funded while the parent still carries the empty
+ * `execute()`. Rebuild `to` + `data` from those nested calls and persist
+ * before approve so publish signs the real batch.
+ *
+ * The background encoder returns the two nested data hexes. The UI bridge
+ * often strips a full TransactionMeta, so confirm patches those hexes onto
+ * the confirmation clone instead of requiring the IPC object to be funded.
+ *
+ * @returns `prepareWithdrawTransaction`, resolving with the encoded
+ * transaction to approve, or `null` when it is not encoded.
+ */
+export function useMoneyAccountWithdrawConfirm() {
+  const dispatch = useDispatch();
+  const accountOverride = useTransactionAccountOverride();
+
+  const prepareWithdrawTransaction = useCallback(
+    async (
+      transactionMeta: TransactionMeta,
+    ): Promise<TransactionMeta | null> => {
+      const fromStore = readTransactionFromStore(dispatch, transactionMeta.id);
+      const ready =
+        withFundedBatchCalldata(fromStore) ??
+        withFundedBatchCalldata(transactionMeta);
+
+      if (ready) {
+        await persistWithdrawTransaction(ready);
+        return ready;
+      }
+
+      const amountHuman = getLastMoneyAccountWithdrawAmount(transactionMeta.id);
+      const hasAmount = Boolean(
+        amountHuman && new BigNumber(amountHuman).gt(0),
+      );
+
+      if (!hasAmount) {
+        console.error(
+          'Money Account withdraw: no committed amount, refusing to approve placeholder',
+          { transactionId: transactionMeta.id, amountHuman },
+        );
+        return null;
+      }
+
+      const rawUpdate = await updateMoneyAccountWithdrawAmount(
+        transactionMeta.id,
+        amountHuman as string,
+        accountOverride,
+      );
+      const update = asFundedWithdrawUpdate(rawUpdate);
+      if (update) {
+        const applied =
+          applyWithdrawCalldata(fromStore, update) ??
+          applyWithdrawCalldata(transactionMeta, update);
+        if (applied) {
+          await persistWithdrawTransaction(applied);
+          return applied;
+        }
+      }
+
+      const fromStoreAfterEncode = withFundedBatchCalldata(
+        readTransactionFromStore(dispatch, transactionMeta.id),
+      );
+      if (fromStoreAfterEncode) {
+        await persistWithdrawTransaction(fromStoreAfterEncode);
+        return fromStoreAfterEncode;
+      }
+
+      console.error(
+        'Money Account withdraw: amount encode did not produce a funded batch, refusing to approve placeholder',
+        {
+          transactionId: transactionMeta.id,
+          amountHuman,
+          encodeCommitted: rawUpdate !== false,
+          encodeFunded: Boolean(update),
+          hasStoreTransaction: Boolean(fromStore),
+          hasStoreNestedCalls: Boolean(
+            fromStore?.nestedTransactions?.[0] &&
+            fromStore?.nestedTransactions[1],
+          ),
+          hasConfirmationNestedCalls: Boolean(
+            transactionMeta.nestedTransactions?.[0] &&
+            transactionMeta.nestedTransactions[1],
+          ),
+        },
+      );
+      return null;
+    },
+    [accountOverride, dispatch],
+  );
+
+  return { prepareWithdrawTransaction };
+}

--- a/ui/pages/confirmations/hooks/transactions/useMoneyAccountWithdrawConfirm.ts
+++ b/ui/pages/confirmations/hooks/transactions/useMoneyAccountWithdrawConfirm.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../selectors/transactionController';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import {
+  clearLastMoneyAccountWithdrawAmount,
   getLastMoneyAccountWithdrawAmount,
   updateMoneyAccountWithdrawAmount,
 } from '../../../../store/controller-actions/transaction-pay-controller';
@@ -16,6 +17,7 @@ import type { MetaMaskReduxDispatch } from '../../../../store/types';
 import {
   applyWithdrawCalldata,
   asFundedWithdrawUpdate,
+  doesWithdrawCalldataMatchAmount,
   withFundedBatchCalldata,
 } from '../../utils/money-account-withdraw';
 import { useTransactionAccountOverride } from './useTransactionAccountOverride';
@@ -24,6 +26,14 @@ async function persistWithdrawTransaction(
   transaction: TransactionMeta,
 ): Promise<void> {
   await submitRequestToBackground('updateTransaction', [transaction]);
+}
+
+async function finalizePreparedWithdraw(
+  transaction: TransactionMeta,
+): Promise<TransactionMeta> {
+  await persistWithdrawTransaction(transaction);
+  clearLastMoneyAccountWithdrawAmount(transaction.id);
+  return transaction;
 }
 
 function readTransactionFromStore(
@@ -51,28 +61,44 @@ function readTransactionFromStore(
  * often strips a full TransactionMeta, so confirm patches those hexes onto
  * the confirmation clone instead of requiring the IPC object to be funded.
  *
- * @returns `prepareWithdrawTransaction`, resolving with the encoded
- * transaction to approve, or `null` when it is not encoded.
+ * Funded nested calldata is reused only when it already encodes the latest
+ * typed amount. Otherwise Send would approve a previous encode while the
+ * footer shows a newer amount that has not finished committing.
+ *
+ * @returns An object with `prepareWithdrawTransaction`.
  */
 export function useMoneyAccountWithdrawConfirm() {
   const dispatch = useDispatch();
   const accountOverride = useTransactionAccountOverride();
 
+  /**
+   * Encodes (when needed) and returns the funded withdraw transaction to
+   * approve, or `null` when it is not encoded.
+   *
+   * @param transactionMeta - Confirmation transaction to prepare.
+   * @returns The funded transaction, or `null`.
+   */
   const prepareWithdrawTransaction = useCallback(
     async (
       transactionMeta: TransactionMeta,
     ): Promise<TransactionMeta | null> => {
+      const amountHuman = getLastMoneyAccountWithdrawAmount(transactionMeta.id);
       const fromStore = readTransactionFromStore(dispatch, transactionMeta.id);
+
+      // Skip re-encode only when nested calldata already matches the amount
+      // on screen. A prior encode can still look "funded" after the user edits.
       const ready =
-        withFundedBatchCalldata(fromStore) ??
-        withFundedBatchCalldata(transactionMeta);
+        (doesWithdrawCalldataMatchAmount(fromStore, amountHuman)
+          ? withFundedBatchCalldata(fromStore)
+          : null) ??
+        (doesWithdrawCalldataMatchAmount(transactionMeta, amountHuman)
+          ? withFundedBatchCalldata(transactionMeta)
+          : null);
 
       if (ready) {
-        await persistWithdrawTransaction(ready);
-        return ready;
+        return finalizePreparedWithdraw(ready);
       }
 
-      const amountHuman = getLastMoneyAccountWithdrawAmount(transactionMeta.id);
       const hasAmount = Boolean(
         amountHuman && new BigNumber(amountHuman).gt(0),
       );
@@ -96,17 +122,21 @@ export function useMoneyAccountWithdrawConfirm() {
           applyWithdrawCalldata(fromStore, update) ??
           applyWithdrawCalldata(transactionMeta, update);
         if (applied) {
-          await persistWithdrawTransaction(applied);
-          return applied;
+          return finalizePreparedWithdraw(applied);
         }
       }
 
-      const fromStoreAfterEncode = withFundedBatchCalldata(
-        readTransactionFromStore(dispatch, transactionMeta.id),
+      const fromStoreAfterEncode = readTransactionFromStore(
+        dispatch,
+        transactionMeta.id,
       );
-      if (fromStoreAfterEncode) {
-        await persistWithdrawTransaction(fromStoreAfterEncode);
-        return fromStoreAfterEncode;
+      // After encode, only accept store calldata that matches the typed amount.
+      // A superseded commit can leave an older funded batch in the store.
+      if (doesWithdrawCalldataMatchAmount(fromStoreAfterEncode, amountHuman)) {
+        const matching = withFundedBatchCalldata(fromStoreAfterEncode);
+        if (matching) {
+          return finalizePreparedWithdraw(matching);
+        }
       }
 
       console.error(

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -30,6 +30,7 @@ import { useGaslessSupportedSmartTransactions } from '../gas/useGaslessSupported
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { useGasSponsorshipPreference } from '../gas/useGasSponsorshipPreference';
 import * as DappSwapActions from './dapp-swap-comparison/useDappSwapActions';
+import { useMoneyAccountWithdrawConfirm } from './useMoneyAccountWithdrawConfirm';
 import { useTransactionConfirm } from './useTransactionConfirm';
 
 const mockGetEnvironmentType = jest.fn();
@@ -74,6 +75,8 @@ jest.mock('../../../../store/actions', () => ({
   updateAndApproveTx: jest.fn(),
 }));
 
+jest.mock('./useMoneyAccountWithdrawConfirm');
+
 const mockUseNavigate = jest.fn();
 jest.mock('react-router-dom', () => {
   return {
@@ -104,6 +107,11 @@ jest.mock(
   }),
 );
 
+const mockPrepareWithdrawTransaction = jest.fn<
+  Promise<TransactionMeta | null>,
+  [TransactionMeta]
+>();
+
 const CUSTOM_NONCE_VALUE = '1234';
 const originalConsoleWarn = console.warn;
 
@@ -130,7 +138,7 @@ function runHook({
     isGasFeeSponsored,
     isExternalSign,
     selectedGasFeeToken,
-  });
+  }) as TransactionMeta;
   if (type) {
     confirmation.type = type;
   }
@@ -145,7 +153,7 @@ function runHook({
     }),
   );
 
-  return result.current;
+  return { ...result.current, confirmation };
 }
 
 describe('useTransactionConfirm', () => {
@@ -162,6 +170,9 @@ describe('useTransactionConfirm', () => {
   const isHardwareWalletMock = jest.mocked(isHardwareWallet);
   const useGasSponsorshipPreferenceMock = jest.mocked(
     useGasSponsorshipPreference,
+  );
+  const useMoneyAccountWithdrawConfirmMock = jest.mocked(
+    useMoneyAccountWithdrawConfirm,
   );
   beforeEach(() => {
     jest.resetAllMocks();
@@ -216,6 +227,10 @@ describe('useTransactionConfirm', () => {
     });
     mockIsHardwareWalletError.mockReturnValue(false);
     mockIsUserRejectedHardwareWalletError.mockReturnValue(false);
+    mockPrepareWithdrawTransaction.mockResolvedValue(null);
+    useMoneyAccountWithdrawConfirmMock.mockReturnValue({
+      prepareWithdrawTransaction: mockPrepareWithdrawTransaction,
+    });
     useHardwareWalletErrorMock.mockReturnValue({
       showErrorModal: jest.fn(),
       dismissErrorModal: jest.fn(),
@@ -896,5 +911,106 @@ describe('useTransactionConfirm', () => {
     const { onTransactionConfirm } = runHook();
 
     await expect(onTransactionConfirm()).rejects.toThrow('Network error');
+  });
+
+  describe('money account withdraw', () => {
+    it('approves the transaction prepared by useMoneyAccountWithdrawConfirm', async () => {
+      const prepared = {
+        id: 'prepared-id',
+        type: TransactionType.moneyAccountWithdraw,
+        txParams: { from: '0xabc', to: '0xabc', data: '0xbatchdata' },
+      } as unknown as TransactionMeta;
+      mockPrepareWithdrawTransaction.mockResolvedValue(prepared);
+
+      const { confirmation, onTransactionConfirm } = runHook({
+        type: TransactionType.moneyAccountWithdraw,
+      });
+
+      const result = await onTransactionConfirm();
+
+      expect(result).toBe(true);
+      expect(mockPrepareWithdrawTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({ id: confirmation.id }),
+      );
+      const approved = updateAndApproveTxMock.mock.calls[0][0];
+      expect(approved.id).toBe('prepared-id');
+      expect(approved.txParams.data).toBe('0xbatchdata');
+    });
+
+    it('does not prepare a withdraw for other transaction types', async () => {
+      const { onTransactionConfirm } = runHook();
+
+      await onTransactionConfirm();
+
+      expect(mockPrepareWithdrawTransaction).not.toHaveBeenCalled();
+      expect(updateAndApproveTxMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not approve when the withdraw could not be prepared', async () => {
+      mockPrepareWithdrawTransaction.mockResolvedValue(null);
+
+      const { onTransactionConfirm } = runHook({
+        type: TransactionType.moneyAccountWithdraw,
+      });
+
+      const result = await onTransactionConfirm();
+
+      expect(result).toBe(false);
+      expect(updateAndApproveTxMock).not.toHaveBeenCalled();
+    });
+
+    it('rethrows when preparing the withdraw fails', async () => {
+      mockPrepareWithdrawTransaction.mockRejectedValue(
+        new Error('Update Amount: Money Account Withdrawal: missing vault'),
+      );
+
+      const { onTransactionConfirm } = runHook({
+        type: TransactionType.moneyAccountWithdraw,
+      });
+
+      await expect(onTransactionConfirm()).rejects.toThrow(
+        'Update Amount: Money Account Withdrawal: missing vault',
+      );
+      expect(updateAndApproveTxMock).not.toHaveBeenCalled();
+    });
+
+    it('keeps gas sponsorship on money account withdraw when gasless support is unknown', async () => {
+      useIsGaslessSupportedMock.mockReturnValue({
+        isSupported: false,
+        isSmartTransaction: false,
+        pending: false,
+      });
+
+      const { confirmation, onTransactionConfirm } = runHook({
+        type: TransactionType.moneyAccountWithdraw,
+        isGasFeeSponsored: true,
+      });
+      mockPrepareWithdrawTransaction.mockResolvedValue(confirmation);
+
+      await onTransactionConfirm();
+
+      expect(updateAndApproveTxMock.mock.calls[0][0].isGasFeeSponsored).toBe(
+        true,
+      );
+    });
+
+    it('clears gas sponsorship on money account withdraw when the user opted out', async () => {
+      useGasSponsorshipPreferenceMock.mockReturnValue({
+        isSponsorshipOptedOut: true,
+        setSponsorshipOptedOut: jest.fn(),
+      });
+
+      const { confirmation, onTransactionConfirm } = runHook({
+        type: TransactionType.moneyAccountWithdraw,
+        isGasFeeSponsored: true,
+      });
+      mockPrepareWithdrawTransaction.mockResolvedValue(confirmation);
+
+      await onTransactionConfirm();
+
+      expect(updateAndApproveTxMock.mock.calls[0][0].isGasFeeSponsored).toBe(
+        false,
+      );
+    });
   });
 });

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -994,6 +994,27 @@ describe('useTransactionConfirm', () => {
       );
     });
 
+    it('keeps isExternalSign on sponsored money account withdraw when gasless is unsupported', async () => {
+      useIsGaslessSupportedMock.mockReturnValue({
+        isSupported: false,
+        isSmartTransaction: false,
+        pending: false,
+      });
+
+      const { confirmation, onTransactionConfirm } = runHook({
+        type: TransactionType.moneyAccountWithdraw,
+        isGasFeeSponsored: true,
+        isExternalSign: true,
+      });
+      mockPrepareWithdrawTransaction.mockResolvedValue(confirmation);
+
+      await onTransactionConfirm();
+
+      const actual = updateAndApproveTxMock.mock.calls[0][0];
+      expect(actual.isExternalSign).toBe(true);
+      expect(actual.isGasFeeSponsored).toBe(true);
+    });
+
     it('clears gas sponsorship on money account withdraw when the user opted out', async () => {
       useGasSponsorshipPreferenceMock.mockReturnValue({
         isSponsorshipOptedOut: true,
@@ -1003,14 +1024,15 @@ describe('useTransactionConfirm', () => {
       const { confirmation, onTransactionConfirm } = runHook({
         type: TransactionType.moneyAccountWithdraw,
         isGasFeeSponsored: true,
+        isExternalSign: true,
       });
       mockPrepareWithdrawTransaction.mockResolvedValue(confirmation);
 
       await onTransactionConfirm();
 
-      expect(updateAndApproveTxMock.mock.calls[0][0].isGasFeeSponsored).toBe(
-        false,
-      );
+      const actual = updateAndApproveTxMock.mock.calls[0][0];
+      expect(actual.isGasFeeSponsored).toBe(false);
+      expect(actual.isExternalSign).toBe(false);
     });
   });
 });

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -3,9 +3,10 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { cloneDeep } from 'lodash';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
+import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
 import { getCustomNonceValue } from '../../../../selectors';
 import { useConfirmContext } from '../../context/confirm';
 import { useSelectedGasFeeToken } from '../../components/confirm/info/hooks/useGasFeeToken';
@@ -22,6 +23,7 @@ import { useSendBundleHwNavigation } from '../../../../hooks/hardware-wallets/us
 import { useDispatch } from '../../../../store/hooks';
 import { useShieldConfirm } from './useShieldConfirm';
 import { useDappSwapActions } from './dapp-swap-comparison/useDappSwapActions';
+import { useMoneyAccountWithdrawConfirm } from './useMoneyAccountWithdrawConfirm';
 
 export function useTransactionConfirm() {
   const dispatch = useDispatch();
@@ -30,6 +32,10 @@ export function useTransactionConfirm() {
   const selectedGasFeeToken = useSelectedGasFeeToken();
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
+  const isMoneyAccountWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountWithdraw,
+  ]);
+  const { prepareWithdrawTransaction } = useMoneyAccountWithdrawConfirm();
 
   const { isSupported: isGaslessSupportedSTX } =
     useGaslessSupportedSmartTransactions();
@@ -42,33 +48,31 @@ export function useTransactionConfirm() {
   const { shouldRedirectToHwSigningPage, redirectToHwSigningPage } =
     useSendBundleHwNavigation({ transactionMeta });
 
-  const newTransactionMeta = useMemo(
-    () => cloneDeep(transactionMeta),
-    [transactionMeta],
+  const handleSmartTransaction = useCallback(
+    (tx: TransactionMeta) => {
+      if (!selectedGasFeeToken) {
+        return;
+      }
+
+      tx.batchTransactions = [
+        {
+          ...selectedGasFeeToken.transferTransaction,
+          type: TransactionType.gasPayment,
+        },
+      ];
+
+      tx.txParams.gas = selectedGasFeeToken.gas;
+      tx.txParams.maxFeePerGas = selectedGasFeeToken.maxFeePerGas;
+
+      tx.txParams.maxPriorityFeePerGas =
+        selectedGasFeeToken.maxPriorityFeePerGas;
+    },
+    [selectedGasFeeToken],
   );
 
-  const handleSmartTransaction = useCallback(() => {
-    if (!selectedGasFeeToken) {
-      return;
-    }
-
-    newTransactionMeta.batchTransactions = [
-      {
-        ...selectedGasFeeToken.transferTransaction,
-        type: TransactionType.gasPayment,
-      },
-    ];
-
-    newTransactionMeta.txParams.gas = selectedGasFeeToken.gas;
-    newTransactionMeta.txParams.maxFeePerGas = selectedGasFeeToken.maxFeePerGas;
-
-    newTransactionMeta.txParams.maxPriorityFeePerGas =
-      selectedGasFeeToken.maxPriorityFeePerGas;
-  }, [newTransactionMeta, selectedGasFeeToken]);
-
-  const handleGasless7702 = useCallback(() => {
-    newTransactionMeta.isExternalSign = true;
-  }, [newTransactionMeta]);
+  const handleGasless7702 = useCallback((tx: TransactionMeta) => {
+    tx.isExternalSign = true;
+  }, []);
 
   const {
     handleShieldSubscriptionApprovalTransactionAfterConfirm,
@@ -76,9 +80,19 @@ export function useTransactionConfirm() {
   } = useShieldConfirm();
 
   const onTransactionConfirm = useCallback(async (): Promise<boolean> => {
-    newTransactionMeta.customNonceValue = customNonceValue;
+    let txToApprove = cloneDeep(transactionMeta);
 
-    updateSwapWithQuoteDetailsIfRequired(newTransactionMeta);
+    if (isMoneyAccountWithdraw) {
+      const committed = await prepareWithdrawTransaction(transactionMeta);
+      if (!committed) {
+        return false;
+      }
+      txToApprove = committed;
+    }
+
+    txToApprove.customNonceValue = customNonceValue;
+
+    updateSwapWithQuoteDetailsIfRequired(txToApprove);
 
     // If the gasless flow is not supported (e.g. stx is disabled by the user,
     // or 7702 is not supported in the chain), or the user has opted out of
@@ -88,10 +102,17 @@ export function useTransactionConfirm() {
     // limitation on the activity list will be that pre-populated transactions
     // on fresh installs will not show as sponsored even if they were because
     // this is not easily observable onchain for all cases.
-    newTransactionMeta.isGasFeeSponsored =
-      isGaslessSupported &&
-      transactionMeta.isGasFeeSponsored &&
-      !isSponsorshipOptedOut;
+    //
+    // Money Account withdrawals are sponsored on Monad by design (the money
+    // account has no native MON). `useIsGaslessSupported` can disagree with
+    // the 7702 publish hook; clearing the flag here made the hook skip and
+    // published the parent `execute()` instead — which mines and moves
+    // nothing when that parent is still the empty placeholder.
+    txToApprove.isGasFeeSponsored = isMoneyAccountWithdraw
+      ? Boolean(transactionMeta.isGasFeeSponsored) && !isSponsorshipOptedOut
+      : isGaslessSupported &&
+        transactionMeta.isGasFeeSponsored &&
+        !isSponsorshipOptedOut;
 
     // Revert the controller's `isExternalSign` flag when this account cannot
     // use an external relay — i.e. gasless is unsupported for the account/chain
@@ -110,31 +131,29 @@ export function useTransactionConfirm() {
         isSponsorshipOptedOut ||
         shouldRedirectToHwSigningPage);
     if (shouldClearExternalSign) {
-      newTransactionMeta.isExternalSign = false;
+      txToApprove.isExternalSign = false;
     }
 
     if (isGaslessSupportedSTX) {
-      handleSmartTransaction();
+      handleSmartTransaction(txToApprove);
     } else if (selectedGasFeeToken) {
-      handleGasless7702();
+      handleGasless7702(txToApprove);
     }
 
     if (shouldRedirectToHwSigningPage) {
-      redirectToHwSigningPage(newTransactionMeta);
+      redirectToHwSigningPage(txToApprove);
       return false;
     }
 
     // transaction confirmation screen is a full screen modal that appear over the app and will be dismissed after transaction approved
     // navigate to shield settings page first before approving transaction to wait for subscription creation there
-    handleShieldSubscriptionApprovalTransactionAfterConfirm(newTransactionMeta);
+    handleShieldSubscriptionApprovalTransactionAfterConfirm(txToApprove);
     try {
-      await dispatch(updateAndApproveTx(newTransactionMeta, true, ''));
+      await dispatch(updateAndApproveTx(txToApprove, true, ''));
       onDappSwapCompleted();
       return true;
     } catch (error) {
-      handleShieldSubscriptionApprovalTransactionAfterConfirmErr(
-        newTransactionMeta,
-      );
+      handleShieldSubscriptionApprovalTransactionAfterConfirmErr(txToApprove);
 
       if (!isHardwareWalletError(error)) {
         // Non-hardware wallet errors - just rethrow
@@ -148,22 +167,23 @@ export function useTransactionConfirm() {
       return false;
     }
   }, [
-    newTransactionMeta,
-    customNonceValue,
-    isGaslessSupported,
-    isGaslessSupportedSTX,
-    isSponsorshipOptedOut,
-    dispatch,
-    showErrorModal,
-    handleSmartTransaction,
     handleGasless7702,
-    selectedGasFeeToken,
-    transactionMeta,
-    shouldRedirectToHwSigningPage,
-    redirectToHwSigningPage,
+    handleSmartTransaction,
+    customNonceValue,
+    dispatch,
     handleShieldSubscriptionApprovalTransactionAfterConfirm,
     handleShieldSubscriptionApprovalTransactionAfterConfirmErr,
+    isGaslessSupported,
+    isGaslessSupportedSTX,
+    isMoneyAccountWithdraw,
+    isSponsorshipOptedOut,
     onDappSwapCompleted,
+    prepareWithdrawTransaction,
+    redirectToHwSigningPage,
+    selectedGasFeeToken,
+    shouldRedirectToHwSigningPage,
+    showErrorModal,
+    transactionMeta,
     updateSwapWithQuoteDetailsIfRequired,
   ]);
 

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -125,8 +125,18 @@ export function useTransactionConfirm() {
     // set, the sign step is skipped (no keyring/device call) and, when no relay
     // catches the publish, an unsigned/empty payload reaches
     // `eth_sendRawTransaction` and is rejected by the node.
+    //
+    // Sponsored money-account withdrawals skip local signing and must stay
+    // externally signed so the 7702 relay publishes them, even when
+    // `useIsGaslessSupported` is false (same reason we keep `isGasFeeSponsored`
+    // above).
+    const shouldKeepSponsoredMoneyAccountWithdraw =
+      isMoneyAccountWithdraw &&
+      Boolean(transactionMeta.isGasFeeSponsored) &&
+      !isSponsorshipOptedOut;
     const shouldClearExternalSign =
       transactionMeta.isExternalSign &&
+      !shouldKeepSponsoredMoneyAccountWithdraw &&
       (!isGaslessSupported ||
         isSponsorshipOptedOut ||
         shouldRedirectToHwSigningPage);

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -194,6 +194,20 @@ describe('useTransactionCustomAmount', () => {
       expect(result.current.amountFiat).toBe('123.46');
     });
 
+    it('does not use target amount USD for money account withdraw Max', () => {
+      const { result } = runHook({
+        transactionMeta: {
+          ...MOCK_TRANSACTION_META,
+          type: TransactionType.moneyAccountWithdraw,
+        } as TransactionMeta,
+        isMaxAmount: true,
+        totals: { targetAmount: { usd: '123.456' } },
+        requiredTokens: [{ amountUsd: '10', skipIfBalance: false }],
+      });
+
+      expect(result.current.amountFiat).toBe('10');
+    });
+
     it('pre-populates from transaction data when user has not typed yet', () => {
       const { result } = runHook({
         isMaxAmount: false,
@@ -409,6 +423,43 @@ describe('useTransactionCustomAmount', () => {
 
       // 33% of 100 = 33, rounded down to 2 decimals
       expect(result.current.amountFiat).toBe('33');
+    });
+
+    it('does not set isMaxAmount for money account withdraw Max', () => {
+      const { result } = runHook({
+        transactionMeta: {
+          ...MOCK_TRANSACTION_META,
+          type: TransactionType.moneyAccountWithdraw,
+        } as TransactionMeta,
+        payTokenBalanceUsd: 100,
+      });
+
+      act(() => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      expect(setIsMaxAmountMock).not.toHaveBeenCalled();
+    });
+
+    it('clears isMaxAmount for money account withdraw when Max was previously set', () => {
+      const { result } = runHook({
+        transactionMeta: {
+          ...MOCK_TRANSACTION_META,
+          type: TransactionType.moneyAccountWithdraw,
+        } as TransactionMeta,
+        payTokenBalanceUsd: 100,
+        isMaxAmount: true,
+      });
+
+      act(() => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      expect(setIsMaxAmountMock).toHaveBeenCalledWith(
+        MOCK_TRANSACTION_META.id,
+        false,
+        { isMoneyAccountDeposit: false },
+      );
     });
 
     it('does not inflate max amount with token fiat rate when balanceUsdOverride is provided', () => {

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -197,6 +197,20 @@ describe('useTransactionCustomAmount', () => {
       expect(result.current.amountFiat).toBe('123.46');
     });
 
+    it('does not use target amount USD for money account withdraw Max', () => {
+      const { result } = runHook({
+        transactionMeta: {
+          ...MOCK_TRANSACTION_META,
+          type: TransactionType.moneyAccountWithdraw,
+        } as TransactionMeta,
+        isMaxAmount: true,
+        totals: { targetAmount: { usd: '123.456' } },
+        requiredTokens: [{ amountUsd: '10', skipIfBalance: false }],
+      });
+
+      expect(result.current.amountFiat).toBe('10');
+    });
+
     it('pre-populates from transaction data when user has not typed yet', () => {
       const { result } = runHook({
         isMaxAmount: false,
@@ -412,6 +426,43 @@ describe('useTransactionCustomAmount', () => {
 
       // 33% of 100 = 33, rounded down to 2 decimals
       expect(result.current.amountFiat).toBe('33');
+    });
+
+    it('does not set isMaxAmount for money account withdraw Max', () => {
+      const { result } = runHook({
+        transactionMeta: {
+          ...MOCK_TRANSACTION_META,
+          type: TransactionType.moneyAccountWithdraw,
+        } as TransactionMeta,
+        payTokenBalanceUsd: 100,
+      });
+
+      act(() => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      expect(setIsMaxAmountMock).not.toHaveBeenCalled();
+    });
+
+    it('clears isMaxAmount for money account withdraw when Max was previously set', () => {
+      const { result } = runHook({
+        transactionMeta: {
+          ...MOCK_TRANSACTION_META,
+          type: TransactionType.moneyAccountWithdraw,
+        } as TransactionMeta,
+        payTokenBalanceUsd: 100,
+        isMaxAmount: true,
+      });
+
+      act(() => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      expect(setIsMaxAmountMock).toHaveBeenCalledWith(
+        MOCK_TRANSACTION_META.id,
+        false,
+        { isMoneyAccountDeposit: false },
+      );
     });
 
     it('does not inflate max amount with token fiat rate when balanceUsdOverride is provided', () => {

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -6,7 +6,10 @@ import {
   type TransactionMeta,
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
-import { setIsMaxAmount } from '../../../../store/controller-actions/transaction-pay-controller';
+import {
+  setIsMaxAmount,
+  setLastMoneyAccountWithdrawAmount,
+} from '../../../../store/controller-actions/transaction-pay-controller';
 import { upsertTransactionUIMetricsFragment } from '../../../../store/actions';
 import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
 import { useTokenFiatRate } from '../tokens/useTokenFiatRates';
@@ -203,16 +206,28 @@ export function useTransactionCustomAmount({
   const amountFiat = useMemo(() => {
     // Quote target USD is the amount that will actually land after fees —
     // use it for Max display so the field matches the submitted total.
+    // Withdrawals: target USD is destination-received value after bridge
+    // fees, not the mUSD being withdrawn — keep the typed amount.
     const targetAmountUsd = totals?.targetAmount?.usd;
 
-    if (isMaxAmount && targetAmountUsd && targetAmountUsd !== '0') {
+    if (
+      !isMoneyAccountWithdraw &&
+      isMaxAmount &&
+      targetAmountUsd &&
+      targetAmountUsd !== '0'
+    ) {
       return new BigNumber(targetAmountUsd)
         .round(2, BigNumber.ROUND_HALF_UP)
         .toString(10);
     }
 
     return amountFiatState;
-  }, [amountFiatState, isMaxAmount, totals?.targetAmount?.usd]);
+  }, [
+    amountFiatState,
+    isMaxAmount,
+    isMoneyAccountWithdraw,
+    totals?.targetAmount?.usd,
+  ]);
 
   const amountHuman = useMemo(
     () =>
@@ -238,6 +253,12 @@ export function useTransactionCustomAmount({
   }, [payToken?.address, payToken?.chainId]);
 
   useEffect(() => {
+    // Record immediately so Send is enabled and confirm can encode without
+    // waiting for the 500ms debounce that writes calldata.
+    if (isMoneyAccountWithdraw && transactionId) {
+      setLastMoneyAccountWithdrawAmount(transactionId, amountHuman);
+    }
+
     // When isMaxAmount is true, amountHuman is driven by quote-controller updates
     // (primaryRequiredToken.amountUsd). Re-feeding it into updateTokenAmount
     // changes txParams.data, which restarts the quote cycle (infinite loop).
@@ -266,8 +287,10 @@ export function useTransactionCustomAmount({
     amountHuman,
     disableUpdate,
     isMaxAmount,
+    isMoneyAccountWithdraw,
     payToken?.address,
     payToken?.chainId,
+    transactionId,
   ]);
 
   useEffect(() => {
@@ -351,8 +374,11 @@ export function useTransactionCustomAmount({
         .times(balanceUsdValue);
       // Max deposits also set isMaxAmount, with isMoneyAccountDeposit so TPC
       // runs them non-atomic instead of substituting token.balanceRaw.
+      // Do not set isMaxAmount for money-account withdraw. TPC would
+      // substitute on-chain mUSD `token.balanceRaw` instead of the typed
+      // withdrawable (mUSD + vmUSD) total. Matches mobile.
       const shouldSetMaxAmountMode =
-        percentage === 100 && !hasBalanceUsdOverride;
+        percentage === 100 && !hasBalanceUsdOverride && !isMoneyAccountWithdraw;
       // Keep the displayed fiat rounded except for balanceUsdOverride Max
       // (Perps withdraw), which must preserve the full typed balance.
       const newAmountFiat = (
@@ -424,6 +450,7 @@ export function useTransactionCustomAmount({
       hasBalanceUsdOverride,
       isMaxAmount,
       isMoneyAccountDeposit,
+      isMoneyAccountWithdraw,
       isNoFeePayToken,
       payToken?.balanceRaw,
       payToken?.decimals,

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -6,7 +6,10 @@ import {
   type TransactionMeta,
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
-import { setIsMaxAmount } from '../../../../store/controller-actions/transaction-pay-controller';
+import {
+  setIsMaxAmount,
+  setLastMoneyAccountWithdrawAmount,
+} from '../../../../store/controller-actions/transaction-pay-controller';
 import { upsertTransactionUIMetricsFragment } from '../../../../store/actions';
 import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
 import { useTokenFiatRate } from '../tokens/useTokenFiatRates';
@@ -170,16 +173,28 @@ export function useTransactionCustomAmount({
   const amountFiat = useMemo(() => {
     // Quote target USD is the amount that will actually land after fees —
     // use it for Max display so the field matches the submitted total.
+    // Withdrawals: target USD is destination-received value after bridge
+    // fees, not the mUSD being withdrawn — keep the typed amount.
     const targetAmountUsd = totals?.targetAmount?.usd;
 
-    if (isMaxAmount && targetAmountUsd && targetAmountUsd !== '0') {
+    if (
+      !isMoneyAccountWithdraw &&
+      isMaxAmount &&
+      targetAmountUsd &&
+      targetAmountUsd !== '0'
+    ) {
       return new BigNumber(targetAmountUsd)
         .round(2, BigNumber.ROUND_HALF_UP)
         .toString(10);
     }
 
     return amountFiatState;
-  }, [amountFiatState, isMaxAmount, totals?.targetAmount?.usd]);
+  }, [
+    amountFiatState,
+    isMaxAmount,
+    isMoneyAccountWithdraw,
+    totals?.targetAmount?.usd,
+  ]);
 
   const amountHuman = useMemo(
     () =>
@@ -205,6 +220,12 @@ export function useTransactionCustomAmount({
   }, [payToken?.address, payToken?.chainId]);
 
   useEffect(() => {
+    // Record immediately so Send is enabled and confirm can encode without
+    // waiting for the 500ms debounce that writes calldata.
+    if (isMoneyAccountWithdraw && transactionId) {
+      setLastMoneyAccountWithdrawAmount(transactionId, amountHuman);
+    }
+
     // When isMaxAmount is true, amountHuman is driven by quote-controller updates
     // (primaryRequiredToken.amountUsd). Re-feeding it into updateTokenAmount
     // changes txParams.data, which restarts the quote cycle (infinite loop).
@@ -219,7 +240,14 @@ export function useTransactionCustomAmount({
     if (debounceRef.current) {
       debounceRef.current(depositMaxHumanRef.current ?? amountHuman);
     }
-  }, [amountHuman, isMaxAmount, payToken?.address, payToken?.chainId]);
+  }, [
+    amountHuman,
+    isMaxAmount,
+    isMoneyAccountWithdraw,
+    payToken?.address,
+    payToken?.chainId,
+    transactionId,
+  ]);
 
   if (!isInputChanged && amountHumanDebounced !== '0') {
     setInputChanged(true);
@@ -299,8 +327,11 @@ export function useTransactionCustomAmount({
         .times(balanceUsdValue);
       // Max deposits also set isMaxAmount, with isMoneyAccountDeposit so TPC
       // runs them non-atomic instead of substituting token.balanceRaw.
+      // Do not set isMaxAmount for money-account withdraw. TPC would
+      // substitute on-chain mUSD `token.balanceRaw` instead of the typed
+      // withdrawable (mUSD + vmUSD) total. Matches mobile.
       const shouldSetMaxAmountMode =
-        percentage === 100 && !hasBalanceUsdOverride;
+        percentage === 100 && !hasBalanceUsdOverride && !isMoneyAccountWithdraw;
       // Keep the displayed fiat rounded except for balanceUsdOverride Max
       // (Perps withdraw), which must preserve the full typed balance.
       const newAmountFiat = (
@@ -370,6 +401,7 @@ export function useTransactionCustomAmount({
       hasBalanceUsdOverride,
       isMaxAmount,
       isMoneyAccountDeposit,
+      isMoneyAccountWithdraw,
       isNoFeePayToken,
       payToken?.balanceRaw,
       payToken?.decimals,

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -329,7 +329,7 @@ export function useTransactionCustomAmount({
       // runs them non-atomic instead of substituting token.balanceRaw.
       // Do not set isMaxAmount for money-account withdraw. TPC would
       // substitute on-chain mUSD `token.balanceRaw` instead of the typed
-      // withdrawable (mUSD + vmUSD) total. Matches mobile.
+      // vault withdrawable (`vmusdValueInMusd`) total. Matches mobile.
       const shouldSetMaxAmountMode =
         percentage === 100 && !hasBalanceUsdOverride && !isMoneyAccountWithdraw;
       // Keep the displayed fiat rounded except for balanceUsdOverride Max

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.test.ts
@@ -114,6 +114,31 @@ describe('useTransactionCustomAmountAlerts', () => {
     });
   });
 
+  it('sets hideResults to true when InsufficientMoneyAccountBalance alert exists', () => {
+    useAlertsMock.mockReturnValue(
+      createMockUseAlertsReturnValue({
+        alerts: [
+          createMockAlert({
+            key: AlertsName.InsufficientMoneyAccountBalance,
+            message: 'Insufficient funds',
+            isBlocking: true,
+            severity: Severity.Danger,
+          }),
+        ],
+        hasDangerAlerts: true,
+        hasAlerts: true,
+        hasUnconfirmedDangerAlerts: true,
+      }),
+    );
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual({
+      disableUpdate: false,
+      hideResults: true,
+    });
+  });
+
   it('sets hideResults to true when InsufficientPayTokenBalance alert exists', () => {
     useAlertsMock.mockReturnValue(
       createMockUseAlertsReturnValue({

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.ts
@@ -8,6 +8,7 @@ const ALERTS_HIDE_RESULTS: string[] = [
   AlertsName.AccountNoFunds,
   AlertsName.DepositLimit,
   AlertsName.InsufficientPayTokenBalance,
+  AlertsName.InsufficientMoneyAccountBalance,
   AlertsName.PayHardwareAccount,
   AlertsName.PerpsWithdrawBalanceUnavailable,
   AlertsName.SigningOrSubmitting,

--- a/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../../store/controller-actions/transaction-pay-controller';
 import * as useTransactionPayDataModule from '../pay/useTransactionPayData';
 import * as transactionPayUtils from '../../utils/transaction-pay';
+import { useTransactionAccountOverride } from './useTransactionAccountOverride';
 import { useUpdateTokenAmount } from './useUpdateTokenAmount';
 
 jest.mock('../../../../store/actions', () => ({
@@ -41,6 +42,7 @@ jest.mock(
 
 jest.mock('../pay/useTransactionPayData');
 jest.mock('../../utils/transaction-pay');
+jest.mock('./useTransactionAccountOverride');
 
 const MOCK_RECIPIENT = '0x1234567890123456789012345678901234567890';
 const MOCK_TOKEN_ADDRESS = '0xabcdef0123456789abcdef0123456789abcdef01';
@@ -110,12 +112,16 @@ function runHook({
 describe('useUpdateTokenAmount', () => {
   const updateEditableParamsMock = jest.mocked(updateEditableParams);
   const updateAtomicBatchDataMock = jest.mocked(updateAtomicBatchData);
+  const useTransactionAccountOverrideMock = jest.mocked(
+    useTransactionAccountOverride,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
     updateAtomicBatchDataMock.mockResolvedValue(undefined);
     updateEditableParamsMock.mockReturnValue((() =>
       Promise.resolve()) as never);
+    useTransactionAccountOverrideMock.mockReturnValue(undefined);
   });
 
   describe('updateTokenAmount', () => {
@@ -156,10 +162,7 @@ describe('useUpdateTokenAmount', () => {
     it('dispatches the withdrawal commit path for a money account withdrawal batch', async () => {
       const updateWithdrawAmountMock = jest
         .mocked(updateMoneyAccountWithdrawAmount)
-        .mockResolvedValue({
-          didCommit: true,
-          recipient: MOCK_RECIPIENT,
-        });
+        .mockResolvedValue(false);
 
       const transactionMeta = createMockTransactionMeta({
         nestedTransactions: [
@@ -184,9 +187,48 @@ describe('useUpdateTokenAmount', () => {
       expect(updateWithdrawAmountMock).toHaveBeenCalledWith(
         transactionMeta.id,
         '2',
+        undefined,
       );
       expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
       expect(updateEditableParamsMock).not.toHaveBeenCalled();
+    });
+
+    it('passes the account override as the withdraw recipient', async () => {
+      const accountOverride =
+        '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
+      useTransactionAccountOverrideMock.mockReturnValue(accountOverride);
+
+      const updateWithdrawAmountMock = jest
+        .mocked(updateMoneyAccountWithdrawAmount)
+        .mockResolvedValue(false);
+
+      const transactionMeta = createMockTransactionMeta({
+        nestedTransactions: [
+          { to: MOCK_TOKEN_ADDRESS, type: 'moneyAccountWithdraw' },
+          { to: MOCK_RECIPIENT, type: 'transfer' },
+        ],
+      } as unknown as Partial<TransactionMeta>);
+
+      const { result } = runHook({
+        transactionMeta,
+        tokenTransferData: {
+          data: undefined,
+          to: undefined,
+          index: undefined,
+        },
+      });
+
+      // The commit promise settles in a microtask, and its `finally` clears the
+      // pending flag, so the state update must be flushed inside `act`.
+      await act(async () => {
+        result.current.updateTokenAmount('2');
+      });
+
+      expect(updateWithdrawAmountMock).toHaveBeenCalledWith(
+        transactionMeta.id,
+        '2',
+        accountOverride,
+      );
     });
 
     it('does nothing when data is undefined', () => {

--- a/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
@@ -8,9 +8,11 @@ import { updateAtomicBatchData } from '../../../../store/controller-actions/tran
 import {
   updateMoneyAccountDepositAmount,
   updateMoneyAccountWithdrawAmount,
+  type MoneyAccountWithdrawAmountUpdate,
 } from '../../../../store/controller-actions/transaction-pay-controller';
 import * as useTransactionPayDataModule from '../pay/useTransactionPayData';
 import * as transactionPayUtils from '../../utils/transaction-pay';
+import { useTransactionAccountOverride } from './useTransactionAccountOverride';
 import { useUpdateTokenAmount } from './useUpdateTokenAmount';
 
 jest.mock('../../../../store/actions', () => ({
@@ -41,6 +43,7 @@ jest.mock(
 
 jest.mock('../pay/useTransactionPayData');
 jest.mock('../../utils/transaction-pay');
+jest.mock('./useTransactionAccountOverride');
 
 const MOCK_RECIPIENT = '0x1234567890123456789012345678901234567890';
 const MOCK_TOKEN_ADDRESS = '0xabcdef0123456789abcdef0123456789abcdef01';
@@ -110,12 +113,16 @@ function runHook({
 describe('useUpdateTokenAmount', () => {
   const updateEditableParamsMock = jest.mocked(updateEditableParams);
   const updateAtomicBatchDataMock = jest.mocked(updateAtomicBatchData);
+  const useTransactionAccountOverrideMock = jest.mocked(
+    useTransactionAccountOverride,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
     updateAtomicBatchDataMock.mockResolvedValue(undefined);
     updateEditableParamsMock.mockReturnValue((() =>
       Promise.resolve()) as never);
+    useTransactionAccountOverrideMock.mockReturnValue(undefined);
   });
 
   describe('updateTokenAmount', () => {
@@ -158,7 +165,7 @@ describe('useUpdateTokenAmount', () => {
     it('dispatches the withdrawal commit path for a money account withdrawal batch', async () => {
       const updateWithdrawAmountMock = jest
         .mocked(updateMoneyAccountWithdrawAmount)
-        .mockResolvedValue(true);
+        .mockResolvedValue(false);
 
       const transactionMeta = createMockTransactionMeta({
         nestedTransactions: [
@@ -185,8 +192,47 @@ describe('useUpdateTokenAmount', () => {
       expect(updateWithdrawAmountMock).toHaveBeenCalledWith(
         transactionMeta.id,
         '2',
+        undefined,
       );
       expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
+    });
+
+    it('passes the account override as the withdraw recipient', async () => {
+      const accountOverride =
+        '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
+      useTransactionAccountOverrideMock.mockReturnValue(accountOverride);
+
+      const updateWithdrawAmountMock = jest
+        .mocked(updateMoneyAccountWithdrawAmount)
+        .mockResolvedValue(false);
+
+      const transactionMeta = createMockTransactionMeta({
+        nestedTransactions: [
+          { to: MOCK_TOKEN_ADDRESS, type: 'moneyAccountWithdraw' },
+          { to: MOCK_RECIPIENT, type: 'transfer' },
+        ],
+      } as unknown as Partial<TransactionMeta>);
+
+      const { result } = runHook({
+        transactionMeta,
+        tokenTransferData: {
+          data: undefined,
+          to: undefined,
+          index: undefined,
+        },
+      });
+
+      // The commit promise settles in a microtask, and its `finally` clears the
+      // pending flag, so the state update must be flushed inside `act`.
+      await act(async () => {
+        result.current.updateTokenAmount('2');
+      });
+
+      expect(updateWithdrawAmountMock).toHaveBeenCalledWith(
+        transactionMeta.id,
+        '2',
+        accountOverride,
+      );
     });
 
     it('does nothing when data is undefined', () => {
@@ -371,7 +417,9 @@ describe('useUpdateTokenAmount', () => {
     });
 
     it('is true while a money withdrawal amount commit is in flight, and false once it resolves', async () => {
-      let resolveCommit: (value: boolean) => void = () => undefined;
+      let resolveCommit: (
+        value: false | MoneyAccountWithdrawAmountUpdate,
+      ) => void = () => undefined;
       jest.mocked(updateMoneyAccountWithdrawAmount).mockReturnValue(
         new Promise((resolve) => {
           resolveCommit = resolve;
@@ -401,7 +449,10 @@ describe('useUpdateTokenAmount', () => {
       await waitFor(() => expect(result.current.isUpdating).toBe(true));
 
       await act(async () => {
-        resolveCommit(true);
+        resolveCommit({
+          withdrawData: '0x',
+          transferData: '0x',
+        });
       });
 
       await waitFor(() => expect(result.current.isUpdating).toBe(false));

--- a/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../store/controller-actions/transaction-pay-controller';
 import { useTransactionPayPrimaryRequiredToken } from '../pay/useTransactionPayData';
 import { useDispatch } from '../../../../store/hooks';
+import { useTransactionAccountOverride } from './useTransactionAccountOverride';
 
 const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
 let erc20Interface: Interface | null = null;
@@ -63,6 +64,7 @@ export function useUpdateTokenAmount() {
   );
 
   const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
+  const accountOverride = useTransactionAccountOverride();
 
   const decimals = primaryRequiredToken?.decimals;
 
@@ -106,17 +108,20 @@ export function useUpdateTokenAmount() {
         return;
       }
 
-      // Same shape as deposits: the placeholder withdraw + transfer batch
-      // has no transfer calldata to parse on the parent.
+      // Placeholder withdraw + transfer batch has no calldata to parse. The
+      // background commit re-encodes both calls (vault rate + recipient).
+      // Confirm patches the returned hexes onto the approval clone.
       if (moneyAccountFlow === MoneyAccountFlow.Withdraw) {
-        updateMoneyAccountWithdrawAmount(transactionId, amountHuman).catch(
-          (error) => {
-            console.error(
-              'Failed to update money account withdrawal amount',
-              error,
-            );
-          },
-        );
+        updateMoneyAccountWithdrawAmount(
+          transactionId,
+          amountHuman,
+          accountOverride,
+        ).catch((error) => {
+          console.error(
+            'Failed to update money account withdrawal amount',
+            error,
+          );
+        });
         return;
       }
 
@@ -166,6 +171,7 @@ export function useUpdateTokenAmount() {
       );
     },
     [
+      accountOverride,
       amountRaw,
       data,
       decimals,

--- a/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../store/controller-actions/transaction-pay-controller';
 import { useTransactionPayPrimaryRequiredToken } from '../pay/useTransactionPayData';
 import { useDispatch } from '../../../../store/hooks';
+import { useTransactionAccountOverride } from './useTransactionAccountOverride';
 
 const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
 let erc20Interface: Interface | null = null;
@@ -61,6 +62,7 @@ export function useUpdateTokenAmount() {
   );
 
   const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
+  const accountOverride = useTransactionAccountOverride();
 
   const decimals = primaryRequiredToken?.decimals;
 
@@ -138,12 +140,16 @@ export function useUpdateTokenAmount() {
         return;
       }
 
-      // Same shape as deposits: the placeholder withdraw + transfer batch has
-      // no calldata to parse, and the background commit path resolves the
-      // recipient (the selected account) and the vault rate.
+      // Placeholder withdraw + transfer batch has no calldata to parse. The
+      // background commit re-encodes both calls (vault rate + recipient).
+      // Confirm patches the returned hexes onto the approval clone.
       if (moneyAccountFlow === MoneyAccountFlow.Withdraw) {
         setMoneyAccountDisplayedAmount(amountHuman, transactionId);
-        updateMoneyAccountWithdrawAmount(transactionId, amountHuman)
+        updateMoneyAccountWithdrawAmount(
+          transactionId,
+          amountHuman,
+          accountOverride,
+        )
           .then((didCommit) => {
             if (didCommit) {
               setMoneyAccountCommittedAmount(amountHuman, transactionId);
@@ -205,6 +211,7 @@ export function useUpdateTokenAmount() {
       );
     },
     [
+      accountOverride,
       amountRaw,
       data,
       decimals,

--- a/ui/pages/confirmations/hooks/useConfirmationAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlerts.test.ts
@@ -2,6 +2,10 @@ import { renderHookWithConfirmContextProvider } from '../../../../test/lib/confi
 import mockState from '../../../../test/data/mock-state.json';
 import useConfirmationAlerts from './useConfirmationAlerts';
 
+jest.mock('@metamask/react-data-query', () => ({
+  useQuery: () => ({ data: undefined, isLoading: false, isError: false }),
+}));
+
 const mockUseNavigate = jest.fn();
 jest.mock('react-router-dom', () => {
   return {

--- a/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
@@ -13,6 +13,7 @@ import { useSuggestedGasFeeHighAlert } from './alerts/transactions/useSuggestedG
 import { useInsufficientBalanceAlerts } from './alerts/transactions/useInsufficientBalanceAlerts';
 import { useAccountNoFundsAlert } from './alerts/transactions/useAccountNoFundsAlert';
 import { useInsufficientPayTokenBalanceAlert } from './alerts/transactions/useInsufficientPayTokenBalanceAlert';
+import { useInsufficientMoneyAccountBalanceAlert } from './alerts/transactions/useInsufficientMoneyAccountBalanceAlert';
 import { usePerpsWithdrawInsufficientBalanceAlert } from './alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert';
 import { useTransactionDepositLimitAlert } from './alerts/transactions/useTransactionDepositLimitAlert';
 import { useMultipleApprovalsAlerts } from './alerts/transactions/useMultipleApprovalsAlerts';
@@ -59,6 +60,8 @@ function useTransactionAlerts(): Alert[] {
   const insufficientBalanceAlerts = useInsufficientBalanceAlerts();
   const insufficientPayTokenBalanceAlerts =
     useInsufficientPayTokenBalanceAlert();
+  const insufficientMoneyAccountBalanceAlerts =
+    useInsufficientMoneyAccountBalanceAlert();
   const perpsWithdrawInsufficientBalanceAlerts =
     usePerpsWithdrawInsufficientBalanceAlert();
   const multipleApprovalAlerts = useMultipleApprovalsAlerts();
@@ -87,6 +90,7 @@ function useTransactionAlerts(): Alert[] {
       ...gasTooLowAlerts,
       ...insufficientBalanceAlerts,
       ...insufficientPayTokenBalanceAlerts,
+      ...insufficientMoneyAccountBalanceAlerts,
       ...perpsWithdrawInsufficientBalanceAlerts,
       ...multipleApprovalAlerts,
       ...noGasPriceAlerts,
@@ -113,6 +117,7 @@ function useTransactionAlerts(): Alert[] {
       gasTooLowAlerts,
       insufficientBalanceAlerts,
       insufficientPayTokenBalanceAlerts,
+      insufficientMoneyAccountBalanceAlerts,
       perpsWithdrawInsufficientBalanceAlerts,
       multipleApprovalAlerts,
       noGasPriceAlerts,

--- a/ui/pages/confirmations/utils/money-account-withdraw.test.ts
+++ b/ui/pages/confirmations/utils/money-account-withdraw.test.ts
@@ -1,0 +1,253 @@
+import {
+  generateEIP7702BatchTransaction,
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+
+import {
+  applyWithdrawCalldata,
+  asFundedWithdrawUpdate,
+  asWithdrawTransactionToApprove,
+  getTransferAmountRawFromData,
+  hasFundedWithdrawCalldata,
+  isEncodedCalldata,
+  withFundedBatchCalldata,
+} from './money-account-withdraw';
+
+const FROM = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc' as Hex;
+const TELLER_ADDRESS = '0x1111111111111111111111111111111111111111' as Hex;
+const MUSD_ADDRESS = '0x3333333333333333333333333333333333333333' as Hex;
+const WITHDRAW_DATA = '0x1234567890abcdef1234567890abcdef12345678' as Hex;
+const PLACEHOLDER_DATA = '0xemptyexecute';
+const FUNDED_TRANSFER_DATA =
+  '0xa9059cbb0000000000000000000000002222222222222222222222222222222222222222000000000000000000000000000000000000000000000000000000000000c350' as Hex;
+const ZERO_TRANSFER_DATA =
+  '0xa9059cbb00000000000000000000000022222222222222222222222222222222222222220000000000000000000000000000000000000000000000000000000000000000' as Hex;
+
+const PLACEHOLDER_NESTED = [
+  { to: TELLER_ADDRESS, data: '0x' as Hex },
+  { to: MUSD_ADDRESS, data: '0x' as Hex },
+] as TransactionMeta['nestedTransactions'];
+
+const FUNDED_NESTED = [
+  { to: TELLER_ADDRESS, data: WITHDRAW_DATA },
+  { to: MUSD_ADDRESS, data: FUNDED_TRANSFER_DATA },
+] as TransactionMeta['nestedTransactions'];
+
+function buildTransaction(
+  nestedTransactions?: TransactionMeta['nestedTransactions'],
+): TransactionMeta {
+  return {
+    id: 'tx-1',
+    type: TransactionType.batch,
+    txParams: { from: FROM, to: FROM, data: PLACEHOLDER_DATA },
+    nestedTransactions,
+  } as unknown as TransactionMeta;
+}
+
+describe('money-account-withdraw', () => {
+  describe('isEncodedCalldata', () => {
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      [undefined, false],
+      ['', false],
+      ['0x', false],
+      ['0x00', false],
+      ['0xa9059cbb', false],
+      [WITHDRAW_DATA, true],
+    ])('returns %s -> %s', (data: string | undefined, expected: boolean) => {
+      expect(isEncodedCalldata(data)).toBe(expected);
+    });
+  });
+
+  describe('getTransferAmountRawFromData', () => {
+    it('decodes the amount argument of a transfer', () => {
+      expect(getTransferAmountRawFromData(FUNDED_TRANSFER_DATA)).toBe('50000');
+    });
+
+    it('decodes a zero amount', () => {
+      expect(getTransferAmountRawFromData(ZERO_TRANSFER_DATA)).toBe('0');
+    });
+
+    it('returns undefined for missing data', () => {
+      expect(getTransferAmountRawFromData(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when the selector is not a transfer', () => {
+      expect(
+        getTransferAmountRawFromData(`0xdeadbeef${'0'.repeat(128)}`),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when the calldata is too short', () => {
+      expect(getTransferAmountRawFromData('0xa9059cbb00')).toBeUndefined();
+    });
+
+    it('returns undefined when the amount word is not hex', () => {
+      expect(
+        getTransferAmountRawFromData(`0xa9059cbb${'z'.repeat(128)}`),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('hasFundedWithdrawCalldata', () => {
+    it('returns true when both nested calls encode a non-zero amount', () => {
+      expect(hasFundedWithdrawCalldata(buildTransaction(FUNDED_NESTED))).toBe(
+        true,
+      );
+    });
+
+    it('returns false for the unencoded placeholder', () => {
+      expect(
+        hasFundedWithdrawCalldata(buildTransaction(PLACEHOLDER_NESTED)),
+      ).toBe(false);
+    });
+
+    it('returns false when the transfer amount is zero', () => {
+      expect(
+        hasFundedWithdrawCalldata(
+          buildTransaction([
+            { to: TELLER_ADDRESS, data: WITHDRAW_DATA },
+            { to: MUSD_ADDRESS, data: ZERO_TRANSFER_DATA },
+          ] as TransactionMeta['nestedTransactions']),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false when there is no transaction', () => {
+      expect(hasFundedWithdrawCalldata(undefined)).toBe(false);
+    });
+  });
+
+  describe('asFundedWithdrawUpdate', () => {
+    it('returns the update when it is funded', () => {
+      expect(
+        asFundedWithdrawUpdate({
+          withdrawData: WITHDRAW_DATA,
+          transferData: FUNDED_TRANSFER_DATA,
+          transactionData: PLACEHOLDER_DATA,
+        }),
+      ).toStrictEqual({
+        withdrawData: WITHDRAW_DATA,
+        transferData: FUNDED_TRANSFER_DATA,
+        transactionData: PLACEHOLDER_DATA,
+      });
+    });
+
+    it('defaults transactionData to undefined when absent', () => {
+      expect(
+        asFundedWithdrawUpdate({
+          withdrawData: WITHDRAW_DATA,
+          transferData: FUNDED_TRANSFER_DATA,
+        }),
+      ).toStrictEqual({
+        withdrawData: WITHDRAW_DATA,
+        transferData: FUNDED_TRANSFER_DATA,
+        transactionData: undefined,
+      });
+    });
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      ['false', false],
+      ['null', null],
+      ['a string', 'nope'],
+      ['a partial object', { withdrawData: WITHDRAW_DATA }],
+      [
+        'unencoded withdraw data',
+        { withdrawData: '0x', transferData: FUNDED_TRANSFER_DATA },
+      ],
+      [
+        'a zero transfer',
+        { withdrawData: WITHDRAW_DATA, transferData: ZERO_TRANSFER_DATA },
+      ],
+      [
+        'an undecodable transfer',
+        { withdrawData: WITHDRAW_DATA, transferData: '0x' },
+      ],
+    ])('returns undefined for %s', (_label: string, value: unknown) => {
+      expect(asFundedWithdrawUpdate(value)).toBeUndefined();
+    });
+  });
+
+  describe('asWithdrawTransactionToApprove', () => {
+    it('clones the transaction and retypes it as a withdraw', () => {
+      const transaction = buildTransaction(FUNDED_NESTED);
+
+      const result = asWithdrawTransactionToApprove(transaction);
+
+      expect(result).not.toBe(transaction);
+      expect(result.type).toBe(TransactionType.moneyAccountWithdraw);
+      expect(transaction.type).toBe(TransactionType.batch);
+    });
+  });
+
+  describe('withFundedBatchCalldata', () => {
+    it('rebuilds the parent execute calldata from the nested calls', () => {
+      const result = withFundedBatchCalldata(buildTransaction(FUNDED_NESTED));
+
+      const expected = generateEIP7702BatchTransaction(
+        FROM,
+        FUNDED_NESTED ?? [],
+      );
+      expect(result?.txParams.to).toBe(expected.to ?? FROM);
+      expect(result?.txParams.data).toBe(expected.data);
+      expect(result?.txParams.data).not.toBe(PLACEHOLDER_DATA);
+      expect(result?.type).toBe(TransactionType.moneyAccountWithdraw);
+    });
+
+    it('returns null when the nested calls are not funded', () => {
+      expect(
+        withFundedBatchCalldata(buildTransaction(PLACEHOLDER_NESTED)),
+      ).toBeNull();
+    });
+
+    it('returns null when there is no transaction', () => {
+      expect(withFundedBatchCalldata(undefined)).toBeNull();
+    });
+  });
+
+  describe('applyWithdrawCalldata', () => {
+    const update = {
+      withdrawData: WITHDRAW_DATA,
+      transferData: FUNDED_TRANSFER_DATA,
+    };
+
+    it('patches nested calldata and rebuilds the parent execute', () => {
+      const result = applyWithdrawCalldata(
+        buildTransaction(PLACEHOLDER_NESTED),
+        update,
+      );
+
+      expect(result?.nestedTransactions?.[0].data).toBe(WITHDRAW_DATA);
+      expect(result?.nestedTransactions?.[1].data).toBe(FUNDED_TRANSFER_DATA);
+      expect(result?.txParams.data).not.toBe(PLACEHOLDER_DATA);
+    });
+
+    it('does not mutate the source transaction', () => {
+      const transaction = buildTransaction(PLACEHOLDER_NESTED);
+
+      applyWithdrawCalldata(transaction, update);
+
+      expect(transaction.nestedTransactions?.[0].data).toBe('0x');
+    });
+
+    it('returns null when there is no transaction', () => {
+      expect(applyWithdrawCalldata(undefined, update)).toBeNull();
+    });
+
+    it('returns null when the nested calls are missing', () => {
+      expect(applyWithdrawCalldata(buildTransaction([]), update)).toBeNull();
+    });
+
+    it('returns null when the update is not funded', () => {
+      expect(
+        applyWithdrawCalldata(buildTransaction(PLACEHOLDER_NESTED), {
+          withdrawData: WITHDRAW_DATA,
+          transferData: ZERO_TRANSFER_DATA,
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/ui/pages/confirmations/utils/money-account-withdraw.test.ts
+++ b/ui/pages/confirmations/utils/money-account-withdraw.test.ts
@@ -95,13 +95,19 @@ describe('money-account-withdraw', () => {
   describe('doesWithdrawCalldataMatchAmount', () => {
     it('returns true when the nested transfer encodes the human amount', () => {
       expect(
-        doesWithdrawCalldataMatchAmount(buildTransaction(FUNDED_NESTED), '0.05'),
+        doesWithdrawCalldataMatchAmount(
+          buildTransaction(FUNDED_NESTED),
+          '0.05',
+        ),
       ).toBe(true);
     });
 
     it('returns false when the typed amount differs from the encoded amount', () => {
       expect(
-        doesWithdrawCalldataMatchAmount(buildTransaction(FUNDED_NESTED), '0.10'),
+        doesWithdrawCalldataMatchAmount(
+          buildTransaction(FUNDED_NESTED),
+          '0.10',
+        ),
       ).toBe(false);
     });
 

--- a/ui/pages/confirmations/utils/money-account-withdraw.test.ts
+++ b/ui/pages/confirmations/utils/money-account-withdraw.test.ts
@@ -9,6 +9,7 @@ import {
   applyWithdrawCalldata,
   asFundedWithdrawUpdate,
   asWithdrawTransactionToApprove,
+  doesWithdrawCalldataMatchAmount,
   getTransferAmountRawFromData,
   hasFundedWithdrawCalldata,
   isEncodedCalldata,
@@ -88,6 +89,29 @@ describe('money-account-withdraw', () => {
       expect(
         getTransferAmountRawFromData(`0xa9059cbb${'z'.repeat(128)}`),
       ).toBeUndefined();
+    });
+  });
+
+  describe('doesWithdrawCalldataMatchAmount', () => {
+    it('returns true when the nested transfer encodes the human amount', () => {
+      expect(
+        doesWithdrawCalldataMatchAmount(buildTransaction(FUNDED_NESTED), '0.05'),
+      ).toBe(true);
+    });
+
+    it('returns false when the typed amount differs from the encoded amount', () => {
+      expect(
+        doesWithdrawCalldataMatchAmount(buildTransaction(FUNDED_NESTED), '0.10'),
+      ).toBe(false);
+    });
+
+    it('returns false when the amount is missing', () => {
+      expect(
+        doesWithdrawCalldataMatchAmount(
+          buildTransaction(FUNDED_NESTED),
+          undefined,
+        ),
+      ).toBe(false);
     });
   });
 

--- a/ui/pages/confirmations/utils/money-account-withdraw.ts
+++ b/ui/pages/confirmations/utils/money-account-withdraw.ts
@@ -1,0 +1,179 @@
+import {
+  generateEIP7702BatchTransaction,
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+import type { MoneyAccountWithdrawAmountUpdate } from '../../../store/controller-actions/transaction-pay-controller';
+
+const TRANSFER_SELECTOR = '0xa9059cbb';
+
+/**
+ * Whether calldata carries a function selector plus arguments, rather than
+ * being the empty placeholder the withdraw batch is created with.
+ *
+ * @param data - Calldata to inspect.
+ * @returns Whether the calldata is encoded.
+ */
+export function isEncodedCalldata(data: string | undefined): boolean {
+  return Boolean(data && data !== '0x' && data !== '0x00' && data.length > 10);
+}
+
+/**
+ * Reads the raw (base units) amount argument out of `transfer(to, amount)`
+ * calldata.
+ *
+ * @param data - Calldata expected to be an ERC-20 transfer.
+ * @returns The raw amount as a decimal string, or `undefined` when the
+ * calldata is not a decodable transfer.
+ */
+export function getTransferAmountRawFromData(
+  data: string | undefined,
+): string | undefined {
+  if (!data) {
+    return undefined;
+  }
+  const lower = data.toLowerCase();
+  if (!lower.startsWith(TRANSFER_SELECTOR) || lower.length < 138) {
+    return undefined;
+  }
+  try {
+    return BigInt(`0x${lower.slice(-64)}`).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Placeholder and zero-amount `transfer(recipient, 0)` calldata both look
+ * "encoded" (they have a selector). The Monadscan withdraw that transferred
+ * nothing was approved because we treated that zero transfer as ready.
+ *
+ * @param transaction - Transaction whose nested calls to inspect.
+ * @returns Whether nested withdraw + transfer encode a non-zero amount.
+ */
+export function hasFundedWithdrawCalldata(
+  transaction: TransactionMeta | undefined,
+): boolean {
+  if (!isEncodedCalldata(transaction?.nestedTransactions?.[0]?.data)) {
+    return false;
+  }
+  const amountRaw = getTransferAmountRawFromData(
+    transaction?.nestedTransactions?.[1]?.data,
+  );
+  return Boolean(amountRaw && amountRaw !== '0');
+}
+
+/**
+ * Narrows an encoder result to a funded withdraw update. The UI bridge can
+ * strip unknown shapes, so anything without encoded withdraw calldata and a
+ * non-zero transfer amount is rejected.
+ *
+ * @param value - Raw value returned by the background amount encoder.
+ * @returns The funded update, or `undefined` when it is not funded.
+ */
+export function asFundedWithdrawUpdate(
+  value: unknown,
+): MoneyAccountWithdrawAmountUpdate | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+  if (!('withdrawData' in value) || !('transferData' in value)) {
+    return undefined;
+  }
+  const { withdrawData, transferData } =
+    value as MoneyAccountWithdrawAmountUpdate;
+  if (!isEncodedCalldata(withdrawData)) {
+    return undefined;
+  }
+  const amountRaw = getTransferAmountRawFromData(transferData);
+  if (!amountRaw || amountRaw === '0') {
+    return undefined;
+  }
+  const transactionData =
+    'transactionData' in value
+      ? (value as MoneyAccountWithdrawAmountUpdate).transactionData
+      : undefined;
+  return { withdrawData, transferData, transactionData };
+}
+
+/**
+ * `addTransactionBatch` stores the parent as `batch`. Persist the withdraw
+ * type on approve so the activity list does not fall through to
+ * "Contract interaction".
+ *
+ * @param transaction - Transaction to clone and retype.
+ * @returns A clone typed as a Money Account withdrawal.
+ */
+export function asWithdrawTransactionToApprove(
+  transaction: TransactionMeta,
+): TransactionMeta {
+  const next = cloneDeep(transaction);
+  next.type = TransactionType.moneyAccountWithdraw;
+  return next;
+}
+
+/**
+ * Nested withdraw + transfer can look funded while the parent still carries
+ * the placeholder `execute([])` (or `execute` of empty calls). That parent
+ * mines successfully and moves no funds. Rebuild `to` + `data` from the
+ * nested calls so publish signs the real batch.
+ *
+ * @param transaction - Transaction with funded nested withdraw + transfer.
+ * @returns The same transaction with parent EIP-7702 execute calldata, or
+ * `null` when the nested calls are not funded.
+ */
+export function withFundedBatchCalldata(
+  transaction: TransactionMeta | undefined,
+): TransactionMeta | null {
+  if (!hasFundedWithdrawCalldata(transaction) || !transaction) {
+    return null;
+  }
+  const next = asWithdrawTransactionToApprove(transaction);
+  const from = next.txParams.from as Hex;
+  const batch = generateEIP7702BatchTransaction(
+    from,
+    next.nestedTransactions ?? [],
+  );
+  next.txParams = {
+    ...next.txParams,
+    to: batch.to ?? from,
+    data: batch.data,
+  };
+  return next;
+}
+
+/**
+ * Patches encoder-returned nested calldata onto a transaction and rebuilds
+ * the parent execute calldata from it.
+ *
+ * @param transaction - Transaction to patch.
+ * @param update - Encoded nested withdraw + transfer calldata.
+ * @returns The patched transaction, or `null` when it cannot be patched into
+ * a funded batch.
+ */
+export function applyWithdrawCalldata(
+  transaction: TransactionMeta | undefined,
+  update: MoneyAccountWithdrawAmountUpdate,
+): TransactionMeta | null {
+  if (!transaction) {
+    return null;
+  }
+  const next = asWithdrawTransactionToApprove(transaction);
+  const nested = [...(next.nestedTransactions ?? [])];
+  if (!nested[0] || !nested[1]) {
+    return null;
+  }
+  nested[0] = {
+    ...nested[0],
+    data: update.withdrawData,
+  };
+  nested[1] = {
+    ...nested[1],
+    data: update.transferData,
+  };
+  next.nestedTransactions = nested;
+  return withFundedBatchCalldata(next);
+}

--- a/ui/pages/confirmations/utils/money-account-withdraw.ts
+++ b/ui/pages/confirmations/utils/money-account-withdraw.ts
@@ -1,13 +1,15 @@
+import { MUSD_DECIMALS } from '@metamask/money-account-utils';
 import {
   generateEIP7702BatchTransaction,
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
 import { cloneDeep } from 'lodash';
 
+import type { MoneyAccountWithdrawAmountUpdate } from '../../../../shared/lib/money/withdraw-amount-commit';
 import { parseStandardTokenTransactionData } from '../../../../shared/lib/transaction.utils';
-import type { MoneyAccountWithdrawAmountUpdate } from '../../../store/controller-actions/transaction-pay-controller';
 
 /**
  * ERC-20 `transfer(address,uint256)` 4-byte selector (`keccak256("transfer(address,uint256)").slice(0, 4)`).
@@ -15,6 +17,15 @@ import type { MoneyAccountWithdrawAmountUpdate } from '../../../store/controller
  * decoding itself goes through {@link parseStandardTokenTransactionData}.
  */
 const TRANSFER_SELECTOR = '0xa9059cbb';
+
+/**
+ * Recipient and raw transfer amount decoded from a Money Account withdraw
+ * batch's nested `tokenMethodTransfer` call.
+ */
+export type MoneyAccountWithdrawTransferDetails = {
+  recipient?: string;
+  amountRaw?: string;
+};
 
 /**
  * Whether calldata carries a function selector plus arguments, rather than
@@ -25,6 +36,47 @@ const TRANSFER_SELECTOR = '0xa9059cbb';
  */
 export function isEncodedCalldata(data: string | undefined): boolean {
   return Boolean(data && data !== '0x' && data !== '0x00' && data.length > 10);
+}
+
+/**
+ * Locates the nested ERC-20 transfer in a Money Account withdraw batch and
+ * returns its recipient and raw (base units) amount. Shared by the activity
+ * hero and activity-list enrichment so decoding cannot drift.
+ *
+ * @param transaction - Transaction whose nested calls to inspect.
+ * @returns Recipient and/or raw amount when the nested transfer is present.
+ */
+export function getMoneyAccountWithdrawTransferDetails(
+  transaction:
+    | {
+        nestedTransactions?: { data?: string; type?: string; to?: string }[];
+      }
+    | undefined,
+): MoneyAccountWithdrawTransferDetails {
+  const transfer = transaction?.nestedTransactions?.find(
+    (nested) => nested.type === TransactionType.tokenMethodTransfer,
+  );
+  if (!transfer?.data) {
+    return {};
+  }
+
+  const parsed = parseStandardTokenTransactionData(transfer.data);
+  const recipient = parsed?.args?._to ?? parsed?.args?.to;
+  const amount = parsed?.args?._value ?? parsed?.args?.value ?? parsed?.args?.[1];
+
+  let amountRaw: string | undefined;
+  if (amount !== undefined && amount !== null) {
+    try {
+      amountRaw = BigInt(amount.toString()).toString();
+    } catch {
+      amountRaw = undefined;
+    }
+  }
+
+  return {
+    ...(typeof recipient === 'string' ? { recipient } : {}),
+    ...(amountRaw === undefined ? {} : { amountRaw }),
+  };
 }
 
 /**
@@ -77,6 +129,63 @@ export function hasFundedWithdrawCalldata(
     transaction?.nestedTransactions?.[1]?.data,
   );
   return Boolean(amountRaw && amountRaw !== '0');
+}
+
+/**
+ * Converts a human-readable mUSD amount to base units for calldata comparison.
+ * Uses the same `ROUND_UP` rules as the background amount commit so a matching
+ * typed amount is not treated as stale.
+ *
+ * @param amountHuman - Exact human-readable mUSD amount.
+ * @returns Raw amount as a decimal string, or `undefined` when invalid.
+ */
+function musdHumanToRaw(amountHuman: string): string | undefined {
+  let value: BigNumber;
+  try {
+    value = new BigNumber(amountHuman);
+  } catch {
+    return undefined;
+  }
+
+  if (!value.isFinite() || value.lte(0)) {
+    return undefined;
+  }
+
+  const raw = value
+    .times(10 ** MUSD_DECIMALS)
+    .round(0, BigNumber.ROUND_UP);
+  if (raw.lte(0)) {
+    return undefined;
+  }
+
+  return raw.toString(10);
+}
+
+/**
+ * Whether funded nested withdraw calldata already encodes `amountHuman`.
+ * The footer enables Send from the latest typed amount immediately, while the
+ * store can still hold a previous encode — confirm must not treat a stale
+ * funded batch as ready.
+ *
+ * @param transaction - Transaction whose nested transfer to inspect.
+ * @param amountHuman - Latest typed human-readable mUSD amount.
+ * @returns Whether the nested transfer amount matches `amountHuman`.
+ */
+export function doesWithdrawCalldataMatchAmount(
+  transaction: TransactionMeta | undefined,
+  amountHuman: string | undefined,
+): boolean {
+  if (!amountHuman || !hasFundedWithdrawCalldata(transaction)) {
+    return false;
+  }
+  const expectedRaw = musdHumanToRaw(amountHuman);
+  if (!expectedRaw) {
+    return false;
+  }
+  const encodedRaw = getTransferAmountRawFromData(
+    transaction?.nestedTransactions?.[1]?.data,
+  );
+  return encodedRaw === expectedRaw;
 }
 
 /**

--- a/ui/pages/confirmations/utils/money-account-withdraw.ts
+++ b/ui/pages/confirmations/utils/money-account-withdraw.ts
@@ -62,7 +62,8 @@ export function getMoneyAccountWithdrawTransferDetails(
 
   const parsed = parseStandardTokenTransactionData(transfer.data);
   const recipient = parsed?.args?._to ?? parsed?.args?.to;
-  const amount = parsed?.args?._value ?? parsed?.args?.value ?? parsed?.args?.[1];
+  const amount =
+    parsed?.args?._value ?? parsed?.args?.value ?? parsed?.args?.[1];
 
   let amountRaw: string | undefined;
   if (amount !== undefined && amount !== null) {
@@ -151,9 +152,7 @@ function musdHumanToRaw(amountHuman: string): string | undefined {
     return undefined;
   }
 
-  const raw = value
-    .times(10 ** MUSD_DECIMALS)
-    .round(0, BigNumber.ROUND_UP);
+  const raw = value.times(10 ** MUSD_DECIMALS).round(0, BigNumber.ROUND_UP);
   if (raw.lte(0)) {
     return undefined;
   }

--- a/ui/pages/confirmations/utils/money-account-withdraw.ts
+++ b/ui/pages/confirmations/utils/money-account-withdraw.ts
@@ -6,8 +6,14 @@ import {
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
+import { parseStandardTokenTransactionData } from '../../../../shared/lib/transaction.utils';
 import type { MoneyAccountWithdrawAmountUpdate } from '../../../store/controller-actions/transaction-pay-controller';
 
+/**
+ * ERC-20 `transfer(address,uint256)` 4-byte selector (`keccak256("transfer(address,uint256)").slice(0, 4)`).
+ * Used as a cheap early-out before calling the shared ABI parser; amount
+ * decoding itself goes through {@link parseStandardTokenTransactionData}.
+ */
 const TRANSFER_SELECTOR = '0xa9059cbb';
 
 /**
@@ -23,7 +29,7 @@ export function isEncodedCalldata(data: string | undefined): boolean {
 
 /**
  * Reads the raw (base units) amount argument out of `transfer(to, amount)`
- * calldata.
+ * calldata via the shared ERC-20 ABI parser.
  *
  * @param data - Calldata expected to be an ERC-20 transfer.
  * @returns The raw amount as a decimal string, or `undefined` when the
@@ -32,15 +38,22 @@ export function isEncodedCalldata(data: string | undefined): boolean {
 export function getTransferAmountRawFromData(
   data: string | undefined,
 ): string | undefined {
-  if (!data) {
+  if (!data || !data.toLowerCase().startsWith(TRANSFER_SELECTOR)) {
     return undefined;
   }
-  const lower = data.toLowerCase();
-  if (!lower.startsWith(TRANSFER_SELECTOR) || lower.length < 138) {
+
+  const parsed = parseStandardTokenTransactionData(data);
+  if (parsed?.name !== 'transfer') {
     return undefined;
   }
+
+  const amount = parsed.args?._value ?? parsed.args?.value ?? parsed.args?.[1];
+  if (amount === undefined || amount === null) {
+    return undefined;
+  }
+
   try {
-    return BigInt(`0x${lower.slice(-64)}`).toString();
+    return BigInt(amount.toString()).toString();
   } catch {
     return undefined;
   }

--- a/ui/pages/confirmations/utils/transaction-pay.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.test.ts
@@ -5,13 +5,19 @@ import type {
   TransactionPaymentToken,
 } from '@metamask/transaction-pay-controller';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { updateAtomicBatchData } from '../../../store/controller-actions/transaction-controller';
 import { Asset, AssetStandard } from '../types/send';
 import {
   getTokenTransferData,
   getTokenAddress,
   getAvailableTokens,
   isTokenBlocked,
+  replaceAccountInNestedTransactions,
 } from './transaction-pay';
+
+jest.mock('../../../store/controller-actions/transaction-controller', () => ({
+  updateAtomicBatchData: jest.fn(),
+}));
 
 const CHAIN_ID_MOCK = '0x1' as Hex;
 const TOKEN_ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678' as Hex;
@@ -427,6 +433,168 @@ describe('transaction-pay utils', () => {
           },
         ),
       ).toBe(false);
+    });
+  });
+
+  describe('replaceAccountInNestedTransactions', () => {
+    const TRANSACTION_ID = 'tx-1';
+    const OLD_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const NEW_ADDRESS = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const OLD_WORD =
+      '000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const NEW_WORD =
+      '000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const SELECTOR = '0x23b872dd';
+
+    const updateAtomicBatchDataMock = jest.mocked(updateAtomicBatchData);
+
+    beforeEach(() => {
+      updateAtomicBatchDataMock.mockReset();
+      updateAtomicBatchDataMock.mockResolvedValue(undefined);
+    });
+
+    it('replaces the old address word in nested transaction data', () => {
+      replaceAccountInNestedTransactions({
+        transactionId: TRANSACTION_ID,
+        nestedTransactions: [{ data: `${SELECTOR}${OLD_WORD}` as Hex }],
+        oldAddress: OLD_ADDRESS,
+        newAddress: NEW_ADDRESS,
+      });
+
+      expect(updateAtomicBatchDataMock).toHaveBeenCalledTimes(1);
+      expect(updateAtomicBatchDataMock).toHaveBeenCalledWith({
+        transactionId: TRANSACTION_ID,
+        transactionIndex: 0,
+        transactionData: `${SELECTOR}${NEW_WORD}`,
+      });
+    });
+
+    it('replaces every occurrence within the same nested transaction data', () => {
+      replaceAccountInNestedTransactions({
+        transactionId: TRANSACTION_ID,
+        nestedTransactions: [
+          { data: `${SELECTOR}${OLD_WORD}${OLD_WORD}` as Hex },
+        ],
+        oldAddress: OLD_ADDRESS,
+        newAddress: NEW_ADDRESS,
+      });
+
+      expect(updateAtomicBatchDataMock).toHaveBeenCalledWith({
+        transactionId: TRANSACTION_ID,
+        transactionIndex: 0,
+        transactionData: `${SELECTOR}${NEW_WORD}${NEW_WORD}`,
+      });
+    });
+
+    it('matches address case-insensitively and writes lowercase output', () => {
+      replaceAccountInNestedTransactions({
+        transactionId: TRANSACTION_ID,
+        nestedTransactions: [
+          { data: `${SELECTOR}${OLD_WORD.toUpperCase()}` as Hex },
+        ],
+        oldAddress: OLD_ADDRESS.toUpperCase(),
+        newAddress: NEW_ADDRESS,
+      });
+
+      expect(updateAtomicBatchDataMock).toHaveBeenCalledWith({
+        transactionId: TRANSACTION_ID,
+        transactionIndex: 0,
+        transactionData: `${SELECTOR}${NEW_WORD}`,
+      });
+    });
+
+    it('preserves the original index when only some nested transactions match', () => {
+      replaceAccountInNestedTransactions({
+        transactionId: TRANSACTION_ID,
+        nestedTransactions: [
+          { data: '0xdeadbeef' as Hex },
+          { data: `${SELECTOR}${OLD_WORD}` as Hex },
+          { data: undefined },
+        ],
+        oldAddress: OLD_ADDRESS,
+        newAddress: NEW_ADDRESS,
+      });
+
+      expect(updateAtomicBatchDataMock).toHaveBeenCalledTimes(1);
+      expect(updateAtomicBatchDataMock).toHaveBeenCalledWith({
+        transactionId: TRANSACTION_ID,
+        transactionIndex: 1,
+        transactionData: `${SELECTOR}${NEW_WORD}`,
+      });
+    });
+
+    it('does nothing when oldAddress is undefined', () => {
+      replaceAccountInNestedTransactions({
+        transactionId: TRANSACTION_ID,
+        nestedTransactions: [{ data: `${SELECTOR}${OLD_WORD}` as Hex }],
+        oldAddress: undefined,
+        newAddress: NEW_ADDRESS,
+      });
+
+      expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when nestedTransactions is undefined or empty', () => {
+      replaceAccountInNestedTransactions({
+        transactionId: TRANSACTION_ID,
+        nestedTransactions: undefined,
+        oldAddress: OLD_ADDRESS,
+        newAddress: NEW_ADDRESS,
+      });
+      replaceAccountInNestedTransactions({
+        transactionId: TRANSACTION_ID,
+        nestedTransactions: [],
+        oldAddress: OLD_ADDRESS,
+        newAddress: NEW_ADDRESS,
+      });
+
+      expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when old and new addresses are the same', () => {
+      replaceAccountInNestedTransactions({
+        transactionId: TRANSACTION_ID,
+        nestedTransactions: [{ data: `${SELECTOR}${OLD_WORD}` as Hex }],
+        oldAddress: OLD_ADDRESS,
+        newAddress: OLD_ADDRESS.toUpperCase(),
+      });
+
+      expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
+    });
+
+    it('skips nested transactions whose data does not contain the old word', () => {
+      replaceAccountInNestedTransactions({
+        transactionId: TRANSACTION_ID,
+        nestedTransactions: [{ data: '0xdeadbeef' as Hex }],
+        oldAddress: OLD_ADDRESS,
+        newAddress: NEW_ADDRESS,
+      });
+
+      expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
+    });
+
+    it('logs an error when updateAtomicBatchData rejects', async () => {
+      const error = new Error('boom');
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+      updateAtomicBatchDataMock.mockRejectedValueOnce(error);
+
+      replaceAccountInNestedTransactions({
+        transactionId: TRANSACTION_ID,
+        nestedTransactions: [{ data: `${SELECTOR}${OLD_WORD}` as Hex }],
+        oldAddress: OLD_ADDRESS,
+        newAddress: NEW_ADDRESS,
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to update account in nested transaction',
+        error,
+      );
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/ui/pages/confirmations/utils/transaction-pay.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.test.ts
@@ -453,8 +453,8 @@ describe('transaction-pay utils', () => {
       updateAtomicBatchDataMock.mockResolvedValue(undefined);
     });
 
-    it('replaces the old address word in nested transaction data', () => {
-      replaceAccountInNestedTransactions({
+    it('replaces the old address word in nested transaction data', async () => {
+      await replaceAccountInNestedTransactions({
         transactionId: TRANSACTION_ID,
         nestedTransactions: [{ data: `${SELECTOR}${OLD_WORD}` as Hex }],
         oldAddress: OLD_ADDRESS,
@@ -469,8 +469,8 @@ describe('transaction-pay utils', () => {
       });
     });
 
-    it('replaces every occurrence within the same nested transaction data', () => {
-      replaceAccountInNestedTransactions({
+    it('replaces every occurrence within the same nested transaction data', async () => {
+      await replaceAccountInNestedTransactions({
         transactionId: TRANSACTION_ID,
         nestedTransactions: [
           { data: `${SELECTOR}${OLD_WORD}${OLD_WORD}` as Hex },
@@ -486,8 +486,8 @@ describe('transaction-pay utils', () => {
       });
     });
 
-    it('matches address case-insensitively and writes lowercase output', () => {
-      replaceAccountInNestedTransactions({
+    it('matches address case-insensitively and writes lowercase output', async () => {
+      await replaceAccountInNestedTransactions({
         transactionId: TRANSACTION_ID,
         nestedTransactions: [
           { data: `${SELECTOR}${OLD_WORD.toUpperCase()}` as Hex },
@@ -503,8 +503,8 @@ describe('transaction-pay utils', () => {
       });
     });
 
-    it('preserves the original index when only some nested transactions match', () => {
-      replaceAccountInNestedTransactions({
+    it('preserves the original index when only some nested transactions match', async () => {
+      await replaceAccountInNestedTransactions({
         transactionId: TRANSACTION_ID,
         nestedTransactions: [
           { data: '0xdeadbeef' as Hex },
@@ -523,8 +523,8 @@ describe('transaction-pay utils', () => {
       });
     });
 
-    it('does nothing when oldAddress is undefined', () => {
-      replaceAccountInNestedTransactions({
+    it('does nothing when oldAddress is undefined', async () => {
+      await replaceAccountInNestedTransactions({
         transactionId: TRANSACTION_ID,
         nestedTransactions: [{ data: `${SELECTOR}${OLD_WORD}` as Hex }],
         oldAddress: undefined,
@@ -534,14 +534,14 @@ describe('transaction-pay utils', () => {
       expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
     });
 
-    it('does nothing when nestedTransactions is undefined or empty', () => {
-      replaceAccountInNestedTransactions({
+    it('does nothing when nestedTransactions is undefined or empty', async () => {
+      await replaceAccountInNestedTransactions({
         transactionId: TRANSACTION_ID,
         nestedTransactions: undefined,
         oldAddress: OLD_ADDRESS,
         newAddress: NEW_ADDRESS,
       });
-      replaceAccountInNestedTransactions({
+      await replaceAccountInNestedTransactions({
         transactionId: TRANSACTION_ID,
         nestedTransactions: [],
         oldAddress: OLD_ADDRESS,
@@ -551,8 +551,8 @@ describe('transaction-pay utils', () => {
       expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
     });
 
-    it('does nothing when old and new addresses are the same', () => {
-      replaceAccountInNestedTransactions({
+    it('does nothing when old and new addresses are the same', async () => {
+      await replaceAccountInNestedTransactions({
         transactionId: TRANSACTION_ID,
         nestedTransactions: [{ data: `${SELECTOR}${OLD_WORD}` as Hex }],
         oldAddress: OLD_ADDRESS,
@@ -562,8 +562,8 @@ describe('transaction-pay utils', () => {
       expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
     });
 
-    it('skips nested transactions whose data does not contain the old word', () => {
-      replaceAccountInNestedTransactions({
+    it('skips nested transactions whose data does not contain the old word', async () => {
+      await replaceAccountInNestedTransactions({
         transactionId: TRANSACTION_ID,
         nestedTransactions: [{ data: '0xdeadbeef' as Hex }],
         oldAddress: OLD_ADDRESS,
@@ -573,22 +573,21 @@ describe('transaction-pay utils', () => {
       expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
     });
 
-    it('logs an error when updateAtomicBatchData rejects', async () => {
+    it('propagates when updateAtomicBatchData rejects', async () => {
       const error = new Error('boom');
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
       updateAtomicBatchDataMock.mockRejectedValueOnce(error);
 
-      replaceAccountInNestedTransactions({
-        transactionId: TRANSACTION_ID,
-        nestedTransactions: [{ data: `${SELECTOR}${OLD_WORD}` as Hex }],
-        oldAddress: OLD_ADDRESS,
-        newAddress: NEW_ADDRESS,
-      });
-
-      await Promise.resolve();
-      await Promise.resolve();
+      await expect(
+        replaceAccountInNestedTransactions({
+          transactionId: TRANSACTION_ID,
+          nestedTransactions: [{ data: `${SELECTOR}${OLD_WORD}` as Hex }],
+          oldAddress: OLD_ADDRESS,
+          newAddress: NEW_ADDRESS,
+        }),
+      ).rejects.toThrow('boom');
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Failed to update account in nested transaction',

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -1,4 +1,7 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  type NestedTransactionMetadata,
+} from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import {
   PaymentOverride,
@@ -8,11 +11,77 @@ import {
 import { BigNumber } from 'bignumber.js';
 import { isTestNetwork } from '../../../helpers/utils/network-helper';
 import { isPostQuoteWithdrawTransaction } from '../../../../shared/lib/transactions.utils';
+import { updateAtomicBatchData } from '../../../store/controller-actions/transaction-controller';
 import { setPaymentOverride } from '../../../store/controller-actions/transaction-pay-controller';
 import type { BlockedPayTokensListConfig } from '../selectors/feature-flags';
 import { Asset, AssetStandard } from '../types/send';
 
 const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
+
+function toAddressWord(address: string): string {
+  return address.toLowerCase().replace(/^0x/u, '').padStart(64, '0');
+}
+
+/**
+ * Replace every occurrence of `oldAddress` (encoded as a 32-byte ABI word)
+ * inside the `data` of each nested transaction with `newAddress`, and persist
+ * the change via `updateAtomicBatchData`. No-ops when there are no nested
+ * transactions or no old address to replace.
+ *
+ * Mirrors mobile `replaceAccountInNestedTransactions`. Used when the From-row
+ * changes the withdraw recipient so the transfer calldata is rewritten
+ * immediately, not only on the next amount encode.
+ *
+ * @param params - Replacement inputs.
+ * @param params.transactionId - Id of the parent batch transaction.
+ * @param params.nestedTransactions - Nested calls to scan.
+ * @param params.oldAddress - Address currently encoded in calldata.
+ * @param params.newAddress - Address to write in its place.
+ */
+export function replaceAccountInNestedTransactions({
+  transactionId,
+  nestedTransactions,
+  oldAddress,
+  newAddress,
+}: {
+  transactionId: string;
+  nestedTransactions: NestedTransactionMetadata[] | undefined;
+  oldAddress: string | undefined;
+  newAddress: string;
+}): void {
+  if (!oldAddress || !nestedTransactions?.length) {
+    return;
+  }
+
+  const oldWord = toAddressWord(oldAddress);
+  const newWord = toAddressWord(newAddress);
+
+  if (oldWord === newWord) {
+    return;
+  }
+
+  nestedTransactions.forEach((nested, index) => {
+    const { data } = nested;
+    if (!data) {
+      return;
+    }
+
+    const lowerData = data.toLowerCase();
+    if (!lowerData.includes(oldWord)) {
+      return;
+    }
+
+    const newData = lowerData.split(oldWord).join(newWord) as Hex;
+
+    updateAtomicBatchData({
+      transactionId,
+      transactionIndex: index,
+      transactionData: newData,
+    }).catch((error) => {
+      console.error('Failed to update account in nested transaction', error);
+    });
+  });
+}
 
 export function getTokenTransferData(
   transactionMeta: TransactionMeta | undefined,

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -37,8 +37,9 @@ function toAddressWord(address: string): string {
  * @param params.nestedTransactions - Nested calls to scan.
  * @param params.oldAddress - Address currently encoded in calldata.
  * @param params.newAddress - Address to write in its place.
+ * @returns Resolves when all nested rewrites have persisted.
  */
-export function replaceAccountInNestedTransactions({
+export async function replaceAccountInNestedTransactions({
   transactionId,
   nestedTransactions,
   oldAddress,
@@ -48,7 +49,7 @@ export function replaceAccountInNestedTransactions({
   nestedTransactions: NestedTransactionMetadata[] | undefined;
   oldAddress: string | undefined;
   newAddress: string;
-}): void {
+}): Promise<void> {
   if (!oldAddress || !nestedTransactions?.length) {
     return;
   }
@@ -59,6 +60,8 @@ export function replaceAccountInNestedTransactions({
   if (oldWord === newWord) {
     return;
   }
+
+  const updates: Promise<void>[] = [];
 
   nestedTransactions.forEach((nested, index) => {
     const { data } = nested;
@@ -73,14 +76,19 @@ export function replaceAccountInNestedTransactions({
 
     const newData = lowerData.split(oldWord).join(newWord) as Hex;
 
-    updateAtomicBatchData({
-      transactionId,
-      transactionIndex: index,
-      transactionData: newData,
-    }).catch((error) => {
-      console.error('Failed to update account in nested transaction', error);
-    });
+    updates.push(
+      updateAtomicBatchData({
+        transactionId,
+        transactionIndex: index,
+        transactionData: newData,
+      }).catch((error) => {
+        console.error('Failed to update account in nested transaction', error);
+        throw error;
+      }),
+    );
   });
+
+  await Promise.all(updates);
 }
 
 export function getTokenTransferData(

--- a/ui/selectors/activity/enrich-local-activity.test.ts
+++ b/ui/selectors/activity/enrich-local-activity.test.ts
@@ -131,6 +131,52 @@ describe('enrichLocalActivity', () => {
     expect(enriched.type).toBe('revokeSpendingCap');
   });
 
+  it('maps a money account withdraw batch to a send of mUSD', () => {
+    const group = buildTokenTransferGroup({
+      type: TransactionType.batch,
+      txParams: {
+        from: '0x1111111111111111111111111111111111111111',
+        to: '0x3333333333333333333333333333333333333333',
+        data: '0x',
+        value: '0x0',
+      },
+      nestedTransactions: [
+        { type: TransactionType.moneyAccountWithdraw, data: '0x00' },
+        {
+          type: TransactionType.tokenMethodTransfer,
+          to: DAI_ADDRESS,
+          data: TRANSFER_DATA,
+        },
+      ],
+    });
+    const activity = {
+      type: 'contractInteraction',
+      chainId: 'eip155:1',
+      status: 'success',
+      timestamp: 1,
+      data: {
+        from: '0x1111111111111111111111111111111111111111',
+        to: '0x3333333333333333333333333333333333333333',
+      },
+    } as ActivityListItem;
+
+    const enriched = enrichLocalActivity(activity, group);
+
+    expect(enriched).toMatchObject({
+      type: 'send',
+      data: {
+        from: '0x1111111111111111111111111111111111111111',
+        to: RECIPIENT,
+        token: {
+          direction: 'out',
+          symbol: 'mUSD',
+          decimals: 6,
+          amount: '10000000000000000000',
+        },
+      },
+    });
+  });
+
   it('does not change unrelated activity items', () => {
     const group = buildTokenTransferGroup({
       type: TransactionType.simpleSend,

--- a/ui/selectors/activity/enrich-local-activity.ts
+++ b/ui/selectors/activity/enrich-local-activity.ts
@@ -1,10 +1,18 @@
+import {
+  MUSD_DECIMALS,
+  MUSD_TOKEN,
+  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
+} from '@metamask/money-account-utils';
 import { TransactionType } from '@metamask/transaction-controller';
+import { KnownCaipNamespace, toCaipChainId } from '@metamask/utils';
 import type { ActivityListItem } from '../../../shared/lib/activity/types';
+import { toAssetId } from '../../../shared/lib/asset-utils';
 import type { TransactionGroup } from '../../../shared/lib/multichain/types';
 import {
   parseApprovalTransactionData,
   parseStandardTokenTransactionData,
 } from '../../../shared/lib/transaction.utils';
+import { hasTransactionType } from '../../../shared/lib/transactions.utils';
 import { enrichLocalMusdClaimActivity } from './enrich-local-musd-claim';
 
 const TOKEN_TRANSFER_TYPES = new Set<TransactionType>([
@@ -113,11 +121,70 @@ function enrichApprovalActivity(
   };
 }
 
+function enrichMoneyAccountWithdrawActivity(
+  activity: ActivityListItem,
+  transactionGroup: LocalActivitySource,
+): ActivityListItem {
+  const transaction = transactionGroup.initialTransaction;
+  if (
+    !hasTransactionType(transaction, [TransactionType.moneyAccountWithdraw])
+  ) {
+    return activity;
+  }
+
+  const transfer = transaction.nestedTransactions?.find(
+    (nested) => nested.type === TransactionType.tokenMethodTransfer,
+  );
+  const parsed = transfer?.data
+    ? parseStandardTokenTransactionData(transfer.data)
+    : undefined;
+  const recipient = parsed?.args?._to ?? parsed?.args?.to;
+  if (typeof recipient !== 'string') {
+    return activity;
+  }
+
+  const parsedAmount = parsed?.args?._value ?? parsed?.args?.value;
+  const amount =
+    parsedAmount === undefined || parsedAmount === null
+      ? undefined
+      : parsedAmount.toString();
+  const tokenAddress = transfer?.to;
+  const { chainId } = transaction;
+  const assetId =
+    (chainId ? MUSD_TOKEN_ASSET_ID_BY_CHAIN[chainId] : undefined) ??
+    (tokenAddress && chainId
+      ? toAssetId(
+          tokenAddress,
+          toCaipChainId(
+            KnownCaipNamespace.Eip155,
+            Number.parseInt(chainId, 16).toString(),
+          ),
+        )
+      : undefined);
+
+  return {
+    ...activity,
+    type: 'send',
+    data: {
+      from: transaction.txParams?.from ?? '',
+      to: recipient,
+      token: {
+        direction: 'out',
+        symbol: MUSD_TOKEN.symbol,
+        decimals: MUSD_DECIMALS,
+        ...(amount ? { amount } : {}),
+        ...(assetId ? { assetId } : {}),
+      },
+    },
+  };
+}
+
 export function enrichLocalActivity(
   activity: ActivityListItem,
   transactionGroup: LocalActivitySource,
 ): ActivityListItem {
   let next = activity;
+  next = enrichMoneyAccountWithdrawActivity(next, transactionGroup);
   next = enrichTokenTransferActivity(next, transactionGroup);
   next = enrichApprovalActivity(next, transactionGroup);
   next = enrichLocalMusdClaimActivity(next, transactionGroup);

--- a/ui/selectors/activity/enrich-local-activity.ts
+++ b/ui/selectors/activity/enrich-local-activity.ts
@@ -13,6 +13,7 @@ import {
   parseStandardTokenTransactionData,
 } from '../../../shared/lib/transaction.utils';
 import { hasTransactionType } from '../../../shared/lib/transactions.utils';
+import { getMoneyAccountWithdrawTransferDetails } from '../../pages/confirmations/utils/money-account-withdraw';
 import { enrichLocalMusdClaimActivity } from './enrich-local-musd-claim';
 
 const TOKEN_TRANSFER_TYPES = new Set<TransactionType>([
@@ -135,19 +136,12 @@ function enrichMoneyAccountWithdrawActivity(
   const transfer = transaction.nestedTransactions?.find(
     (nested) => nested.type === TransactionType.tokenMethodTransfer,
   );
-  const parsed = transfer?.data
-    ? parseStandardTokenTransactionData(transfer.data)
-    : undefined;
-  const recipient = parsed?.args?._to ?? parsed?.args?.to;
+  const { recipient, amountRaw: amount } =
+    getMoneyAccountWithdrawTransferDetails(transaction);
   if (typeof recipient !== 'string') {
     return activity;
   }
 
-  const parsedAmount = parsed?.args?._value ?? parsed?.args?.value;
-  const amount =
-    parsedAmount === undefined || parsedAmount === null
-      ? undefined
-      : parsedAmount.toString();
   const tokenAddress = transfer?.to;
   const { chainId } = transaction;
   const assetId =

--- a/ui/store/controller-actions/transaction-pay-controller.test.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.test.ts
@@ -10,6 +10,7 @@ import {
   createMoneyAccountWithdrawTransaction,
   updateMoneyAccountDepositAmount,
   updateMoneyAccountWithdrawAmount,
+  getLastMoneyAccountWithdrawAmount,
 } from './transaction-pay-controller';
 
 jest.mock('../background-connection');
@@ -180,29 +181,6 @@ describe('transaction-pay-controller actions', () => {
     });
   });
 
-  describe('updateMoneyAccountWithdrawAmount', () => {
-    it('forwards the transaction id and human amount', async () => {
-      mockSubmitRequestToBackground.mockResolvedValue({
-        didCommit: true,
-        recipient: '0xabcdef1234567890abcdef1234567890abcdef12',
-      });
-
-      const result = await updateMoneyAccountWithdrawAmount(
-        'tx-withdraw',
-        '10',
-      );
-
-      expect(result).toStrictEqual({
-        didCommit: true,
-        recipient: '0xabcdef1234567890abcdef1234567890abcdef12',
-      });
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-        'updateMoneyAccountWithdrawAmount',
-        ['tx-withdraw', '10'],
-      );
-    });
-  });
-
   describe('setPaymentOverride', () => {
     it('calls submitRequestToBackground with setTransactionPayPaymentOverride', async () => {
       const transactionId = 'tx-pay-override';
@@ -233,6 +211,34 @@ describe('transaction-pay-controller actions', () => {
         'setTransactionPayPaymentOverride',
         ['tx-clear', { paymentOverride: undefined, refundTo: undefined }],
       );
+    });
+  });
+
+  describe('updateMoneyAccountWithdrawAmount', () => {
+    it('forwards transactionId, amount, and recipient override', async () => {
+      const transactionId = 'tx-withdraw';
+      const recipientOverride =
+        '0xabcdef1234567890abcdef1234567890abcdef12' as const;
+
+      await updateMoneyAccountWithdrawAmount(
+        transactionId,
+        '0.05',
+        recipientOverride,
+      );
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'updateMoneyAccountWithdrawAmount',
+        [transactionId, '0.05', recipientOverride],
+      );
+    });
+
+    it('records the last withdraw amount for confirm to re-encode', async () => {
+      const transactionId = 'tx-withdraw-last-amount';
+      mockSubmitRequestToBackground.mockResolvedValue({ id: transactionId });
+
+      await updateMoneyAccountWithdrawAmount(transactionId, '1.25');
+
+      expect(getLastMoneyAccountWithdrawAmount(transactionId)).toBe('1.25');
     });
   });
 });

--- a/ui/store/controller-actions/transaction-pay-controller.test.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.test.ts
@@ -6,6 +6,8 @@ import {
   setPostQuote,
   setAccountOverride,
   setPaymentOverride,
+  updateMoneyAccountWithdrawAmount,
+  getLastMoneyAccountWithdrawAmount,
 } from './transaction-pay-controller';
 
 jest.mock('../background-connection');
@@ -153,6 +155,34 @@ describe('transaction-pay-controller actions', () => {
         'setTransactionPayPaymentOverride',
         ['tx-clear', { paymentOverride: undefined, refundTo: undefined }],
       );
+    });
+  });
+
+  describe('updateMoneyAccountWithdrawAmount', () => {
+    it('forwards transactionId, amount, and recipient override', async () => {
+      const transactionId = 'tx-withdraw';
+      const recipientOverride =
+        '0xabcdef1234567890abcdef1234567890abcdef12' as const;
+
+      await updateMoneyAccountWithdrawAmount(
+        transactionId,
+        '0.05',
+        recipientOverride,
+      );
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'updateMoneyAccountWithdrawAmount',
+        [transactionId, '0.05', recipientOverride],
+      );
+    });
+
+    it('records the last withdraw amount for confirm to re-encode', async () => {
+      const transactionId = 'tx-withdraw-last-amount';
+      mockSubmitRequestToBackground.mockResolvedValue({ id: transactionId });
+
+      await updateMoneyAccountWithdrawAmount(transactionId, '1.25');
+
+      expect(getLastMoneyAccountWithdrawAmount(transactionId)).toBe('1.25');
     });
   });
 });

--- a/ui/store/controller-actions/transaction-pay-controller.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.ts
@@ -1,7 +1,12 @@
 import type { PaymentOverride } from '@metamask/transaction-pay-controller';
 import type { Hex } from '@metamask/utils';
-import type { WithdrawAmountCommitResult } from '../../../shared/lib/money/withdraw-amount-commit';
 import { submitRequestToBackground } from '../background-connection';
+
+export type MoneyAccountWithdrawAmountUpdate = {
+  transactionData?: Hex;
+  transferData: Hex;
+  withdrawData: Hex;
+};
 
 export async function updateTransactionPaymentToken({
   transactionId,
@@ -92,25 +97,76 @@ export async function createMoneyAccountWithdrawTransaction(
   );
 }
 
+const lastWithdrawAmountByTransactionId = new Map<string, string>();
+const lastWithdrawAmountListeners = new Set<() => void>();
+
 /**
- * Prepares and commits a Money Account withdrawal amount in the background:
- * re-encodes the withdraw + transfer calldata for the new amount, with the
- * redeemed mUSD forwarded to the Pay account override (the account shown on
- * the confirmation) or, when unset, the currently selected account.
- * Superseded intents resolve `{ didCommit: false }`.
+ * Last human-readable withdraw amount dispatched for this transaction.
+ * Confirm uses this so Send can re-encode even if the confirmation UI still
+ * holds the unencoded placeholder. The footer uses it to enable Send when
+ * TPC has no required token / quote totals (direct withdraws).
+ *
+ * @param transactionId - Id of the Money Account withdrawal transaction.
+ * @returns The last amount, if any update has been dispatched.
+ */
+export function getLastMoneyAccountWithdrawAmount(
+  transactionId: string,
+): string | undefined {
+  return lastWithdrawAmountByTransactionId.get(transactionId);
+}
+
+/**
+ * Record the typed withdraw amount immediately so Send can encode before the
+ * debounced background write finishes.
  *
  * @param transactionId - Id of the Money Account withdrawal transaction.
  * @param amountHuman - Exact human-readable amount.
- * @returns Whether this intent committed transaction metadata, and the
- * recipient it encoded if so.
+ */
+export function setLastMoneyAccountWithdrawAmount(
+  transactionId: string,
+  amountHuman: string,
+): void {
+  lastWithdrawAmountByTransactionId.set(transactionId, amountHuman);
+  lastWithdrawAmountListeners.forEach((listener) => listener());
+}
+
+/**
+ * Subscribe to last-withdraw-amount writes. Used by
+ * `useLastMoneyAccountWithdrawAmount`.
+ *
+ * @param onStoreChange - Listener invoked after any amount is recorded.
+ * @returns Unsubscribe function.
+ */
+export function subscribeLastMoneyAccountWithdrawAmount(
+  onStoreChange: () => void,
+): () => void {
+  lastWithdrawAmountListeners.add(onStoreChange);
+  return () => {
+    lastWithdrawAmountListeners.delete(onStoreChange);
+  };
+}
+
+/**
+ * Encodes and commits a Money Account withdrawal amount in the background.
+ * Confirm approves the returned transaction so Send does not use the empty
+ * placeholder. Superseded or zero-amount intents resolve `false`.
+ *
+ * @param transactionId - Id of the Money Account withdrawal transaction.
+ * @param amountHuman - Exact human-readable amount.
+ * @param recipientOverride - Optional EVM address to receive the redeemed mUSD.
+ * @returns The encoded nested calldata, or `false` if this intent did not
+ * commit.
  */
 export async function updateMoneyAccountWithdrawAmount(
   transactionId: string,
   amountHuman: string,
-): Promise<WithdrawAmountCommitResult> {
+  recipientOverride?: Hex,
+): Promise<MoneyAccountWithdrawAmountUpdate | false> {
+  setLastMoneyAccountWithdrawAmount(transactionId, amountHuman);
   return await submitRequestToBackground('updateMoneyAccountWithdrawAmount', [
     transactionId,
     amountHuman,
+    recipientOverride,
   ]);
 }
 

--- a/ui/store/controller-actions/transaction-pay-controller.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.ts
@@ -1,12 +1,9 @@
 import type { PaymentOverride } from '@metamask/transaction-pay-controller';
 import type { Hex } from '@metamask/utils';
+import type { MoneyAccountWithdrawAmountUpdate } from '../../../shared/lib/money/withdraw-amount-commit';
 import { submitRequestToBackground } from '../background-connection';
 
-export type MoneyAccountWithdrawAmountUpdate = {
-  transactionData?: Hex;
-  transferData: Hex;
-  withdrawData: Hex;
-};
+export type { MoneyAccountWithdrawAmountUpdate };
 
 export async function updateTransactionPaymentToken({
   transactionId,
@@ -101,13 +98,13 @@ const lastWithdrawAmountByTransactionId = new Map<string, string>();
 const lastWithdrawAmountListeners = new Set<() => void>();
 
 /**
- * Last human-readable withdraw amount dispatched for this transaction.
+ * Last human-readable withdraw amount recorded for this transaction.
  * Confirm uses this so Send can re-encode even if the confirmation UI still
  * holds the unencoded placeholder. The footer uses it to enable Send when
  * TPC has no required token / quote totals (direct withdraws).
  *
  * @param transactionId - Id of the Money Account withdrawal transaction.
- * @returns The last amount, if any update has been dispatched.
+ * @returns The last amount, if any update has been recorded.
  */
 export function getLastMoneyAccountWithdrawAmount(
   transactionId: string,
@@ -127,6 +124,22 @@ export function setLastMoneyAccountWithdrawAmount(
   amountHuman: string,
 ): void {
   lastWithdrawAmountByTransactionId.set(transactionId, amountHuman);
+  lastWithdrawAmountListeners.forEach((listener) => listener());
+}
+
+/**
+ * Clears the recorded withdraw amount for a transaction. Called when the
+ * confirmation unmounts or after a successful prepare so the module-level map
+ * does not retain stale entries for the UI process lifetime.
+ *
+ * @param transactionId - Id of the Money Account withdrawal transaction.
+ */
+export function clearLastMoneyAccountWithdrawAmount(
+  transactionId: string,
+): void {
+  if (!lastWithdrawAmountByTransactionId.delete(transactionId)) {
+    return;
+  }
   lastWithdrawAmountListeners.forEach((listener) => listener());
 }
 

--- a/ui/store/controller-actions/transaction-pay-controller.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.ts
@@ -2,6 +2,12 @@ import type { PaymentOverride } from '@metamask/transaction-pay-controller';
 import type { Hex } from '@metamask/utils';
 import { submitRequestToBackground } from '../background-connection';
 
+export type MoneyAccountWithdrawAmountUpdate = {
+  transactionData?: Hex;
+  transferData: Hex;
+  withdrawData: Hex;
+};
+
 export async function updateTransactionPaymentToken({
   transactionId,
   tokenAddress,
@@ -82,23 +88,76 @@ export async function createMoneyAccountWithdrawTransaction(): Promise<{
   );
 }
 
+const lastWithdrawAmountByTransactionId = new Map<string, string>();
+const lastWithdrawAmountListeners = new Set<() => void>();
+
 /**
- * Prepares and commits a Money Account withdrawal amount in the background:
- * re-encodes the withdraw + transfer calldata for the new amount, with the
- * redeemed mUSD forwarded to the currently selected account. Superseded
- * intents resolve `false`.
+ * Last human-readable withdraw amount dispatched for this transaction.
+ * Confirm uses this so Send can re-encode even if the confirmation UI still
+ * holds the unencoded placeholder. The footer uses it to enable Send when
+ * TPC has no required token / quote totals (direct withdraws).
+ *
+ * @param transactionId - Id of the Money Account withdrawal transaction.
+ * @returns The last amount, if any update has been dispatched.
+ */
+export function getLastMoneyAccountWithdrawAmount(
+  transactionId: string,
+): string | undefined {
+  return lastWithdrawAmountByTransactionId.get(transactionId);
+}
+
+/**
+ * Record the typed withdraw amount immediately so Send can encode before the
+ * debounced background write finishes.
  *
  * @param transactionId - Id of the Money Account withdrawal transaction.
  * @param amountHuman - Exact human-readable amount.
- * @returns Whether this intent committed transaction metadata.
+ */
+export function setLastMoneyAccountWithdrawAmount(
+  transactionId: string,
+  amountHuman: string,
+): void {
+  lastWithdrawAmountByTransactionId.set(transactionId, amountHuman);
+  lastWithdrawAmountListeners.forEach((listener) => listener());
+}
+
+/**
+ * Subscribe to last-withdraw-amount writes. Used by
+ * `useLastMoneyAccountWithdrawAmount`.
+ *
+ * @param onStoreChange - Listener invoked after any amount is recorded.
+ * @returns Unsubscribe function.
+ */
+export function subscribeLastMoneyAccountWithdrawAmount(
+  onStoreChange: () => void,
+): () => void {
+  lastWithdrawAmountListeners.add(onStoreChange);
+  return () => {
+    lastWithdrawAmountListeners.delete(onStoreChange);
+  };
+}
+
+/**
+ * Encodes and commits a Money Account withdrawal amount in the background.
+ * Confirm approves the returned transaction so Send does not use the empty
+ * placeholder. Superseded or zero-amount intents resolve `false`.
+ *
+ * @param transactionId - Id of the Money Account withdrawal transaction.
+ * @param amountHuman - Exact human-readable amount.
+ * @param recipientOverride - Optional EVM address to receive the redeemed mUSD.
+ * @returns The encoded nested calldata, or `false` if this intent did not
+ * commit.
  */
 export async function updateMoneyAccountWithdrawAmount(
   transactionId: string,
   amountHuman: string,
-): Promise<boolean> {
+  recipientOverride?: Hex,
+): Promise<MoneyAccountWithdrawAmountUpdate | false> {
+  setLastMoneyAccountWithdrawAmount(transactionId, amountHuman);
   return await submitRequestToBackground('updateMoneyAccountWithdrawAmount', [
     transactionId,
     amountHuman,
+    recipientOverride,
   ]);
 }
 


### PR DESCRIPTION
## **Description**

Make money-account withdrawals (including the default same-token mUSD on Monad path) actually move funds, mirroring the mobile implementation:

- Treat the Money Keyring as EIP-7702-**relay** capable at the publish gate only (`KEYRING_TYPES_SUPPORTING_7702_RELAY`). Shared Smart Account helpers keep the narrower `KEYRING_TYPES_SUPPORTING_7702` allowlist so Money accounts stay out of gas-fee-token / Tempo / bridge-batch paths.
- Relay the parent `execute()` as a single `exactExecution` delegation like mobile's publish hook, instead of expanding `nestedTransactions` into a batch redeem that mined without moving funds.
- Throw (like mobile) when a sponsored or gas-included transaction lands on a chain without EIP-7702 support instead of silently falling through to the unsigned raw send.
- Approve only funded withdraw batches that match the **latest typed amount**: re-encode when nested calldata is stale, rebuild the parent batch calldata from the funded nested calls, and refuse placeholders / zero transfers.
- Block Send when the typed amount exceeds vault withdrawable balance (`vmusdValueInMusd`).
- Enrich local withdraw activity (and the activity hero) from the nested transfer recipient + amount.
- When changing the From account, await nested calldata recipient rewrites before updating `accountOverride`.
- Hide result rows for zero withdraw amounts even when a no-op quote is stored.

## **Changelog**

CHANGELOG entry: Fixed money account withdrawals not submitting on Monad

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1816

## **Manual testing steps**

1. Open a confirmation for a money account withdrawal (mUSD on Monad).
2. Enter a withdraw amount and confirm; verify the transaction is submitted via the relay and funds move.
3. Enter an amount larger than the vault withdrawable balance; verify Send is blocked by the insufficient-balance alert.
4. Change the amount after an earlier encode completed, then confirm quickly; verify the submitted amount matches the amount on screen (not the previous encode).
5. Change the From account after an amount is encoded; verify the nested transfer recipient updates before confirm, and activity / hero show the correct recipient and mUSD amount after submit.
6. Verify a zero withdraw amount hides the result rows and Confirm/Send stays disabled.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes EIP-7702 relay publish, delegation encoding, and transaction approval for sponsored Money Account withdrawals—errors could block submits or send wrong calldata on-chain.
> 
> **Overview**
> Fixes **Money Account withdrawals on Monad** so sponsored batches publish through the EIP-7702 relay and actually move funds, aligned with mobile.
> 
> **Publish / delegation:** The transaction publish gate now uses `accountSupports7702ForRelay` (Money keyring included) while general Smart Account features keep the narrower `KEYRING_TYPES_SUPPORTING_7702` list. The relay hook relays the parent `execute()` as a single execution (`useParentExecution`) instead of redeeming expanded nested calls, and **throws** when sponsored or gas-included txs hit a chain without EIP-7702 instead of raw-sending unsigned payloads.
> 
> **Confirm / encode:** Withdraw amount commits return nested `withdrawData` / `transferData` (and optional parent `transactionData`) rather than `didCommit` + recipient. Confirm runs `prepareWithdrawTransaction` before approve—re-encode when calldata is stale, rebuild parent batch from funded nested calls, and refuse placeholders or zero transfers—while keeping `isGasFeeSponsored` / `isExternalSign` for sponsored withdraws even when local gasless checks disagree.
> 
> **Confirmation UX:** Send enables from the last typed withdraw amount; gasless/pay loading no longer spins forever on direct withdraws; new vault withdrawable-balance alert; From-account changes await nested recipient rewrites before `accountOverride`; activity hero and related rows handle mUSD amounts, no-fee tags, and sponsored fee display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8818e389483dc4c4b019b5addef81ea58237961e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->