### PR TITLE
fix(security-trust): reclassify IMPERSONATOR_LOW_CONFIDENCE as Info

### DIFF
--- a/ui/pages/asset/utils/security-utils.test.ts
+++ b/ui/pages/asset/utils/security-utils.test.ts
@@ -69,6 +69,18 @@ describe('security-utils', () => {
 
       expect(tags).toEqual([{ label: 'securityTrustFeatureHoneypot' }]);
     });
+
+    it('excludes Info features such as IMPERSONATOR_LOW_CONFIDENCE from Warning result type tags', () => {
+      const features = [
+        makeFeature('IMPERSONATOR_LOW_CONFIDENCE'),
+        makeFeature('HONEYPOT'),
+      ];
+
+      const { tags, remainingCount } = getFeatureTags(features, 'Warning', t);
+
+      expect(tags).toEqual([{ label: 'securityTrustFeatureHoneypot' }]);
+      expect(remainingCount).toBe(0);
+    });
   });
 
   describe('formatFeePercent', () => {

--- a/ui/pages/asset/utils/security-utils.ts
+++ b/ui/pages/asset/utils/security-utils.ts
@@ -260,7 +260,7 @@ export const getNegativeFeatureLabels = (
   },
   IMPERSONATOR_LOW_CONFIDENCE: {
     label: t('securityTrustFeatureImpersonatorLowConfidence'),
-    type: 'Warning',
+    type: 'Info',
   },
   IS_MINTABLE: {
     label: t('securityTrustFeatureIsMintable'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The `IMPERSONATOR_LOW_CONFIDENCE` security signal was classified as a `Warning`-type feature in the token security trust feature map. Blockaid classifies this signal as `Info`-level, and `Info`-level features should not be surfaced to users as warnings. This PR updates its `BlockaidFeatureType` in `ui/pages/asset/utils/security-utils.ts` to `Info`.

The equivalent change is being made in metamask-mobile ([#35084](https://github.com/MetaMask/metamask-mobile/pull/35084)).

## **Changelog**

CHANGELOG entry: Fixed an issue where the low-confidence "Unconfirmed impersonator" security signal was shown as a warning on the token details page

## **Related issues**

Fixes: [ASSETS-3902](https://consensyssoftware.atlassian.net/browse/ASSETS-3902)

## **Manual testing steps**

Test token from the ticket: `0x2524592CfD16eAb328eE54636259b43a48154A8D` (CUBIT) on Ethereum Mainnet.

1. Switch the wallet to Ethereum Mainnet and open the token details page for CUBIT (`0x2524592CfD16eAb328eE54636259b43a48154A8D`).
2. View the security trust section.
3. Verify the "Unconfirmed impersonator" tag is no longer listed among the risk feature tags.
4. Verify the legitimate warning-level "Unstable price" tag is still listed, and that the overflow count ("+N more") reflects the reduced number of warning features.

## **Screenshots/Recordings**

N/A — no visual design change. The change removes one feature tag from an existing list; layout, styling, and all other tags are unchanged.

<!--
### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76a5d6cf-8a80-4493-8f1b-dd11ff0c33de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76a5d6cf-8a80-4493-8f1b-dd11ff0c33de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ASSETS-3902]: https://consensyssoftware.atlassian.net/browse/ASSETS-3902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