### PR TITLE
feat: scan trust signals on the Multichain API pipeline

### DIFF
--- a/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
@@ -1420,6 +1420,68 @@ describe('createTrustSignalsMiddleware', () => {
     });
   });
 
+  describe('Multichain API (CAIP) requests', () => {
+    // `wallet_invokeMethod` unwraps the inner request in place before this
+    // middleware runs, so the request arrives under its EIP-1193 method name
+    // with `networkClientId` already resolved from the request's own scope.
+    const createUnwrappedRequest = (
+      method: string,
+      params: Json[] = [],
+      origin = 'https://example.com',
+    ) => ({
+      ...createMockRequest(method, params, origin),
+      scope: 'eip155:1',
+    });
+
+    it('scans transaction addresses for a request unwrapped from wallet_invokeMethod', async () => {
+      scanAddressMockAndAddToCache.mockResolvedValue(
+        MOCK_SCAN_RESPONSES.BENIGN,
+      );
+      const { middleware, appStateController, phishingController } =
+        createMiddleware();
+      appStateController.getAddressSecurityAlertResponse.mockReturnValue(
+        undefined,
+      );
+      const req = createUnwrappedRequest('eth_sendTransaction', [
+        createTransactionParams(),
+      ]);
+      const res = createMockResponse();
+      const next = jest.fn();
+
+      await middleware(req, res, next);
+
+      expect(scanAddressMockAndAddToCache).toHaveBeenCalledWith(
+        TEST_ADDRESSES.TO,
+        appStateController.getAddressSecurityAlertResponse,
+        appStateController.addAddressSecurityAlertResponse,
+        CHAIN_IDS.MAINNET,
+        phishingController,
+      );
+      expect(phishingController.scanUrl).toHaveBeenCalledWith(req.origin);
+      expect(next).toHaveBeenCalled();
+    });
+
+    // Connect-time coverage is PSAFE-589 part B. These methods are answered by
+    // `createMultichainApiMethodMiddleware`, which sits above this middleware
+    // in the CAIP engine, so they do not reach it at all today.
+    [
+      MESSAGE_TYPE.WALLET_CREATE_SESSION,
+      MESSAGE_TYPE.WALLET_GET_SESSION,
+    ].forEach((method) => {
+      it(`does not scan the origin for ${method}`, async () => {
+        const { middleware, phishingController } = createMiddleware();
+        const req = createMockRequest(method);
+        const res = createMockResponse();
+        const next = jest.fn();
+
+        await middleware(req, res, next);
+
+        expect(phishingController.scanUrl).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('non-transaction methods', () => {
     it('ignores non-transaction RPC methods', async () => {
       const { middleware, appStateController } = createMiddleware();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5896,6 +5896,21 @@ export default class MetamaskController extends EventEmitter {
       ),
     );
 
+    // Placed after the `wallet_invokeMethod` unwrap so it sees the inner method
+    // under its EIP-1193 name, with `networkClientId` already resolved from the
+    // request's own CAIP scope. Connect-time methods (`wallet_createSession`,
+    // `wallet_getSession`) end further up the stack and are not covered here.
+    engine.push(
+      createTrustSignalsMiddleware(
+        this.networkController,
+        this.appStateController,
+        this.phishingController,
+        this.preferencesController,
+        this.getPermittedAccounts.bind(this),
+        sender?.url,
+      ),
+    );
+
     engine.push(this.metamaskMiddleware);
 
     engine.push(this.eip5792Middleware);


### PR DESCRIPTION
## **Description**

`createTrustSignalsMiddleware` is pushed only in `setupProviderEngineEip1193`. The Multichain API engine (`setupProviderEngineCaip`) never had it, so dapp requests arriving over that transport are never address-scanned.

**Why this matters beyond missing UI signals.** `isTrusted` in `shared/lib/transaction/enforced-simulations.ts` treats a cache miss as trusted; only a cached non-`Trusted` verdict disqualifies. Its own comment says so: _"Recipients that no scan path covers stay cache misses and are treated as trusted here."_ Since nothing on this pipeline is ever scanned, every dapp transaction submitted through the Multichain API is structurally exempt from the enforced-simulations eligibility gate once `confirmations_enforced_simulations` rolls out. This is the same failure shape [PSAFE-572](https://consensyssoftware.atlassian.net/browse/PSAFE-572) closed for `wallet_sendCalls` batches, reopened one pipeline over. Confirmations also render no address trust signals for these dapps, since both `useTrustSignals` and `useAddressTrustSignalAlerts` read the cache this middleware populates.

Note that `createPPOMMiddleware` **is** already present in the CAIP engine, so Blockaid transaction validation was never affected. This is a trust-signals and enforcement gap, not a total security gap.

**Solution:** push the existing factory into the CAIP engine directly after `createPPOMMiddleware`, with the same six arguments as the EIP-1193 site including `sender?.url`.

Deliberately **not** a CAIP-aware fork of the middleware. A second implementation would leave [PSAFE-613](https://consensyssoftware.atlassian.net/browse/PSAFE-613) consolidating three middlewares instead of two, which is the one way this change would make that work harder. It turns out no fork is needed: verified against the installed `@metamask/multichain-api-middleware` that `handleWalletInvokeMethod` assigns the unwrapped method, params and a scope-derived `networkClientId` onto the request before calling `next()`, and ends with an internal error rather than forwarding if it cannot resolve one. So placing the middleware below the unwrap means it sees the inner method under its exact EIP-1193 name with chain context already resolved, request-scoped rather than falling back to the globally selected network.

Non-EVM scopes never reach this point at all, since `handleWalletInvokeMethod` services them inline through `handleNonEvmRequestForOrigin` and ends the request. So the EVM-only limit of `ADDRESS_SCAN_SUPPORTED_CHAINS` is not reachable here and no guard is needed at this call site.

**What this does not cover.** Connect-time origin scanning. `wallet_createSession` and `wallet_getSession` are answered by `createMultichainApiMethodMiddleware`, which sits above this insertion point, and both handlers end the request, so they cannot reach this middleware regardless of its gate list. Covering them needs a second install site above the unwrap plus a CAIP connectedness predicate (`getPermittedAccounts` is the wrong accessor; the analogue is the presence of a CAIP-25 caveat). That is tracked as part B on PSAFE-589 with a recommended design, and is intentionally out of scope here because part A carries all of the enforcement urgency.

## **Changelog**

CHANGELOG entry: Added address trust-signal scanning for dapp requests made through the Multichain API

## **Related issues**

Fixes: [PSAFE-589](https://consensyssoftware.atlassian.net/browse/PSAFE-589) (part A)

## **Manual testing steps**

1. **Control (EIP-1193, should already work).** On [test-dapp](https://metamask.github.io/test-dapp/), use the PPOM section's Malicious Eth Transfer button. The confirmation shows a malicious verdict on the recipient row, and `AppStateController.addressSecurityAlertResponses` gains an entry for that address (background service worker console, `stateHooks.getCleanAppState()` in dev builds).
2. **Repro on `main`.** On [test-dapp-multichain](https://metamask.github.io/test-dapp-multichain/), create a session with an `eip155` scope, pick `eth_sendTransaction` in the scope card, and edit the request JSON in the textarea to the same malicious params: `to: 0x5FbDB2315678afecb367f032d93F642f64180aa3` with `value: 0x9184e72a000`. No malicious trust signal appears and no new `addressSecurityAlertResponses` entry is created.
3. **On this branch.** Repeat step 2. The malicious verdict now renders and the cache entry appears.
4. **Approval variant (spender path).** Repeat step 2 with `to: 0x4fabb145d64652a948d72533023f6e7a623c7c53` and `data: 0x095ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6000000000000000000000000000000000000000000000000ffffffffffffffff`. `parseApprovalTransactionData` decodes the `approve` and the middleware scans the spender as well as `to`, so `addressSecurityAlertResponses` should gain two entries: the token contract and `0xe50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6`. Note the malicious ERC-20 *transfer* button cannot be used for this: `APPROVAL_METHOD_NAMES` has no `transfer` entry, and the decoded-recipient scan (#45307) and `wallet_sendCalls` target scan (#45210) are both still open, so neither path exists on this base.
5. **Enforcement.** Only a malicious contract in `to` can reach the gate. `isTrusted` reads each call's own `to` and nothing else, so decoded spenders and transfer recipients never count, and `TransactionType.simpleSend` is short-circuited as trusted before the cache read. Steps 3 and 4 therefore cannot demonstrate enforcement.
   - Setup: `.manifest-overrides.json` containing `{"_flags":{"remoteFeatureFlags":{"confirmations_enforced_simulations":{"enabled":true}}}}`, with `MANIFEST_OVERRIDES=.manifest-overrides.json` in `.metamaskrc`. Do not set `FORCE_ENFORCED_SIMULATIONS`; it skips `isTrusted` entirely. Use Sepolia, which is already in `confirmations_eip_7702.supportedChains` and, unlike a local chain, produces the `hasBalanceChanges(simulationData)` eligibility also requires.
   - Run: eligibility is evaluated in a UI hook, so set `localStorage.debug = 'metamask:enforced-simulations-eligibility'` in the **confirmation popup's** console, not the service worker. Then send `to: 0x00008f1149168c1d2fa1eba1ad3e9cd644510000` with `data: 0xef5cfb8c0000000000000000000000000b3e87a076ac4b0d1975f0f232444af6deb96c59` over an `eip155:11155111` session.
   - Expect `Address 1 - Not Trusted - Malicious` then `Eligible`, and the enforced simulations row rendering with protection auto-enabled. `main` logs `Address 1 - Trusted - Unknown Signal` and renders no row. If this branch logs that too, inspect `addressSecurityAlertResponses` at key `0xaa36a7:0x00008f1149168c1d2fa1eba1ad3e9cd644510000`: a `Benign` entry means the wiring works and the address endpoint simply does not flag that contract.

## **Screenshots/Recordings**

### **Before**

<!-- Multichain test dapp confirmation with no trust signal on the recipient row -->

https://github.com/user-attachments/assets/13326754-504f-45a6-b352-517fc8625073


<img width="800" height="974" alt="no-added-protection" src="https://github.com/user-attachments/assets/771835cb-17f4-4d1d-947c-4b44381b6fbf" />


### **After**

https://github.com/user-attachments/assets/09596847-8be8-4d37-b4cd-db7451a32cd8


<img width="800" height="974" alt="added-protection" src="https://github.com/user-attachments/assets/dabc35e9-23cd-4824-83d9-8b48e0b92f0a" />


<!-- Same confirmation showing the malicious verdict -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[PSAFE-572]: https://consensyssoftware.atlassian.net/browse/PSAFE-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSAFE-613]: https://consensyssoftware.atlassian.net/browse/PSAFE-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3d45cc7d4f0ba9cae5fc935462eba69ec48f10fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


