### PR TITLE
fix(confirmations): hide irrelevant alerts on money account transactions

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
@@ -5,6 +5,7 @@ import {
   SimulationTokenBalanceChange,
   SimulationTokenStandard,
   TransactionMeta,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
@@ -961,37 +962,75 @@ describe('useMultipleApprovalsAlerts', () => {
     });
   });
 
-  describe('when origin is in allow list', () => {
-    it('returns no alerts', () => {
-      const originAllowedMock = 'https://example.com';
-      const nestedTransactions = [
-        createMockNestedTransaction('0x123', TOKEN_ADDRESS_1),
-      ];
+  describe('when transaction is a MetaMask Pay transaction', () => {
+    [
+      TransactionType.moneyAccountDeposit,
+      TransactionType.moneyAccountWithdraw,
+      TransactionType.perpsDeposit,
+    ].forEach((nestedType) => {
+      it(`returns no alerts for ${nestedType} with unused approvals`, () => {
+        const nestedTransactions = [
+          {
+            ...createMockNestedTransaction('0x123', TOKEN_ADDRESS_1),
+            type: nestedType,
+          },
+        ];
 
-      mockParseApprovalTransactionData.mockReturnValue({
-        name: 'approve',
-        amountOrTokenId: new BigNumber('1000'),
-        tokenAddress: undefined,
-        isRevokeAll: false,
+        mockParseApprovalTransactionData.mockReturnValue({
+          name: 'approve',
+          amountOrTokenId: new BigNumber('1000'),
+          tokenAddress: undefined,
+          isRevokeAll: false,
+        });
+
+        const alerts = runHook({
+          currentConfirmation: {
+            txParams: { from: ACCOUNT_ADDRESS },
+            chainId: '0x5',
+          },
+          nestedTransactions,
+          simulationData: {
+            tokenBalanceChanges: [], // no outflows - approval is unused
+          },
+          approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
+        });
+
+        expect(alerts).toEqual([]);
       });
+    });
 
-      const alerts = runHook({
-        currentConfirmation: {
-          txParams: { from: ACCOUNT_ADDRESS },
-          chainId: '0x5',
-          origin: originAllowedMock,
-        },
-        nestedTransactions,
-        simulationData: {
-          tokenBalanceChanges: [],
-        },
-        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
-        remoteFeatureFlags: {
-          nonZeroUnusedApprovals: [originAllowedMock],
-        },
+    describe('when origin is in allow list', () => {
+      it('returns no alerts', () => {
+        const originAllowedMock = 'https://example.com';
+        const nestedTransactions = [
+          createMockNestedTransaction('0x123', TOKEN_ADDRESS_1),
+        ];
+
+        mockParseApprovalTransactionData.mockReturnValue({
+          name: 'approve',
+          amountOrTokenId: new BigNumber('1000'),
+          tokenAddress: undefined,
+          isRevokeAll: false,
+        });
+
+        const alerts = runHook({
+          currentConfirmation: {
+            txParams: { from: ACCOUNT_ADDRESS },
+            chainId: '0x5',
+            origin: originAllowedMock,
+          },
+          nestedTransactions,
+          simulationData: {
+            tokenBalanceChanges: [],
+          },
+          approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
+          remoteFeatureFlags: {
+            nonZeroUnusedApprovals: [originAllowedMock],
+          },
+        });
+
+        expect(alerts).toHaveLength(0);
       });
-
-      expect(alerts).toHaveLength(0);
     });
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
@@ -10,6 +10,7 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { TokenStandard } from '../../../../../../shared/constants/transaction';
 import { parseApprovalTransactionData } from '../../../../../../shared/lib/transaction.utils';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { Severity } from '../../../../../helpers/constants/design-system';
@@ -17,6 +18,7 @@ import { useAsyncResult } from '../../../../../hooks/useAsync';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { getTokenStandardAndDetailsByChain } from '../../../../../store/actions';
 import { useBatchApproveBalanceChanges } from '../../../components/confirm/info/hooks/useBatchApproveBalanceChanges';
+import { PAY_TRANSACTION_TYPES } from '../../../constants/pay';
 import { useConfirmContext } from '../../../context/confirm';
 import {
   getUseTransactionSimulations,
@@ -298,11 +300,20 @@ export function useMultipleApprovalsAlerts(): Alert[] {
     return findUnusedApprovals(approvals, tokenOutflows);
   }, [approvals, tokenOutflows]);
 
+  // MetaMask Pay flows (money account deposits/withdrawals, perps, mUSD)
+  // batch their own approvals internally; mirrors mobile's
+  // `useBatchedUnusedApprovalsAlert` MM_PAY_TRANSACTION_TYPES skip.
+  const isPayTransaction = hasTransactionType(
+    currentConfirmation,
+    PAY_TRANSACTION_TYPES,
+  );
+
   const shouldShowAlert =
     unusedApprovals.length > 0 &&
     Boolean(currentConfirmation?.simulationData) &&
     isSimulationSupported &&
-    !skipAlertOriginAllowed;
+    !skipAlertOriginAllowed &&
+    !isPayTransaction;
 
   return useMemo(() => {
     if (!shouldShowAlert) {

--- a/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.test.ts
@@ -1,4 +1,7 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 
 import mockState from '../../../../../test/data/mock-state.json';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
@@ -64,6 +67,28 @@ describe('useSelectedAccountAlerts', () => {
       getMockConfirmStateForTransaction(contractInteraction as TransactionMeta),
     );
     expect(result.current).toEqual(expectedAlert);
+  });
+
+  [
+    TransactionType.moneyAccountDeposit,
+    TransactionType.moneyAccountWithdraw,
+  ].forEach((nestedType) => {
+    it(`does not return an alert for a ${nestedType} transaction from a different account`, () => {
+      const contractInteraction = {
+        ...genUnapprovedContractInteractionConfirmation({
+          address: '0x0',
+        }),
+        type: TransactionType.batch,
+        nestedTransactions: [{ type: nestedType }],
+      };
+      const { result } = renderHookWithConfirmContextProvider(
+        () => useSelectedAccountAlerts(),
+        getMockConfirmStateForTransaction(
+          contractInteraction as TransactionMeta,
+        ),
+      );
+      expect(result.current).toEqual([]);
+    });
   });
 
   it('does not returns an alert for transaction if signing account is same as selected account', () => {

--- a/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.ts
@@ -10,6 +10,7 @@ import { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
 import { RowAlertKey } from '../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { getMoneyAccountTransactionType } from '../../../../../shared/lib/transactions.utils';
 import { SignatureRequestType } from '../../types/confirm';
 import { useConfirmContext } from '../../context/confirm';
 
@@ -38,8 +39,15 @@ export const useSelectedAccountAlerts = (): Alert[] => {
   const confirmationAccountSameAsSelectedAccount =
     !fromAccount || isAccountFromSelectedAccountGroup;
 
+  // Money account deposits/withdrawals are wallet-initiated and always sent
+  // from the dedicated money account, never the selected account group, so
+  // the "different account" warning is noise there.
+  const isMoneyAccountTransaction = Boolean(
+    getMoneyAccountTransactionType(currentConfirmation as TransactionMeta),
+  );
+
   return useMemo<Alert[]>((): Alert[] => {
-    if (confirmationAccountSameAsSelectedAccount) {
+    if (confirmationAccountSameAsSelectedAccount || isMoneyAccountTransaction) {
       return [];
     }
 
@@ -52,5 +60,5 @@ export const useSelectedAccountAlerts = (): Alert[] => {
         message: t('alertSelectedAccountWarning'),
       },
     ];
-  }, [confirmationAccountSameAsSelectedAccount, t]);
+  }, [confirmationAccountSameAsSelectedAccount, isMoneyAccountTransaction, t]);
 };

--- a/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.ts
@@ -12,6 +12,7 @@ import { Severity } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { SignatureRequestType } from '../../types/confirm';
 import { useConfirmContext } from '../../context/confirm';
+import { getMoneyAccountTransactionType } from '../../utils/confirm';
 
 export const useSelectedAccountAlerts = (): Alert[] => {
   const t = useI18nContext();
@@ -38,8 +39,15 @@ export const useSelectedAccountAlerts = (): Alert[] => {
   const confirmationAccountSameAsSelectedAccount =
     !fromAccount || isAccountFromSelectedAccountGroup;
 
+  // Money account deposits/withdrawals are wallet-initiated and always sent
+  // from the dedicated money account, never the selected account group, so
+  // the "different account" warning is noise there.
+  const isMoneyAccountTransaction = Boolean(
+    getMoneyAccountTransactionType(currentConfirmation as TransactionMeta),
+  );
+
   return useMemo<Alert[]>((): Alert[] => {
-    if (confirmationAccountSameAsSelectedAccount) {
+    if (confirmationAccountSameAsSelectedAccount || isMoneyAccountTransaction) {
       return [];
     }
 
@@ -52,5 +60,5 @@ export const useSelectedAccountAlerts = (): Alert[] => {
         message: t('alertSelectedAccountWarning'),
       },
     ];
-  }, [confirmationAccountSameAsSelectedAccount, t]);
+  }, [confirmationAccountSameAsSelectedAccount, isMoneyAccountTransaction, t]);
 };


### PR DESCRIPTION
## Description

Money account deposits and withdrawals were showing two confirmation alerts that are not relevant to them:

- **"Different account selected"** (`useSelectedAccountAlerts`): money account flows are wallet-initiated and always sent from the dedicated money account, which is never the selected account group — so this warning fired on every money account transaction as noise.
- **"Unnecessary permission"** (`useMultipleApprovalsAlerts`): MetaMask Pay flows (money account deposits/withdrawals, perps, mUSD) batch their own approvals internally. This mirrors mobile's `MM_PAY_TRANSACTION_TYPES` skip in `useBatchedUnusedApprovalsAlert`.

## Changes

- `useSelectedAccountAlerts`: skip the alert when the confirmation is a money account transaction (via `getMoneyAccountTransactionType`).
- `useMultipleApprovalsAlerts`: skip the alert when the confirmation contains a `PAY_TRANSACTION_TYPES` transaction, matching mobile parity.
- Tests for both hooks covering money account deposit/withdraw (and perps deposit for the approvals alert).

## Related issues

Fixes: [CONF-1822](https://consensyssoftware.atlassian.net/browse/CONF-1822)

## Manual testing steps

1. Open the money account page and start an "Add funds" (deposit) or withdraw flow.
2. Confirm the transaction screen no longer shows the "Different account selected" or "Unnecessary permission" alerts.
3. Verify both alerts still appear for regular dapp batch transactions with unused approvals / mismatched accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONF-1822]: https://consensyssoftware.atlassian.net/browse/CONF-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only confirmation alert gating for known wallet-initiated pay transaction types; does not change signing, auth, or transaction submission.
> 
> **Overview**
> Stops two confirmation alerts from appearing on **MetaMask Pay / money account** flows where they were misleading.
> 
> **`useSelectedAccountAlerts`** no longer shows the “different account selected” info alert when the confirmation is a money account deposit or withdrawal (`getMoneyAccountTransactionType`), since those txs always sign from the dedicated money account rather than the selected account group.
> 
> **`useMultipleApprovalsAlerts`** suppresses the “unnecessary permission” / unused-approvals warning when the batch includes **`PAY_TRANSACTION_TYPES`** (e.g. money account deposit/withdraw, perps deposit), aligning with mobile’s pay-transaction skip because pay flows batch approvals internally.
> 
> Tests cover money account nested types for the account alert and pay nested types (including perps deposit) for the approvals alert; the origin allow-list case for multiple approvals remains nested under the pay-transaction describe block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82506447a26905a039c029b27f4fc0eb81edfe23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->