### PR TITLE
chore: convert ESLint config to ESM

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -26,7 +26,7 @@ ignores:
   #
 
   # ESLint import resolvers, referenced by short name in `import-x/resolver`
-  # settings in .eslintrc.js (`node`, `typescript`) rather than imported
+  # settings in eslint.config.mjs (`node`, `typescript`) rather than imported
   - 'eslint-import-resolver-node'
   - 'eslint-import-resolver-typescript'
   # invoked as a string transform (`bundler.transform('babelify')`) in the

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -266,10 +266,10 @@ ui/selectors/money/                  @MetaMask/earn
 
 # Lint
 /.editorconfig                                        @MetaMask/extension-platform
-/.eslintrc.js                                         @MetaMask/extension-platform
-/.eslintrc.*.js                                       @MetaMask/extension-platform
 /.prettierignore                                      @MetaMask/extension-platform
 /.prettierrc.yml                                      @MetaMask/extension-platform
+/eslint.config.mjs                                    @MetaMask/extension-platform
+/eslint.config.*.mjs                                  @MetaMask/extension-platform
 /stylelint.config.js                                  @MetaMask/extension-platform
 
 # Test

--- a/.github/rules/filter-rules.yml
+++ b/.github/rules/filter-rules.yml
@@ -33,7 +33,6 @@ test_files: &test_files
 config_files: &config_files
   - '.depcheckrc.yml'
   - '.editorconfig'
-  - '.eslint*'
   - '.git-blame-ignore-revs'
   - '.gitattributes'
   - '.madgerc'
@@ -43,7 +42,7 @@ config_files: &config_files
   - 'codecov.yml'
   - 'coverage.json'
   - 'crowdin.yml'
-  - 'eslint.config.js'
+  - 'eslint.config.*'
   - 'oxfmt.config.mts'
   - 'privacy-snapshot.json'
   - 'sonar-project.properties'

--- a/development/eslint-restricted-paths-zones.mjs
+++ b/development/eslint-restricted-paths-zones.mjs
@@ -1,24 +1,24 @@
 // Shared zone definitions for `import-x/no-restricted-paths`.
 //
-// These are required (not extended) by both `.eslintrc.base.js` and
-// `.eslintrc.js`, so the same zone list is used wherever the rule needs
-// to be configured (notably the router-registry override in `.eslintrc.js`
+// These are required (not extended) by both `eslint.config.base.mjs` and
+// `eslint.config.mjs`, so the same zone list is used wherever the rule needs
+// to be configured (notably the router-registry override in `eslint.config.mjs`
 // re-enables only the non-route-isolation source-boundary zones).
 //
-// Kept outside `.eslintrc*.js` because ESLint v8 validates every config
+// Kept outside ESLint config modules because ESLint v8 validates every config
 // it loads and rejects unknown top-level exports.
 //
 // See ADR 0021 (modularize-routes):
 // https://github.com/MetaMask/decisions/tree/main/decisions/core/0021-modularize-routes.md
 
-const fs = require('node:fs');
-const path = require('node:path');
+import fs from 'node:fs';
+import path from 'node:path';
 
 // Architectural boundaries between the three top-level source trees:
 // - `app/`     (background script — service worker, controllers, RPC)
 // - `ui/`      (React UI rendered in the extension popup/expanded view)
 // - `shared/`  (code safe to import from either side)
