### PR TITLE
feat(confirmations): block money account withdrawals above withdrawable balance as user types

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -787,6 +787,10 @@
     "ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonInfo.test.ts": {
       "MetaMask: Background connection not initialized": 2
     },
+    "ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts": {
+      "error: Money Account withdraw: amount encode": 3,
+      "error: Money Account withdraw: no committed": 1
+    },
     "ui/pages/confirmations/hooks/useConfirmationAlerts.test.ts": {
       "MetaMask: Background connection not initialized": 5,
       "React: Act warnings (component updates not wrapped)": 3,

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -781,6 +781,10 @@
     "ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonInfo.test.ts": {
       "MetaMask: Background connection not initialized": 2
     },
+    "ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts": {
+      "error: Money Account withdraw: amount encode": 3,
+      "error: Money Account withdraw: no committed": 1
+    },
     "ui/pages/confirmations/hooks/useConfirmationAlerts.test.ts": {
       "MetaMask: Background connection not initialized": 5,
       "React: Act warnings (component updates not wrapped)": 3,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
@@ -11,6 +11,7 @@ import { getMockConfirmStateForTransaction } from '../../../../../../test/data/c
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
+import { useLastMoneyAccountWithdrawAmount } from '../../transactions/useLastMoneyAccountWithdrawAmount';
 import { AlertsName } from '../constants';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../helpers/constants/design-system';
@@ -20,10 +21,14 @@ jest.mock('@metamask/react-data-query', () => ({
   useQuery: jest.fn(),
 }));
 jest.mock('../../pay/useTransactionPayData');
+jest.mock('../../transactions/useLastMoneyAccountWithdrawAmount');
 
 const useQueryMock = jest.mocked(useQuery);
 const usePrimaryRequiredTokenMock = jest.mocked(
   useTransactionPayPrimaryRequiredToken,
+);
+const useLastMoneyAccountWithdrawAmountMock = jest.mocked(
+  useLastMoneyAccountWithdrawAmount,
 );
 
 const EXPECTED_ALERT = {
@@ -92,6 +97,7 @@ describe('useInsufficientMoneyAccountBalanceAlert', () => {
         typeof useTransactionPayPrimaryRequiredToken
       >,
     );
+    useLastMoneyAccountWithdrawAmountMock.mockReturnValue(undefined);
   });
 
   it('returns alert when pending amount exceeds available balance', () => {
@@ -201,5 +207,37 @@ describe('useInsufficientMoneyAccountBalanceAlert', () => {
     const { result } = runHook();
 
     expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns alert when the live typed amount exceeds the balance', () => {
+    // Mirrors mobile: the alert reacts to the current input, not just the
+    // debounced calldata commit.
+    useLastMoneyAccountWithdrawAmountMock.mockReturnValue('150');
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([EXPECTED_ALERT]);
+  });
+
+  it('prefers the live typed amount over the stale required token amount', () => {
+    // The user reduced the amount below the balance; the committed calldata
+    // still carries the previous over-balance amount until the debounce
+    // re-encodes. The alert must clear immediately.
+    useLastMoneyAccountWithdrawAmountMock.mockReturnValue('50');
+    usePrimaryRequiredTokenMock.mockReturnValue({
+      amountHuman: '150',
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('prefers pendingAmount over the live typed amount', () => {
+    useLastMoneyAccountWithdrawAmountMock.mockReturnValue('50');
+
+    const { result } = runHook({ pendingAmount: '150' });
+
+    expect(result.current).toEqual([EXPECTED_ALERT]);
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.test.ts
@@ -221,4 +221,35 @@ describe('useInsufficientMoneyAccountBalanceAlert', () => {
 
     expect(result.current).toStrictEqual([]);
   });
+  it('returns alert when the live typed amount exceeds the balance', () => {
+    // Mirrors mobile: the alert reacts to the current input, not just the
+    // debounced calldata commit.
+    useLastWithdrawAmountMock.mockReturnValue('150');
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([EXPECTED_ALERT]);
+  });
+
+  it('prefers the live typed amount over the stale required token amount', () => {
+    // The user reduced the amount below the balance; the committed calldata
+    // still carries the previous over-balance amount until the debounce
+    // re-encodes. The alert must clear immediately.
+    useLastWithdrawAmountMock.mockReturnValue('50');
+    usePrimaryRequiredTokenMock.mockReturnValue({
+      amountHuman: '150',
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('prefers pendingAmount over the live typed amount', () => {
+    useLastWithdrawAmountMock.mockReturnValue('50');
+
+    const { result } = runHook({ pendingAmount: '150' });
+
+    expect(result.current).toEqual([EXPECTED_ALERT]);
+  });
 });

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.ts
@@ -17,6 +17,7 @@ import { hasTransactionType } from '../../../../../../shared/lib/transactions.ut
 import { MoneyAccountBalanceServiceQueryKeys } from '../../../../../../shared/lib/money/query-keys';
 import { useConfirmContext } from '../../../context/confirm';
 import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
+import { useLastMoneyAccountWithdrawAmount } from '../../transactions/useLastMoneyAccountWithdrawAmount';
 import { AlertsName } from '../constants';
 
 const MUSD_UNIT = 10 ** MUSD_DECIMALS;
@@ -35,7 +36,11 @@ const NON_WITHDRAW_QUERY_KEY = 'money-account-withdraw-alert:disabled';
  * withdraw info messenger) so this can run in `useConfirmationAlerts` without
  * requiring a money-account route messenger.
  *
- * Mirrors mobile `useInsufficientMoneyAccountBalanceAlert`.
+ * Mirrors mobile `useInsufficientMoneyAccountBalanceAlert`, including its
+ * live-input responsiveness: mobile evaluates the pending typed amount, so
+ * the extension prefers the synchronously-recorded last withdraw amount over
+ * `primaryRequiredToken.amountHuman`, which lags typing by the debounced
+ * calldata encode.
  *
  * @param options
  * @param options.pendingAmount - Optional in-progress human mUSD amount.
@@ -48,6 +53,9 @@ export function useInsufficientMoneyAccountBalanceAlert({
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
+  const lastWithdrawAmount = useLastMoneyAccountWithdrawAmount(
+    currentConfirmation?.id ?? '',
+  );
 
   const isMoneyAccountWithdraw = hasTransactionType(currentConfirmation, [
     TransactionType.moneyAccountWithdraw,
@@ -71,7 +79,11 @@ export function useInsufficientMoneyAccountBalanceAlert({
     enabled: false,
   });
 
-  const amountHuman = pendingAmount ?? primaryRequiredToken?.amountHuman ?? '0';
+  const amountHuman =
+    pendingAmount ??
+    lastWithdrawAmount ??
+    primaryRequiredToken?.amountHuman ??
+    '0';
 
   const withdrawableMusd = useMemo(() => {
     if (

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientMoneyAccountBalanceAlert.ts
@@ -48,7 +48,11 @@ function disabledWithdrawAlertQueryFn(): never {
  * withdraw info messenger) so this can run in `useConfirmationAlerts` without
  * requiring a money-account route messenger.
  *
- * Mirrors mobile `useInsufficientMoneyAccountBalanceAlert`.
+ * Mirrors mobile `useInsufficientMoneyAccountBalanceAlert`, including its
+ * live-input responsiveness: mobile evaluates the pending typed amount, so
+ * the extension prefers the synchronously-recorded last withdraw amount over
+ * `primaryRequiredToken.amountHuman`, which lags typing by the debounced
+ * calldata encode.
  *
  * @param options
  * @param options.pendingAmount - Optional in-progress human mUSD amount.


### PR DESCRIPTION
## **Description**

The insufficient-money-account-balance alert compared the withdrawable vmUSD against the amount parsed from committed calldata, which lags the input by the debounced encode. Prefer the synchronously recorded last withdraw amount so the blocking alert reacts on every keystroke — Send disables and shows "Insufficient funds" immediately, and clears immediately when the amount is reduced. Mirrors mobile, which evaluates the pending typed amount.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1814

## **Manual testing steps**

1. Open a confirmation for a money account withdrawal (mUSD on Monad)
2. Type an amount above the withdrawable balance
3. Verify Send disables and the "Insufficient funds" alert shows immediately on the keystroke, without waiting for the debounced encode
4. Reduce the amount below the withdrawable balance and verify the alert clears immediately

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to confirmation UI alerts for money-account withdraws; no change to signing or on-chain submission, with behavior covered by new unit tests.
> 
> **Overview**
> Money-account withdraw confirmations now treat the **insufficient withdrawable balance** alert as tied to what the user is typing, not only the amount baked into debounced calldata.
> 
> The hook’s documented behavior matches mobile: **`pendingAmount`**, then the synchronously recorded **last withdraw amount**, then **`primaryRequiredToken.amountHuman`** (which can stay stale until re-encode). That way Send can disable and show **Insufficient funds** on the keystroke that goes over withdrawable vmUSD, and clear as soon as the user types back under the limit.
> 
> This diff adds **unit tests** for live input, stale committed amount, and `pendingAmount` precedence, expands the hook **JSDoc**, and updates the Jest **console baseline** for expected logs from `useTransactionConfirm.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 320dfe6c47f20903f6bd44e13541ea630d491d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->