### PR TITLE
feat(enforced-simulations): always native caveat cp-13.45.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1351,7 +1351,7 @@
     "message": "Added"
   },
   "addedProtectionDescription": {
-    "message": "You're interacting with an unknown address. This helps prevent malicious transactions."
+    "message": "Because you're interacting with an unknown address, protection can prevent some malicious transactions."
   },
   "addedProtectionIncludesNetworkFee": {
     "message": "Includes $1 for added protection",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1351,7 +1351,7 @@
     "message": "Added"
   },
   "addedProtectionDescription": {
-    "message": "You're interacting with an unknown address. This helps prevent malicious transactions."
+    "message": "Because you're interacting with an unknown address, protection can prevent some malicious transactions."
   },
   "addedProtectionIncludesNetworkFee": {
     "message": "Includes $1 for added protection",

--- a/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
@@ -12,6 +12,10 @@ import {
 } from '@metamask/messenger';
 import { cloneDeep } from 'lodash';
 import { DELEGATOR_CONTRACTS } from '@metamask/delegation-deployments';
+import {
+  BalanceChangeType,
+  createNativeBalanceChangeTerms,
+} from '@metamask/delegation-core';
 import { Hex, remove0x } from '@metamask/utils';
 import { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
 import { toHex } from '@metamask/controller-utils';
@@ -326,6 +330,16 @@ describe('Enforced Simulations Utils', () => {
           ).toLowerCase(),
         ),
       );
+
+      const expectedTerms = createNativeBalanceChangeTerms({
+        recipient: TX_PARAMS_MOCK.from as Hex,
+        balance: 1n,
+        changeType: BalanceChangeType.Decrease,
+      });
+
+      expect(newTransaction.txParams.data).toStrictEqual(
+        expect.stringContaining(remove0x(expectedTerms).toLowerCase()),
+      );
     });
 
     it('adds a no-decrease native caveat when simulation data is missing', async () => {
@@ -346,6 +360,16 @@ describe('Enforced Simulations Utils', () => {
             DELEGATOR_CONTRACTS['1.3.0']['1'].NativeBalanceChangeEnforcer,
           ).toLowerCase(),
         ),
+      );
+
+      const expectedTerms = createNativeBalanceChangeTerms({
+        recipient: TX_PARAMS_MOCK.from as Hex,
+        balance: 1n,
+        changeType: BalanceChangeType.Decrease,
+      });
+
+      expect(newTransaction.txParams.data).toStrictEqual(
+        expect.stringContaining(remove0x(expectedTerms).toLowerCase()),
       );
     });
 

--- a/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
@@ -305,30 +305,48 @@ describe('Enforced Simulations Utils', () => {
       );
     });
 
