### PR TITLE
feat(bridge): add Mobile-parity SwapQuoteFetch traces and relay tests

### DIFF
--- a/app/scripts/messenger-client-init/bridge-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/bridge-controller-init.test.ts
@@ -1,9 +1,11 @@
 import {
   BridgeController,
   BridgeControllerMessenger,
+  UnifiedSwapBridgeEventName,
 } from '@metamask/bridge-controller';
 import { BRIDGE_API_BASE_URL } from '../../../shared/constants/bridge';
 import { getRootMessenger } from '../lib/messenger';
+import { trackEvent } from '../controllers/analytics';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
 import {
@@ -19,6 +21,11 @@ jest.mock('@metamask/bridge-controller', () => {
     BridgeController: jest.fn(),
   };
 });
+
+jest.mock('../controllers/analytics', () => ({
+  ...jest.requireActual('../controllers/analytics'),
+  trackEvent: jest.fn(),
+}));
 
 function getInitRequestMock(): jest.Mocked<
   MessengerClientInitRequest<
@@ -65,5 +72,39 @@ describe('BridgeControllerInit', () => {
       traceFn: expect.any(Function),
       getUseAssetsControllerForRates: expect.any(Function),
     });
+  });
+
+  it('correctly sets up trackMetaMetricsFn', () => {
+    BridgeControllerInit(getInitRequestMock());
+    const constructorOptions = jest.mocked(BridgeController).mock.calls[0][0];
+    const {trackMetaMetricsFn} = constructorOptions;
+    const properties = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      error_message: 'Snap request failed',
+    };
+
+    trackMetaMetricsFn(UnifiedSwapBridgeEventName.Failed, properties as never);
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: UnifiedSwapBridgeEventName.Failed,
+        properties: expect.objectContaining(properties),
+      }),
+    );
+  });
+
+  it('handles trackMetaMetricsFn with no properties', () => {
+    BridgeControllerInit(getInitRequestMock());
+    const constructorOptions = jest.mocked(BridgeController).mock.calls[0][0];
+    const {trackMetaMetricsFn} = constructorOptions;
+
+    trackMetaMetricsFn(UnifiedSwapBridgeEventName.Failed, {} as never);
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: UnifiedSwapBridgeEventName.Failed,
+        properties: expect.any(Object),
+      }),
+    );
   });
 });

