### PR TITLE
feat(bridge): add TanStack Query dual-read path for bridge quotes

### DIFF
--- a/ui/hooks/bridge/queries/index.ts
+++ b/ui/hooks/bridge/queries/index.ts
@@ -1,0 +1,17 @@
+import { bridgeQuotesKeys, bridgeQuotesOptions } from './quotes';
+
+export const bridgeQueries = {
+  quotes: {
+    keys: bridgeQuotesKeys,
+    options: bridgeQuotesOptions,
+  },
+};
+
+export {
+  bridgeQuotesDefaultMaxRefreshCount,
+  bridgeQuotesDefaultRefreshIntervalMs,
+  bridgeQuotesKeys,
+  bridgeQuotesOptions,
+  type BridgeQuotesQueryOptions,
+  type BridgeQuotesQueryParams,
+} from './quotes';

--- a/ui/hooks/bridge/queries/quotes.test.ts
+++ b/ui/hooks/bridge/queries/quotes.test.ts
@@ -1,0 +1,95 @@
+import { FeatureId } from '@metamask/bridge-controller';
+import { bridgeQuotesKeys, bridgeQuotesOptions } from './quotes';
+
+describe('bridgeQuotesKeys', () => {
+  it('builds a stable detail key from quote request params', () => {
+    expect(
+      bridgeQuotesKeys.detail({
+        walletAddress: '0xabc',
+        destWalletAddress: '0xdef',
+        srcChainId: '0x1',
+        destChainId: '0x89',
+        srcTokenAddress: '0xsrc',
+        destTokenAddress: '0xdest',
+        srcTokenAmount: '1000000',
+        slippage: 0.5,
+        insufficientBal: false,
+        gasIncluded: true,
+        gasIncluded7702: false,
+      }),
+    ).toEqual([
+      'bridge',
+      'quotes',
+      '0x1',
+      '0x89',
+      '0xsrc',
+      '0xdest',
+      '1000000',
+      '0xabc',
+      '0xdef',
+      0.5,
+      false,
+      true,
+      false,
+    ]);
+  });
+
+  it('changes when amount or tokens change', () => {
+    const base = {
+      walletAddress: '0xabc',
+      srcChainId: '0x1',
+      destChainId: '0x89',
+      srcTokenAddress: '0xsrc',
+      destTokenAddress: '0xdest',
+      srcTokenAmount: '1000000',
+      gasIncluded: false,
+      gasIncluded7702: false,
+    };
+
+    expect(bridgeQuotesKeys.detail(base)).not.toEqual(
+      bridgeQuotesKeys.detail({ ...base, srcTokenAmount: '2000000' }),
+    );
+    expect(bridgeQuotesKeys.detail(base)).not.toEqual(
+      bridgeQuotesKeys.detail({ ...base, destTokenAddress: '0xother' }),
+    );
+  });
+});
+
+describe('bridgeQuotesOptions', () => {
+  it('stops refetching after maxRefreshCount updates', () => {
+    const options = bridgeQuotesOptions(
+      {
+        walletAddress: '0xabc',
+        srcChainId: '0x1',
+        destChainId: '0x89',
+        srcTokenAddress: '0xsrc',
+        destTokenAddress: '0xdest',
+        srcTokenAmount: '1000',
+        gasIncluded: false,
+        gasIncluded7702: false,
+      },
+      {
+        refetchIntervalMs: 30_000,
+        maxRefreshCount: 2,
+        featureId: FeatureId.UNIFIED_SWAP_BRIDGE,
+      },
+    );
+
+    const refetchInterval = options.refetchInterval;
+    expect(typeof refetchInterval).toBe('function');
+    if (typeof refetchInterval !== 'function') {
+      throw new Error('expected refetchInterval function');
+    }
+
+    expect(
+      refetchInterval({
+        state: { dataUpdateCount: 1 },
+      } as never),
+    ).toBe(30_000);
+    expect(
+      refetchInterval({
+        state: { dataUpdateCount: 2 },
+      } as never),
+    ).toBe(false);
+  });
+});

