### PR TITLE
feat: auto-enable network from token details

### DIFF
--- a/ui/hooks/discover-search/useDiscoverAssetPress.test.ts
+++ b/ui/hooks/discover-search/useDiscoverAssetPress.test.ts
@@ -16,6 +16,7 @@ describe('useEnableDiscoverAssetNetwork', () => {
   });
 
   it('adds a missing popular network without changing the network filter', async () => {
+    mockDispatch.mockResolvedValue({});
     const mockAddNetwork = jest
       .spyOn(ActionsModule, 'addNetwork')
       .mockReturnValue(jest.fn().mockResolvedValue(undefined) as never);
@@ -36,5 +37,25 @@ describe('useEnableDiscoverAssetNetwork', () => {
       expect.objectContaining({ chainId: '0x89', name: 'Polygon' }),
       { setActive: false },
     );
+  });
+
+  it('does not report success when adding the network fails', async () => {
+    jest
+      .spyOn(ActionsModule, 'addNetwork')
+      .mockReturnValue(jest.fn().mockResolvedValue(undefined) as never);
+    const hook = renderHookWithProvider(
+      () => useEnableDiscoverAssetNetwork(),
+      createBridgeMockStore({
+        metamaskStateOverrides: {
+          networkConfigurationsByChainId: {},
+        },
+      }),
+    );
+
+    await expect(
+      hook.result.current(
+        'eip155:137/erc20:0x0000000000000000000000000000000000000000',
+      ),
+    ).resolves.toBeNull();
   });
 });

--- a/ui/hooks/discover-search/useDiscoverAssetPress.test.ts
+++ b/ui/hooks/discover-search/useDiscoverAssetPress.test.ts
@@ -1,0 +1,40 @@
+import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { createBridgeMockStore } from '../../../test/data/bridge/mock-bridge-store';
+import * as ActionsModule from '../../store/actions';
+import { useEnableDiscoverAssetNetwork } from './useDiscoverAssetPress';
+
+const mockDispatch = jest.fn();
+
+jest.mock('../../store/hooks', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+describe('useEnableDiscoverAssetNetwork', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDispatch.mockResolvedValue(undefined);
+  });
+
+  it('adds a missing popular network without changing the network filter', async () => {
+    const mockAddNetwork = jest
+      .spyOn(ActionsModule, 'addNetwork')
+      .mockReturnValue(jest.fn().mockResolvedValue(undefined) as never);
+    const hook = renderHookWithProvider(
+      () => useEnableDiscoverAssetNetwork(),
+      createBridgeMockStore({
+        metamaskStateOverrides: {
+          networkConfigurationsByChainId: {},
+        },
+      }),
+    );
+
+    await hook.result.current(
+      'eip155:137/erc20:0x0000000000000000000000000000000000000000',
+    );
+
+    expect(mockAddNetwork).toHaveBeenCalledWith(
+      expect.objectContaining({ chainId: '0x89', name: 'Polygon' }),
+      { setActive: false },
+    );
+  });
+});

--- a/ui/hooks/discover-search/useDiscoverAssetPress.ts
+++ b/ui/hooks/discover-search/useDiscoverAssetPress.ts
@@ -40,8 +40,10 @@ export const useEnableDiscoverAssetNetwork = () => {
         return null;
       }
 
-      await dispatch(addNetwork(featuredEvmNetwork, { setActive: false }));
-      return featuredEvmNetwork.name;
+      const addedNetwork = await dispatch(
+        addNetwork(featuredEvmNetwork, { setActive: false }),
+      );
+      return addedNetwork ? featuredEvmNetwork.name : null;
     },
     [dispatch, evmNetworkConfigurations, featuredEvmNetworks],
   );

