### PR TITLE
test: fix flaky test Tron send wait for submitted toast before Activity

### DIFF
--- a/test/e2e/page-objects/flows/tron-send.flow.ts
+++ b/test/e2e/page-objects/flows/tron-send.flow.ts
@@ -1,5 +1,6 @@
 import { WINDOW_TITLES } from '../../constants';
 import { Driver } from '../../webdriver/driver';
+import { TxToastNotification } from '../components/tx-toast-notification';
 import SnapTransactionConfirmation from '../pages/confirmations/snap-transaction-confirmation';
 import ActivityTab from '../pages/home/activity-tab';
 import HomePage from '../pages/home/homepage';
@@ -109,8 +110,10 @@ export async function confirmTronSendAndAssertActivity({
     await snapConfirmation.clickFooterConfirmButton();
   }
 
+  const txToast = new TxToastNotification(driver);
+  await txToast.checkTxSubmittedToast();
+
   const homePage = new HomePage(driver);
-  // Same mitigation as BTC Bug #43641: confirm may leave Assets/Home selected.
   await homePage.goToActivityList();
 
   const activityList = new ActivityTab(driver);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark this PR as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Stabilizes Tron send E2E after Confirm by waiting for the submitted toast before opening Activity.

**Root cause:**

- The test confirms a Tron send, then opens Activity to check the transaction.
- Confirm returns as soon as the Confirm button is gone. The send is still broadcasting.
- The test then clicks Activity. The URL becomes Activity for a moment.
- When the send finishes, the wallet navigates to Home with a "Transaction submitted" toast. That overwrites Activity.
- The test then waits for a transaction row (`data-tx-status`) on Activity.
- Home is still on screen (token list, Home tab selected), so the wait times out.
- With classic in-page tabs, Activity shares the Home screen, so the same test often passed.

**Solution:**

- After Confirm, wait for the "Transaction submitted" toast (`checkTxSubmittedToast`) so the send has finished and the wallet has already navigated to Home.
- Then click Activity once (`goToActivityList`) so the Activity list is on screen and cannot be overwritten by that late Home navigation.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Start a test build: `yarn start:test`
2. Run:

```
SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/tron/send.spec.ts --debug --leave-running
```

3. After Confirm, expect the "Transaction submitted" toast, then Activity, with a confirmed send row.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/contributor-docs/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only E2E flow change with no production code impact.
> 
> **Overview**
> **Stabilizes Tron send E2E** by synchronizing on the post-confirm UI before opening Activity.
> 
> In `confirmTronSendAndAssertActivity`, the flow now uses `TxToastNotification.checkTxSubmittedToast()` immediately after confirm (same pattern as `bitcoin-send.flow.ts`). That waits until the send has finished and the wallet has navigated to Home with the submitted toast, so a subsequent `goToActivityList()` is not overwritten by late navigation.
> 
> Also drops an inline comment that referenced the BTC #43641 Home-vs-Activity workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef737ac256ab67eb35484b78d49ec8a6fa74196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->