### PR TITLE
test(e2e): restore Tron header coverage and wait on selectors

### DIFF
--- a/test/e2e/helpers/tron-fixtures.test.ts
+++ b/test/e2e/helpers/tron-fixtures.test.ts
@@ -1,4 +1,7 @@
-import { TRON_ACCOUNT_ADDRESS } from '../tests/tron/mocks/common-tron';
+import {
+  TRON_ACCOUNT_ADDRESS,
+  TRX_BALANCE,
+} from '../tests/tron/mocks/common-tron';
 import {
   GAS_FREE,
   HTX,
@@ -7,6 +10,7 @@ import {
   USDD,
   USDT,
 } from '../tests/tron/fixtures/tokens';
+import { TRON_CHECK_BALANCE_ACCOUNT } from '../tests/tron/fixtures/environments';
 import { buildTronNodeOptions } from '../tests/tron/fixtures/with-tron-fixtures';
 
 describe('withTronFixtures', () => {
@@ -28,6 +32,27 @@ describe('withTronFixtures', () => {
     ).toStrictEqual({
       initialBalances: {
         [TRON_ACCOUNT_ADDRESS]: 6_072_392,
+      },
+      trc10Balances: {
+        [TRON_ACCOUNT_ADDRESS]: {
+          GAS_FREE: '33333333',
+        },
+      },
+      trc20Balances: {
+        [TRON_ACCOUNT_ADDRESS]: {
+          HTX: '3156454956836360132407885',
+          SEED: '89851311',
+          USDD: '289757448699320931',
+          USDT: '2804595',
+        },
+      },
+    });
+  });
+
+  it('builds the check-balance funded account with 106.072 TRX', () => {
+    expect(buildTronNodeOptions([TRON_CHECK_BALANCE_ACCOUNT])).toStrictEqual({
+      initialBalances: {
+        [TRON_ACCOUNT_ADDRESS]: TRX_BALANCE,
       },
       trc10Balances: {
         [TRON_ACCOUNT_ADDRESS]: {

--- a/test/e2e/page-objects/flows/tron-assets.flow.ts
+++ b/test/e2e/page-objects/flows/tron-assets.flow.ts
@@ -1,12 +1,19 @@
 import { Driver } from '../../webdriver/driver';
 import HomePage from '../pages/home/homepage';
+import TokensTab from '../pages/home/tokens-tab';
 import { addMultipleAccounts } from './add-account.flow';
 import { switchToAccount } from './account-list.flow';
 import { login } from './login.flow';
 import { switchToNetworkFromNetworkSelect } from './network.flow';
 import { waitUntilAccountTreeSyncIdle } from './tron-account-derivation.flow';
+import { returnToTronHome } from './tron-home.flow';
 
-const PORTFOLIO_ACCOUNT_INDEX = 1;
+const TRON_HOMEPAGE_TOKEN_TIMEOUT_MS = 30_000;
+
+/** Account 1 empty, Account 2 portfolio, Account 3 funded check-balance. */
+const EXTRA_HD_ACCOUNT_COUNT = 2;
+
+export { returnToTronHome };
 
 export async function prepareTronAssetsHomepage(driver: Driver): Promise<void> {
   await login(driver, { validateBalance: false });
@@ -14,29 +21,61 @@ export async function prepareTronAssetsHomepage(driver: Driver): Promise<void> {
   await addMultipleAccounts({
     accountToSelect: 'Account 1',
     driver,
-    numberOfAccounts: PORTFOLIO_ACCOUNT_INDEX,
+    numberOfAccounts: EXTRA_HD_ACCOUNT_COUNT,
   });
   await homePage.checkPageIsLoaded();
   await homePage.waitForNonEvmAccountsLoaded();
   await waitUntilAccountTreeSyncIdle(driver);
   await switchToNetworkFromNetworkSelect(driver, 'Tron');
-  await homePage.reloadHome();
+  const tokensTab = new TokensTab(driver);
+  await tokensTab.checkTokenExistsInList('Tron', '0', {
+    timeout: TRON_HOMEPAGE_TOKEN_TIMEOUT_MS,
+  });
 }
 
-export async function returnToTronHome(driver: Driver): Promise<void> {
-  const homePage = new HomePage(driver);
-  await homePage.navigateToHome();
+/**
+ * Switches to an already-derived account, re-selects Tron, and waits for the
+ * native TRX token row instead of reloading the page.
+ *
+ * @param driver - The webdriver instance.
+ * @param options - Account switch options.
+ * @param options.accountName - Account label, for example `Account 2`.
+ * @param options.expectedTrxAmount - Optional TRX amount shown in the token list.
+ */
+export async function switchToTronAccount(
+  driver: Driver,
+  {
+    accountName,
+    expectedTrxAmount,
+  }: {
+    accountName: string;
+    expectedTrxAmount?: string;
+  },
+): Promise<void> {
+  await returnToTronHome(driver);
+  await switchToAccount(driver, accountName);
+  await waitUntilAccountTreeSyncIdle(driver);
+  await switchToNetworkFromNetworkSelect(driver, 'Tron');
+  const tokensTab = new TokensTab(driver);
+  await tokensTab.checkTokenExistsInList('Tron', expectedTrxAmount, {
+    timeout: TRON_HOMEPAGE_TOKEN_TIMEOUT_MS,
+  });
 }
 
 export async function switchToPortfolioTronAccount(
   driver: Driver,
 ): Promise<void> {
-  await returnToTronHome(driver);
-  await switchToAccount(driver, 'Account 2');
-  await waitUntilAccountTreeSyncIdle(driver);
-  await switchToNetworkFromNetworkSelect(driver, 'Tron');
-  // Account-group switch leaves isEvmSelected true; re-select Tron then
-  // reload so native-as-main applies.
-  const homePage = new HomePage(driver);
-  await homePage.reloadHome();
+  await switchToTronAccount(driver, {
+    accountName: 'Account 2',
+    expectedTrxAmount: '6.072',
+  });
+}
+
+export async function switchToFundedTronAccount(
+  driver: Driver,
+): Promise<void> {
+  await switchToTronAccount(driver, {
+    accountName: 'Account 3',
+    expectedTrxAmount: '106.072',
+  });
 }

--- a/test/e2e/page-objects/flows/tron-home.flow.ts
+++ b/test/e2e/page-objects/flows/tron-home.flow.ts
@@ -1,0 +1,19 @@
+import { Driver } from '../../webdriver/driver';
+import HomePage from '../pages/home/homepage';
+
+/**
+ * Leaves the current route and returns to the Tron homepage.
+ *
+ * @param driver - The webdriver instance.
+ * @param expectedBalance - Optional homepage header balance to wait for.
+ */
+export async function returnToTronHome(
+  driver: Driver,
+  expectedBalance?: string,
+): Promise<void> {
+  const homePage = new HomePage(driver);
+  await homePage.navigateToHome();
+  if (expectedBalance !== undefined) {
+    await homePage.checkExpectedBalanceIsDisplayed(expectedBalance);
+  }
+}

--- a/test/e2e/page-objects/flows/tron-send.flow.ts
+++ b/test/e2e/page-objects/flows/tron-send.flow.ts
@@ -67,12 +67,6 @@ export async function prepareTronHomepageForSend({
   await selectTronNetwork(driver);
   await waitUntilAccountTreeSyncIdle(driver);
 
-  // Reload re-hydrates Account 1 from background state so Snap balances
-  // appear in the token list. Account switches already trigger that hydration.
-  if (extraHdAccountCount === 0 || accountToSelect === 'Account 1') {
-    await home.reloadHome();
-  }
-
   await home.checkPageIsLoaded();
   // Wait for the live TRX balance to land on the homepage before navigating to
   // Send. Without this gate, Send opens with the cached "0 TRX available" and

--- a/test/e2e/page-objects/flows/tron-swap.flow.ts
+++ b/test/e2e/page-objects/flows/tron-swap.flow.ts
@@ -2,17 +2,14 @@ import { Driver } from '../../webdriver/driver';
 import HomePage from '../pages/home/homepage';
 import { login } from './login.flow';
 import { switchToNetworkFromNetworkSelect } from './network.flow';
+import { returnToTronHome } from './tron-home.flow';
+
+export { returnToTronHome };
 
 export async function landOnTronHome(driver: Driver): Promise<void> {
   await login(driver);
   await switchToNetworkFromNetworkSelect(driver, 'Tron');
   const homePage = new HomePage(driver);
   await homePage.checkPageIsLoaded();
-  await homePage.checkExpectedBalanceIsDisplayed('106.07');
-}
-
-export async function returnToTronHome(driver: Driver): Promise<void> {
-  const homePage = new HomePage(driver);
-  await homePage.navigateToHome();
   await homePage.checkExpectedBalanceIsDisplayed('106.07');
 }

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -598,9 +598,9 @@ class HomePage {
   }
 
   /**
-   * Reloads the home UI from background state. Tron Snap balances and
-   * `isEvmSelected` after an account-group switch do not always land without
-   * this. Prefer waiting for a selector when a stable one exists.
+   * Last-resort home reload. Prefer waiting for a selector such as the token
+   * list or header balance (`checkExpectedBalanceIsDisplayed`) so Snap /
+   * `isEvmSelected` state can land without a full refresh.
    */
   async reloadHome(): Promise<void> {
     console.log('Reload home to rehydrate Snap / network state');

--- a/test/e2e/page-objects/pages/swap/swap-page.ts
+++ b/test/e2e/page-objects/pages/swap/swap-page.ts
@@ -241,6 +241,31 @@ class SwapPage {
     });
   }
 
+  /**
+   * Waits until both swap amount fields have a non-empty value, then asserts
+   * they stayed populated so the timeout error names the empty field.
+   */
+  async checkSwapAmountsArePopulated(): Promise<void> {
+    console.log('Check swap from-amount and to-amount are populated');
+    await this.driver.wait(async () => {
+      const fromAmount = await this.getFromAmountValue();
+      const toAmount = await this.getToAmountValue();
+      return fromAmount !== '' && toAmount !== '';
+    });
+    const fromAmount = await this.getFromAmountValue();
+    const toAmount = await this.getToAmountValue();
+    assert.notEqual(
+      fromAmount,
+      '',
+      'Swap from-amount should be populated after the quote loads',
+    );
+    assert.notEqual(
+      toAmount,
+      '',
+      'Swap to-amount should be populated after the quote loads',
+    );
+  }
+
   async checkSwapButtonIsEnabled(): Promise<void> {
     await this.driver.waitForSelector(this.swapButton, {
       state: 'enabled',

--- a/test/e2e/tests/tron/assets.spec.ts
+++ b/test/e2e/tests/tron/assets.spec.ts
@@ -14,6 +14,7 @@ import { enableNativeTokenAsMainBalance } from '../../page-objects/flows/setting
 import {
   prepareTronAssetsHomepage,
   returnToTronHome,
+  switchToFundedTronAccount,
   switchToPortfolioTronAccount,
 } from '../../page-objects/flows/tron-assets.flow';
 import HomePage from '../../page-objects/pages/home/homepage';
@@ -22,6 +23,7 @@ import TronAssetDetailsPage from '../../page-objects/pages/asset/tron-asset-deta
 import { TronNode } from '../../seeder/tron/node';
 import {
   EMPTY_TRON_ACCOUNT,
+  TRON_CHECK_BALANCE_ACCOUNT,
   TRON_PORTFOLIO_ACCOUNT,
   TRON_PORTFOLIO_LOW_VALUE_ASSET_NAMES,
   TRON_PORTFOLIO_MAIN_LIST_ASSET_NAMES,
@@ -63,9 +65,22 @@ const PORTFOLIO_ACCOUNT_FIXTURE: TronFixtureAccount[] = [
   },
 ];
 
+const CHECK_BALANCE_ACCOUNT_FIXTURE: TronFixtureAccount[] = [
+  {
+    ...TRON_CHECK_BALANCE_ACCOUNT,
+    address: EXPECTED_TRON_ADDRESSES_BY_INDEX[2],
+  },
+];
+
+const TRON_ASSETS_ACCOUNTS: TronFixtureAccount[] = [
+  ...EMPTY_ACCOUNT_FIXTURE,
+  ...PORTFOLIO_ACCOUNT_FIXTURE,
+  ...CHECK_BALANCE_ACCOUNT_FIXTURE,
+];
+
 function buildTronAssetsFixture(): FixtureBuilderV2 {
-  // Native-as-main stays ON so Account 1/2 header tests can assert `0 TRX`
-  // and `6.072 TRX`. Toggle it off after those tests.
+  // Native-as-main stays ON so Account 1/2/3 header tests can assert `0 TRX`,
+  // `6.072 TRX`, and `106.072 TRX`. Toggle it off after those tests.
   return new FixtureBuilderV2().withRemoteFeatureFlagController(
     TRON_ASSETS_REMOTE_FEATURE_FLAGS,
   );
@@ -89,16 +104,11 @@ describe('Tron - Assets', function (this: Suite) {
   let session: HeldTronFixturesSession | undefined;
 
   before(async function () {
-    await sharedTronNode.start(
-      buildTronNodeOptions([
-        ...EMPTY_ACCOUNT_FIXTURE,
-        ...PORTFOLIO_ACCOUNT_FIXTURE,
-      ]),
-    );
+    await sharedTronNode.start(buildTronNodeOptions(TRON_ASSETS_ACCOUNTS));
     session = await startHeldSession((callback) =>
       withTronFixtures(
         {
-          accounts: [...EMPTY_ACCOUNT_FIXTURE, ...PORTFOLIO_ACCOUNT_FIXTURE],
+          accounts: TRON_ASSETS_ACCOUNTS,
           borrowedTronNode: sharedTronNode,
           fixtures: buildTronAssetsFixture().build(),
           manifestFlags: TRON_ASSETS_MANIFEST_FLAGS,
@@ -151,7 +161,7 @@ describe('Tron - Assets', function (this: Suite) {
     });
   });
 
-  it('For an empty account, TRX should be present with a balance of 0', async function () {
+  it('empty account lists TRX with balance 0', async function () {
     await returnToTronHome(driver);
 
     const tokensTab = new TokensTab(driver);
@@ -164,6 +174,15 @@ describe('Tron - Assets', function (this: Suite) {
       '0 TRX',
       '$',
     ]);
+  });
+
+  it('funded account shows 106.072 TRX as the main balance', async function () {
+    await switchToFundedTronAccount(driver);
+    const homePage = new HomePage(driver);
+    await homePage.checkExpectedBalanceIsDisplayed({
+      expectedBalance: '106.072 TRX',
+      timeout: HOMEPAGE_BALANCE_ASSERTION_TIMEOUT_MS,
+    });
   });
 
   it('Portfolio account shows native TRX as the main balance', async function () {
@@ -181,6 +200,15 @@ describe('Tron - Assets', function (this: Suite) {
     await homePage.checkPageIsLoaded();
     await homePage.checkExpectedBalanceIsDisplayed({
       expectedBalance: '$10.18',
+      timeout: HOMEPAGE_BALANCE_ASSERTION_TIMEOUT_MS,
+    });
+  });
+
+  it('funded account shows $39.65 as the main balance when native token is disabled', async function () {
+    await switchToFundedTronAccount(driver);
+    const homePage = new HomePage(driver);
+    await homePage.checkExpectedBalanceIsDisplayed({
+      expectedBalance: '$39.65',
       timeout: HOMEPAGE_BALANCE_ASSERTION_TIMEOUT_MS,
     });
   });

--- a/test/e2e/tests/tron/fixtures/environments.ts
+++ b/test/e2e/tests/tron/fixtures/environments.ts
@@ -1,4 +1,8 @@
-import { TRON_ACCOUNT_ADDRESS, TRX_TO_USD_RATE } from '../mocks/common-tron';
+import {
+  TRON_ACCOUNT_ADDRESS,
+  TRX_BALANCE,
+  TRX_TO_USD_RATE,
+} from '../mocks/common-tron';
 import { TronFixtureAccount } from './with-tron-fixtures';
 import { GAS_FREE, HTX, SEED, TRX, USDD, USDT } from './tokens';
 
@@ -43,6 +47,19 @@ export const TRON_PORTFOLIO_ACCOUNT: TronFixtureAccount = {
     { ...USDD, balance: '289757448699320931', priceUsd: 0.999959 },
     { ...USDT, balance: '2804595', priceUsd: 0.999176 },
   ],
+};
+
+/**
+ * Funded Account 1 profile from the former check-balance spec (`mockTronApis`).
+ * Header expectations: `106.072 TRX` with native-as-main on, `$39.65` with it off.
+ */
+export const TRON_CHECK_BALANCE_ACCOUNT: TronFixtureAccount = {
+  address: TRON_ACCOUNT_ADDRESS,
+  assets: TRON_PORTFOLIO_ACCOUNT.assets.map((asset) =>
+    asset.type === 'native'
+      ? { ...asset, balance: TRX_BALANCE }
+      : { ...asset },
+  ),
 };
 
 export const TRON_LOW_TRX_WITH_USDT_ACCOUNT: TronFixtureAccount = {

--- a/test/e2e/tests/tron/swap.spec.ts
+++ b/test/e2e/tests/tron/swap.spec.ts
@@ -1,4 +1,3 @@
-import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import {
@@ -89,7 +88,7 @@ describe('Swap on Tron', function (this: Suite) {
     });
 
     it('Quote displayed for USDT to TRX swap (reverse direction)', async function () {
-      await returnToTronHome(driver);
+      await returnToTronHome(driver, '106.07');
       const homePage = new HomePage(driver);
       const swapPage = new SwapPage(driver);
       await homePage.clickOnSwapButton();
@@ -103,12 +102,11 @@ describe('Swap on Tron', function (this: Suite) {
       await swapPage.checkQuoteIsDisplayed();
       await swapPage.checkSourceToken('USDT');
       await swapPage.checkDestinationToken('TRX');
-      assert.notEqual(await swapPage.getFromAmountValue(), '');
-      assert.notEqual(await swapPage.getToAmountValue(), '');
+      await swapPage.checkSwapAmountsArePopulated();
     });
 
     it('Amount exceeding balance shows insufficient funds', async function () {
-      await returnToTronHome(driver);
+      await returnToTronHome(driver, '106.07');
       const homePage = new HomePage(driver);
       const swapPage = new SwapPage(driver);
       await homePage.clickOnSwapButton();
@@ -122,7 +120,7 @@ describe('Swap on Tron', function (this: Suite) {
     });
 
     it('Quote updates when selecting different destination token', async function () {
-      await returnToTronHome(driver);
+      await returnToTronHome(driver, '106.07');
       const homePage = new HomePage(driver);
       const swapPage = new SwapPage(driver);
       await homePage.clickOnSwapButton();
@@ -142,7 +140,7 @@ describe('Swap on Tron', function (this: Suite) {
     });
 
     it('Swap form shows default token on open', async function () {
-      await returnToTronHome(driver);
+      await returnToTronHome(driver, '106.07');
       const homePage = new HomePage(driver);
       const swapPage = new SwapPage(driver);
       await homePage.clickOnSwapButton();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Follow-up to #45355 review items **1, 4, 6, 7, and 8**. These cases belong in the shared Tron Assets spec so Account 1 can stay empty while the former check-balance header amounts still exist.

1. Renamed the empty-account asset list test so the title does not use `should`.
4. Restored `106.072 TRX` and `$39.65` homepage header coverage on **Account 3** (`TRON_CHECK_BALANCE_ACCOUNT`, native `TRX_BALANCE`). Native-as-main stays on for the TRX header, then the existing settings toggle turns it off for the fiat header.
6. Moved `returnToTronHome` into `test/e2e/page-objects/flows/tron-home.flow.ts` and re-exported it from the Tron asset and swap flows.
7. Added `SwapPage.checkSwapAmountsArePopulated()` so quote amount checks wait until both fields are non-empty instead of racing `getText` / `getAttribute`.
8. Account switches wait for the Tokens tab `Tron` row instead of calling `reloadHome()`. `reloadHome()` remains as a last-resort helper.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Stacked on #45355 (`ulissesferreira/tron-shared-fixtures`).

<!--
Fixes:
-->

## **Manual testing steps**

1. Run the extension from this branch.
2. Open the homepage Tokens tab on Tron.
3. Use an empty Tron account and confirm the list shows TRX with amount `0`.
4. Switch to a funded Tron account with `106.072 TRX` and confirm the homepage header shows `106.072 TRX` while native token as main balance is enabled.
5. Disable native token as main balance and confirm the same funded account header shows `$39.65`.
6. Open Swap, wait for a quote, and confirm from/to amounts stay populated without a page reload.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d38e8a89-acc0-4996-a99b-2e360b587aef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d38e8a89-acc0-4996-a99b-2e360b587aef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

