### PR TITLE
test: add page parent selectors for perps

### DIFF
--- a/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
+++ b/test/e2e/page-objects/flows/perps-activity-close-fill.flow.ts
@@ -30,10 +30,7 @@ export async function assertPerpsActivityShowsCloseFill({
   await marketDetailPage.clickBack();
 
   const marketListPage = new PerpsMarketListPage(driver);
-  const onMarketList = await driver.isElementPresentAndVisible(
-    { testId: 'market-list-view' },
-    2000,
-  );
+  const onMarketList = await marketListPage.isPageLoaded();
   if (onMarketList) {
     await marketListPage.clickBack();
   }

--- a/test/e2e/page-objects/pages/perps/perps-activity-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-activity-page.ts
@@ -27,16 +27,18 @@ export class PerpsActivityPage {
     };
   };
 
-  private readonly activityPage = { testId: 'perps-activity-page' };
-
   private readonly anyTransactionCard = {
     xpath:
-      "//*[@data-testid='perps-activity-page']//*[starts-with(@data-testid,'transaction-card-')]",
+      "//*[@data-testid='parent-selector-perps-activity']//*[starts-with(@data-testid,'transaction-card-')]",
   };
 
   private readonly driver: Driver;
 
   private readonly filterButton = { testId: 'perps-activity-filter-button' };
+
+  private readonly parentSelector = {
+    testId: 'parent-selector-perps-activity',
+  };
 
   constructor(driver: Driver) {
     this.driver = driver;
@@ -46,7 +48,7 @@ export class PerpsActivityPage {
    * Waits for the Perps Activity page to be loaded.
    */
   async checkPageIsLoaded(): Promise<void> {
-    await this.driver.waitForSelector(this.activityPage);
+    await this.driver.waitForSelector(this.parentSelector);
   }
 
   /**
@@ -90,7 +92,7 @@ export class PerpsActivityPage {
    */
   async waitForActivityTradeTitleContaining(fragment: string): Promise<void> {
     await this.driver.waitForSelector({
-      xpath: `//*[@data-testid='perps-activity-page']//*[contains(normalize-space(.), "${fragment}")]`,
+      xpath: `//*[@data-testid='parent-selector-perps-activity']//*[contains(normalize-space(.), "${fragment}")]`,
     });
   }
 

--- a/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
@@ -108,8 +108,6 @@ export class PerpsMarketDetailPage {
     testId: 'perps-market-detail-back-button',
   };
 
-  private readonly marketDetailPage = { testId: 'perps-market-detail-page' };
-
   private readonly modifyCtaButton = { testId: 'perps-modify-cta-button' };
 
   private readonly modifyMenu = { testId: 'perps-modify-menu' };
@@ -127,6 +125,10 @@ export class PerpsMarketDetailPage {
   };
 
   private readonly orderEntry = { testId: 'order-entry' };
+
+  private readonly parentSelector = {
+    testId: 'parent-selector-perps-market-detail',
+  };
 
   private static readonly perpsClosePositionModalTestId =
     'perps-close-position-modal';
@@ -248,7 +250,7 @@ export class PerpsMarketDetailPage {
   async checkPageIsLoaded(): Promise<void> {
     await this.driver.waitForMultipleSelectors([
       this.marketDetailBackButton,
-      this.marketDetailPage,
+      this.parentSelector,
     ]);
   }
 

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -104,17 +104,8 @@ export class PerpsMarketListPage {
     return { testId: `filter-select-option-${optionId}` };
   }
 
-  /**
-   * Checks whether the Perps Market List page is visible.
-   *
-   * @param timeout - Maximum time in milliseconds to wait for the page.
-   * @returns Whether the page is present and visible.
-   */
   async isPageLoaded(timeout = 2000): Promise<boolean> {
-    return this.driver.isElementPresentAndVisible(
-      this.parentSelector,
-      timeout,
-    );
+    return this.driver.isElementPresentAndVisible(this.parentSelector, timeout);
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -33,10 +33,12 @@ export class PerpsMarketListPage {
 
   private readonly headerBackButton = { testId: 'back-button' };
 
-  private readonly marketListView = { testId: 'market-list-view' };
-
   private readonly marketRow = {
     xpath: "//*[starts-with(@data-testid,'market-row-')]",
+  };
+
+  private readonly parentSelector = {
+    testId: 'parent-selector-perps-market-list',
   };
 
   /**
@@ -72,7 +74,7 @@ export class PerpsMarketListPage {
   async checkPageIsLoaded(): Promise<void> {
     await this.driver.waitForMultipleSelectors([
       this.filterSortRow,
-      this.marketListView,
+      this.parentSelector,
     ]);
   }
 
@@ -100,6 +102,19 @@ export class PerpsMarketListPage {
    */
   private getFilterOptionSelector(optionId: string): { testId: string } {
     return { testId: `filter-select-option-${optionId}` };
+  }
+
+  /**
+   * Checks whether the Perps Market List page is visible.
+   *
+   * @param timeout - Maximum time in milliseconds to wait for the page.
+   * @returns Whether the page is present and visible.
+   */
+  async isPageLoaded(timeout = 2000): Promise<boolean> {
+    return this.driver.isElementPresentAndVisible(
+      this.parentSelector,
+      timeout,
+    );
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-order-entry-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-order-entry-page.ts
@@ -38,23 +38,25 @@ export class PerpsOrderEntryPage {
 
   private readonly limitPriceInput = '[data-testid="limit-price-input"] input';
 
-  private readonly orderEntryPage = { testId: 'perps-order-entry-page' };
-
   private readonly orderSubmitError = { testId: 'perps-order-submit-error' };
 
   private readonly orderTypeLimitButton = { testId: 'order-type-limit' };
 
   private readonly orderTypeMarketButton = { testId: 'order-type-market' };
 
+  private readonly parentSelector = {
+    testId: 'parent-selector-perps-order-entry',
+  };
+
   private readonly slPriceInput =
-    '[data-testid="perps-order-entry-page"] [data-testid="sl-price-input"]';
+    '[data-testid="parent-selector-perps-order-entry"] [data-testid="sl-price-input"]';
 
   private readonly slValidationError = { testId: 'sl-validation-error' };
 
   private readonly submitOrderButton = { testId: 'submit-order-button' };
 
   private readonly tpPriceInput =
-    '[data-testid="perps-order-entry-page"] [data-testid="tp-price-input"]';
+    '[data-testid="parent-selector-perps-order-entry"] [data-testid="tp-price-input"]';
 
   private readonly tpValidationError = { testId: 'tp-validation-error' };
 
@@ -70,7 +72,7 @@ export class PerpsOrderEntryPage {
    */
   async checkPageIsLoaded(options?: { timeout?: number }): Promise<void> {
     await this.driver.waitForMultipleSelectors(
-      [this.orderEntryPage, this.submitOrderButton],
+      [this.parentSelector, this.submitOrderButton],
       {
         timeout: options?.timeout ?? 20000,
       },
@@ -204,7 +206,7 @@ export class PerpsOrderEntryPage {
    * @param timeout - Max wait in ms (default 15_000).
    */
   async waitForPageClosed(timeout = 15000): Promise<void> {
-    await this.driver.assertElementNotPresent(this.orderEntryPage, { timeout });
+    await this.driver.assertElementNotPresent(this.parentSelector, { timeout });
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-withdraw-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-withdraw-page.ts
@@ -25,6 +25,10 @@ export class PerpsWithdrawPage {
 
   private readonly headerTitle = { testId: 'perps-withdraw-header-title' };
 
+  private readonly parentSelector = {
+    testId: 'parent-selector-perps-withdraw',
+  };
+
   private readonly submitButton = { testId: 'perps-withdraw-submit' };
 
   private readonly summaryAssetRow = { testId: 'perps-withdraw-summary-asset' };
@@ -37,10 +41,8 @@ export class PerpsWithdrawPage {
 
   private readonly summaryTimeRow = { testId: 'perps-withdraw-summary-time' };
 
-  private readonly withdrawPage = { testId: 'perps-withdraw-page' };
-
   private readonly withdrawPageChildren =
-    '[data-testid="perps-withdraw-page"] *';
+    '[data-testid="parent-selector-perps-withdraw"] *';
 
   private readonly withdrawToast = { testId: 'perps-withdraw-toast' };
 
@@ -62,7 +64,7 @@ export class PerpsWithdrawPage {
    */
   async checkPageIsLoaded(): Promise<void> {
     await this.driver.waitForMultipleSelectors([
-      this.withdrawPage,
+      this.parentSelector,
       this.headerTitle,
     ]);
   }

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -68,7 +68,9 @@ describe('MarketListView', () => {
     it('renders the market list view', () => {
       renderWithProvider(<MarketListView />, mockStore);
 
-      expect(screen.getByTestId('market-list-view')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('parent-selector-perps-market-list'),
+      ).toBeInTheDocument();
     });
 
     it('displays search input', () => {

--- a/ui/pages/perps/market-list/index.tsx
+++ b/ui/pages/perps/market-list/index.tsx
@@ -601,7 +601,7 @@ export const MarketListView = () => {
     <Box
       className="flex h-full flex-col bg-background-default"
       flexDirection={BoxFlexDirection.Column}
-      data-testid="market-list-view"
+      data-testid="parent-selector-perps-market-list"
     >
       {/* Header */}
       <Box

--- a/ui/pages/perps/perps-activity-page.test.tsx
+++ b/ui/pages/perps/perps-activity-page.test.tsx
@@ -72,7 +72,9 @@ describe('PerpsActivityPage', () => {
   it('renders with correct data-testid', () => {
     renderWithProvider(<PerpsActivityPage />, createMockStore());
 
-    expect(screen.getByTestId('perps-activity-page')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('parent-selector-perps-activity'),
+    ).toBeInTheDocument();
   });
 
   it('displays all four filter options', () => {

--- a/ui/pages/perps/perps-activity-page.tsx
+++ b/ui/pages/perps/perps-activity-page.tsx
@@ -167,7 +167,7 @@ const PerpsActivityPage = () => {
   }
 
   return (
-    <Page data-testid="perps-activity-page">
+    <Page data-testid="parent-selector-perps-activity">
       <Header
         startAccessory={
           <ButtonIcon

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -593,7 +593,9 @@ describe('PerpsMarketDetailPage', () => {
 
       const { getByTestId } = await renderPage(store);
 
-      expect(getByTestId('perps-market-detail-page')).toBeInTheDocument();
+      expect(
+        getByTestId('parent-selector-perps-market-detail'),
+      ).toBeInTheDocument();
       expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
         'perpsActivatePriceStream',
         [{ symbols: ['ETH'], includeMarketData: true }],
@@ -882,7 +884,9 @@ describe('PerpsMarketDetailPage', () => {
 
       const { getByTestId } = await renderPage(store);
 
-      expect(getByTestId('perps-market-detail-page')).toBeInTheDocument();
+      expect(
+        getByTestId('parent-selector-perps-market-detail'),
+      ).toBeInTheDocument();
       expect(getByTestId('perps-market-detail-name')).toHaveTextContent(
         'Bitcoin',
       );
@@ -1109,7 +1113,9 @@ describe('PerpsMarketDetailPage', () => {
 
       const { getByTestId } = await renderPage(store);
 
-      expect(getByTestId('perps-market-detail-page')).toBeInTheDocument();
+      expect(
+        getByTestId('parent-selector-perps-market-detail'),
+      ).toBeInTheDocument();
       // Should display the full name and the ticker-collateral pair (stripped display name)
       expect(getByTestId('perps-market-detail-name')).toHaveTextContent(
         'Tesla',

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -1172,7 +1172,7 @@ const PerpsMarketDetailPage = () => {
   return (
     <Box
       className="main-container asset__container"
-      data-testid="perps-market-detail-page"
+      data-testid="parent-selector-perps-market-detail"
     >
       {/* Header */}
       <Box

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -571,7 +571,9 @@ describe('PerpsOrderEntryPage', () => {
       const store = mockStore(createMockState());
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
-      expect(screen.getByTestId('perps-order-entry-page')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('parent-selector-perps-order-entry'),
+      ).toBeInTheDocument();
       expect(screen.getByTestId('order-entry')).toBeInTheDocument();
     });
 
@@ -1210,7 +1212,7 @@ describe('PerpsOrderEntryPage', () => {
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       expect(
-        screen.queryByTestId('perps-order-entry-page'),
+        screen.queryByTestId('parent-selector-perps-order-entry'),
       ).not.toBeInTheDocument();
     });
 
@@ -1226,7 +1228,7 @@ describe('PerpsOrderEntryPage', () => {
         screen.queryByText(messages.perpsMarketNotFound.message),
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByTestId('perps-order-entry-page'),
+        screen.queryByTestId('parent-selector-perps-order-entry'),
       ).not.toBeInTheDocument();
     });
 
@@ -3324,7 +3326,9 @@ describe('PerpsOrderEntryPage', () => {
       const store = mockStore(createMockState());
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
-      expect(screen.getByTestId('perps-order-entry-page')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('parent-selector-perps-order-entry'),
+      ).toBeInTheDocument();
     });
   });
 
@@ -3381,7 +3385,9 @@ describe('PerpsOrderEntryPage', () => {
         ]);
       });
 
-      expect(screen.getByTestId('perps-order-entry-page')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('parent-selector-perps-order-entry'),
+      ).toBeInTheDocument();
     });
 
     it('preserves missing markPrice when absent from the stream update', async () => {
@@ -3401,7 +3407,9 @@ describe('PerpsOrderEntryPage', () => {
         ]);
       });
 
-      expect(screen.getByTestId('perps-order-entry-page')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('parent-selector-perps-order-entry'),
+      ).toBeInTheDocument();
     });
 
     it('ignores price updates for other symbols', async () => {
@@ -3418,7 +3426,9 @@ describe('PerpsOrderEntryPage', () => {
         ]);
       });
 
-      expect(screen.getByTestId('perps-order-entry-page')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('parent-selector-perps-order-entry'),
+      ).toBeInTheDocument();
     });
 
     it('processes order book updates from subscribeToOrderBook callback', async () => {
@@ -3437,7 +3447,9 @@ describe('PerpsOrderEntryPage', () => {
         });
       });
 
-      expect(screen.getByTestId('perps-order-entry-page')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('parent-selector-perps-order-entry'),
+      ).toBeInTheDocument();
     });
 
     it('ignores empty order book updates', async () => {
@@ -3456,7 +3468,9 @@ describe('PerpsOrderEntryPage', () => {
         });
       });
 
-      expect(screen.getByTestId('perps-order-entry-page')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('parent-selector-perps-order-entry'),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -2274,7 +2274,7 @@ const PerpsOrderEntryPage = () => {
   return (
     <form
       className="main-container asset__container relative overflow-hidden"
-      data-testid="perps-order-entry-page"
+      data-testid="parent-selector-perps-order-entry"
       onSubmit={handleFormSubmit}
     >
       <OrderEntryHeader

--- a/ui/pages/perps/perps-withdraw-page.test.tsx
+++ b/ui/pages/perps/perps-withdraw-page.test.tsx
@@ -307,7 +307,9 @@ describe('PerpsWithdrawPage', () => {
 
     await settleInitialWithdrawRoutesFetch();
 
-    expect(screen.getByTestId('perps-withdraw-page')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('parent-selector-perps-withdraw'),
+    ).toBeInTheDocument();
     expect(screen.getByTestId('perps-withdraw-cancel')).toBeInTheDocument();
     expect(screen.getByTestId('perps-withdraw-submit')).toBeInTheDocument();
     expect(
@@ -1252,7 +1254,9 @@ describe('PerpsWithdrawPage', () => {
     });
     await flushRejectedWithdrawRoutesPromises();
 
-    expect(screen.getByTestId('perps-withdraw-page')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('parent-selector-perps-withdraw'),
+    ).toBeInTheDocument();
   });
 
   describe('analytics', () => {

--- a/ui/pages/perps/perps-withdraw-page.tsx
+++ b/ui/pages/perps/perps-withdraw-page.tsx
@@ -570,7 +570,7 @@ const PerpsWithdrawPage = () => {
   const amountHasAlert = Boolean(validationMessage);
 
   return (
-    <Page data-testid="perps-withdraw-page">
+    <Page data-testid="parent-selector-perps-withdraw">
       <Box
         alignItems={BoxAlignItems.Center}
         className="bg-background-default"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds stable parent selectors to Perps pages 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/MMQA-2251

## **Manual testing steps**

CI should pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and `data-testid` attribute renames with no production behavior changes; any external automation still targeting the old IDs would need updating.
> 
> **Overview**
> **Standardizes Perps screen boundaries for automation** by replacing page-specific root `data-testid`s (e.g. `market-list-view`, `perps-activity-page`, `perps-order-entry-page`) with a shared `parent-selector-perps-*` naming pattern on six Perps UI routes.
> 
> **E2E page objects** now anchor waits, XPath scoping, and “page closed” checks on those parent selectors instead of the old IDs. The close-fill flow uses `PerpsMarketListPage.isPageLoaded()` rather than inlining a raw `market-list-view` visibility check.
> 
> **Unit tests** for the affected pages assert the new parent selector test IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cace89a05bfa636d157fb630662cdaa5ebb0d44e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->