### PR TITLE
test: fix flaky test Settings after Activity

### DIFF
--- a/test/e2e/tests/settings/clear-activity.spec.ts
+++ b/test/e2e/tests/settings/clear-activity.spec.ts
@@ -34,6 +34,7 @@ describe('Clear account activity', function (this: Suite) {
         });
 
         // Clear activity and nonce data
+        await homePage.goToHomePage();
         await homePage.headerNavbar.openSettingsPage();
         const settingsPage = new SettingsPage(driver);
         await settingsPage.checkPageIsLoaded();

--- a/test/e2e/tests/settings/clear-activity.spec.ts
+++ b/test/e2e/tests/settings/clear-activity.spec.ts
@@ -43,6 +43,7 @@ describe('Clear account activity', function (this: Suite) {
         await settingsPage.confirmDeleteActivityAndNonceModal();
         await closeSettings(driver);
 
+        await homePage.goToActivityList();
         await activityTab.checkNoTxInActivity();
       },
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Stabilizes the clear-activity E2E so it can open Settings after checking Activity, including when bottom nav is on.

**Root cause:**

- The test logs in, opens Activity, and checks that a Sent ETH row is confirmed.
- With bottom nav on, that click leaves Home and opens Activity as its own screen.
- Next, the test tries to open the account options menu so it can go to Settings.
- That menu button only exists on Home, so the click times out.
- After Settings close, the test checks that Activity is empty while still on Home.
- With bottom nav, Home has no activity rows, so that empty check can pass even if the list was not cleared.
- With classic in-page tabs, Activity and the menu share the same screen, so the same test often passed.

**Solution:**

- Call `goToHomePage()` after the Activity check - so the account options menu is on screen before Settings is opened.
- That helper is a no-op when Home is already showing. If bottom nav is on, it clicks Home and waits for Home to load.
- After Settings close, call `goToActivityList()` before the empty-list check - so the assert runs on Activity, not Home.

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Start a test build: `yarn start:test`
2. Run:

```
SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/settings/clear-activity.spec.ts --debug --leave-running
```

3. Confirm the test can open Settings after checking Activity, including when bottom nav is on.
4. Confirm it returns to Activity after Settings and that the Sent ETH row is gone.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->
