### PR TITLE
fix: cp-13.45.0 Fix mUSD banner navigation

### DIFF
--- a/ui/hooks/musd/useMusdConversion.test.ts
+++ b/ui/hooks/musd/useMusdConversion.test.ts
@@ -205,9 +205,11 @@ describe('useMusdConversion', () => {
 
       expect(mockAddTransaction).toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pathname: `/confirm-transaction/${MOCK_TX_ID}`,
-        }),
+        {
+          pathname: '/confirm-transaction/tx-abc-123',
+          search: 'loader=customAmount&goBackTo=%2Fasset%2F0x1%2F0xtest',
+        },
+        { replace: true },
       );
 
       useMusdGeoBlocking.mockReturnValue({
@@ -294,9 +296,11 @@ describe('useMusdConversion', () => {
 
       expect(mockAddTransaction).not.toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalledWith(
-        expect.objectContaining({
+        {
           pathname: '/confirm-transaction/existing-tx-id',
-        }),
+          search: 'loader=customAmount&goBackTo=%2Fasset%2F0x1%2F0xtest',
+        },
+        { replace: true },
       );
     });
 
@@ -346,10 +350,11 @@ describe('useMusdConversion', () => {
       );
       expect(mockAddTransaction).toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pathname: `/confirm-transaction/${MOCK_TX_ID}`,
+        {
+          pathname: '/confirm-transaction/tx-abc-123',
           search: 'loader=customAmount&goBackTo=%2Fasset%2F0x1%2F0xtest',
-        }),
+        },
+        { replace: true },
       );
     });
 

--- a/ui/hooks/musd/useMusdConversion.ts
+++ b/ui/hooks/musd/useMusdConversion.ts
@@ -271,13 +271,16 @@ export function useMusdConversion(): UseMusdConversionResult {
 
         await ensureMusdTokenPromise;
 
-        navigate({
-          pathname: `${CONFIRM_TRANSACTION_ROUTE}/${txId}`,
-          search: new URLSearchParams({
-            loader: ConfirmationLoader.CustomAmount,
-            goBackTo: location.pathname + location.search,
-          }).toString(),
-        });
+        navigate(
+          {
+            pathname: `${CONFIRM_TRANSACTION_ROUTE}/${txId}`,
+            search: new URLSearchParams({
+              loader: ConfirmationLoader.CustomAmount,
+              goBackTo: location.pathname + location.search,
+            }).toString(),
+          },
+          { replace: true },
+        );
 
         if (preferredToken?.address) {
           await updateTransactionPaymentToken({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When navigating to the mUSD conversion confirmation screen from the asset page, the confirmation was pushed onto the browser history stack on top of the asset page entry. This meant that after the user returned to the asset page (via the confirmation's back/cancel button), pressing the asset page's back button would call `navigate(-1)` and land back on the now-gone confirmation URL instead of the home page.

The fix is a one-liner: pass `{ replace: true }` to the `navigate()` call in `startConversionFlow`. This replaces the asset page history entry with the confirmation instead of pushing on top of it, so any navigation back from confirmation correctly skips over it. The `goBackTo` query param is still passed so the confirmation's own cancel/reject button can navigate explicitly back to the asset page path.

## **Changelog**

CHANGELOG entry: Fixed a bug where the back button on the token detail page navigated to a stale mUSD conversion confirmation screen instead of the home page

## **Related issues**

Fixes: [MWPE-44](https://consensyssoftware.atlassian.net/browse/MWPE-44)

## **Manual testing steps**

1. Open the extension and navigate to a token detail page for a stablecoin eligible for mUSD conversion (e.g. USDC on Linea)
2. Tap the mUSD conversion CTA to start the conversion flow — this navigates to the confirmation screen
3. On the confirmation screen, press the back arrow to return to the token detail page
4. On the token detail page, press the back arrow again
5. Verify you land on the home page — **not** a blank/broken confirmation screen

## **Screenshots/Recordings**

### **After**


https://github.com/user-attachments/assets/4948f44e-48b9-4b7c-be2b-4796c6402a57


<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MWPE-44]: https://consensyssoftware.atlassian.net/browse/MWPE-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d2173fdcddaa68afbe30c6174cf10aa4e85abfc0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->