### PR TITLE
fix:  ledger gen 5 signing 712 permit payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -403,7 +403,7 @@
     "@metamask/eth-hd-keyring": "^15.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
     "@metamask/eth-json-rpc-middleware": "^24.0.0",
-    "@metamask/eth-ledger-bridge-keyring": "npm:@metamask-previews/eth-ledger-bridge-keyring@13.0.2-de95397",
+    "@metamask/eth-ledger-bridge-keyring": "^13.1.0",
     "@metamask/eth-money-keyring": "3.0.0",
     "@metamask/eth-qr-keyring": "^3.0.0",
     "@metamask/eth-sig-util": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -403,7 +403,7 @@
     "@metamask/eth-hd-keyring": "^15.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
     "@metamask/eth-json-rpc-middleware": "^24.0.0",
-    "@metamask/eth-ledger-bridge-keyring": "^13.0.1",
+    "@metamask/eth-ledger-bridge-keyring": "npm:@metamask-previews/eth-ledger-bridge-keyring@13.0.2-de95397",
     "@metamask/eth-money-keyring": "3.0.0",
     "@metamask/eth-qr-keyring": "^3.0.0",
     "@metamask/eth-sig-util": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6701,9 +6701,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-ledger-bridge-keyring@npm:^13.0.1":
-  version: 13.0.2
-  resolution: "@metamask/eth-ledger-bridge-keyring@npm:13.0.2"
+"@metamask/eth-ledger-bridge-keyring@npm:@metamask-previews/eth-ledger-bridge-keyring@13.0.2-de95397":
+  version: 13.0.2-de95397
+  resolution: "@metamask-previews/eth-ledger-bridge-keyring@npm:13.0.2-de95397"
   dependencies:
     "@ethereumjs/rlp": "npm:^5.0.2"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -6714,12 +6714,12 @@ __metadata:
     "@ledgerhq/hw-app-eth": "npm:^6.42.0"
     "@ledgerhq/hw-transport": "npm:^6.31.3"
     "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/hw-wallet-sdk": "npm:^1.0.0"
-    "@metamask/keyring-api": "npm:^24.0.0"
-    "@metamask/keyring-sdk": "npm:^3.1.0"
+    "@metamask/hw-wallet-sdk": "npm:1.0.0"
+    "@metamask/keyring-api": "npm:24.1.0"
+    "@metamask/keyring-sdk": "npm:3.1.0"
     hdkey: "npm:^2.1.0"
     rxjs: "npm:^7.8.2"
-  checksum: 10/b4c06bead6c998601ac4bd06fecf8d09216f0d60e6a07e6e41e00ab58a965cb516405316c828b2970aac51c2534ae7b2456b3bc5067ff7cf544e3d70d223c25a
+  checksum: 10/2c0a888f0fd8174d9d0f4fd3280843fecff32c87688361ba62702695db861b54e7f7df7bb36d321e1dd742291c5ccbb31295d705628941f16d2e4076b77e6381
   languageName: node
   linkType: hard
 
@@ -7066,7 +7066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/hw-wallet-sdk@npm:^1.0.0":
+"@metamask/hw-wallet-sdk@npm:1.0.0, @metamask/hw-wallet-sdk@npm:^1.0.0":
   version: 1.0.0
   resolution: "@metamask/hw-wallet-sdk@npm:1.0.0"
   checksum: 10/f70bcf91d35da52df70f7772d464754d571c10cefb239f9d167006123d0a33c7fb59ba9db16ccb5496c3c7d3c17fed2b78b16fcb6dd6a17fe33ba3e45231a295
@@ -7222,25 +7222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-sdk@npm:^2.0.2, @metamask/keyring-sdk@npm:^2.1.1":
-  version: 2.2.0
-  resolution: "@metamask/keyring-sdk@npm:2.2.0"
-  dependencies:
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/keyring-api": "npm:^23.2.0"
-    "@metamask/keyring-utils": "npm:^3.3.1"
-    "@metamask/scure-bip39": "npm:^2.1.1"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.11.0"
-    async-mutex: "npm:^0.5.0"
-    ethereum-cryptography: "npm:^2.2.1"
-    uuid: "npm:^9.0.1"
-  checksum: 10/5cb7f2496f0fc95e85eb97932b69da9c02c232e2310b5f390bfc7c56996bf8516d15db54260e68288f6d6f5604bfacc19b4b82b9b28b7f794a3ab5ee9a1f10d1
-  languageName: node
-  linkType: hard
-
-"@metamask/keyring-sdk@npm:^3.0.0, @metamask/keyring-sdk@npm:^3.1.0":
+"@metamask/keyring-sdk@npm:3.1.0, @metamask/keyring-sdk@npm:^3.0.0, @metamask/keyring-sdk@npm:^3.1.0":
   version: 3.1.0
   resolution: "@metamask/keyring-sdk@npm:3.1.0"
   dependencies:
