### PR TITLE
fix: cp-13.45.0 Remove preventing hardware wallet to pick token in MMPay confirmation

### DIFF
--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -275,17 +275,6 @@ describe('PayWithRow', () => {
     expect(screen.getByTestId('pay-with-symbol')).toHaveTextContent('ETH');
   });
 
-  it('does not open modal when hardware account', () => {
-    isHardwareAccountMock.mockReturnValue(true);
-
-    const store = mockStore(getMockState());
-    renderWithProvider(<PayWithRow />, store);
-
-    fireEvent.click(screen.getByTestId('pay-with-pill'));
-
-    expect(screen.queryByTestId('pay-with-modal')).not.toBeInTheDocument();
-  });
-
   [TransactionType.perpsWithdraw, TransactionType.moneyAccountDeposit].forEach(
     (transactionType) => {
       describe(`${transactionType} fallback behaviour`, () => {
@@ -365,15 +354,6 @@ describe('PayWithRow', () => {
       renderWithProvider(<PayWithRow />, store);
 
       expect(screen.getByTestId('pay-with-arrow')).toBeInTheDocument();
-    });
-
-    it('hides arrow icon for hardware account', () => {
-      isHardwareAccountMock.mockReturnValue(true);
-
-      const store = mockStore(getMockState());
-      renderWithProvider(<PayWithRow />, store);
-
-      expect(screen.queryByTestId('pay-with-arrow')).not.toBeInTheDocument();
     });
   });
 

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -139,7 +139,6 @@ export function PayWithRow({
     displayToken,
     balanceUsdFormatted,
     label,
-    canEdit,
     from,
     ownerId,
     isPostQuoteWithdraw,
@@ -174,18 +173,18 @@ export function PayWithRow({
       >
         <Box
           data-testid="pay-with-pill"
-          onClick={canEdit ? openModal : undefined}
+          onClick={openModal}
           display={Display.InlineFlex}
           alignItems={AlignItems.center}
           gap={1}
-          style={{ cursor: canEdit ? 'pointer' : 'default' }}
+          style={{ cursor: 'pointer' }}
         >
           <PaySelectorContent
             displayToken={displayToken}
             emptyLabel={t('payWithEmptySelection')}
             balanceText={` (${balanceUsdFormatted})`}
             showBalance={Boolean(displayToken) && !isPostQuoteWithdraw}
-            showArrow={canEdit && Boolean(from)}
+            showArrow={Boolean(from)}
             isMoneyAccountSelected={isMoneyAccountSelected}
           />
         </Box>

--- a/ui/pages/confirmations/hooks/pay/usePayWithToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePayWithToken.test.tsx
@@ -10,7 +10,6 @@ import {
 } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
 import { useConfirmContext } from '../../context/confirm';
-import { getInternalAccountByAddress } from '../../../../selectors/accounts';
 import { selectPaymentOverrideByTransactionId } from '../../../../selectors/transactionPayController';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
@@ -30,9 +29,6 @@ jest.mock('./useTransactionPayToken', () => ({
 jest.mock('./useTransactionPayData', () => ({
   useTransactionPayRequiredTokens: jest.fn(),
 }));
-jest.mock('../../../../selectors/accounts', () => ({
-  getInternalAccountByAddress: jest.fn(),
-}));
 jest.mock('../../../../selectors/transactionPayController', () => ({
   selectPaymentOverrideByTransactionId: jest.fn(),
 }));
@@ -49,12 +45,6 @@ jest.mock('../../../../hooks/useI18nContext', () => ({
 jest.mock('../../../../hooks/useFiatFormatter', () => ({
   useFiatFormatter: () => (value: number) => `$${value.toFixed(2)}`,
 }));
-jest.mock(
-  '../../../multichain-accounts/account-details/account-type-utils',
-  () => ({
-    isHardwareAccount: jest.fn(() => false),
-  }),
-);
 jest.mock('../../components/modals/pay-with-modal', () => ({
   PayWithModal: ({ isOpen }: { isOpen: boolean }) =>
     isOpen ? <div data-testid="pay-with-modal" /> : null,
@@ -85,15 +75,9 @@ describe('usePayWithToken', () => {
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
   );
-  const getInternalAccountByAddressMock = jest.mocked(
-    getInternalAccountByAddress,
-  );
   const selectPaymentOverrideByTransactionIdMock = jest.mocked(
     selectPaymentOverrideByTransactionId,
   );
-  const { isHardwareAccount } = jest.requireMock(
-    '../../../multichain-accounts/account-details/account-type-utils',
-  ) as { isHardwareAccount: jest.Mock };
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -112,9 +96,7 @@ describe('usePayWithToken', () => {
       isNative: false,
     });
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
-    getInternalAccountByAddressMock.mockReturnValue(ACCOUNT as never);
     selectPaymentOverrideByTransactionIdMock.mockReturnValue(undefined);
-    isHardwareAccount.mockReturnValue(false);
 
     useSelectorMock.mockImplementation(
       (selector: (state: unknown) => unknown) => selector({}),
@@ -132,7 +114,6 @@ describe('usePayWithToken', () => {
     expect(result.current.balanceUsdFormatted).toBe('$25.00');
     expect(result.current.label).toBe('Pay with');
     expect(result.current.isMoneyAccountSelected).toBe(false);
-    expect(result.current.canEdit).toBe(true);
   });
 
   it('returns Money account display values when paymentOverride is MoneyAccount', () => {
@@ -178,20 +159,6 @@ describe('usePayWithToken', () => {
     });
 
     expect(result.current.modal).not.toBeNull();
-  });
-
-  it('does not open the modal for hardware accounts', () => {
-    isHardwareAccount.mockReturnValue(true);
-
-    const { result } = renderHook(() => usePayWithToken());
-
-    expect(result.current.canEdit).toBe(false);
-
-    act(() => {
-      result.current.openModal();
-    });
-
-    expect(result.current.modal).toBeNull();
   });
 
   it('waits for payToken on perps withdraw instead of falling back to required token', () => {

--- a/ui/pages/confirmations/hooks/pay/usePayWithToken.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePayWithToken.tsx
@@ -12,13 +12,10 @@ import {
 } from '../../../../../shared/lib/transactions.utils';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../../hooks/useFiatFormatter';
-import { getInternalAccountByAddress } from '../../../../selectors/accounts';
 import {
   selectPaymentOverrideByTransactionId,
   type TransactionPayState,
 } from '../../../../selectors/transactionPayController';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
-import { isHardwareAccount } from '../../../multichain-accounts/account-details/account-type-utils';
 import { useConfirmContext } from '../../context/confirm';
 import { PayWithModal } from '../../components/modals/pay-with-modal';
 import { useTransactionPayToken } from './useTransactionPayToken';
@@ -36,7 +33,6 @@ type PayWithToken = {
   displayToken: PayWithDisplayToken | undefined;
   balanceUsdFormatted: string;
   label: string;
-  canEdit: boolean;
   from: string | undefined;
   ownerId: string;
   isPostQuoteWithdraw: boolean;
@@ -63,17 +59,12 @@ export function usePayWithToken(): PayWithToken {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const from = currentConfirmation?.txParams?.from;
   const transactionId = currentConfirmation?.id ?? '';
-
-  const fromAccount = useSelector((state) =>
-    getInternalAccountByAddress(state, from ?? ''),
-  );
   const paymentOverride = useSelector((state: TransactionPayState) =>
     selectPaymentOverrideByTransactionId(state, transactionId),
   );
   const isMoneyAccountSelected =
     paymentOverride === PaymentOverride.MoneyAccount;
 
-  const canEdit = fromAccount ? !isHardwareAccount(fromAccount) : true;
   const isPostQuoteWithdraw =
     isPostQuoteWithdrawTransaction(currentConfirmation);
   // Avoid flashing the destination/required token (e.g. mUSD on Monad) while
@@ -85,10 +76,8 @@ export function usePayWithToken(): PayWithToken {
     ]);
 
   const openModal = useCallback(() => {
-    if (canEdit) {
-      setIsModalOpen(true);
-    }
-  }, [canEdit]);
+    setIsModalOpen(true);
+  }, []);
 
   const closeModal = useCallback(() => {
     setIsModalOpen(false);
@@ -128,7 +117,6 @@ export function usePayWithToken(): PayWithToken {
     displayToken,
     balanceUsdFormatted,
     label: isPostQuoteWithdraw ? t('withdrawTo') : t('payWith'),
-    canEdit,
     from,
     ownerId: currentConfirmation?.id ?? '',
     isPostQuoteWithdraw,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR removes the restriction that prevented hardware wallet accounts from selecting a token in the MMPay confirmation flow.

Previously, `usePayWithToken` checked whether the `from` account was a hardware wallet (`isHardwareAccount`) and, if so, set `canEdit = false` — blocking the token picker modal from opening and hiding the arrow icon on the pay-with pill. This was overly restrictive: hardware wallet users should be able to pick a different token just like any other account.

**Changes:**
- Removed the `canEdit` flag from `usePayWithToken` and all its consumers
- Removed the `getInternalAccountByAddress` selector lookup and `isHardwareAccount` import (also cleans up a `route-isolation` lint suppression comment)
- `openModal` now always allows the modal to open regardless of account type
- The arrow icon and pointer cursor on the pay-with pill are now always shown
- Removed corresponding tests that verified the now-deleted hardware-wallet restriction

## **Changelog**

CHANGELOG entry: Fixed a bug that prevented hardware wallet accounts from selecting a token in the MMPay confirmation flow

## **Related issues**

Fixes: [CONF-1874](https://consensyssoftware.atlassian.net/browse/CONF-1874)

## **Manual testing steps**

1. Connect a hardware wallet (e.g. Ledger or Trezor)
2. Initiate an MMPay transaction that shows the confirmation flow
3. Verify the pay-with pill shows the arrow icon and is clickable
4. Click the pill and confirm the token picker modal opens
5. Select a different token and confirm the selection is applied

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1499" height="1266" alt="Screenshot 2026-08-20 at 10 34 19" src="https://github.com/user-attachments/assets/fcc432d3-19a9-4bdc-bdb0-e7b646b14a9c" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[CONF-1874]: https://consensyssoftware.atlassian.net/browse/CONF-1874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6a105046c4d5ee74eedf56f0bc28bd682e4fa0be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->