--- a/app/scripts/messenger-client-init/bridge-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/bridge-controller-init.test.ts
@@ -77,7 +77,7 @@ describe('BridgeControllerInit', () => {
   it('correctly sets up trackMetaMetricsFn', () => {
     BridgeControllerInit(getInitRequestMock());
     const constructorOptions = jest.mocked(BridgeController).mock.calls[0][0];
-    const {trackMetaMetricsFn} = constructorOptions;
+    const { trackMetaMetricsFn } = constructorOptions;
     const properties = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       error_message: 'Snap request failed',
@@ -96,7 +96,7 @@ describe('BridgeControllerInit', () => {
   it('handles trackMetaMetricsFn with no properties', () => {
     BridgeControllerInit(getInitRequestMock());
     const constructorOptions = jest.mocked(BridgeController).mock.calls[0][0];
-    const {trackMetaMetricsFn} = constructorOptions;
+    const { trackMetaMetricsFn } = constructorOptions;
 
     trackMetaMetricsFn(UnifiedSwapBridgeEventName.Failed, {} as never);
 

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -42,6 +42,7 @@ export enum TraceName {
   SendCompleted = 'Send Completed',
   SetupStore = 'Setup Store',
   Signature = 'Signature',
+  SwapQuoteFetch = 'Swap Quote Fetch',
   SwapQuotesFetched = 'Swap Quotes Fetched',
   SwapViewLoaded = 'Swap View Loaded',
   Transaction = 'Transaction',

--- a/ui/hooks/bridge/useQuoteFetchEvents.test.ts
+++ b/ui/hooks/bridge/useQuoteFetchEvents.test.ts
@@ -8,10 +8,21 @@ import mockBridgeQuotesNativeErc20 from '../../../test/data/bridge/mock-quotes-n
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { mockNetworkState } from '../../../test/stub/networks';
 import * as bridgeActions from '../../ducks/bridge/actions';
+import { TraceName } from '../../../shared/lib/trace';
 import { useIsTxSubmittable } from './useIsTxSubmittable';
 import { useQuoteFetchEvents } from './useQuoteFetchEvents';
 
 const mockDispatch = jest.fn((...args: unknown[]) => jest.fn()(...args));
+
+const mockEndTrace = jest.fn();
+
+jest.mock('../../../shared/lib/trace', () => {
+  const actual = jest.requireActual('../../../shared/lib/trace');
+  return {
+    ...actual,
+    endTrace: (...args: unknown[]) => mockEndTrace(...args),
+  };
+});
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -153,5 +164,66 @@ describe('useQuoteFetchEvents', () => {
         provider: expect.stringMatching(/.+_.+/u),
       }),
     );
+  });
+
+  it('ends the quote fetch trace when the first quote becomes available', () => {
+    renderUseQuoteFetchEvents(
+      createBridgeMockStore({
+        bridgeStateOverrides: {
+          quotesRefreshCount: 1,
+          quotesLastFetched: Date.now(),
+          quotesLoadingStatus: RequestStatus.LOADING,
+          quotes: mockBridgeQuotesNativeErc20,
+        },
+        metamaskStateOverrides: {
+          ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
+          currencyRates: {
+            ETH: { conversionRate: 2500, usdConversionRate: 2500 },
+          },
+        },
+      }),
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: TraceName.SwapQuoteFetch,
+      timestamp: expect.any(Number),
+    });
+  });
+
+  it('ends the quote fetch trace when a completed request has no quotes', () => {
+    renderUseQuoteFetchEvents(
+      createBridgeMockStore({
+        bridgeStateOverrides: {
+          quotesRefreshCount: 1,
+          quotesLastFetched: Date.now(),
+          quotesLoadingStatus: RequestStatus.FETCHED,
+          quotes: [],
+        },
+      }),
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: TraceName.SwapQuoteFetch,
+      timestamp: expect.any(Number),
+    });
+  });
+
+  it('ends the quote fetch trace as unsuccessful when quote fetching fails', () => {
+    renderUseQuoteFetchEvents(
+      createBridgeMockStore({
+        bridgeStateOverrides: {
+          quotesRefreshCount: 1,
+          quotesLastFetched: Date.now(),
+          quotesLoadingStatus: RequestStatus.ERROR,
+          quoteFetchError: 'Network error',
+        },
+      }),
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: TraceName.SwapQuoteFetch,
+      timestamp: expect.any(Number),
+      data: { success: false },
+    });
   });
 });

--- a/ui/hooks/bridge/useQuoteFetchEvents.test.ts
+++ b/ui/hooks/bridge/useQuoteFetchEvents.test.ts
@@ -226,4 +226,24 @@ describe('useQuoteFetchEvents', () => {
       data: { success: false },
     });
   });
+
+  it('ends the quote fetch trace as unsuccessful when the hook unmounts', () => {
+    const { unmount } = renderUseQuoteFetchEvents(
+      createBridgeMockStore({
+        bridgeStateOverrides: {
+          quotesRefreshCount: 0,
+          quotesLoadingStatus: RequestStatus.LOADING,
+        },
+      }),
+    );
+
+    mockEndTrace.mockClear();
+    unmount();
+
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: TraceName.SwapQuoteFetch,
+      timestamp: expect.any(Number),
+      data: { success: false },
+    });
+  });
 });

--- a/ui/hooks/bridge/useQuoteFetchEvents.ts
+++ b/ui/hooks/bridge/useQuoteFetchEvents.ts
@@ -11,6 +11,7 @@ import {
   type BridgeAppState,
 } from '../../ducks/bridge/selectors';
 import { trackUnifiedSwapBridgeEvent } from '../../ducks/bridge/actions';