@@ -7256,6 +7238,24 @@ __metadata:
     ethereum-cryptography: "npm:^2.2.1"
     uuid: "npm:^9.0.1"
   checksum: 10/9bec3d530da5484e9b28234c1d5e62bdd402d0cec25d107152efdc617e5d818becb25049621c97cc6af821e151ce43af798cbc1c421828c28c1ed20e611d2477
+  languageName: node
+  linkType: hard
+
+"@metamask/keyring-sdk@npm:^2.0.2, @metamask/keyring-sdk@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "@metamask/keyring-sdk@npm:2.2.0"
+  dependencies:
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/keyring-api": "npm:^23.2.0"
+    "@metamask/keyring-utils": "npm:^3.3.1"
+    "@metamask/scure-bip39": "npm:^2.1.1"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    async-mutex: "npm:^0.5.0"
+    ethereum-cryptography: "npm:^2.2.1"
+    uuid: "npm:^9.0.1"
+  checksum: 10/5cb7f2496f0fc95e85eb97932b69da9c02c232e2310b5f390bfc7c56996bf8516d15db54260e68288f6d6f5604bfacc19b4b82b9b28b7f794a3ab5ee9a1f10d1
   languageName: node
   linkType: hard
 
@@ -33232,7 +33232,7 @@ __metadata:
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
     "@metamask/eth-json-rpc-middleware": "npm:^24.0.0"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
-    "@metamask/eth-ledger-bridge-keyring": "npm:^13.0.1"
+    "@metamask/eth-ledger-bridge-keyring": "npm:@metamask-previews/eth-ledger-bridge-keyring@13.0.2-de95397"
     "@metamask/eth-money-keyring": "npm:3.0.0"
     "@metamask/eth-qr-keyring": "npm:^3.0.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6701,9 +6701,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-ledger-bridge-keyring@npm:@metamask-previews/eth-ledger-bridge-keyring@13.0.2-de95397":
-  version: 13.0.2-de95397
-  resolution: "@metamask-previews/eth-ledger-bridge-keyring@npm:13.0.2-de95397"
+"@metamask/eth-ledger-bridge-keyring@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "@metamask/eth-ledger-bridge-keyring@npm:13.1.0"
   dependencies:
     "@ethereumjs/rlp": "npm:^5.0.2"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -6714,12 +6714,12 @@ __metadata:
     "@ledgerhq/hw-app-eth": "npm:^6.42.0"
     "@ledgerhq/hw-transport": "npm:^6.31.3"
     "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/hw-wallet-sdk": "npm:1.0.0"
-    "@metamask/keyring-api": "npm:24.1.0"
-    "@metamask/keyring-sdk": "npm:3.1.0"
+    "@metamask/hw-wallet-sdk": "npm:^1.0.0"
+    "@metamask/keyring-api": "npm:^24.1.0"
+    "@metamask/keyring-sdk": "npm:^3.1.0"
     hdkey: "npm:^2.1.0"
     rxjs: "npm:^7.8.2"
-  checksum: 10/2c0a888f0fd8174d9d0f4fd3280843fecff32c87688361ba62702695db861b54e7f7df7bb36d321e1dd742291c5ccbb31295d705628941f16d2e4076b77e6381
+  checksum: 10/9639ee6b5139fa447c0486417963dfaa4bb023e78d88f449c4cdcc9b4d21a0407298fc91cb42e3087b63bd2bb1a05cd7e8fd6dcce8884d725df67755a3dc40ff
   languageName: node
   linkType: hard
 
@@ -7066,7 +7066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/hw-wallet-sdk@npm:1.0.0, @metamask/hw-wallet-sdk@npm:^1.0.0":
+"@metamask/hw-wallet-sdk@npm:^1.0.0":
   version: 1.0.0
   resolution: "@metamask/hw-wallet-sdk@npm:1.0.0"
   checksum: 10/f70bcf91d35da52df70f7772d464754d571c10cefb239f9d167006123d0a33c7fb59ba9db16ccb5496c3c7d3c17fed2b78b16fcb6dd6a17fe33ba3e45231a295
@@ -7222,25 +7222,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-sdk@npm:3.1.0, @metamask/keyring-sdk@npm:^3.0.0, @metamask/keyring-sdk@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@metamask/keyring-sdk@npm:3.1.0"
-  dependencies:
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/keyring-api": "npm:^24.0.0"
-    "@metamask/keyring-utils": "npm:^5.0.0"
-    "@metamask/scure-bip39": "npm:^2.1.1"
-    "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
-    "@noble/hashes": "npm:^1.8.0"
-    async-mutex: "npm:^0.5.0"
-    ethereum-cryptography: "npm:^2.2.1"
-    uuid: "npm:^9.0.1"
-  checksum: 10/9bec3d530da5484e9b28234c1d5e62bdd402d0cec25d107152efdc617e5d818becb25049621c97cc6af821e151ce43af798cbc1c421828c28c1ed20e611d2477
-  languageName: node
-  linkType: hard
-
 "@metamask/keyring-sdk@npm:^2.0.2, @metamask/keyring-sdk@npm:^2.1.1":
   version: 2.2.0
   resolution: "@metamask/keyring-sdk@npm:2.2.0"