--- a/ui/hooks/discover-search/useDiscoverAssetPress.ts
+++ b/ui/hooks/discover-search/useDiscoverAssetPress.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  type CaipAssetType,
+  parseCaipAssetType,
+  parseCaipChainId,
+} from '@metamask/utils';
+
+import { getNetworkConfigurationsByChainId } from '../../../shared/lib/selectors/networks';
+import { convertCaipToHexChainId } from '../../../shared/lib/network.utils';
+import { getFeaturedEvmNetworks } from '../../selectors/config-registry/config-registry';
+import { addNetwork } from '../../store/actions';
+import { useDispatch } from '../../store/hooks';
+
+/**
+ * Adds a missing popular EVM network for an asset and returns its name.
+ * @returns A callback that resolves to the added network's name, or null when
+ * no network was added.
+ */
+export const useEnableDiscoverAssetNetwork = () => {
+  const dispatch = useDispatch();
+  const evmNetworkConfigurations = useSelector(
+    getNetworkConfigurationsByChainId,
+  );
+  const featuredEvmNetworks = useSelector(getFeaturedEvmNetworks);
+
+  return useCallback(
+    async (assetId: CaipAssetType): Promise<string | null> => {
+      const { chainId } = parseCaipAssetType(assetId);
+      const { namespace } = parseCaipChainId(chainId);
+      if (namespace !== 'eip155') {
+        return null;
+      }
+
+      const chainIdHex = convertCaipToHexChainId(chainId);
+      const featuredEvmNetwork = featuredEvmNetworks.find(
+        (network) => network.chainId === chainIdHex,
+      );
+      if (!featuredEvmNetwork || evmNetworkConfigurations[chainIdHex]) {
+        return null;
+      }
+
+      await dispatch(addNetwork(featuredEvmNetwork, { setActive: false }));
+      return featuredEvmNetwork.name;
+    },
+    [dispatch, evmNetworkConfigurations, featuredEvmNetworks],
+  );
+};

--- a/ui/pages/discover-search/discover-search.test.tsx
+++ b/ui/pages/discover-search/discover-search.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -13,6 +13,8 @@ const mockNavigate = jest.fn();
 const mockRunCloseTransition = jest.fn((callback: () => void) => callback());
 const mockUseDiscoverSearch = jest.fn();
 const mockGetIsPerpsExperienceAvailable = jest.fn();
