### PR TITLE
fix(sentry): stop billing spans that declared a parent as segments

### DIFF
--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -526,13 +526,7 @@ describe('Trace', () => {
     // Measured consequence: ~44.6% of extension transactions carry a
     // `parent_span` id while being billed as roots, across 25 families.
     //
-    // Marked `.failing` because it asserts the INTENDED behaviour, which the
-    // current implementation does not have. It passes today by failing. When
-    // the fix lands this test will start passing and `.failing` will report
-    // that as an error — at which point change `it.failing` to `it`.
-    it.failing(
-      'does not promote an unresolvable in-process parent to a segment',
-      () => {
+    it('does not promote an unresolvable in-process parent to a segment', () => {
         continueTraceMock.mockImplementation((_opts, fn) => fn());
 
         // No pending trace is created, so the map lookup misses.
@@ -553,11 +547,24 @@ describe('Trace', () => {
           () => true,
         );
 
-        // A parent was named. Failing to resolve it locally must not silently
-        // convert the span into a billed root.
-        expect(continueTraceMock).not.toHaveBeenCalled();
-      },
-    );
+      // A parent was named. Failing to resolve it locally must not silently
+      // convert the span into a billed root.
+      expect(continueTraceMock).not.toHaveBeenCalled();
+    });
+
+    // `undefined` and `null` are different statements; only the first may be
+    // promoted to a transaction. See MetaMask/MetaMask-planning#7569.
+    it('does not promote a null parentContext to a segment', () => {
+      const activeSpanMock = { spanContext: jest.fn() } as unknown as Sentry.Span;
+      getActiveSpanMock.mockReturnValue(activeSpanMock);
+
+      trace({ name: NAME_MOCK, parentContext: null }, () => true);
+
+      expect(startSpanMock).toHaveBeenCalledWith(
+        expect.objectContaining({ forceTransaction: undefined }),
+        expect.any(Function),
+      );
+    });
   });
 
   describe('getSerializedTraceContext', () => {

--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -512,6 +512,52 @@ describe('Trace', () => {
         expect.any(Function),
       );
     });
+
+    // Regression test for MetaMask-planning#7569.
+    //
+    // The case above covers a map-lookup HIT. This covers the MISS: an
+    // in-process parent whose span is not in `tracesByKey` (it ended, or was
+    // never registered). `resolveParentSpan` returns `null` for that, which is
+    // the same value it returns for "no parent intended" — so `startSpan`
+    // cannot tell the two apart, sees the serialized ids, and routes to
+    // `continueTrace` with `parentSpan: undefined`. That promotes the span to a
+    // segment, and a segment is a billed transaction.
+    //
+    // Measured consequence: ~44.6% of extension transactions carry a
+    // `parent_span` id while being billed as roots, across 25 families.
+    //
+    // Marked `.failing` because it asserts the INTENDED behaviour, which the
+    // current implementation does not have. It passes today by failing. When
+    // the fix lands this test will start passing and `.failing` will report
+    // that as an error — at which point change `it.failing` to `it`.
+    it.failing(
+      'does not promote an unresolvable in-process parent to a segment',
+      () => {
+        continueTraceMock.mockImplementation((_opts, fn) => fn());
+
+        // No pending trace is created, so the map lookup misses.
+        trace(
+          {
+            name: TraceName.Middleware,
+            parentContext: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              _name: TraceName.Transaction,
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              _id: 'absent-from-map',
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              _traceId: 'trace123',
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              _spanId: 'span456',
+            },
+          },
+          () => true,
+        );
+
+        // A parent was named. Failing to resolve it locally must not silently
+        // convert the span into a billed root.
+        expect(continueTraceMock).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe('getSerializedTraceContext', () => {

--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -527,25 +527,25 @@ describe('Trace', () => {
     // `parent_span` id while being billed as roots, across 25 families.
     //
     it('does not promote an unresolvable in-process parent to a segment', () => {
-        continueTraceMock.mockImplementation((_opts, fn) => fn());
+      continueTraceMock.mockImplementation((_opts, fn) => fn());
 
-        // No pending trace is created, so the map lookup misses.
-        trace(
-          {
-            name: TraceName.Middleware,
-            parentContext: {
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              _name: TraceName.Transaction,
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              _id: 'absent-from-map',
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              _traceId: 'trace123',
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              _spanId: 'span456',
-            },
+      // No pending trace is created, so the map lookup misses.
+      trace(
+        {
+          name: TraceName.Middleware,
+          parentContext: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            _name: TraceName.Transaction,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            _id: 'absent-from-map',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            _traceId: 'trace123',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            _spanId: 'span456',
           },
-          () => true,
-        );
+        },
+        () => true,
+      );
 
       // A parent was named. Failing to resolve it locally must not silently
       // convert the span into a billed root.
@@ -555,7 +555,9 @@ describe('Trace', () => {
     // `undefined` and `null` are different statements; only the first may be
     // promoted to a transaction. See MetaMask/MetaMask-planning#7569.
     it('does not promote a null parentContext to a segment', () => {
-      const activeSpanMock = { spanContext: jest.fn() } as unknown as Sentry.Span;
+      const activeSpanMock = {
+        spanContext: jest.fn(),
+      } as unknown as Sentry.Span;
       getActiveSpanMock.mockReturnValue(activeSpanMock);
 
       trace({ name: NAME_MOCK, parentContext: null }, () => true);

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -483,7 +483,9 @@ function isValidSentrySpan(value: unknown): value is Sentry.Span {
  * @returns Resolved Sentry Span or null.
  */
 function resolveParentSpan(parentContext: unknown): Sentry.Span | null {
-  if (!parentContext) {
+  // Nullish, not falsy: `TraceContext` is `unknown`, so `0` / `''` / `false`
+  // reach here, and none of them state "no parent was declared".
+  if (parentContext === null || parentContext === undefined) {
     return null;
   }
 
@@ -508,6 +510,22 @@ function resolveParentSpan(parentContext: unknown): Sentry.Span | null {
   return null;
 }
 
+/**
+ * Whether a parent context names a trace this process started and expects to
+ * resolve from `tracesByKey`. Such a context is not a cross-process
+ * continuation, even when it also carries serialized ids for propagation.
+ *
+ * @param value - Candidate parent context.
+ * @returns True when the context names an in-process parent.
+ */
+function hasInProcessIdentity(value: unknown): value is { _name: string } {
+  return (
+    isObject(value) &&
+    hasProperty(value, '_name') &&
+    typeof value._name === 'string'
+  );
+}
+
 function hasDistributedTraceIds(
   value: unknown,
 ): value is { _traceId: string; _spanId: string } {
@@ -529,13 +547,26 @@ function startSpan<T>(
   const { data: attributes, name, parentContext, startTime, op } = request;
   let parentSpan = resolveParentSpan(parentContext);
 
+  // `undefined` and `null` are different statements and must not be collapsed:
+  //
+  //   undefined -> no parent was declared. Inheriting the ambient span and
+  //                promoting to a transaction is the intended behaviour.
+  //   null      -> a parent WAS intended but no span exists for it.
+  //                `traceCallback` is typed `(span: Sentry.Span | null)`, so a
+  //                caller receives `null` whenever the SDK created no span and
+  //                passes it straight back. Promoting that to a transaction
+  //                bills a root for what the caller asked to be a child.
+  //
+  // See https://github.com/MetaMask/MetaMask-planning/issues/7569
+  const parentDeclared = parentContext !== undefined;
+
   // Inherit from active span (e.g. browserTracingIntegration's pageload/navigation)
   // when no explicit parent is provided. Must capture before withIsolationScope
   // severs the active span context chain.
   // forceTransaction preserves transaction-level visibility for monitoring while
   // linking to the auto-instrumentation hierarchy.
   let forceTransaction: boolean | undefined;
-  if (!parentSpan && !parentContext) {
+  if (!parentSpan && !parentDeclared) {
     const activeSpan = sentryGetActiveSpan();
     if (activeSpan) {
       parentSpan = activeSpan;
@@ -554,7 +585,14 @@ function startSpan<T>(
 
   // Cross-process propagation via continueTrace when we have serialized
   // trace/span IDs but couldn't resolve a local parent span from the map.
-  if (!parentSpan && hasDistributedTraceIds(parentContext)) {
+  // Only a context WITHOUT in-process identity is a genuine cross-process
+  // continuation. One that names a local trace was meant to resolve from the
+  // map; routing a lookup miss here mints a segment, and a segment is billed.
+  if (
+    !parentSpan &&
+    hasDistributedTraceIds(parentContext) &&
+    !hasInProcessIdentity(parentContext)
+  ) {
     const sentryTrace = `${parentContext._traceId}-${parentContext._spanId}-1`;
     return sentryContinueTrace(sentryTrace, () =>
       sentryWithIsolationScope((scope: Sentry.Scope) => {
@@ -562,6 +600,20 @@ function startSpan<T>(
         return callback({ ...spanOptions, parentSpan: undefined });
       }),
     );
+  }
+
+  // A parent was declared (`null`, or an in-process context that missed the
+  // map) but did not resolve. Nest under whatever is active rather than
+  // starting a new segment — and deliberately WITHOUT `forceTransaction`, since
+  // a failed lookup is not a statement that this operation is a root.
+  if (!parentSpan && parentDeclared) {
+    const activeSpan = sentryGetActiveSpan();
+    if (activeSpan) {
+      return sentryWithIsolationScope((scope: Sentry.Scope) => {
+        initScope(scope, request);
+        return callback({ ...spanOptions, parentSpan: activeSpan });
+      });
+    }
   }
 
   return sentryWithIsolationScope((scope: Sentry.Scope) => {


### PR DESCRIPTION
CHANGELOG entry: null

## Summary

- `startSpan` conflated three distinct parent states, two of which billed a transaction for a span that asked to be a child. Measured at **~44.6% of extension transactions** across 25 families.
- Checks are now **nullish rather than falsy** — `TraceContext` is `unknown`, so `0` / `''` / `false` were reaching the no-parent branch.
- `undefined` and `null` are no longer collapsed: `traceCallback` is typed `(span: Sentry.Span | null)`, so a caller receives `null` whenever the SDK created no span and passes it straight back. That was being promoted to a transaction.
- A declared-but-unresolvable in-process parent now nests under the active span instead of routing to `continueTrace` with `parentSpan: undefined`.
- Includes the regression tests. Fixes [MetaMask-planning#7569](https://github.com/MetaMask/MetaMask-planning/issues/7569).

## The three states, before and after

| `parentContext` | Before | After |
|---|---|---|
| `undefined` — no parent declared | ambient + `forceTransaction` → segment | unchanged (intended) |
| `null` — parent intended, no span | ambient + `forceTransaction` → **segment** | child of ambient, no promotion |
| `0` / `''` / `false` | treated as no parent → **segment** | child of ambient, no promotion |
| `{_name}` in-process, map **miss** | `continueTrace` → **segment** | child of ambient, no promotion |
| `{_name, _traceId, _spanId}`, map miss | `continueTrace` → **segment** | child of ambient, no promotion |
| `{_traceId, _spanId}` only | `continueTrace` → segment | unchanged (genuine cross-process) |
| live span | child | unchanged |

## Context: the suite currently asserts the defect as correct

`shared/lib/trace.test.ts` already covers this path in `cross-process trace context (continueTrace)`, and stays green — because one of its cases asserts the segment-producing value as the expected outcome:

```js
it('passes parentSpan as undefined inside continueTrace callback', () => {
  expect(startSpanMock).toHaveBeenCalledWith(
    expect.objectContaining({ parentSpan: undefined }),
```

No test anywhere asserts that a span is *not* a segment. Every `forceTransaction` reference in the suite lives in the sampler tests, which measure sample rates rather than trace shape. That test will need to be corrected as part of the fix, or the fix will present as a regression.

The existing block also covers the map-lookup **hit** (`falls back to map lookup when _name is also present`) but not the **miss**. The miss is the defect, and is what this test adds.

## Measured impact

Measured 2026-08-17, project `metamask` (273505), production, 15–17 Aug (after the `AggregatedBalanceSelector` inbound filter, so free of that spike):

| Day | Transactions | Carrying a `parent_span` id | Share |
|---|---|---|---|
| 15 Aug | 21,142,155 | 9,652,049 | 45.7% |
| 16 Aug | 21,150,135 | 9,189,376 | 43.4% |
| 17 Aug *(partial)* | 11,482,038 | 5,071,566 | 44.2% |

[Segments carrying a parent id, live in Sentry](https://metamask.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22transaction%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28%29%22%5D%7D&environment=production&field=transaction&field=count%28%29&mode=aggregate&project=273505&query=is_transaction%3Atrue%20has%3Aparent_span&sort=-count%28%29&start=2026-08-15T00%3A00%3A00.000&end=2026-08-18T00%3A00%3A00.000&table=span) · [true roots, for comparison](https://metamask.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22transaction%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28%29%22%5D%7D&environment=production&field=transaction&field=count%28%29&mode=aggregate&project=273505&query=is_transaction%3Atrue%20%21has%3Aparent_span&sort=-count%28%29&start=2026-08-15T00%3A00%3A00.000&end=2026-08-18T00%3A00%3A00.000&table=span)

Across 25 transaction families, including `Provider Create Accounts (v2 - batched)`, `Wallet Alignment`, `UI Startup`, `Contact Sync Full`, `BackendWebSocketService Connection` and `Smart Transactions: *`.

## Relationship to #45405 (stop force-promoting child spans)

[#45405](https://github.com/MetaMask/metamask-extension/pull/45405) touches the same function and should land in a compatible order, but addresses a **different condition**:

| | condition | defect |
|---|---|---|
| [#45405](https://github.com/MetaMask/metamask-extension/pull/45405) | `!parentSpan && !parentContext` | no parent declared; ambient span inherited **and** promoted via inferred `forceTransaction` |
| This / [#7569](https://github.com/MetaMask/MetaMask-planning/issues/7569) | `!parentSpan && hasDistributedTraceIds(parentContext)` | a parent **was** declared but could not be resolved; routed to `continueTrace` with `parentSpan: undefined` |

[#45405](https://github.com/MetaMask/metamask-extension/pull/45405) does not change the `continueTrace` branch, so it does not resolve [#7569](https://github.com/MetaMask/MetaMask-planning/issues/7569). Expect a textual conflict in `startSpan` if both land — this PR adds no production code, so resolution should be trivial.

## Test plan

- [ ] `yarn jest shared/lib/trace.test.ts` — two new cases, existing cases unchanged
- [ ] The pre-existing case `passes parentSpan as undefined inside continueTrace callback` still passes: it uses a `{_traceId, _spanId}`-only context, which is a genuine cross-process continuation and still takes that path
- [ ] Post-merge, re-measure `is_transaction:true has:parent_span` — expect a large drop, with the residual explicable as genuine cross-process traffic

⚠️ **Not run locally.** Authored from a shallow clone with no installed dependencies, so neither the test suite nor eslint/prettier has executed on this branch. The behaviour change is derived from reading `startSpan` and its callers, with no runtime signal behind it. CI is the first execution, and the diff warrants a careful read rather than a rubber stamp.

**Rollout note.** This removes a large fraction of billed transactions across many families at once. That is the intent, but the drop should be expected rather than investigated as a regression — worth announcing before it lands.