@@ -7256,6 +7237,25 @@ __metadata:
     ethereum-cryptography: "npm:^2.2.1"
     uuid: "npm:^9.0.1"
   checksum: 10/5cb7f2496f0fc95e85eb97932b69da9c02c232e2310b5f390bfc7c56996bf8516d15db54260e68288f6d6f5604bfacc19b4b82b9b28b7f794a3ab5ee9a1f10d1
+  languageName: node
+  linkType: hard
+
+"@metamask/keyring-sdk@npm:^3.0.0, @metamask/keyring-sdk@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/keyring-sdk@npm:3.1.0"
+  dependencies:
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/keyring-api": "npm:^24.0.0"
+    "@metamask/keyring-utils": "npm:^5.0.0"
+    "@metamask/scure-bip39": "npm:^2.1.1"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    "@noble/hashes": "npm:^1.8.0"
+    async-mutex: "npm:^0.5.0"
+    ethereum-cryptography: "npm:^2.2.1"
+    uuid: "npm:^9.0.1"
+  checksum: 10/9bec3d530da5484e9b28234c1d5e62bdd402d0cec25d107152efdc617e5d818becb25049621c97cc6af821e151ce43af798cbc1c421828c28c1ed20e611d2477
   languageName: node
   linkType: hard
 
@@ -33232,7 +33232,7 @@ __metadata:
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
     "@metamask/eth-json-rpc-middleware": "npm:^24.0.0"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
-    "@metamask/eth-ledger-bridge-keyring": "npm:@metamask-previews/eth-ledger-bridge-keyring@13.0.2-de95397"
+    "@metamask/eth-ledger-bridge-keyring": "npm:^13.1.0"
     "@metamask/eth-money-keyring": "npm:3.0.0"
     "@metamask/eth-qr-keyring": "npm:^3.0.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the issue where ledger gen 5 is unable to sign the 712 permit payload without the domain. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix ledger gen 5 712 permit signing. 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-2054
Fixes: https://github.com/MetaMask/metamask-extension/issues/42625

## **Manual testing steps**

1. Using a ledger gen 5 device
2. Go to the console of any browser 
3. Enter the following
4.  Malformed payload

``` const ethereum = window.ethereum;

const [account] = await ethereum.request({ method: 'eth_requestAccounts' });
const chainId = parseInt(await ethereum.request({ method: 'eth_chainId' }), 16);

// ⚠️ THE TRIGGER: `types` declares only `Permit` — no EIP712Domain entry,
// exactly like the test dapp's getNFTMsgParams()
const nftPermit = {
  domain: {
    name: 'My NFT',
    version: '1',
    chainId,
    verifyingContract: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
  },
  types: {
    Permit: [
      { name: 'spender', type: 'address' },
      { name: 'tokenId', type: 'uint256' },
      { name: 'nonce', type: 'uint256' },
      { name: 'deadline', type: 'uint256' },
    ],
  },
  primaryType: 'Permit',
  message: {
    spender: '0xE4735cF6A14D3015dfFA080D2DFA6B943e554317',
    tokenId: 57,
    nonce: 5,
    deadline: Math.floor(Date.now() / 1000) + 3600,
  },
};

try {
  const signature = await ethereum.request({
    method: 'eth_signTypedData_v4',
    params: [account, JSON.stringify(nftPermit)],
  });
  console.log('✅ signature:', signature);
  window.__nftPermitSignature = signature; // for the verify step below
} catch (err) {
  // Gen5 + unfixed build: "…Error: Ledger: The signature doesn't match the right address"
  console.error('❌', err.message ?? err);
}
```
5. For regular payload 

``` 
const wellFormed = {
  ...nftPermit,
  types: {
    EIP712Domain: [
      { name: 'name', type: 'string' },
      { name: 'version', type: 'string' },
      { name: 'chainId', type: 'uint256' },
      { name: 'verifyingContract', type: 'address' },
    ],
    ...nftPermit.types,
  },
};
const sig = await ethereum.request({
  method: 'eth_signTypedData_v4',
  params: [account, JSON.stringify(wellFormed)],
});
Verify the returned signature (ethers, spec-correct)
const { verifyTypedData } = await import('https://esm.sh/ethers');

// ethers derives the domain type from the domain keys — i.e. it verifies against
// the SAME normalized payload our fix sends to the device
const recovered = verifyTypedData(
  nftPermit.domain,
  { ...nftPermit.types, EIP712Domain: [
    { name: 'name', type: 'string' },
    { name: 'version', type: 'string' },
    { name: 'chainId', type: 'uint256' },
    { name: 'verifyingContract', type: 'address' },
  ] },
  nftPermit.message,
  window.__nftPermitSignature,
);
console.log(recovered === account ? '✅ valid per EIP-712' : '❌ mismatch'); 
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit caf19508029134f5d3c4e986ea3fe4660a03746b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->