### PR TITLE
test(e2e): seed Tron bridge txHistory for activity coverage

### DIFF
--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -42,6 +42,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import type { AssetsControllerState } from '@metamask/assets-controller';
+import type { BridgeStatusControllerState } from '@metamask/bridge-status-controller';
 import type { PerpsControllerState } from '@metamask/perps-controller';
 import type { PasskeyControllerState } from '@metamask/passkey-controller';
 import type { AppStateControllerState } from '../../../app/scripts/controllers/app-state-controller';
@@ -285,6 +286,11 @@ class FixtureBuilderV2 {
 
   withAppStateController(data: Partial<AppStateControllerState>): this {
     merge(this.fixture.data.AppStateController, data);
+    return this;
+  }
+
+  withBridgeStatusController(data: Partial<BridgeStatusControllerState>): this {
+    merge(this.fixture.data.BridgeStatusController, data);
     return this;
   }
 

--- a/test/e2e/tests/tron/activity/activity-types.spec.ts
+++ b/test/e2e/tests/tron/activity/activity-types.spec.ts
@@ -8,12 +8,14 @@ import {
 import ActivityTab from '../../../page-objects/pages/home/activity-tab';
 import { TronNode } from '../../../seeder/tron/node';
 import { Driver } from '../../../webdriver/driver';
+import FixtureBuilderV2 from '../../../fixtures/fixture-builder-v2';
 import { buildTronNodeOptions } from '../fixtures/with-tron-fixtures';
 import { TRON_ACCOUNT_ADDRESS } from '../mocks/common-tron';
 import {
   bridgeTx,
   swapTx,
   trc20ApproveTx,
+  tronBridgeHistoryItem,
   trxReceiveTx,
   trxSendTx,
 } from '../mocks/tron-tx-fixtures';
@@ -26,14 +28,14 @@ import {
   mockAccountsApiWithEvmActivity,
 } from './helpers';
 
-// Newest-first list order. Approve is first so clickActivityByText on
-// "Approved spending cap" opens the real approval, not the bridge fallback.
 const ACTIVITY_TIMESTAMP = 1_700_000_000_000;
 const APPROVE_TIMESTAMP = ACTIVITY_TIMESTAMP + 4_000;
 const SEND_TIMESTAMP = ACTIVITY_TIMESTAMP + 3_000;
 const RECEIVE_TIMESTAMP = ACTIVITY_TIMESTAMP + 2_000;
 const SWAP_TIMESTAMP = ACTIVITY_TIMESTAMP + 1_000;
-const BRIDGE_FALLBACK_TIMESTAMP = ACTIVITY_TIMESTAMP;
+const BRIDGE_TIMESTAMP = ACTIVITY_TIMESTAMP;
+const BRIDGE_SRC_AMOUNT = '5000000';
+const BRIDGE_DEST_AMOUNT = '5000000';
 
 const CONFIRMED_TRON_ACTIVITY_COUNT = 5;
 
@@ -68,19 +70,31 @@ describe('Tron - Activity types', function (this: Suite) {
     status: 'Confirmed',
     timestamp: SWAP_TIMESTAMP,
   });
-  const bridgeFallback = bridgeTx({
+  const bridge = bridgeTx({
     srcSymbol: 'USDT',
-    srcAmount: '5000000',
+    srcAmount: BRIDGE_SRC_AMOUNT,
     destChain: 'eip155:1',
     status: 'Confirmed',
-    timestamp: BRIDGE_FALLBACK_TIMESTAMP,
+    timestamp: BRIDGE_TIMESTAMP,
   });
   const chromeSession = createSharedTronActivitySession({
     borrowedTronNode: sharedTronNode,
+    fixtures: new FixtureBuilderV2()
+      .withBridgeStatusController({
+        txHistory: {
+          [bridge.raw.txID]: tronBridgeHistoryItem({
+            destAmount: BRIDGE_DEST_AMOUNT,
+            srcAmount: BRIDGE_SRC_AMOUNT,
+            timestamp: BRIDGE_TIMESTAMP,
+            txId: bridge.raw.txID,
+          }),
+        },
+      })
+      .build(),
     testSpecificMock: mockAccountsApiWithEvmActivity,
     transactions: {
-      raw: [approve.raw, send, receive, swap.raw, bridgeFallback.raw],
-      trc20: [approve.trc20, swap.trc20, bridgeFallback.trc20],
+      raw: [approve.raw, send, receive, swap.raw, bridge.raw],
+      trc20: [approve.trc20, swap.trc20, bridge.trc20],
     },
   });
 
@@ -176,13 +190,20 @@ describe('Tron - Activity types', function (this: Suite) {
     await details.checkAmount('-5 TRX');
   });
 
-  it('Approval event without bridge history falls back to spending cap rendering', async function () {
-    // TronGrid-only bridge fixtures are an Approval to the router. A real
-    // bridge row needs BridgeStatusController txHistory keyed by the snap tx
-    // id, which these activity fixtures do not seed. List-only: details match
-    // the spending-cap case above.
-    await activity.checkTransactionActivityByText('Approved spending cap');
-    await activity.checkTransactionAmount('-5 USDT');
+  it('Bridge transaction uses the bridge transaction presentation', async function () {
+    await activity.checkTransactionActivityByText('Bridged USDT');
+    // destAmount is USDC base units (6 decimals): 5000000 → 5 USDC.
+    await activity.checkTransactionAmount('5 USDC');
+    const details = await openTronTransactionDetails({
+      driver,
+      activityTab: activity,
+      activityText: 'Bridged USDT',
+    });
+    await details.checkTitle('Bridged USDT');
+    await details.checkStatus('Confirmed');
+    await details.checkAmount('-5 USDT');
+    await details.checkAmount('+5 USDC');
+    await details.checkHashLinkPresent();
   });
 
   it('Tron-only filter hides EVM transactions', async function () {

--- a/test/e2e/tests/tron/activity/helpers.ts
+++ b/test/e2e/tests/tron/activity/helpers.ts
@@ -81,6 +81,7 @@ export async function mockAccountsApiWithEvmActivity(mockServer: Mockttp) {
 export async function withTronActivityFixtures(
   options: {
     borrowedTronNode: TronNode;
+    fixtures?: ReturnType<FixtureBuilderV2['build']>;
     title?: string;
     transactions?: TronFixtureAccount['transactions'];
     testSpecificMock?: (
@@ -100,7 +101,7 @@ export async function withTronActivityFixtures(
         },
       ],
       borrowedTronNode: options.borrowedTronNode,
-      fixtures: new FixtureBuilderV2().build(),
+      fixtures: options.fixtures ?? new FixtureBuilderV2().build(),
       includeAnvil: false,
       testSpecificMock: options.testSpecificMock,
       title: options.title,

--- a/test/e2e/tests/tron/mocks/tron-tx-fixtures.ts
+++ b/test/e2e/tests/tron/mocks/tron-tx-fixtures.ts
@@ -1,8 +1,14 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import { StatusTypes } from '@metamask/bridge-controller';
+import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { sha256 } from 'ethereum-cryptography/sha256';
 import { bytesToHex } from 'ethereum-cryptography/utils';
 import { base58AddressToHex } from '../../../seeder/tron/assets';
-import { SUN_PER_TRX, TRON_ACCOUNT_ADDRESS } from './common-tron';
+import {
+  SUN_PER_TRX,
+  TRON_ACCOUNT_ADDRESS,
+  TRON_CHAIN_ID,
+} from './common-tron';
 
 export type TronTxStatus = 'Confirmed' | 'Pending' | 'Failed';
 
@@ -21,6 +27,11 @@ export const MOCK_TRON_BLOCK_NUMBER = 77_000_000;
 // arbitrary placeholder strings here.
 const SUNSWAP_ROUTER_ADDRESS = 'TKzxdSv2FZKQrEqkKVgp5DcwEXBEKMg2Ax';
 const USDT_CONTRACT_ADDRESS = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
+const ETH_MAINNET_CHAIN_ID = 1;
+const ETH_USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const ETH_USDC_ASSET_ID = `eip155:${ETH_MAINNET_CHAIN_ID}/erc20:${ETH_USDC_ADDRESS}`;
+const TRON_MAINNET_CHAIN_ID = 728126428;
+const TRON_USDT_ASSET_ID = `${TRON_CHAIN_ID}/trc20:${USDT_CONTRACT_ADDRESS}`;
 
 const TRC20_INFO = {
   USDT: {
@@ -335,10 +346,9 @@ function buildSwapTrc20(opts: {
 }
 
 /**
- * A bridge transaction without `bridgeHistoryItem` should fall back to the
- * Interaction (i.e. Unknown) rendering. The snap maps a TriggerSmartContract
- * with a TRC20 transfer of type='Approval' as TransactionType.Unknown, which
- * the activity hook renders as 'Interaction'.
+ * TronGrid's view of a USDT bridge is an Approval to the router. Pair this with
+ * {@link tronBridgeHistoryItem} keyed by `raw.txID` so Activity reclassifies the
+ * snap tx as a bridge. Without that history, the row stays a spending cap.
  * @param opts
  * @param opts.srcSymbol
  * @param opts.srcAmount
@@ -413,4 +423,76 @@ function buildBridgeTrc20(opts: {
     value: opts.srcAmount,
     final_result: STATUS_TO_CONTRACT_RET[opts.status],
   };
+}
+
+/**
+ * Seeds BridgeStatusController txHistory so Activity can reclassify the matching
+ * snap tx (keyed by TronGrid `txID`) as a bridge instead of a spending cap.
+ *
+ * @param opts
+ * @param opts.txId - Must match `bridgeTx().raw.txID`
+ * @param opts.srcAmount - Atomic USDT amount sent on Tron
+ * @param opts.destAmount - Atomic dest-token amount received on Ethereum
+ * @param opts.timestamp
+ */
+export function tronBridgeHistoryItem(opts: {
+  txId: string;
+  srcAmount: string;
+  destAmount: string;
+  timestamp: number;
+}): BridgeHistoryItem {
+  const srcAsset = {
+    address: USDT_CONTRACT_ADDRESS,
+    assetId: TRON_USDT_ASSET_ID,
+    chainId: TRON_MAINNET_CHAIN_ID,
+    decimals: 6,
+    name: 'Tether USD',
+    symbol: 'USDT',
+  };
+  const destAsset = {
+    address: ETH_USDC_ADDRESS,
+    assetId: ETH_USDC_ASSET_ID,
+    chainId: ETH_MAINNET_CHAIN_ID,
+    decimals: 6,
+    name: 'USD Coin',
+    symbol: 'USDC',
+  };
+
+  return {
+    account: TRON_ACCOUNT_ADDRESS,
+    approvalTxId: opts.txId,
+    estimatedProcessingTimeInSeconds: 60,
+    hasApprovalTx: true,
+    slippagePercentage: 0,
+    startTime: opts.timestamp,
+    quote: {
+      destAsset,
+      destChainId: ETH_MAINNET_CHAIN_ID,
+      destTokenAmount: opts.destAmount,
+      feeData: {
+        metabridge: {
+          amount: '0',
+          asset: srcAsset,
+        },
+      },
+      requestId: `tron-bridge-${opts.txId}`,
+      srcAsset,
+      srcChainId: TRON_MAINNET_CHAIN_ID,
+      srcTokenAmount: opts.srcAmount,
+      steps: [],
+    },
+    status: {
+      destChain: {
+        amount: opts.destAmount,
+        chainId: ETH_MAINNET_CHAIN_ID,
+        txHash: `0x${'ab'.repeat(32)}`,
+      },
+      srcChain: {
+        amount: opts.srcAmount,
+        chainId: TRON_MAINNET_CHAIN_ID,
+        txHash: opts.txId,
+      },
+      status: StatusTypes.COMPLETE,
+    },
+  } as BridgeHistoryItem;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

TronGrid’s view of a USDT bridge is an Approval to the router, so Activity only renders a **Bridged** row when `BridgeStatusController.txHistory` is keyed by the snap tx id. This PR seeds that history instead of treating the row as a spending-cap fallback.

- Adds `FixtureBuilderV2.withBridgeStatusController()` so E2E fixtures can persist `txHistory`.
- Adds `tronBridgeHistoryItem()` keyed by `bridgeTx().raw.txID`.
- Asserts list + details for `Bridged USDT` (Tron USDT → Ethereum USDC).

Spending-cap coverage remains on the dedicated Approve case.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: WPN-435

## **Manual testing steps**

1. Run the Tron activity types E2E spec (`test/e2e/tests/tron/activity/activity-types.spec.ts`).
2. On the Tron activity list, confirm a **Bridged USDT** row with destination amount **5 USDC**.
3. Open that row and confirm details title **Bridged USDT**, status **Confirmed**, sent **-5 USDT**, received **+5 USDC**.
4. Confirm the separate **Approved spending cap** row is still present for the 10 USDT approval.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a8a3a22-f15b-487f-821a-569ae6b42d29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a8a3a22-f15b-487f-821a-569ae6b42d29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