+import { endTrace, TraceName } from '../../../shared/lib/trace';
 import { useDispatch } from '../../store/hooks';
 import { useIsTxSubmittable } from './useIsTxSubmittable';
 import { useHasSufficientGasForQuoteForMetrics } from './useHasSufficientGasForQuoteForMetrics';
@@ -38,9 +39,17 @@ export const useQuoteFetchEvents = () => {
     activeQuote ?? null,
   );
 
+  const firstQuoteRequestId = recommendedQuote?.quote.requestId;
+
   // Emitted each time quotes are fetched successfully
   useEffect(() => {
     if (!isLoading && quotesRefreshCount > 0 && !quoteFetchError) {
+      if (!firstQuoteRequestId) {
+        endTrace({
+          name: TraceName.SwapQuoteFetch,
+          timestamp: Date.now(),
+        });
+      }
       dispatch(
         trackUnifiedSwapBridgeEvent(
           UnifiedSwapBridgeEventName.QuotesReceived,
@@ -56,4 +65,25 @@ export const useQuoteFetchEvents = () => {
       );
     }
   }, [quotesRefreshCount]);
+
+  // End the trace as soon as the first quote becomes available, including
+  // while the controller is still streaming additional quotes.
+  useEffect(() => {
+    if (firstQuoteRequestId) {
+      endTrace({
+        name: TraceName.SwapQuoteFetch,
+        timestamp: Date.now(),
+      });
+    }
+  }, [firstQuoteRequestId]);
+
+  useEffect(() => {
+    if (quoteFetchError) {
+      endTrace({
+        name: TraceName.SwapQuoteFetch,
+        timestamp: Date.now(),
+        data: { success: false },
+      });
+    }
+  }, [quoteFetchError]);
 };

--- a/ui/hooks/bridge/useQuoteFetchEvents.ts
+++ b/ui/hooks/bridge/useQuoteFetchEvents.ts
@@ -86,4 +86,14 @@ export const useQuoteFetchEvents = () => {
       });
     }
   }, [quoteFetchError]);
+
+  useEffect(() => {
+    return () => {
+      endTrace({
+        name: TraceName.SwapQuoteFetch,
+        timestamp: Date.now(),
+        data: { success: false },
+      });
+    };
+  }, []);
 };

--- a/ui/pages/bridge/prepare/prepare-bridge-page.test.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.test.tsx
@@ -31,6 +31,7 @@ import { TraceName } from '../../../../shared/lib/trace';
 import PrepareBridgePage from './prepare-bridge-page';
 
 const mockTrace = jest.fn();
+const mockEndTrace = jest.fn();
 
 jest.mock('../../../../shared/lib/trace', () => {
   const actual = jest.requireActual('../../../../shared/lib/trace');
@@ -39,6 +40,10 @@ jest.mock('../../../../shared/lib/trace', () => {
     trace: (...args: unknown[]) => {
       mockTrace(...args);
       return actual.trace(...args);
+    },
+    endTrace: (...args: unknown[]) => {
+      mockEndTrace(...args);
+      return actual.endTrace(...args);
     },
   };
 });
@@ -674,9 +679,25 @@ describe('PrepareBridgePage', () => {
         await Promise.resolve();
       });
 
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.SwapQuoteFetch,
+      });
       expect(mockTrace).toHaveBeenCalledWith({
         name: TraceName.SwapQuoteFetch,
       });
