### PR TITLE
fix: Ensure multichain notification subscriptions are torn down

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5957,15 +5957,13 @@ export default class MetamaskController extends EventEmitter {
       return end();
     });
 
-    const subscriptionManager = this.multichainSubscriptionManager;
-
-    function destroy() {
+    const destroy = () => {
       engine.destroy();
-      subscriptionManager.removeListener(
+      this.multichainSubscriptionManager.removeListener(
         'notification',
         onMultichainNotification,
       );
-    }
+    };
 
     return { engine, destroy };
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -534,6 +534,7 @@ export default class MetamaskController extends EventEmitter {
         'NetworkController:findNetworkClientIdByChainId',
       ),
     });
+    this.multichainSubscriptionManager.setMaxListeners(25);
     this.multichainMiddlewareManager = new MultichainMiddlewareManager();
     this.deprecatedNetworkVersions = {};
 
@@ -5126,7 +5127,7 @@ export default class MetamaskController extends EventEmitter {
       mainFrameOrigin = new URL(sender.tab.url).origin;
     }
 
-    const engine = this.setupProviderEngineCaip({
+    const { engine, destroy } = this.setupProviderEngineCaip({
       origin,
       sender,
       subjectType,
@@ -5163,7 +5164,7 @@ export default class MetamaskController extends EventEmitter {
       outStream,
       (err) => {
         // handle any middleware cleanup
-        engine.destroy();
+        destroy();
         connectionId && this.removeConnection(origin, connectionId);
         // For context and todos related to the error message match, see https://github.com/MetaMask/metamask-extension/issues/26337
         if (err && !err.message?.match('Premature close')) {
@@ -5930,13 +5931,15 @@ export default class MetamaskController extends EventEmitter {
       // noop
     }
 
+    const onMultichainNotification = (targetOrigin, targetTabId, message) => {
+      if (origin === targetOrigin && tabId === targetTabId) {
+        engine.emit('notification', message);
+      }
+    };
+
     this.multichainSubscriptionManager.on(
       'notification',
-      (targetOrigin, targetTabId, message) => {
-        if (origin === targetOrigin && tabId === targetTabId) {
-          engine.emit('notification', message);
-        }
-      },
+      onMultichainNotification,
     );
 
     engine.push(
@@ -5954,7 +5957,17 @@ export default class MetamaskController extends EventEmitter {
       return end();
     });
 
-    return engine;
+    const subscriptionManager = this.multichainSubscriptionManager;
+
+    function destroy() {
+      engine.destroy();
+      subscriptionManager.removeListener(
+        'notification',
+        onMultichainNotification,
+      );
+    }
+
+    return { engine, destroy };
   }
 
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR makes two changes, firstly it ensures that listeners attached to `multichainSubscriptionManager` are properly removed when the engine/connection is destroyed. Secondly, it increases the max number of listeners on `multichainSubscriptionManager` before it logs warnings about too many attached listeners. If we see warnings above 25 listeners, we may have regressed.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a memory leak that would get worse the longer MetaMask ran

## **Related issues**

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 609ef94ca5a5d2ba979f8cec06a3f31b8b831bed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->