### PR TITLE
fix: Display failover information for custom hardcoded networks

### DIFF
--- a/ui/components/multichain/networks-form/networks-form.tsx
+++ b/ui/components/multichain/networks-form/networks-form.tsx
@@ -143,8 +143,12 @@ export const NetworksForm = ({
   // failover URLs solely for Infura endpoints; applying them to custom RPCs
   // would leak requests to the failover, so it does not. Only surface failover
   // in the form for Infura endpoints so the UI matches the actual behaviour.
-  const failoverUrlsForEndpoint = (endpoint?: { type?: RpcEndpointType }) =>
-    endpoint?.type === RpcEndpointType.Infura ? chainFailoverUrls : [];
+  const failoverUrlsForEndpoint = (endpoint?: { url: string }) => {
+    return endpoint?.url &&
+      new URL(endpoint.url).hostname.endsWith('.infura.io')
+      ? chainFailoverUrls
+      : [];
+  };
 
   const defaultFailoverUrls = failoverUrlsForEndpoint(defaultRpcEndpoint);
 
@@ -567,12 +571,16 @@ export const NetworksForm = ({
           selectedItemIndex={rpcUrls.defaultRpcEndpointIndex}
           error={Boolean(errors.rpcUrl)}
           buttonDataTestId="test-add-rpc-drop-down"
-          renderItem={(item, isList) =>
-            isList || item?.name || item?.type === RpcEndpointType.Infura ? (
+          renderItem={(item, isList) => {
+            const failoverUrls = failoverUrlsForEndpoint(item);
+            return isList ||
+              item?.name ||
+              item?.type === RpcEndpointType.Infura ||
+              failoverUrls.length > 0 ? (
               <RpcListItem
                 rpcEndpoint={{
                   ...item,
-                  failoverUrls: failoverUrlsForEndpoint(item),
+                  failoverUrls,
                 }}
               />
             ) : (
@@ -590,8 +598,8 @@ export const NetworksForm = ({
               >
                 {stripProtocol(stripKeyFromInfuraUrl(item.url))}
               </Text>
-            )
-          }
+            );
+          }}
           renderTooltip={(item, isList) => {
             const url = stripKeyFromInfuraUrl(item.url);
             return url.length > (isList ? 37 : 35) ? url : undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

While testing https://github.com/MetaMask/metamask-extension/pull/45230 I discovered that some networks weren't showing up with failovers even if they had them configured. This PR fixes that by mirroring the implementation in `NetworkController`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where networks wouldn't properly display fallback URLs

## **Related issues**

N/A

## **Manual testing steps**

1. Go to networks page
2. Click edit on Robinhood
3. See failover URL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bf4e26fffb9122bb6caef3809fc16be2247350b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->