### PR TITLE
chore: reset drawer scroll

### DIFF
--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
@@ -98,6 +98,7 @@ export const GlobalMenuDrawer = ({
   const isLargeDrawer = isFullscreen || isSidepanel;
 
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     const dialog = dialogRef.current;
@@ -113,6 +114,9 @@ export const GlobalMenuDrawer = ({
           // jsdom does not implement HTMLDialogElement.showModal
           dialog.setAttribute('open', '');
         }
+      }
+      if (scrollRef.current) {
+        scrollRef.current.scrollTop = 0;
       }
       return;
     }
@@ -181,6 +185,7 @@ export const GlobalMenuDrawer = ({
       )}
 
       <Box
+        ref={scrollRef}
         flexDirection={BoxFlexDirection.Column}
         className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pb-6"
       >


### PR DESCRIPTION
## **Description**

Resets that scroll container to the top when the drawer is shown

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Open the extension and unlock the wallet.
2. Open the global menu from the header menu icon.
3. Scroll the menu down to the bottom.
4. Close the drawer (back arrow, `Esc`, or clicking the backdrop).
5. Reopen the global menu.
6. Verify the menu is scrolled to the top rather than where it was left.
7. Repeat in the expanded/fullscreen view and in the side panel to confirm the same behavior.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)