+      const quoteFetchEndIndex = mockEndTrace.mock.calls.findIndex(
+        ([request]) =>
+          (request as { name: string }).name === TraceName.SwapQuoteFetch,
+      );
+      const quoteFetchStartIndex = mockTrace.mock.calls.findIndex(
+        ([request]) =>
+          (request as { name: string }).name === TraceName.SwapQuoteFetch,
+      );
+      expect(quoteFetchEndIndex).toBeGreaterThanOrEqual(0);
+      expect(quoteFetchStartIndex).toBeGreaterThanOrEqual(0);
+      expect(
+        mockEndTrace.mock.invocationCallOrder[quoteFetchEndIndex],
+      ).toBeLessThan(mockTrace.mock.invocationCallOrder[quoteFetchStartIndex]);
     });
 
     it('starts a trace when quotes are manually refreshed', async () => {
@@ -692,6 +713,7 @@ describe('PrepareBridgePage', () => {
         await Promise.resolve();
       });
       mockTrace.mockClear();
+      mockEndTrace.mockClear();
 
       await act(async () => {
         fireEvent.click(getByTestId('bridge-cta-button'));
@@ -701,6 +723,9 @@ describe('PrepareBridgePage', () => {
         await Promise.resolve();
       });
 
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.SwapQuoteFetch,
+      });
       expect(mockTrace).toHaveBeenCalledWith({
         name: TraceName.SwapQuoteFetch,
       });
@@ -722,6 +747,9 @@ describe('PrepareBridgePage', () => {
       expect(mockTrace).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: TraceName.SwapQuoteFetch }),
       );
+      expect(mockEndTrace).not.toHaveBeenCalledWith({
+        name: TraceName.SwapQuoteFetch,
+      });
     });
   });
 