--- a/ui/hooks/bridge/queries/quotes.ts
+++ b/ui/hooks/bridge/queries/quotes.ts
@@ -1,0 +1,76 @@
+import { queryOptions } from '@tanstack/react-query';
+import {
+  DEFAULT_MAX_REFRESH_COUNT,
+  FeatureId,
+  REFRESH_INTERVAL_MS,
+  type GenericQuoteRequest,
+  type QuoteResponseV1,
+} from '@metamask/bridge-controller';
+import { fetchQuotes } from '../../../store/controller-actions/bridge-controller';
+
+export const bridgeQuotesDefaultRefreshIntervalMs = REFRESH_INTERVAL_MS;
+export const bridgeQuotesDefaultMaxRefreshCount = DEFAULT_MAX_REFRESH_COUNT;
+
+export type BridgeQuotesQueryParams = Pick<
+  GenericQuoteRequest,
+  | 'walletAddress'
+  | 'destWalletAddress'
+  | 'srcChainId'
+  | 'destChainId'
+  | 'srcTokenAddress'
+  | 'destTokenAddress'
+  | 'srcTokenAmount'
+  | 'slippage'
+  | 'insufficientBal'
+  | 'gasIncluded'
+  | 'gasIncluded7702'
+>;
+
+export type BridgeQuotesQueryOptions = {
+  refetchIntervalMs?: number;
+  maxRefreshCount?: number;
+  featureId?: FeatureId;
+};
+
+export const bridgeQuotesKeys = {
+  all: () => ['bridge', 'quotes'] as const,
+  detail: (params: BridgeQuotesQueryParams) =>
+    [
+      ...bridgeQuotesKeys.all(),
+      String(params.srcChainId ?? ''),
+      String(params.destChainId ?? ''),
+      String(params.srcTokenAddress ?? ''),
+      String(params.destTokenAddress ?? ''),
+      String(params.srcTokenAmount ?? ''),
+      String(params.walletAddress ?? ''),
+      String(params.destWalletAddress ?? ''),
+      params.slippage ?? null,
+      Boolean(params.insufficientBal),
+      Boolean(params.gasIncluded),
+      Boolean(params.gasIncluded7702),
+    ] as const,
+};
+
+export const bridgeQuotesOptions = (
+  params: BridgeQuotesQueryParams,
+  options: BridgeQuotesQueryOptions = {},
+) => {
+  const refetchIntervalMs =
+    options.refetchIntervalMs ?? bridgeQuotesDefaultRefreshIntervalMs;
+  const maxRefreshCount =
+    options.maxRefreshCount ?? bridgeQuotesDefaultMaxRefreshCount;
+  const featureId = options.featureId ?? FeatureId.UNIFIED_SWAP_BRIDGE;
+
+  return queryOptions({
+    queryKey: bridgeQuotesKeys.detail(params),
+    queryFn: async (): Promise<QuoteResponseV1[]> =>
+      fetchQuotes(params as GenericQuoteRequest, featureId),
+    staleTime: refetchIntervalMs,
+    refetchInterval: (query) => {
+      if (query.state.dataUpdateCount >= maxRefreshCount) {
+        return false;
+      }
+      return refetchIntervalMs;
+    },
+  });
+};