+const mockEnsureNetworkEnabled = jest.fn();
+const mockToastSuccess = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -25,6 +27,23 @@ jest.mock('../routes/global-menu-route-transition', () => ({
 
 jest.mock('../../hooks/discover-search/useDiscoverSearch', () => ({
   useDiscoverSearch: (options: unknown) => mockUseDiscoverSearch(options),
+}));
+
+jest.mock('../../hooks/discover-search/useDiscoverAssetPress', () => ({
+  useEnableDiscoverAssetNetwork: () => mockEnsureNetworkEnabled,
+}));
+
+jest.mock('../../components/ui/toast/toast', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+  ToastContent: ({
+    title,
+    dataTestId,
+  }: {
+    title: string;
+    dataTestId?: string;
+  }) => <div data-testid={dataTestId}>{title}</div>,
 }));
 
 const getDefaultDiscoverSearchResult = () => ({
@@ -114,6 +133,8 @@ describe('DiscoverSearchPage', () => {
     mockRunCloseTransition.mockClear();
     mockGetIsPerpsExperienceAvailable.mockReturnValue(false);
     mockUseDiscoverSearch.mockReturnValue(getDefaultDiscoverSearchResult());
+    mockEnsureNetworkEnabled.mockResolvedValue(null);
+    mockToastSuccess.mockClear();
   });
 
   const renderPage = ({
@@ -305,19 +326,43 @@ describe('DiscoverSearchPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 
-  it('navigates to the CAIP asset route when an asset result is clicked', () => {
+  it('navigates to the CAIP asset route when an asset result is clicked', async () => {
     renderPage();
 
     fireEvent.click(
       screen.getByTestId('discover-crypto-preview-eip155:1/slip44:60'),
     );
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      '/asset/eip155:1/eip155%3A1%2Fslip44%3A60',
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/asset/eip155:1/eip155%3A1%2Fslip44%3A60',
+      ),
     );
   });
 
-  it('renders no-results search design and opens popular assets', () => {
+  it('shows a success toast when it enables a popular network', async () => {
+    mockEnsureNetworkEnabled.mockResolvedValue('Base');
+    renderPage();
+
+    fireEvent.click(
+      screen.getByTestId('discover-crypto-preview-eip155:1/slip44:60'),
+    );
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/asset/eip155:1/eip155%3A1%2Fslip44%3A60',
+      ),
+    );
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          dataTestId: 'discover-network-added-success-toast',
+        }),
+      }),
+    );
+  });
+
+  it('renders no-results search design and opens popular assets', async () => {
     const searchQuery = 'erwerwqer';
 
     mockUseDiscoverSearch.mockReturnValue(getEmptyDiscoverSearchResult());
@@ -350,8 +395,10 @@ describe('DiscoverSearchPage', () => {
 
     fireEvent.click(screen.getByTestId('discover-search-popular-asset-btc'));
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      '/asset/bip122:000000000019d6689c085ae165831e93/bip122%3A000000000019d6689c085ae165831e93%2Fslip44%3A0',
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/asset/bip122:000000000019d6689c085ae165831e93/bip122%3A000000000019d6689c085ae165831e93%2Fslip44%3A0',
+      ),
     );
   });
 

--- a/ui/pages/discover-search/discover-search.tsx
+++ b/ui/pages/discover-search/discover-search.tsx
@@ -9,7 +9,11 @@ import { useSelector } from 'react-redux';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import type { PerpsMarketData } from '@metamask/perps-controller';
-import type { Json } from '@metamask/utils';
+import {
+  isCaipAssetType,
+  type CaipAssetType,
+  type Json,
+} from '@metamask/utils';
 import {
   Box,
   BoxAlignItems,
@@ -25,10 +29,10 @@ import {
   TextFieldSearch,
   TextVariant,
 } from '@metamask/design-system-react';
-import { isCaipAssetType } from '@metamask/utils';
 
 import { MarketRow } from '../../components/app/perps/market-row';
 import { Tab, Tabs } from '../../components/ui/tabs';
+import { toast, ToastContent } from '../../components/ui/toast/toast';
 import { VirtualizedList } from '../../components/ui/virtualized-list/virtualized-list';
 import { ScrollContainer } from '../../contexts/scroll-container';
 import {
@@ -38,6 +42,7 @@ import {
 import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
 import { DISCOVER_SEARCH_PREVIEW_COUNT } from '../../hooks/discover-search/constants';
 import { getDiscoverViewMoreAction } from '../../hooks/discover-search/get-discover-view-more-action';
+import { useEnableDiscoverAssetNetwork } from '../../hooks/discover-search/useDiscoverAssetPress';
 import { useDiscoverSearch } from '../../hooks/discover-search/useDiscoverSearch';
 import type {
   DiscoverSearchSectionId,
@@ -84,21 +89,16 @@ const DiscoverSearchErrorState = () => {
 type DiscoverSearchEmptyStateProps = {
   noResultsMessage: string;
   query: string;
+  onAssetPress: (assetId: CaipAssetType) => void;
 };
 
 const DiscoverSearchEmptyState = ({
   noResultsMessage,
   query,
+  onAssetPress,
 }: DiscoverSearchEmptyStateProps) => {
-  const navigate = useNavigate();
-
   if (query) {
-    return (
-      <DiscoverNoResultsState
-        query={query}
-        onAssetPress={(assetId) => navigate(buildAssetRoutePath(assetId))}
-      />
-    );
+    return <DiscoverNoResultsState query={query} onAssetPress={onAssetPress} />;
   }
 
   return <EmptyState message={noResultsMessage} />;
@@ -188,6 +188,7 @@ export const DiscoverSearchPage = () => {
   const { createEventBuilder, trackEvent } = useAnalytics();
   const [searchParams, setSearchParams] = useSearchParams();
   const runCloseTransition = useGlobalMenuRouteTransition();
+  const enableDiscoverAssetNetwork = useEnableDiscoverAssetNetwork();
   const isPerpsAvailable = useSelector(getIsPerpsExperienceAvailable);
   const trackedSearchKey = useRef<string | null>(null);
   const pendingTabSwitch = useRef<PendingTabSwitch | null>(null);
@@ -314,7 +315,7 @@ export const DiscoverSearchPage = () => {
   );
 
   const handleAssetPress = useCallback(
-    (
+    async (
       asset: TrendingAsset,
       section: DiscoverSearchSectionId,
       position: number,
@@ -339,10 +340,43 @@ export const DiscoverSearchPage = () => {
         result_count: getResultCount(activeTab),
       });
       if (isCaipAssetType(asset.assetId)) {
+        const networkName = await enableDiscoverAssetNetwork(asset.assetId);
         navigate(buildAssetRoutePath(asset.assetId));
+        if (networkName) {
+          toast.success(
+            <ToastContent
+              title={t('newNetworkAdded', [networkName])}
+              dataTestId="discover-network-added-success-toast"
+            />,
+          );
+        }
       }
     },
-    [activeTab, getResultCount, navigate, searchQuery, trackExploreSearchEvent],
+    [
+      activeTab,
+      enableDiscoverAssetNetwork,
+      getResultCount,
+      navigate,
+      searchQuery,
+      t,
+      trackExploreSearchEvent,
+    ],
+  );
+
+  const handlePopularAssetPress = useCallback(
+    async (assetId: CaipAssetType) => {
+      const networkName = await enableDiscoverAssetNetwork(assetId);
+      navigate(buildAssetRoutePath(assetId));
+      if (networkName) {
+        toast.success(
+          <ToastContent
+            title={t('newNetworkAdded', [networkName])}
+            dataTestId="discover-network-added-success-toast"
+          />,
+        );
+      }
+    },
+    [enableDiscoverAssetNetwork, navigate, t],
   );
 
   const handlePerpsPress = useCallback(
@@ -656,6 +690,7 @@ export const DiscoverSearchPage = () => {
         <DiscoverSearchEmptyState
           noResultsMessage={noResultsMessage}
           query={trimmedSearchQuery}
+          onAssetPress={handlePopularAssetPress}
         />
       );
     }
@@ -693,6 +728,7 @@ export const DiscoverSearchPage = () => {
         <DiscoverSearchEmptyState
           noResultsMessage={noResultsMessage}
           query={trimmedSearchQuery}
+          onAssetPress={handlePopularAssetPress}
         />
       );
     }
@@ -735,6 +771,7 @@ export const DiscoverSearchPage = () => {
         <DiscoverSearchEmptyState
           noResultsMessage={noResultsMessage}
           query={trimmedSearchQuery}
+          onAssetPress={handlePopularAssetPress}
         />
       );
     }


### PR DESCRIPTION
When a user opens a token from Discover Search, they can land on token details for an asset on a network they have not enabled yet. That breaks the flow or shows incomplete data.

This PR adds automatic network enablement on asset selection in Discover Search

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [issue](https://consensyssoftware.atlassian.net/browse/CEUX-1294)

## **Manual testing steps**

1.  Go to Header Search
2. Remove a popular network you will test with (e.g. Base or Polygon) via Settings → Networks, if it is already enabled.
3. Open Discover Search (global menu → search).
4. Search for a token on that network (e.g. search for a Base token if Base was removed).
5. Tap a search result for that token.
6. You are navigated to the token details page.
7. A success toast appears (e.g. “Base network added”).
8. The network appears in Settings → Networks.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/f994d232-8a8c-4d55-ba73-b75a2099b53a


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet network configuration via `addNetwork`, though limited to curated featured chains and non-active adds; scope is Discover Search UI only.
> 
> **Overview**
> Discover Search now **silently adds missing “featured” EVM networks** when the user opens a token from search results or from popular assets in the no-results state, so token details are not blocked by an unenabled chain.
> 
> A new `useEnableDiscoverAssetNetwork` hook parses the asset’s CAIP id, skips non-EVM assets, and dispatches `addNetwork` with **`setActive: false`** only when the chain is in the featured list and not already configured. Navigation to the asset route still happens after that step; if a network was added, a **success toast** uses the existing `newNetworkAdded` copy.
> 
> Tests cover the hook (Polygon add + failure returns null) and the page (toast when the mock reports a network name, async navigation waits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 884045c00d6468132158ed84bc85d25103d6ac41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->