-    it('throws when no caveats can be generated', async () => {
+    it('adds a no-decrease native caveat when simulationData has no native balance change', async () => {
       const transactionMeta = cloneDeep(TRANSACTION_META_MOCK);
       transactionMeta.simulationData = {
         tokenBalanceChanges: [],
       };
 
-      await expect(
-        enforceSimulations({
-          ...options,
-          transactionMeta,
-        }),
-      ).rejects.toThrow('No caveats generated for enforced simulations');
+      const { updateTransaction } = await enforceSimulations({
+        ...options,
+        transactionMeta,
+      });
+
+      const newTransaction = cloneDeep(TRANSACTION_META_MOCK);
+      updateTransaction?.(newTransaction);
+
+      expect(newTransaction.txParams.data).toStrictEqual(
+        expect.stringContaining(
+          remove0x(
+            DELEGATOR_CONTRACTS['1.3.0']['1'].NativeBalanceChangeEnforcer,
+          ).toLowerCase(),
+        ),
+      );
     });
 
-    it('throws when simulation data is missing', async () => {
+    it('adds a no-decrease native caveat when simulation data is missing', async () => {
       const transactionMeta = cloneDeep(TRANSACTION_META_MOCK);
       transactionMeta.simulationData = undefined;
 
-      await expect(
-        enforceSimulations({
-          ...options,
-          transactionMeta,
-        }),
-      ).rejects.toThrow('No caveats generated for enforced simulations');
+      const { updateTransaction } = await enforceSimulations({
+        ...options,
+        transactionMeta,
+      });
+
+      const newTransaction = cloneDeep(TRANSACTION_META_MOCK);
+      updateTransaction?.(newTransaction);
+
+      expect(newTransaction.txParams.data).toStrictEqual(
+        expect.stringContaining(
+          remove0x(
+            DELEGATOR_CONTRACTS['1.3.0']['1'].NativeBalanceChangeEnforcer,
+          ).toLowerCase(),
+        ),
+      );
     });
 
     describe('applies slippage', () => {

--- a/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
@@ -12,10 +12,6 @@ import {
 } from '@metamask/messenger';
 import { cloneDeep } from 'lodash';
 import { DELEGATOR_CONTRACTS } from '@metamask/delegation-deployments';
-import {
-  BalanceChangeType,
-  createNativeBalanceChangeTerms,
-} from '@metamask/delegation-core';
 import { Hex, remove0x } from '@metamask/utils';
 import { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
 import { toHex } from '@metamask/controller-utils';
@@ -47,6 +43,11 @@ const TX_PARAMS_MOCK: TransactionParams = {
 
 const DELEGATION_ADDRESS_MOCK =
   '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B' as Hex;
+
+// Expected `NativeBalanceChangeEnforcer` terms for a zero-tolerance decrease:
+// `0x01` (enforceDecrease) + recipient (from) + 32 zero bytes (amount = 0).
+const NO_NATIVE_DECREASE_TERMS_MOCK =
+  `0x01${remove0x(TX_PARAMS_MOCK.from as Hex)}${'00'.repeat(32)}`.toLowerCase() as Hex;
 
 const TRANSACTION_META_MOCK: TransactionMeta = {
   chainId: CHAIN_ID_MOCK,
@@ -331,14 +332,8 @@ describe('Enforced Simulations Utils', () => {
         ),
       );
 
-      const expectedTerms = createNativeBalanceChangeTerms({
-        recipient: TX_PARAMS_MOCK.from as Hex,
-        balance: 1n,
-        changeType: BalanceChangeType.Decrease,
-      });
-
       expect(newTransaction.txParams.data).toStrictEqual(
-        expect.stringContaining(remove0x(expectedTerms).toLowerCase()),
+        expect.stringContaining(remove0x(NO_NATIVE_DECREASE_TERMS_MOCK)),
       );
     });
 
@@ -362,14 +357,8 @@ describe('Enforced Simulations Utils', () => {
         ),
       );
 
-      const expectedTerms = createNativeBalanceChangeTerms({
-        recipient: TX_PARAMS_MOCK.from as Hex,
-        balance: 1n,
-        changeType: BalanceChangeType.Decrease,
-      });
-
       expect(newTransaction.txParams.data).toStrictEqual(
-        expect.stringContaining(remove0x(expectedTerms).toLowerCase()),
+        expect.stringContaining(remove0x(NO_NATIVE_DECREASE_TERMS_MOCK)),
       );
     });
 

--- a/app/scripts/lib/transaction/containers/enforced-simulations.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.ts
@@ -145,7 +145,7 @@ function generateCaveats(
       terms: createNativeBalanceChangeTerms({
         recipient,
         balance: 1n,
-        changeType: BalanceChangeType.Increase,
+        changeType: BalanceChangeType.Decrease,
       }),
       args,
     });
@@ -229,6 +229,7 @@ function generateCaveats(
     }
   }
 
+  // Defensive invariant — unreachable since a native caveat is always emitted above
   if (caveats.length === 0) {
     throw new Error('No caveats generated for enforced simulations');
   }

--- a/app/scripts/lib/transaction/containers/enforced-simulations.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.ts
@@ -137,6 +137,18 @@ function generateCaveats(
       }),
       args,
     });