-const architecturalZones = [
+export const architecturalZones = [
   {
     target: './app',
     from: './ui',
@@ -43,7 +43,7 @@ const architecturalZones = [
   },
 ];
 
-const buildSystemZones = [
+export const buildSystemZones = [
   {
     target: './app',
     from: './development',
@@ -68,8 +68,8 @@ const buildSystemZones = [
 // is treated as a "route module" per ADR 0021 (modularize-routes). The
 // `routes` subdirectory holds the React Router registry (which must
 // reference every route by design) and is exempted via overrides in
-// `.eslintrc.js`.
-const PAGES_DIR = path.join(__dirname, '..', 'ui/pages');
+// `eslint.config.mjs`.
+const PAGES_DIR = path.join(import.meta.dirname, '..', 'ui/pages');
 const ROUTE_ISOLATION_EXEMPT_DIRS = new Set(['routes']);
 const routeDirs = fs
   .readdirSync(PAGES_DIR, { withFileTypes: true })
@@ -83,7 +83,7 @@ const routeDirs = fs
 // except itself and the router registry. `import-x/no-restricted-paths`
 // resolves `except` paths relative to `from`, so we can keep one zone
 // per route instead of a quadratic pair list.
-const routeIsolationZones = routeDirs.map((route) => ({
+export const routeIsolationZones = routeDirs.map((route) => ({
   target: `./ui/pages/${route}`,
   from: './ui/pages',
   except: [`./${route}`, './routes'],
@@ -91,5 +91,3 @@ const routeIsolationZones = routeDirs.map((route) => ({
     `Route directories must be isolated. "${route}" must not import ` +
     `from a sibling route directory. See ADR 0021 (modularize-routes).`,
 }));
-
-module.exports = { architecturalZones, buildSystemZones, routeIsolationZones };

--- a/development/eslint-rules/page-object-member-order.mjs
+++ b/development/eslint-rules/page-object-member-order.mjs
@@ -116,7 +116,7 @@ function classify(member) {
   return null;
 }
 
-module.exports = {
+export default {
   meta: {
     type: 'suggestion',
     docs: {

--- a/development/eslint-rules/page-object-member-order.test.js
+++ b/development/eslint-rules/page-object-member-order.test.js
@@ -2,7 +2,7 @@
 
 const { RuleTester } = require('eslint');
 const { parser: tsParser } = require('typescript-eslint');
-const rule = require('./page-object-member-order');
+const rule = require('./page-object-member-order.mjs');
 
 const ruleTester = new RuleTester({
   languageOptions: {

--- a/development/lint-changed.mts
+++ b/development/lint-changed.mts
@@ -134,8 +134,6 @@ function main(): void {
     '--cache',
     '--cache-location',
     path.join('node_modules', '.cache', 'eslint', '.eslint-cache'),
-    '-c',
-    './.eslintrc.js',
   ];
 
   const eslintArgsWithDelimiter = [...eslintArgsBase, '--'];

--- a/development/ts-migration-dashboard/files-to-convert.json
+++ b/development/ts-migration-dashboard/files-to-convert.json
@@ -1,5 +1,5 @@
 [
-  ".eslintrc.js",
+  "eslint.config.mjs",
   "app/scripts/background.js",
   "app/scripts/contentscript.js",
   "app/scripts/detect-multiple-instances.js",

--- a/development/webpack/README.md
+++ b/development/webpack/README.md
@@ -153,10 +153,6 @@ Linting is exactly the same as the rest of the MetaMask project. To lint the bui
 yarn lint
 ```
 
-That said, the webpack build has its [own eslint configuration](./.eslintrc.js) that overrides some restrictive rules
-that either: don't work well when optimizing for performance, or disable JavaScript features that are useful and
-generally necessary.
-
 ### Testing
 
 To run the build tool's test suite, run the following command:

--- a/docs/tailwind-css-guide.md
+++ b/docs/tailwind-css-guide.md
@@ -72,7 +72,7 @@ Tailwind CSS classes have **the lowest CSS specificity** compared to our existin
 Because we have **legacy SASS classes** throughout the codebase, Tailwind CSS linting is **opt-in by directory** to prevent conflicts with the `no-custom-classname` rule.
 
 ```javascript
-// .eslintrc.js - Strict Tailwind enforcement areas
+// eslint.config.mjs - Strict Tailwind enforcement areas
 {
   files: [
     'ui/pages/design-system/**/*.{ts,tsx}', // ✅ Fully migrated
@@ -100,7 +100,7 @@ When you're ready to use **strict Tailwind** in your workspace:
 2. **Add your directory to the strict enforcement list**:
 
 ```javascript
-// .eslintrc.js
+// eslint.config.mjs
 {
   files: [
     'ui/pages/design-system/**/*.{ts,tsx}',

--- a/eslint.config.babel.mjs
+++ b/eslint.config.babel.mjs
@@ -1,7 +1,7 @@
-const babelPlugin = require('@babel/eslint-plugin');
-const babelParser = require('@babel/eslint-parser');
+import babelPlugin from '@babel/eslint-plugin';
+import babelParser from '@babel/eslint-parser';
 
-module.exports = {
+export const config = {
   languageOptions: {
     parser: babelParser,
   },

--- a/eslint.config.base.mjs
+++ b/eslint.config.base.mjs
@@ -1,11 +1,9 @@
-const designTokensPlugin = require('@metamask/eslint-plugin-design-tokens');
-const {
-  architecturalZones,
-  buildSystemZones,
-  routeIsolationZones,
-} = require('./development/eslint-restricted-paths-zones');
+import * as designTokensPlugin from '@metamask/eslint-plugin-design-tokens';
 
-module.exports = {
+const { architecturalZones, buildSystemZones, routeIsolationZones } =
+  await import('./development/eslint-restricted-paths-zones.mjs');
+
+export const config = {
   plugins: {
     '@metamask/design-tokens': designTokensPlugin,
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,33 +1,32 @@
-const { readFileSync } = require('node:fs');
-const { defineConfig } = require('eslint/config');
-const eslintConfig = require('@metamask/eslint-config').default;
-const typescriptConfig = require('@metamask/eslint-config-typescript').default;
-const mochaConfig = require('@metamask/eslint-config-mocha').default;
-const jestConfig = require('@metamask/eslint-config-jest').default;
-const ts = require('typescript');
-const babelParser = require('@babel/eslint-parser');
-const reactPackageJson = require('react/package.json');
-const reactPlugin = require('eslint-plugin-react');
-const reactHooksPlugin = require('eslint-plugin-react-hooks');
-const storybookPlugin = require('eslint-plugin-storybook');
-const tailwindCssPlugin = require('eslint-plugin-tailwindcss');
-const pageObjectMemberOrderRule = require('./development/eslint-rules/page-object-member-order');
-
-const {
+import { readFileSync } from 'node:fs';
+import { defineConfig } from 'eslint/config';
+import eslintConfig from '@metamask/eslint-config';
+import typescriptConfig from '@metamask/eslint-config-typescript';
+import mochaConfig from '@metamask/eslint-config-mocha';
+import jestConfig from '@metamask/eslint-config-jest';
+import ts from 'typescript';
+import babelParser from '@babel/eslint-parser';
+import reactPackageJson from 'react/package.json' with { type: 'json' };
+import reactPlugin from 'eslint-plugin-react';
+import reactHooksPlugin from 'eslint-plugin-react-hooks';
+import storybookPlugin from 'eslint-plugin-storybook';
+import tailwindCssPlugin from 'eslint-plugin-tailwindcss';
+import pageObjectMemberOrderRule from './development/eslint-rules/page-object-member-order.mjs';
+import { config as baseConfig } from './eslint.config.base.mjs';
+import { config as babelConfig } from './eslint.config.babel.mjs';
+import { configs as nodeConfigs } from './eslint.config.node.mjs';
+import { config as typescriptCompatConfig } from './eslint.config.typescript-compat.mjs';
+import {
   architecturalZones,
   buildSystemZones,
-} = require('./development/eslint-restricted-paths-zones');
-const baseConfig = require('./.eslintrc.base');
-const babelConfig = require('./.eslintrc.babel');
-const nodeConfigs = require('./.eslintrc.node');
-const typescriptCompatConfig = require('./.eslintrc.typescript-compat');
+} from './development/eslint-restricted-paths-zones.mjs';
 
 const reactVersion = reactPackageJson.version;
 const tsconfigPath = ts.findConfigFile('./', ts.sys.fileExists);
 const { config } = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
 const tsconfig = ts.parseJsonConfigFileContent(config, ts.sys, './');
 
-module.exports = defineConfig([
+export default defineConfig([
   {
     // Ignore files which are also in .prettierignore
     ignores: readFileSync('.prettierignore', 'utf8')
@@ -61,8 +60,6 @@ module.exports = defineConfig([
      * export other modules.
      */
     files: [
-      '.eslintrc.js',
-      '.eslintrc.*.js',
       '.mocharc.js',
       '*.config.js',
       'development/**/*.js',
@@ -103,6 +100,8 @@ module.exports = defineConfig([
    */
   {
     files: [
+      'eslint.config.mjs',
+      'eslint.config.*.mjs',
       'app/**/*.js',
       'shared/**/*.js',
       'ui/**/*.js',
@@ -149,7 +148,7 @@ module.exports = defineConfig([
     languageOptions: {
       parserOptions: {
         // https://github.com/typescript-eslint/typescript-eslint/issues/251#issuecomment-463943250
-        tsconfigRootDir: __dirname,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
     extends: [

--- a/eslint.config.node.mjs
+++ b/eslint.config.node.mjs
@@ -1,6 +1,6 @@
-const nodeConfig = require('@metamask/eslint-config-nodejs').default;
+import nodeConfig from '@metamask/eslint-config-nodejs';
 
-module.exports = [
+export const configs = [
   ...nodeConfig,
   {
     rules: {
@@ -26,6 +26,9 @@ module.exports = [
       //
       // TODO: Remove these modifications after the ESLint v9 update
       'no-restricted-globals': 'off',
+
+      // Extensions are required by the `import` keyword in Node.js
+      'import-x/extensions': 'off',
     },
   },
 ];

--- a/eslint.config.typescript-compat.mjs
+++ b/eslint.config.typescript-compat.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export const config = {
   settings: {
     'import-x/extensions': ['.js', '.ts', '.tsx'],
     'import-x/parsers': {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "lint:changelog": "auto-changelog validate --prettier",
     "lint:changelog:rc": "auto-changelog validate --prettier --rc",
     "lint:debug": "DEBUG=eslint:cli-engine yarn lint",
-    "lint:eslint": "NODE_OPTIONS='--max-old-space-size=6144' eslint . -c  ./.eslintrc.js --ext js,ts,tsx,snap --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
+    "lint:eslint": "NODE_OPTIONS='--max-old-space-size=6144' eslint . --ext js,ts,tsx,snap --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
     "lint:eslint:fix": "yarn lint:eslint --fix --prune-suppressions",
     "lint:lockfile:dedupe": "yarn dedupe --check",
     "lint:lockfile:dedupe:fix": "yarn dedupe",


### PR DESCRIPTION
## **Description**

The ESLint config and our two custom ESLint rules have been converted to ESM, and renamed to match the ESM conventional config filename.

This eliminates the need to use the `-c .eslintrc.js` flag whenever invoking ESLint.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