--- a/ui/hooks/bridge/useBridgeQuotesQuery.test.tsx
+++ b/ui/hooks/bridge/useBridgeQuotesQuery.test.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { isValidQuoteRequest } from '@metamask/bridge-controller';
+import {
+  selectBridgeQuotesTanStackQueryEnabled,
+  useBridgeQuotesQuery,
+} from './useBridgeQuotesQuery';
+
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: jest.fn(),
+  };
+});
+
+jest.mock('@metamask/bridge-controller', () => {
+  const actual = jest.requireActual('@metamask/bridge-controller');
+  return {
+    ...actual,
+    isValidQuoteRequest: jest.fn(),
+  };
+});
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn((selector) =>
+    selector({
+      metamask: {
+        remoteFeatureFlags: {},
+      },
+    }),
+  ),
+}));
+
+jest.mock('../../ducks/bridge/selectors', () => ({
+  getQuoteRequest: jest.fn(() => ({
+    walletAddress: '0xabc',
+    srcChainId: '0x1',
+    destChainId: '0x89',
+    srcTokenAddress: '0xsrc',
+    destTokenAddress: '0xdest',
+    srcTokenAmount: '1000',
+    gasIncluded: false,
+    gasIncluded7702: false,
+  })),
+  getQuoteRefreshRate: jest.fn(() => 30_000),
+  getBridgeFeatureFlags: jest.fn(() => ({ maxRefreshCount: 5 })),
+  getBridgeQuotes: jest.fn(() => ({
+    isLoading: false,
+    quoteFetchError: null,
+    sortedQuotes: [],
+    activeQuote: null,
+    recommendedQuote: null,
+  })),
+}));
+
+jest.mock('../../../shared/lib/selectors/remote-feature-flags', () => ({
+  getRemoteFeatureFlags: jest.fn((state) => state.metamask.remoteFeatureFlags),
+}));
+
+jest.mock('../../store/controller-actions/bridge-controller', () => ({
+  fetchQuotes: jest.fn().mockResolvedValue([]),
+}));
+
+const mockedUseQuery = jest.mocked(useQuery);
+const mockedIsValidQuoteRequest = jest.mocked(isValidQuoteRequest);
+
+const {
+  getBridgeQuotes,
+} = jest.requireMock('../../ducks/bridge/selectors') as {
+  getBridgeQuotes: jest.Mock;
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('selectBridgeQuotesTanStackQueryEnabled', () => {
+  it('returns true only when the remote flag is boolean true', () => {
+    expect(
+      selectBridgeQuotesTanStackQueryEnabled({
+        metamask: {
+          remoteFeatureFlags: { bridgeQuotesTanStackQuery: true },
+        },
+      }),
+    ).toBe(true);
+    expect(
+      selectBridgeQuotesTanStackQueryEnabled({
+        metamask: {
+          remoteFeatureFlags: { bridgeQuotesTanStackQuery: false },
+        },
+      }),
+    ).toBe(false);
+    expect(
+      selectBridgeQuotesTanStackQueryEnabled({
+        metamask: { remoteFeatureFlags: {} },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('useBridgeQuotesQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedIsValidQuoteRequest.mockReturnValue(true);
+    getBridgeQuotes.mockReturnValue({
+      isLoading: false,
+      quoteFetchError: null,
+      sortedQuotes: [],
+      activeQuote: null,
+      recommendedQuote: null,
+    });
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      dataUpdatedAt: 0,
+    } as never);
+  });
+
+  it('keeps the query disabled when the remote flag is off', () => {
+    const { result } = renderHook(() => useBridgeQuotesQuery(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isQueryEnabled).toBe(false);
+    expect(mockedUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(result.current.quotes).toBeNull();
+  });
+
+  it('enables the query when enabled override is true and request is valid', () => {
+    mockedUseQuery.mockReturnValue({
+      data: [{ quote: { requestId: 'q1' } }],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      dataUpdatedAt: 123,
+    } as never);
+
+    const { result } = renderHook(
+      () => useBridgeQuotesQuery({ enabled: true }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(result.current.isQueryEnabled).toBe(true);
+    expect(mockedUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+    expect(result.current.quotes).toEqual([{ quote: { requestId: 'q1' } }]);
+    expect(result.current.dataUpdatedAt).toBe(123);
+  });
+
+  it('dual-reads loading from Redux when the query path is disabled', () => {
+    getBridgeQuotes.mockReturnValue({
+      isLoading: true,
+      quoteFetchError: null,
+      sortedQuotes: [],
+      activeQuote: null,
+      recommendedQuote: null,
+    });
+
+    const { result } = renderHook(() => useBridgeQuotesQuery(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isQueryEnabled).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('prefers TanStack loading/error when the query path is enabled', () => {
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isError: true,
+      error: new Error('quote failed'),
+      dataUpdatedAt: 0,
+    } as never);
+
+    const { result } = renderHook(
+      () => useBridgeQuotesQuery({ enabled: true }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isFetching).toBe(true);
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error).toEqual(new Error('quote failed'));
+  });
+
+  it('stays disabled when the quote request is invalid', () => {
+    mockedIsValidQuoteRequest.mockReturnValue(false);
+
+    const { result } = renderHook(
+      () => useBridgeQuotesQuery({ enabled: true }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(result.current.isQueryEnabled).toBe(false);
+    expect(mockedUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+});

--- a/ui/hooks/bridge/useBridgeQuotesQuery.ts
+++ b/ui/hooks/bridge/useBridgeQuotesQuery.ts
@@ -1,0 +1,103 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  FeatureId,
+  isValidQuoteRequest,
+  type QuoteResponseV1,
+} from '@metamask/bridge-controller';
+import { useSelector } from 'react-redux';
+import {
+  getBridgeFeatureFlags,
+  getBridgeQuotes,
+  getQuoteRefreshRate,
+  getQuoteRequest,
+} from '../../ducks/bridge/selectors';
+import { getRemoteFeatureFlags } from '../../../shared/lib/selectors/remote-feature-flags';
+import { bridgeQueries } from './queries';
+
+export const bridgeQuotesTanStackQueryFlag = 'bridgeQuotesTanStackQuery';
+
+export type UseBridgeQuotesQueryResult = {
+  quotes: QuoteResponseV1[] | null;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  error: unknown | null;
+  dataUpdatedAt: number;
+  isQueryEnabled: boolean;
+  reduxQuotes: ReturnType<typeof getBridgeQuotes>;
+};
+
+export function selectBridgeQuotesTanStackQueryEnabled(state: {
+  metamask: {
+    remoteFeatureFlags: Record<string, unknown>;
+  };
+}): boolean {
+  return (
+    getRemoteFeatureFlags(state)[bridgeQuotesTanStackQueryFlag] === true
+  );
+}
+
+export function useBridgeQuotesQuery(options?: {
+  enabled?: boolean;
+}): UseBridgeQuotesQueryResult {
+  const quoteRequest = useSelector(getQuoteRequest);
+  const refreshRate = useSelector(getQuoteRefreshRate);
+  const bridgeFeatureFlags = useSelector(getBridgeFeatureFlags);
+  const reduxQuotes = useSelector(getBridgeQuotes);
+  const remoteFlagEnabled = useSelector(selectBridgeQuotesTanStackQueryEnabled);
+
+  const hasValidQuoteRequest = isValidQuoteRequest(quoteRequest);
+  const isQueryEnabled =
+    (options?.enabled ?? remoteFlagEnabled) && hasValidQuoteRequest;
+
+  const maxRefreshCount = bridgeFeatureFlags.maxRefreshCount;
+
+  const quotesQuery = useQuery({
+    ...bridgeQueries.quotes.options(
+      {
+        walletAddress: quoteRequest.walletAddress ?? '',
+        destWalletAddress: quoteRequest.destWalletAddress,
+        srcChainId: quoteRequest.srcChainId ?? '',
+        destChainId: quoteRequest.destChainId ?? '',
+        srcTokenAddress: quoteRequest.srcTokenAddress ?? '',
+        destTokenAddress: quoteRequest.destTokenAddress ?? '',
+        srcTokenAmount: quoteRequest.srcTokenAmount ?? '',
+        slippage: quoteRequest.slippage,
+        insufficientBal: quoteRequest.insufficientBal,
+        gasIncluded: Boolean(quoteRequest.gasIncluded),
+        gasIncluded7702: Boolean(quoteRequest.gasIncluded7702),
+      },
+      {
+        refetchIntervalMs: refreshRate,
+        maxRefreshCount,
+        featureId: FeatureId.UNIFIED_SWAP_BRIDGE,
+      },
+    ),
+    enabled: isQueryEnabled,
+  });
+
+  const isLoading = isQueryEnabled
+    ? quotesQuery.isLoading
+    : Boolean(reduxQuotes.isLoading);
+  const isFetching = isQueryEnabled
+    ? quotesQuery.isFetching
+    : Boolean(reduxQuotes.isLoading);
+  const isError = isQueryEnabled
+    ? quotesQuery.isError
+    : Boolean(reduxQuotes.quoteFetchError);
+  const error = isQueryEnabled
+    ? (quotesQuery.error ?? null)
+    : (reduxQuotes.quoteFetchError ?? null);
+
+  return {
+    // Dual-read: prefer TanStack cache when the migration path is active.
+    quotes: isQueryEnabled ? (quotesQuery.data ?? null) : null,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    dataUpdatedAt: quotesQuery.dataUpdatedAt,
+    isQueryEnabled,
+    reduxQuotes,
+  };
+}

--- a/ui/pages/bridge/prepare/prepare-bridge-page.test.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.test.tsx
@@ -37,6 +37,22 @@ jest.mock('../hooks/useGasIncludedSupport', () => ({
   }),
 }));
 
+jest.mock('../../../hooks/bridge/useBridgeQuotesQuery', () => ({
+  useBridgeQuotesQuery: jest.fn().mockReturnValue({
+    quotes: null,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    dataUpdatedAt: 0,
+    isQueryEnabled: false,
+    reduxQuotes: {
+      isLoading: false,
+      quoteFetchError: null,
+    },
+  }),
+}));
+
 const mockUseHardwareWalletConfig = jest.fn();
 const mockUseHardwareWalletActions = jest.fn();
 const mockUseHardwareWalletState = jest.fn();

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -92,6 +92,7 @@ import { useDispatch } from '../../../store/hooks';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import { getCurrencySymbol } from '../../../helpers/utils/common.util';
 import { useSourceInputAmount } from '../../../hooks/bridge/useSourceInputAmount';
+import { useBridgeQuotesQuery } from '../../../hooks/bridge/useBridgeQuotesQuery';
 import { BridgeInputGroup } from './bridge-input-group';
 import { PrepareBridgePageFooter } from './prepare-bridge-page-footer';
 import { DestinationAccountPickerModal } from './components/destination-account-picker-modal';
@@ -138,10 +139,16 @@ const PrepareBridgePage = ({
 
   const quoteRequest = useSelector(getQuoteRequest);
   const {
-    isLoading,
+    isLoading: reduxIsLoading,
     // This quote may be older than the refresh rate, but we keep it for display purposes
     activeQuote: unvalidatedQuote,
   } = useSelector(getBridgeQuotes);
+  // TanStack dual-read path (gated by remote flag `bridgeQuotesTanStackQuery`).
+  // BridgeController still owns quote state for selectors / submit / dapp-swap.
+  const bridgeQuotesQuery = useBridgeQuotesQuery();
+  const isLoading = bridgeQuotesQuery.isQueryEnabled
+    ? bridgeQuotesQuery.isLoading || reduxIsLoading
+    : reduxIsLoading;
   const { dest } = unvalidatedQuote?.quote ?? {};
 
   const wasTxDeclined = useSelector(getWasTxDeclined);

--- a/ui/store/controller-actions/bridge-controller.ts
+++ b/ui/store/controller-actions/bridge-controller.ts
@@ -1,11 +1,16 @@
 import {
-  GenericQuoteRequest,
-  QuoteResponseV1,
+  type FeatureId,
+  type GenericQuoteRequest,
+  type QuoteResponseV1,
 } from '@metamask/bridge-controller';
 import { submitRequestToBackground } from '../background-connection';
 
 export async function fetchQuotes(
   quoteRequest: GenericQuoteRequest,
+  featureId?: FeatureId,
 ): Promise<QuoteResponseV1[]> {
-  return await submitRequestToBackground('fetchQuotes', [quoteRequest]);
+  return await submitRequestToBackground('fetchQuotes', [
+    quoteRequest,
+    featureId,
+  ]);
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds an opt-in TanStack Query path for bridge quotes on the prepare page, dual-reading with existing BridgeController Redux state.

- BridgeController remains the source of truth (poll via `updateBridgeQuoteRequestParams`, submit/`activeQuote` unchanged).
- New `useBridgeQuotesQuery` calls `fetchQuotes` (same background method dapp-swap uses) with a stable queryKey + `refetchInterval`.
- Remote flag `bridgeQuotesTanStackQuery` defaults **off** — flag off = no behavior change.
- Dapp-swap background path untouched.

This is a first slice toward UI-owned quote refresh, not a BridgeController removal.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

<!--
No linked issue yet — follow-up from local TanStack migration planning.
-->

## **Manual testing steps**

1. Run the extension with `bridgeQuotesTanStackQuery` unset/false.
2. Open Bridge/Swap prepare page, enter an amount, confirm quotes load and submit still works as today.
3. Enable remote/manifest flag `bridgeQuotesTanStackQuery: true`.
4. Repeat prepare flow — quotes still appear, loading state still behaves, submit still uses controller `activeQuote`.
5. Confirm a dapp-swap comparison / middleware path still works (background `fetchQuotes` unchanged).

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)