+  } else {
+    log('Caveat - Native Balance Change - Enforce No Decrease', { recipient });
+
+    caveats.push({
+      enforcer: environment.caveatEnforcers.NativeBalanceChangeEnforcer,
+      terms: createNativeBalanceChangeTerms({
+        recipient,
+        balance: 1n,
+        changeType: BalanceChangeType.Increase,
+      }),
+      args,
+    });
   }
 
   for (const tokenChange of tokenBalanceChanges) {

--- a/app/scripts/lib/transaction/containers/enforced-simulations.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.ts
@@ -3,7 +3,14 @@ import {
   SimulationTokenStandard,
   TransactionMeta,
 } from '@metamask/transaction-controller';
-import { Hex, createProjectLogger, hexToNumber } from '@metamask/utils';
+import {
+  Hex,
+  bytesToHex,
+  concatBytes,
+  createProjectLogger,
+  hexToBytes,
+  hexToNumber,
+} from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 import {
   createERC1155BalanceChangeTerms,
@@ -142,11 +149,13 @@ function generateCaveats(
 
     caveats.push({
       enforcer: environment.caveatEnforcers.NativeBalanceChangeEnforcer,
-      terms: createNativeBalanceChangeTerms({
-        recipient,
-        balance: 1n,
-        changeType: BalanceChangeType.Decrease,
-      }),
+      // Enforce that the native balance does not decrease at all (zero
+      // tolerance). The `NativeBalanceChangeEnforcer` contract checks
+      // `after >= before - amount`, so an amount of `0` requires
+      // `after >= before`. We encode the 53-byte terms directly because
+      // `createNativeBalanceChangeTerms` rejects a zero balance, even though
+      // the on-chain enforcer accepts it.
+      terms: createNoNativeBalanceDecreaseTerms(recipient),
       args,
     });
   }
@@ -235,6 +244,32 @@ function generateCaveats(
   }
 
   return caveats;
+}
+
+/**
+ * Encodes `NativeBalanceChangeEnforcer` terms that forbid any decrease in the
+ * recipient's native balance.
+ *
+ * The terms are 53 packed bytes (per the on-chain enforcer):
+ * byte 0 is the `enforceDecrease` flag (`0x01` = decrease), bytes 1-20 are the
+ * recipient address, and bytes 21-52 are the guardrail amount (here `0`, so the
+ * balance must not decrease at all: `after >= before - 0`).
+ *
+ * We encode these terms directly rather than via
+ * `createNativeBalanceChangeTerms` because that helper rejects a zero balance,
+ * even though the on-chain enforcer treats a zero amount as valid.
+ *
+ * @param recipient - The address whose native balance must not decrease.
+ * @returns The 53-byte hex-encoded enforcer terms.
+ */
+function createNoNativeBalanceDecreaseTerms(recipient: Hex): Hex {
+  const enforceDecreaseByte = new Uint8Array([1]);
+  const recipientBytes = hexToBytes(recipient);
+  const amountBytes = new Uint8Array(32);
+
+  return bytesToHex(
+    concatBytes([enforceDecreaseByte, recipientBytes, amountBytes]),
+  );
 }
 
 function getBalanceChangeType(enforceDecrease: boolean): BalanceChangeType {

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -219,13 +219,13 @@ describe('enforced-simulations', () => {
       ).toBe(true);
     });
 
-    it('returns true when simulation data is undefined', () => {
+    it('returns false when simulation data is not yet loaded', () => {
       expect(
         isEnforcedSimulationsEligible(
           { ...BASE_TRANSACTION_META, simulationData: undefined },
           buildState(ResultType.Benign),
         ),
-      ).toBe(true);
+      ).toBe(false);
     });
 
     it('returns true when simulation data has no balance changes', () => {

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -177,7 +177,7 @@ describe('enforced-simulations', () => {
           ).toBe(false);
         });
 
-        it('returns false when there are no balance changes', () => {
+        it('returns true when there are no balance changes', () => {
           expect(
             isEnforcedSimulationsEligible(
               {
@@ -187,7 +187,7 @@ describe('enforced-simulations', () => {
               },
               buildState(ResultType.Benign),
             ),
-          ).toBe(false);
+          ).toBe(true);
         });
 
         it('returns false when the recipient is trusted', () => {
@@ -219,16 +219,16 @@ describe('enforced-simulations', () => {
       ).toBe(true);
     });
 
-    it('returns false when simulation data is undefined', () => {
+    it('returns true when simulation data is undefined', () => {
       expect(
         isEnforcedSimulationsEligible(
           { ...BASE_TRANSACTION_META, simulationData: undefined },
           buildState(ResultType.Benign),
         ),
-      ).toBe(false);
+      ).toBe(true);
     });
 
-    it('returns false when simulation data has no balance changes', () => {
+    it('returns true when simulation data has no balance changes', () => {
       expect(
         isEnforcedSimulationsEligible(
           {
@@ -237,7 +237,7 @@ describe('enforced-simulations', () => {
           },
           buildState(ResultType.Benign),
         ),
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('returns true when simulation data has only token balance changes', () => {
@@ -947,7 +947,7 @@ describe('enforced-simulations', () => {
         ).toBe(true);
       });
 
-      it('still returns false when there are no balance changes', () => {
+      it('returns true even when there are no balance changes', () => {
         expect(
           isEnforcedSimulationsEligible(
             {
@@ -956,7 +956,7 @@ describe('enforced-simulations', () => {
             },
             buildState(ResultType.Trusted),
           ),
-        ).toBe(false);
+        ).toBe(true);
       });
 
       it('returns true when origin is MetaMask internal', () => {

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -255,4 +255,3 @@ function isTrusted(
 
   return trusted;
 }
-

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -145,7 +145,7 @@ export function isEnforcedSimulationsEligible(
   transactionMeta: TransactionMeta,
   state: EnforcedSimulationsState,
 ): boolean {
-  const { chainId, type } = transactionMeta;
+  const { chainId, simulationData, type } = transactionMeta;
 
   if (
     !state.eip7702SupportedChains?.some(
@@ -156,6 +156,11 @@ export function isEnforcedSimulationsEligible(
       chainId,
       type,
     });
+    return false;
+  }
+
+  if (!simulationData) {
+    log('Not eligible - simulation not complete', { type });
     return false;
   }
 

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -1,5 +1,4 @@
 import {
-  SimulationData,
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
@@ -146,7 +145,7 @@ export function isEnforcedSimulationsEligible(
   transactionMeta: TransactionMeta,
   state: EnforcedSimulationsState,
 ): boolean {
-  const { chainId, simulationData, type } = transactionMeta;
+  const { chainId, type } = transactionMeta;
 
   if (
     !state.eip7702SupportedChains?.some(
@@ -157,11 +156,6 @@ export function isEnforcedSimulationsEligible(
       chainId,
       type,
     });
-    return false;
-  }
-
-  if (!hasBalanceChanges(simulationData)) {
-    log('Not eligible - no simulated balance changes', { type });
     return false;
   }
 
@@ -262,9 +256,3 @@ function isTrusted(
   return trusted;
 }
 
-function hasBalanceChanges(simulationData?: SimulationData | null): boolean {
-  return (
-    Boolean(simulationData?.nativeBalanceChange) ||
-    Boolean(simulationData?.tokenBalanceChanges?.length)
-  );
-}

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -615,7 +615,7 @@
       "React: Act warnings (component updates not wrapped)": 2
     },
     "ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts": {
-      "MetaMask: Background connection not initialized": 32
+      "MetaMask: Background connection not initialized": 36
     },
     "ui/pages/confirmations/components/confirm/info/info.test.tsx": {
       "MetaMask: Background connection not initialized": 61,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -147,6 +147,73 @@ describe('useFeeCalculations', () => {
     `);
   });
 
+  it('derives the added protection fee from the no-buffer original gas limit', () => {
+    const transactionMeta = genUnapprovedContractInteractionConfirmation({
+      address: CONTRACT_INTERACTION_SENDER_ADDRESS,
+      chainId: CHAIN_IDS.SEPOLIA,
+    }) as TransactionMeta;
+
+    transactionMeta.containerTypes = [
+      TransactionContainerType.EnforcedSimulations,
+    ];
+
+    // No-buffer original estimate (what the wrapped estimate should be compared
+    // against).
+    transactionMeta.gasLimitNoBuffer = toHex(50000);
+
+    // `txParamsOriginal.gas` retains the 1.5x buffer (75000). Using this as the
+    // baseline would understate the added fee (the bug).
+    transactionMeta.txParamsOriginal = {
+      ...transactionMeta.txParams,
+      gas: toHex(75000),
+    };
+
+    // No-buffer wrapped estimate returned by `applyTransactionContainers`.
+    transactionMeta.txParams.gas = toHex(90000);
+
+    const mockStateWithSepoliaNativeTicker = merge({}, mockState, {
+      metamask: {
+        currencyRates: {
+          ETH: {
+            usdConversionRate: 556.12,
+          },
+          SepoliaETH: {
+            conversionRate: 0,
+          },
+        },
+        networkConfigurationsByChainId: {
+          [CHAIN_IDS.SEPOLIA]: {
+            nativeCurrency: 'SepoliaETH',
+            ticker: 'SepoliaETH',
+          },
+        },
+      },
+    });
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useFeeCalculations(transactionMeta),
+      mockStateWithSepoliaNativeTicker,
+    );
+
+    // Added fee reflects the 90000 - 50000 = 40000 gas delta, not the buggy
+    // 90000 - 75000 = 15000 delta from the buffered original.
+    expect(result.current).toMatchInlineSnapshot(`
+      {
+        "addedProtectionFeeFiat": "$0.06",
+        "addedProtectionFeeUsd": 0.063522273,
+        "calculateGasEstimate": [Function],
+        "estimatedFeeFiat": "$0.14",
+        "estimatedFeeFiatWith18SignificantDigits": null,
+        "estimatedFeeNative": "0.0003",
+        "estimatedFeeNativeHex": "0xe9be6d60abb0",
+        "maxFeeFiat": "$0.14",
+        "maxFeeFiatWith18SignificantDigits": null,
+        "maxFeeHex": "0xe9be6d60abb0",
+        "maxFeeNative": "0.0003",
+      }
+    `);
+  });
+
   it('picks up gasLimitNoBuffer for estimations', () => {
     const transactionMeta = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -70,7 +70,7 @@ function getOriginalGasLimit(
 ): Hex | undefined {
   // Compare like-for-like: the wrapped `txParams.gas` is a no-buffer estimate,
   // so the original must be too. `txParamsOriginal.gas` has the 1.5x gas buffer,
-  // which would understate the added fee (CONF-1827); prefer `gasLimitNoBuffer`.
+  // which would understate the added fee; prefer `gasLimitNoBuffer`.
   return (transactionMeta.gasUsed ||
     transactionMeta.gasLimitNoBuffer ||
     transactionMeta.txParamsOriginal?.gas ||

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -67,14 +67,15 @@ function shouldUseEthConversionRateFallback(chainId?: Hex): boolean {
 
 function getOriginalGasLimit(
   transactionMeta: TransactionMeta,
-  quotedGasLimit?: Hex,
 ): Hex | undefined {
-  return (transactionMeta.txParamsOriginal?.gas ||
+  // Compare like-for-like: the wrapped `txParams.gas` is a no-buffer estimate,
+  // so the original must be too. `txParamsOriginal.gas` has the 1.5x gas buffer,
+  // which would understate the added fee (CONF-1827); prefer `gasLimitNoBuffer`.
+  return (transactionMeta.gasUsed ||
+    transactionMeta.gasLimitNoBuffer ||
+    transactionMeta.txParamsOriginal?.gas ||
     transactionMeta.defaultGasEstimates?.gas ||
-    transactionMeta.dappSuggestedGasFees?.gas ||
-    quotedGasLimit ||
-    transactionMeta.gasUsed ||
-    transactionMeta.gasLimitNoBuffer) as Hex | undefined;
+    transactionMeta.dappSuggestedGasFees?.gas) as Hex | undefined;
 }
 
 function getGasLimitDelta(gasLimit: Hex, originalGasLimit: string): Hex | null {
@@ -281,7 +282,7 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
     ),
   );
 
-  const originalGasLimit = getOriginalGasLimit(transactionMeta, quotedGasLimit);
+  const originalGasLimit = getOriginalGasLimit(transactionMeta);
 
   const addedProtectionFee = useMemo(() => {
     if (!hasEnforcedSimulations || !originalGasLimit) {

--- a/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.test.tsx
@@ -380,7 +380,7 @@ describe('EnforcedSimulationsRow', () => {
     await waitFor(() => {
       expect(
         getByText(
-          "You're interacting with an unknown address. This helps prevent malicious transactions.",
+          "Because you're interacting with an unknown address, protection can prevent some malicious transactions.",
         ),
       ).toBeInTheDocument();
     });

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
@@ -4,6 +4,7 @@ import { renderHookWithConfirmContextProvider } from '../../../../test/lib/confi
 import { getMockConfirmStateForTransaction } from '../../../../test/data/confirmations/helper';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../test/data/confirmations/contract-interaction';
 import { isEnforcedSimulationsEligible } from '../../../../shared/lib/transaction/enforced-simulations';
+import { useIsHardwareWalletAccount } from '../../../hooks/useIsHardwareWalletAccount';
 import { useIsEnforcedSimulationsEligible } from './useIsEnforcedSimulationsEligible';
 
 jest.mock('../../../../shared/lib/transaction/enforced-simulations', () => ({
@@ -13,20 +14,27 @@ jest.mock('../../../../shared/lib/transaction/enforced-simulations', () => ({
   isEnforcedSimulationsEligible: jest.fn(),
 }));
 
+jest.mock('../../../hooks/useIsHardwareWalletAccount');
+
 const getIsEnforcedSimulationsEligibleMock = jest.mocked(
   isEnforcedSimulationsEligible,
 );
 
+const useIsHardwareWalletAccountMock = jest.mocked(useIsHardwareWalletAccount);
+
 function runHook({
   eligible = true,
   enabled = true,
+  isHardwareWalletAccount = false,
   addressSecurityAlertResponses = {},
 }: {
   eligible?: boolean;
   enabled?: boolean;
+  isHardwareWalletAccount?: boolean;
   addressSecurityAlertResponses?: Record<string, unknown>;
 } = {}) {
   getIsEnforcedSimulationsEligibleMock.mockReturnValue(eligible);
+  useIsHardwareWalletAccountMock.mockReturnValue(isHardwareWalletAccount);
 
   const transaction = genUnapprovedContractInteractionConfirmation({
     origin: 'https://some-dapp.com',
@@ -56,6 +64,7 @@ function runHook({
 describe('useIsEnforcedSimulationsEligible', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useIsHardwareWalletAccountMock.mockReturnValue(false);
   });
 
   it('returns true when eligible', () => {
@@ -86,6 +95,13 @@ describe('useIsEnforcedSimulationsEligible', () => {
 
   it('returns false and skips the eligibility check when the flag is disabled', () => {
     expect(runHook({ enabled: false })).toBe(false);
+    expect(getIsEnforcedSimulationsEligibleMock).not.toHaveBeenCalled();
+  });
+
+  it('returns false and skips the eligibility check for hardware wallet accounts', () => {
+    expect(runHook({ eligible: true, isHardwareWalletAccount: true })).toBe(
+      false,
+    );
     expect(getIsEnforcedSimulationsEligibleMock).not.toHaveBeenCalled();
   });
 });

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
@@ -10,6 +10,7 @@ import {
   isEnforcedSimulationsForceEnabled,
 } from '../../../../shared/lib/transaction/enforced-simulations';
 import { getEip7702SupportedChains } from '../../../../shared/lib/eip7702-support-utils';
+import { useIsHardwareWalletAccount } from '../../../hooks/useIsHardwareWalletAccount';
 import { useConfirmContext } from '../context/confirm';
 import { selectIsEnforcedSimulationsEnabled } from '../selectors/feature-flags';
 import { getInternalAccounts } from '../../../selectors/accounts';
@@ -43,9 +44,14 @@ export function useIsEnforcedSimulationsEligible(): boolean {
 
   const enabled = useSelector(selectIsEnforcedSimulationsEnabled);
 
+  const isHardwareWallet = useIsHardwareWalletAccount(
+    currentConfirmation?.txParams?.from,
+  );
+
   if (
     (!enabled && !isEnforcedSimulationsForceEnabled()) ||
-    !currentConfirmation
+    !currentConfirmation ||
+    isHardwareWallet
   ) {
     return false;
   }


### PR DESCRIPTION
## **Description**

Enforced simulations improvements:

- **Always enforce native balance:** enforced simulations now activates on supported chains for untrusted recipients even when the simulation shows no balance changes. A native balance caveat is always emitted — the per-delta caveat when there is a simulated native change, otherwise a zero-tolerance no-decrease caveat via `NativeBalanceChangeEnforcer` (terms encoded directly with the decrease flag and a zero amount, so `after >= before`) to prevent any unexpected native ETH drain at execution.
- **Added protection fee reconciliation:** derive the added protection fee from the no-buffer original gas limit (`gasLimitNoBuffer` / `gasUsed`) instead of the buffered `txParamsOriginal.gas`, so the fee reconciles with the wrapped no-buffer estimate.
- **Hardware wallet gating:** exclude hardware wallets from enforced simulations eligibility so the added protection option is never auto-enabled or offered (they cannot sign the required EIP-7702 authorization).
- **Copy:** update the added protection description text.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

- [CONF-1812](https://consensyssoftware.atlassian.net/browse/CONF-1812)
- [CONF-1827](https://consensyssoftware.atlassian.net/browse/CONF-1827)
- [CONF-1835](https://consensyssoftware.atlassian.net/browse/CONF-1835)

## **Manual testing steps**

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[CONF-1812]: https://consensyssoftware.atlassian.net/browse/CONF-1812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction signing constraints and confirmation fee display for untrusted contract interactions; broader eligibility and on-chain native guardrails affect security-sensitive confirmation flows.
> 
> **Overview**
> **Enforced simulations** now applies to untrusted transactions on EIP-7702 chains even when simulation shows no balance changes. Eligibility no longer requires simulated native or token deltas. When there is no native delta, caveat generation adds a **zero-tolerance** `NativeBalanceChangeEnforcer` caveat (direct 53-byte terms with decrease flag and zero amount so `after >= before`) instead of failing with no caveats.
> 
> **Added protection fee** on the confirmation screen compares wrapped gas to the **no-buffer** baseline (`gasUsed` / `gasLimitNoBuffer` before buffered `txParamsOriginal.gas`), so the optional protection surcharge matches the real gas delta.
> 
> **Hardware wallet** senders are excluded in `useIsEnforcedSimulationsEligible` because they cannot sign the required EIP-7702 authorization.
> 
> **Copy:** `addedProtectionDescription` in en/en_GB clarifies that protection *can* prevent some malicious transactions when interacting with unknown addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e248d44c3378f4b45f9c0d8643b025e3a0013a7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->