--- a/ui/pages/bridge/prepare/prepare-bridge-page.test.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.test.tsx
@@ -715,9 +715,7 @@ describe('PrepareBridgePage', () => {
       mockTrace.mockClear();
       mockEndTrace.mockClear();
 
-      await act(async () => {
-        fireEvent.click(getByTestId('bridge-cta-button'));
-      });
+      fireEvent.click(getByTestId('bridge-cta-button'));
       await act(async () => {
         jest.advanceTimersByTime(300);
         await Promise.resolve();

--- a/ui/pages/bridge/prepare/prepare-bridge-page.test.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.test.tsx
@@ -27,7 +27,21 @@ import {
   HardwareConnectionPermissionState,
   HardwareWalletProvider,
 } from '../../../contexts/hardware-wallets';
+import { TraceName } from '../../../../shared/lib/trace';
 import PrepareBridgePage from './prepare-bridge-page';
+
+const mockTrace = jest.fn();
+
+jest.mock('../../../../shared/lib/trace', () => {
+  const actual = jest.requireActual('../../../../shared/lib/trace');
+  return {
+    ...actual,
+    trace: (...args: unknown[]) => {
+      mockTrace(...args);
+      return actual.trace(...args);
+    },
+  };
+});
 
 // Mock the bridge hooks
 jest.mock('../hooks/useGasIncludedSupport', () => ({
@@ -584,6 +598,131 @@ describe('PrepareBridgePage', () => {
     );
 
     jest.useRealTimers();
+  });
+
+  describe('quote fetch trace', () => {
+    const TOKEN_ADDRESS = '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984';
+
+    const makeQuoteRequestStore = (
+      bridgeSliceOverrides: Record<string, unknown> = {},
+    ) =>
+      createBridgeMockStore({
+        featureFlagOverrides: {
+          bridgeConfig: {
+            chains: {
+              [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: true },
+              [CHAIN_IDS.LINEA_MAINNET]: {
+                isActiveSrc: true,
+                isActiveDest: true,
+              },
+            },
+          },
+        },
+        bridgeSliceOverrides: {
+          fromTokenInputValue: '1',
+          fromToken: {
+            address: TOKEN_ADDRESS,
+            decimals: 6,
+            symbol: 'USDC',
+            chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET),
+            assetId: toAssetId(
+              TOKEN_ADDRESS,
+              formatChainIdToCaip(CHAIN_IDS.MAINNET),
+            ),
+          },
+          toToken: {
+            address: TOKEN_ADDRESS,
+            decimals: 6,
+            symbol: 'UNI',
+            chainId: formatChainIdToCaip(CHAIN_IDS.LINEA_MAINNET),
+            assetId: toAssetId(
+              TOKEN_ADDRESS,
+              formatChainIdToCaip(CHAIN_IDS.LINEA_MAINNET),
+            ),
+          },
+          ...bridgeSliceOverrides,
+        },
+      });
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest
+        .spyOn(reactRouterUtils, 'useSearchParams')
+        .mockReturnValue([{ get: () => null }] as never);
+      setBackgroundConnection({
+        resetState: jest.fn(),
+        getStatePatches: jest.fn().mockResolvedValue([]),
+        updateBridgeQuoteRequestParams: jest.fn().mockResolvedValue(undefined),
+        trackUnifiedSwapBridgeEvent: jest.fn().mockResolvedValue(undefined),
+      } as never);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('starts a trace when a valid quote request is dispatched', async () => {
+      renderWithProvider(
+        <HardwareWalletProvider>
+          <PrepareBridgePage onOpenSettings={jest.fn()} />
+        </HardwareWalletProvider>,
+        configureStore(makeQuoteRequestStore()),
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+        await Promise.resolve();
+      });
+
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.SwapQuoteFetch,
+      });
+    });
+
+    it('starts a trace when quotes are manually refreshed', async () => {
+      const { getByTestId } = renderWithProvider(
+        <HardwareWalletProvider>
+          <PrepareBridgePage onOpenSettings={jest.fn()} />
+        </HardwareWalletProvider>,
+        configureStore(makeQuoteRequestStore({ wasTxDeclined: true })),
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+        await Promise.resolve();
+      });
+      mockTrace.mockClear();
+
+      await act(async () => {
+        fireEvent.click(getByTestId('bridge-cta-button'));
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+        await Promise.resolve();
+      });
+
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.SwapQuoteFetch,
+      });
+    });
+
+    it('does not start a trace for an incomplete quote request', async () => {
+      renderWithProvider(
+        <HardwareWalletProvider>
+          <PrepareBridgePage onOpenSettings={jest.fn()} />
+        </HardwareWalletProvider>,
+        configureStore(makeQuoteRequestStore({ fromTokenInputValue: null })),
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+        await Promise.resolve();
+      });
+
+      expect(mockTrace).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: TraceName.SwapQuoteFetch }),
+      );
+    });
   });
 
   describe('token_security_type_destination coverage', () => {

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -14,7 +14,7 @@ import {
   formatAddressToCaipReference,
 } from '@metamask/bridge-controller';
 import { Box, BoxBackgroundColor } from '@metamask/design-system-react';
-import { endTrace, TraceName } from '../../../../shared/lib/trace';
+import { endTrace, trace, TraceName } from '../../../../shared/lib/trace';
 import {
   setFromToken,
   setFromTokenInputValue,
@@ -323,6 +323,10 @@ const PrepareBridgePage = ({
   // making it safe not to worry about recreating this function on dependency updates.
   const debouncedUpdateQuoteRequestInController = useRef(
     debounce((...args: Parameters<typeof updateQuoteRequestParams>) => {
+      const [params] = args;
+      if (isValidQuoteRequest(params)) {
+        trace({ name: TraceName.SwapQuoteFetch });
+      }
       dispatch(updateQuoteRequestParams(...args));
     }, 300),
   );

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -325,6 +325,7 @@ const PrepareBridgePage = ({
     debounce((...args: Parameters<typeof updateQuoteRequestParams>) => {
       const [params] = args;
       if (isValidQuoteRequest(params)) {
+        endTrace({ name: TraceName.SwapQuoteFetch });
         trace({ name: TraceName.SwapQuoteFetch });
       }
       dispatch(updateQuoteRequestParams(...args));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->


This pull request introduces comprehensive tracing and analytics improvements for bridge quote fetching in the app. It adds new trace events for quote fetch operations, ensures that traces are properly started and ended in both the UI and hooks, and enhances testing to validate these behaviors. Additionally, it improves analytics event tracking in the bridge controller initialization.

**Bridge Quote Fetch Tracing Enhancements:**

* Added a new trace event `SwapQuoteFetch` to the `TraceName` enum to represent the lifecycle of bridge quote fetching.
* In `PrepareBridgePage`, integrated calls to `endTrace` and `trace` when a valid quote request is dispatched or refreshed, ensuring that traces are started and ended at the correct times. [[1]](diffhunk://#diff-967c021bb07a48d6dffd7b4aaf898a14a5e8a1c2024cbc7eb9ed5b59217c297aL17-R17) [[2]](diffhunk://#diff-967c021bb07a48d6dffd7b4aaf898a14a5e8a1c2024cbc7eb9ed5b59217c297aR326-R330)
* Updated the `useQuoteFetchEvents` hook to end the `SwapQuoteFetch` trace when quotes are received, when fetching fails, or when the hook unmounts, providing robust trace coverage for all quote fetch scenarios. [[1]](diffhunk://#diff-b65882736538c0b66a3b8a06d4539e2b220484a4fa83ac18ba0f3d3451b33a74R14) [[2]](diffhunk://#diff-b65882736538c0b66a3b8a06d4539e2b220484a4fa83ac18ba0f3d3451b33a74R42-R52) [[3]](diffhunk://#diff-b65882736538c0b66a3b8a06d4539e2b220484a4fa83ac18ba0f3d3451b33a74R68-R98)

**Testing Improvements for Tracing and Analytics:**

* Enhanced tests for `PrepareBridgePage` and `useQuoteFetchEvents` to mock and assert correct invocation of `trace` and `endTrace`, verifying that traces are started and ended as expected in various scenarios (e.g., successful fetch, error, unmount). [[1]](diffhunk://#diff-69c22302073ef7996a082297fdc23f295513339ec267f3cea51e1f671a51ff4dR30-R50) [[2]](diffhunk://#diff-69c22302073ef7996a082297fdc23f295513339ec267f3cea51e1f671a51ff4dR608-R753) [[3]](diffhunk://#diff-c04a95c7487aa7c249b18ada3d19f8859fdb797dd2e19bbeb5b25a76f69ac2cfR11-R26) [[4]](diffhunk://#diff-c04a95c7487aa7c249b18ada3d19f8859fdb797dd2e19bbeb5b25a76f69ac2cfR168-R248)

**Bridge Controller Analytics Integration:**

* Updated `bridge-controller-init.test.ts` to mock and test the `trackEvent` analytics function, ensuring that analytics events are correctly triggered from the bridge controller initialization logic. [[1]](diffhunk://#diff-b82e233a35865ec6d391c17d7c9bd6b295d1615e483aebde72635ad83597175bR4-R8) [[2]](diffhunk://#diff-b82e233a35865ec6d391c17d7c9bd6b295d1615e483aebde72635ad83597175bR25-R29) [[3]](diffhunk://#diff-b82e233a35865ec6d391c17d7c9bd6b295d1615e483aebde72635ad83597175bR76-R109)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add Mobile-parity SwapQuoteFetch traces

## **Related issues**

Fixes: null

## **Manual testing steps**

1. Request a swap quote
2. No breaking behavior

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: tracing and tests around quote fetch, no change to quote selection, trading, or auth. Unmount always ends the span as unsuccessful, which is a metrics-accuracy concern rather than a product risk.
> 
> **Overview**
> Adds a `SwapQuoteFetch` performance trace around bridge/swap quote requests so first-quote latency (and failures) can be measured like Mobile.
> 
> On a valid (debounced) quote request, `PrepareBridgePage` ends any in-flight span then starts a new one. `useQuoteFetchEvents` ends it when the first quote arrives, when a completed fetch has no quotes, on fetch error (`success: false`), or on unmount.
> 
> Also adds tests that `trackMetaMetricsFn` in bridge controller init forwards events to `trackEvent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 731321a00ae302364dd662d71bbfe42023a6141c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->