### PR TITLE
fix: Do not render 0 balance when balance has not been fetched yet

### DIFF
--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -630,6 +630,52 @@ class AccountListPage {
     }
   }
 
+  /**
+   * Checks that no balance at all is rendered for a specific account on the
+   * multichain account list page.
+   *
+   * Balances are only fetched eagerly for the selected account group. Groups
+   * whose balance has not been fetched yet are indistinguishable from genuinely
+   * empty ones, so the cell renders nothing rather than a misleading "$0.00".
+   *
+   * @param options - The account and optional wallet to check.
+   * @param options.wallet - The wallet name. Only pass when multiple wallets are present.
+   * @param options.account - The account name (default: 'Account 1').
+   */
+  async checkMultichainAccountBalanceNotDisplayed({
+    wallet,
+    account = 'Account 1',
+  }: {
+    wallet?: string;
+    account?: string;
+  } = {}): Promise<void> {
+    console.log(
+      `Check that no multichain account balance is displayed for ${account}${wallet ? ` under ${wallet}` : ''}`,
+    );
+
+    if (wallet) {
+      // Throws if the wallet header never renders, so the assertion below can
+      // never pass just because the list is still empty.
+      await this.driver.waitForSelector({
+        css: this.walletHeader,
+        text: wallet,
+      });
+      await this.driver.assertElementNotPresent({
+        xpath: `//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]/../following-sibling::*//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display']`,
+      });
+    } else {
+      // Throws if the account cell never renders, so the assertion below can
+      // never pass just because the list is still empty.
+      await this.driver.waitForSelector({
+        css: this.multichainAccountListItem,
+        text: account,
+      });
+      await this.driver.assertElementNotPresent({
+        xpath: `//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display']`,
+      });
+    }
+  }
+
   async checkMultiChainAccountMenuIsDisplayed(): Promise<void> {
     console.log(`Check that multichain account menu is displayed`);
     await this.driver.waitForMultipleSelectors([

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -20,6 +20,36 @@ import { ACCOUNT_TYPE } from '../../constants';
  * @see ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
  */
 class AccountListPage {
+  /**
+   * Builds an xpath matching the account cell for `account` within `wallet`'s
+   * section of the multichain account list.
+   *
+   * Every row of the virtualized list is a sibling of every other, so the
+   * `preceding-sibling` predicate is what confines the match to this wallet: on
+   * a reverse axis `[1]` is the *nearest* match, so this keeps only rows whose
+   * closest preceding wallet header is this wallet's. A bare
+   * `following-sibling::*` would spill into every later wallet and match a
+   * same-named account there — and account names are matched by substring, so
+   * e.g. 'Account 1' also matches 'Snap Account 1'.
+   *
+   * @param options - The anchor, wallet, and account to match.
+   * @param options.anchor - XPath resolving to the wallet header's row wrapper.
+   * Pass `'..'` to build an xpath relative to an already-found header element.
+   * @param options.wallet - The wallet name whose section to search.
+   * @param options.account - The account name to match.
+   * @returns The xpath for the account cell.
+   */
+  private readonly accountCellInWalletXPath = ({
+    anchor,
+    wallet,
+    account,
+  }: {
+    anchor: string;
+    wallet: string;
+    account: string;
+  }) =>
+    `${anchor}/following-sibling::*[preceding-sibling::*[.//*[@data-testid='multichain-account-tree-wallet-header']][1]//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]]//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]`;
+
   private readonly accountDetailsTab = {
     text: 'Account details',
     tag: 'button',
@@ -615,8 +645,13 @@ class AccountListPage {
         css: this.walletHeader,
         text: wallet,
       });
+      const accountCell = this.accountCellInWalletXPath({
+        anchor: '..',
+        wallet,
+        account,
+      });
       await this.driver.findNestedElement(walletHeader, {
-        xpath: `../following-sibling::*[preceding-sibling::*[.//*[@data-testid='multichain-account-tree-wallet-header']][1]//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]]//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display' and contains(text(), ${quoteXPathText(balance)})]`,
+        xpath: `${accountCell}//*[@data-testid='balance-display' and contains(text(), ${quoteXPathText(balance)})]`,
       });
     } else {
       // Single wallet (no wallet header rendered): find the account cell directly.
@@ -654,25 +689,27 @@ class AccountListPage {
     );
 
     if (wallet) {
-      // Throws if the wallet header never renders, so the assertion below can
-      // never pass just because the list is still empty.
-      await this.driver.waitForSelector({
-        css: this.walletHeader,
-        text: wallet,
+      // Same wallet-scoped cell xpath as checkMultichainAccountBalanceDisplayed,
+      // so this can never match a same-named account under a different wallet.
+      const accountCell = this.accountCellInWalletXPath({
+        anchor: `//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]/..`,
+        wallet,
+        account,
       });
-      await this.driver.assertElementNotPresent({
-        xpath: `//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]/../following-sibling::*//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display']`,
-      });
+      // Guard on the cell itself: without it this would pass while the list is
+      // still rendering, before any balance could have appeared.
+      await this.driver.assertElementNotPresent(
+        { xpath: `${accountCell}//*[@data-testid='balance-display']` },
+        { findElementGuard: { xpath: accountCell } },
+      );
     } else {
-      // Throws if the account cell never renders, so the assertion below can
-      // never pass just because the list is still empty.
-      await this.driver.waitForSelector({
-        css: this.multichainAccountListItem,
-        text: account,
-      });
-      await this.driver.assertElementNotPresent({
-        xpath: `//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display']`,
-      });
+      // Single wallet (no wallet header rendered): only one cell can match the
+      // account name, so scoping by name alone is equivalent to the cell.
+      const accountCell = `//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]`;
+      await this.driver.assertElementNotPresent(
+        { xpath: `${accountCell}//*[@data-testid='balance-display']` },
+        { findElementGuard: { xpath: accountCell } },
+      );
     }
   }
 

--- a/test/e2e/page-objects/pages/accounts/list-page.ts
+++ b/test/e2e/page-objects/pages/accounts/list-page.ts
@@ -20,6 +20,36 @@ import { ACCOUNT_TYPE } from '../../../constants';
  * @see ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
  */
 class AccountListPage {
+  /**
+   * Builds an xpath matching the account cell for `account` within `wallet`'s
+   * section of the multichain account list.
+   *
+   * Every row of the virtualized list is a sibling of every other, so the
+   * `preceding-sibling` predicate is what confines the match to this wallet: on
+   * a reverse axis `[1]` is the *nearest* match, so this keeps only rows whose
+   * closest preceding wallet header is this wallet's. A bare
+   * `following-sibling::*` would spill into every later wallet and match a
+   * same-named account there — and account names are matched by substring, so
+   * e.g. 'Account 1' also matches 'Snap Account 1'.
+   *
+   * @param options - The anchor, wallet, and account to match.
+   * @param options.anchor - XPath resolving to the wallet header's row wrapper.
+   * Pass `'..'` to build an xpath relative to an already-found header element.
+   * @param options.wallet - The wallet name whose section to search.
+   * @param options.account - The account name to match.
+   * @returns The xpath for the account cell.
+   */
+  private readonly accountCellInWalletXPath = ({
+    anchor,
+    wallet,
+    account,
+  }: {
+    anchor: string;
+    wallet: string;
+    account: string;
+  }) =>
+    `${anchor}/following-sibling::*[preceding-sibling::*[.//*[@data-testid='multichain-account-tree-wallet-header']][1]//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]]//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]`;
+
   private readonly accountDetailsTab = {
     text: 'Account details',
     tag: 'button',
@@ -618,8 +648,13 @@ class AccountListPage {
         css: this.walletHeader,
         text: wallet,
       });
+      const accountCell = this.accountCellInWalletXPath({
+        anchor: '..',
+        wallet,
+        account,
+      });
       await this.driver.findNestedElement(walletHeader, {
-        xpath: `../following-sibling::*[preceding-sibling::*[.//*[@data-testid='multichain-account-tree-wallet-header']][1]//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]]//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display' and contains(text(), ${quoteXPathText(balance)})]`,
+        xpath: `${accountCell}//*[@data-testid='balance-display' and contains(text(), ${quoteXPathText(balance)})]`,
       });
     } else {
       // Single wallet (no wallet header rendered): find the account cell directly.
@@ -657,25 +692,27 @@ class AccountListPage {
     );
 
     if (wallet) {
-      // Throws if the wallet header never renders, so the assertion below can
-      // never pass just because the list is still empty.
-      await this.driver.waitForSelector({
-        css: this.walletHeader,
-        text: wallet,
+      // Same wallet-scoped cell xpath as checkMultichainAccountBalanceDisplayed,
+      // so this can never match a same-named account under a different wallet.
+      const accountCell = this.accountCellInWalletXPath({
+        anchor: `//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]/..`,
+        wallet,
+        account,
       });
-      await this.driver.assertElementNotPresent({
-        xpath: `//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]/../following-sibling::*//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display']`,
-      });
+      // Guard on the cell itself: without it this would pass while the list is
+      // still rendering, before any balance could have appeared.
+      await this.driver.assertElementNotPresent(
+        { xpath: `${accountCell}//*[@data-testid='balance-display']` },
+        { findElementGuard: { xpath: accountCell } },
+      );
     } else {
-      // Throws if the account cell never renders, so the assertion below can
-      // never pass just because the list is still empty.
-      await this.driver.waitForSelector({
-        css: this.multichainAccountListItem,
-        text: account,
-      });
-      await this.driver.assertElementNotPresent({
-        xpath: `//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display']`,
-      });
+      // Single wallet (no wallet header rendered): only one cell can match the
+      // account name, so scoping by name alone is equivalent to the cell.
+      const accountCell = `//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]`;
+      await this.driver.assertElementNotPresent(
+        { xpath: `${accountCell}//*[@data-testid='balance-display']` },
+        { findElementGuard: { xpath: accountCell } },
+      );
     }
   }
 

--- a/test/e2e/page-objects/pages/accounts/list-page.ts
+++ b/test/e2e/page-objects/pages/accounts/list-page.ts
@@ -633,6 +633,52 @@ class AccountListPage {
     }
   }
 
+  /**
+   * Checks that no balance at all is rendered for a specific account on the
+   * multichain account list page.
+   *
+   * Balances are only fetched eagerly for the selected account group. Groups
+   * whose balance has not been fetched yet are indistinguishable from genuinely
+   * empty ones, so the cell renders nothing rather than a misleading "$0.00".
+   *
+   * @param options - The account and optional wallet to check.
+   * @param options.wallet - The wallet name. Only pass when multiple wallets are present.
+   * @param options.account - The account name (default: 'Account 1').
+   */
+  async checkMultichainAccountBalanceNotDisplayed({
+    wallet,
+    account = 'Account 1',
+  }: {
+    wallet?: string;
+    account?: string;
+  } = {}): Promise<void> {
+    console.log(
+      `Check that no multichain account balance is displayed for ${account}${wallet ? ` under ${wallet}` : ''}`,
+    );
+
+    if (wallet) {
+      // Throws if the wallet header never renders, so the assertion below can
+      // never pass just because the list is still empty.
+      await this.driver.waitForSelector({
+        css: this.walletHeader,
+        text: wallet,
+      });
+      await this.driver.assertElementNotPresent({
+        xpath: `//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]/../following-sibling::*//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display']`,
+      });
+    } else {
+      // Throws if the account cell never renders, so the assertion below can
+      // never pass just because the list is still empty.
+      await this.driver.waitForSelector({
+        css: this.multichainAccountListItem,
+        text: account,
+      });
+      await this.driver.assertElementNotPresent({
+        xpath: `//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display']`,
+      });
+    }
+  }
+
   async checkMultiChainAccountMenuIsDisplayed(): Promise<void> {
     console.log(`Check that multichain account menu is displayed`);
     await this.driver.waitForMultipleSelectors([

--- a/test/e2e/tests/multichain-accounts/add-account.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-account.spec.ts
@@ -66,10 +66,9 @@ describe('Add account', function () {
         await accountListPage.checkAccountDisplayedInAccountList(
           SECOND_ACCOUNT_NAME,
         );
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           wallet: 'Wallet 1',
           account: SECOND_ACCOUNT_NAME,
-          balance: '$0.00',
         });
         await accountListPage.closeMultichainAccountsPage();
 
@@ -197,10 +196,9 @@ describe('Add account', function () {
         await accountListPage.checkAccountDisplayedInAccountList(
           SECOND_ACCOUNT_NAME,
         );
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           account: SECOND_ACCOUNT_NAME,
           wallet: 'Wallet 1',
-          balance: '$0.00',
         });
         await accountListPage.openMultichainAccountMenu({
           accountLabel: SECOND_ACCOUNT_NAME,
@@ -222,10 +220,9 @@ describe('Add account', function () {
         await accountListPage.checkAccountDisplayedInAccountList(
           IMPORTED_ACCOUNT_NAME,
         );
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           account: IMPORTED_ACCOUNT_NAME,
           wallet: 'Imported accounts',
-          balance: '$0.00',
         });
 
         // Remove the 3rd account imported with a private key

--- a/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
@@ -163,10 +163,9 @@ describe('Add wallet', function () {
         await accountListPage.checkAccountDisplayedInAccountList(
           IMPORTED_ACCOUNT_NAME,
         );
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           wallet: 'Imported accounts',
           account: IMPORTED_ACCOUNT_NAME,
-          balance: '$0.00',
         });
         await accountListPage.checkNumberOfAvailableAccounts(4);
         await accountListPage.switchToAccount(IMPORTED_ACCOUNT_NAME);

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
@@ -67,10 +67,9 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
           wallet: 'Wallet 1',
           balance: '$85,025.00',
         });
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           account: 'Account 1',
           wallet: 'Wallet 2',
-          balance: '$0.00',
         });
         await accountListPage.checkNumberOfAvailableAccounts(2);
       },
@@ -129,9 +128,9 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
         await accountListPage.checkWalletDisplayedInAccountListMenu('Ledger');
         await accountListPage.checkAddWalletButtonIsDisplayed();
 
-        // The balance is not loaded for a non-selected account (which was never selected before)
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
-          balance: '$0.00',
+        // The balance is not loaded for a non-selected account (which was never
+        // selected before), so nothing is rendered rather than a misleading $0.00
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           wallet: 'Wallet 1',
           account: 'Account 1',
         });
@@ -205,10 +204,9 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
           wallet: 'Wallet 1',
           balance: '$85,025.00',
         });
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           account: 'Snap Account 1',
           wallet: 'MetaMask Simple Snap Keyring',
-          balance: '$0.00',
         });
         await accountListPage.checkAccountDisplayedInAccountList('Account 1');
         await accountListPage.checkAccountDisplayedInAccountList(

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts
@@ -107,16 +107,15 @@ describe('Multichain Accounts - Multichain accounts list page', function (this: 
         await accountListPage.checkWalletDisplayedInAccountListMenu('Ledger');
 
         // Ensure that accounts within the wallets are displayed
-        // The balance is not loaded for a non-selected account (which was never selected before)
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
+        // The balance is not loaded for a non-selected account (which was never
+        // selected before), so nothing is rendered rather than a misleading $0.00
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           wallet: 'Wallet 1',
           account: 'Account 1',
-          balance: '$0.00',
         });
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           wallet: 'Ledger',
           account: 'Ledger 1',
-          balance: '$0.00',
         });
         await accountListPage.checkMultichainAccountNameDisplayed('Account 1');
         await accountListPage.checkMultichainAccountNameDisplayed('Ledger 1');
@@ -180,10 +179,9 @@ describe('Multichain Accounts - Multichain accounts list page', function (this: 
           account: 'Account 1',
           balance: '$85,025.00',
         });
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           wallet: 'MetaMask Simple Snap Keyring',
           account: 'Snap Account 1',
-          balance: '$0.00',
         });
         await accountListPage.checkMultichainAccountNameDisplayed('Account 1');
         await accountListPage.checkMultichainAccountNameDisplayed(

--- a/test/e2e/tests/multichain-accounts/multichain-wallet-details.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-wallet-details.spec.ts
@@ -46,10 +46,9 @@ describe('Multichain Accounts - Wallet Details', function (this: Suite) {
           balance: '$85,025.00',
         });
 
-        await accountListPage.checkMultichainAccountBalanceDisplayed({
+        await accountListPage.checkMultichainAccountBalanceNotDisplayed({
           wallet: 'Wallet 2',
           account: 'Account 1',
-          balance: '$0.00',
         });
       },
     );

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
@@ -248,6 +248,37 @@ describe('MultichainAccountCell', () => {
     expect(balanceContainer.textContent).toMatch(/^[•]+$/u);
   });
 
+  it('renders no balance element when balance is undefined', () => {
+    renderWithProvider(
+      <MultichainAccountCell {...defaultProps} balance={undefined} />,
+      store,
+    );
+
+    expect(screen.queryByTestId('balance-display')).not.toBeInTheDocument();
+  });
+
+  it('renders no balance element when balance is an empty string', () => {
+    renderWithProvider(
+      <MultichainAccountCell {...defaultProps} balance="" />,
+      store,
+    );
+
+    expect(screen.queryByTestId('balance-display')).not.toBeInTheDocument();
+  });
+
+  it('renders no balance element when balance is missing and privacy mode is enabled', () => {
+    renderWithProvider(
+      <MultichainAccountCell
+        {...defaultProps}
+        balance={undefined}
+        privacyMode
+      />,
+      store,
+    );
+
+    expect(screen.queryByTestId('balance-display')).not.toBeInTheDocument();
+  });
+
   describe('Connection Status', () => {
     beforeEach(() => {
       mockIsInternalAccountInPermittedAccountIds.mockReturnValue(false);

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -56,7 +56,7 @@ const AccountCellAvatar = ({
 };
 
 type BalanceDisplayProps = {
-  balance: string;
+  balance?: string;
   isSubtitle?: boolean;
   isHidden?: boolean;
 };
@@ -66,6 +66,12 @@ const BalanceDisplay = ({
   isSubtitle = false,
   isHidden = false,
 }: BalanceDisplayProps) => {
+  // Account group balances are fetched lazily, so a cell may have no balance to
+  // show yet. Render nothing rather than a placeholder that reads as "no funds".
+  if (!balance) {
+    return null;
+  }
+
   return (
     <SensitiveText
       className="multichain-account-cell__account-balance"
@@ -87,7 +93,11 @@ export type MultichainAccountCellProps = {
   accountName: string | React.ReactNode;
   accountNameString?: string; // Optional string version for accessibility labels
   onClick?: (accountGroupId: AccountGroupId) => void;
-  balance: string;
+  /**
+   * Formatted balance to display. Omit (or pass an empty string) when no
+   * balance is known yet so that nothing is rendered in its place.
+   */
+  balance?: string;
   balancePosition?: 'end' | 'subtitle';
   startAccessory?: React.ReactNode;
   endAccessory?: React.ReactNode;

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -222,6 +222,16 @@ describe('MultichainAccountList', () => {
     expect(screen.getByText('Account 1 from wallet 2')).toBeInTheDocument();
   });
 
+  it('renders no balance for account groups with no fetched balance', () => {
+    renderComponent();
+
+    // Balances are only fetched eagerly for the selected account group, and an
+    // unfetched group aggregates to 0 just like an empty one. Rendering "$0.00"
+    // would read as "your funds are gone", so nothing is rendered instead.
+    expect(screen.queryAllByTestId('balance-display')).toHaveLength(0);
+    expect(screen.queryByText('$0.00')).not.toBeInTheDocument();
+  });
+
   it('does not render wallet headers based on prop', () => {
     renderComponent({ displayWalletHeader: false });
 

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -301,10 +301,15 @@ export const MultichainAccountList = ({
     ) => {
       // Undefined when this group has no known balance yet, so the cell renders
       // nothing instead of a misleading "$0.00".
-      const balance = getAccountGroupDisplayBalance(
+      const groupBalance = getAccountGroupDisplayBalance(
         allBalances?.wallets?.[walletId]?.groups?.[groupId],
-        formatCurrencyWithMinThreshold,
       );
+      const balance =
+        groupBalance &&
+        formatCurrencyWithMinThreshold(
+          groupBalance.amount,
+          groupBalance.currency,
+        );
 
       // TODO: Implement logic for removable accounts
       const isRemovable = false;

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -63,6 +63,7 @@ import {
 import { selectBalanceForAllWallets } from '../../../selectors/assets';
 import { EMPTY_ARRAY } from '../../../selectors/shared';
 import { useFormatters } from '../../../hooks/useFormatters';
+import { getAccountGroupDisplayBalance } from '../../../helpers/utils/account-group-balance';
 import { VirtualizedList } from '../../ui/virtualized-list/virtualized-list';
 import { useDispatch } from '../../../store/hooks';
 
@@ -298,10 +299,12 @@ export const MultichainAccountList = ({
       walletId: string,
       showWalletName: boolean,
     ) => {
-      // If prop is provided, attempt render balance. Otherwise do not render balance.
-      const account = allBalances?.wallets?.[walletId]?.groups?.[groupId];
-      const balance = account?.totalBalanceInUserCurrency ?? 0;
-      const currency = account?.userCurrency ?? '';
+      // Undefined when this group has no known balance yet, so the cell renders
+      // nothing instead of a misleading "$0.00".
+      const balance = getAccountGroupDisplayBalance(
+        allBalances?.wallets?.[walletId]?.groups?.[groupId],
+        formatCurrencyWithMinThreshold,
+      );
 
       // TODO: Implement logic for removable accounts
       const isRemovable = false;
@@ -330,7 +333,7 @@ export const MultichainAccountList = ({
             accountId={groupId as AccountGroupId}
             accountName={groupData.metadata.name}
             accountNameString={groupData.metadata.name}
-            balance={formatCurrencyWithMinThreshold(balance, currency)}
+            balance={balance}
             selected={selectedAccountGroupsSet.has(groupId as AccountGroupId)}
             onClick={handleAccountClickToUse}
             pending={isSwitchPending}

--- a/ui/components/multichain-accounts/multichain-address-rows-triggered-list/multichain-triggered-address-rows-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-triggered-list/multichain-triggered-address-rows-list.tsx
@@ -154,13 +154,18 @@ export const MultichainTriggeredAddressRowsList = ({
 
   const { balance, accountGroup } = useMemo(() => {
     const group = allAccountGroups.find((g) => g.id === groupId);
+    // Undefined when this group has no known balance yet, so nothing is
+    // rendered instead of a misleading "$0.00".
+    const groupBalance = getAccountGroupDisplayBalance(
+      allBalances?.wallets?.[group?.walletId]?.groups?.[groupId],
+    );
     return {
-      // Undefined when this group has no known balance yet, so nothing is
-      // rendered instead of a misleading "$0.00".
-      balance: getAccountGroupDisplayBalance(
-        allBalances?.wallets?.[group?.walletId]?.groups?.[groupId],
-        formatCurrencyWithMinThreshold,
-      ),
+      balance:
+        groupBalance &&
+        formatCurrencyWithMinThreshold(
+          groupBalance.amount,
+          groupBalance.currency,
+        ),
       accountGroup: group,
     };
   }, [allBalances, groupId, allAccountGroups, formatCurrencyWithMinThreshold]);

--- a/ui/components/multichain-accounts/multichain-address-rows-triggered-list/multichain-triggered-address-rows-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-triggered-list/multichain-triggered-address-rows-list.tsx
@@ -32,6 +32,7 @@ import {
 import { MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE } from '../../../helpers/constants/routes';
 import { selectBalanceForAllWallets } from '../../../selectors/assets';
 import { useFormatters } from '../../../hooks/useFormatters';
+import { getAccountGroupDisplayBalance } from '../../../helpers/utils/account-group-balance';
 import { normalizeSafeAddress } from '../../../../shared/lib/multichain/address';
 import { MultichainAggregatedAddressListRow } from './multichain-aggregated-list-row';
 import { DefaultAddress } from './default-address';
@@ -149,15 +150,20 @@ export const MultichainTriggeredAddressRowsList = ({
 
   const allAccountGroups = useSelector(getAllAccountGroups);
   const allBalances = useSelector(selectBalanceForAllWallets);
-  const { balance, currency, accountGroup } = useMemo(() => {
-    const group = allAccountGroups.find((g) => g.id === groupId);
-    const account = allBalances?.wallets?.[group?.walletId]?.groups?.[groupId];
-    const bal = account?.totalBalanceInUserCurrency ?? 0;
-    const curr = account?.userCurrency ?? '';
-    return { balance: bal, currency: curr, accountGroup: group };
-  }, [allBalances, groupId, allAccountGroups]);
-
   const { formatCurrencyWithMinThreshold } = useFormatters();
+
+  const { balance, accountGroup } = useMemo(() => {
+    const group = allAccountGroups.find((g) => g.id === groupId);
+    return {
+      // Undefined when this group has no known balance yet, so nothing is
+      // rendered instead of a misleading "$0.00".
+      balance: getAccountGroupDisplayBalance(
+        allBalances?.wallets?.[group?.walletId]?.groups?.[groupId],
+        formatCurrencyWithMinThreshold,
+      ),
+      accountGroup: group,
+    };
+  }, [allBalances, groupId, allAccountGroups, formatCurrencyWithMinThreshold]);
 
   const getAccountsSpreadByNetworkByGroupId = useSelector((state) =>
     getInternalAccountListSpreadByScopesByGroupId(state, groupId),
@@ -413,7 +419,7 @@ export const MultichainTriggeredAddressRowsList = ({
                 fontWeight={FontWeight.Medium}
                 color={TextColor.TextAlternative}
               >
-                {formatCurrencyWithMinThreshold(balance, currency)}
+                {balance}
               </Text>
             </Box>
           )}

--- a/ui/components/multichain/multi-srp/srp-list/srp-card.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-card.tsx
@@ -169,7 +169,7 @@ export const SrpCard = ({
                 key={`account-${group.id}`}
                 accountId={group.id}
                 accountName={group.metadata.name}
-                balance={walletAccountBalance(group.id) ?? ''}
+                balance={walletAccountBalance(group.id)}
               />
             );
           })}

--- a/ui/components/multichain/multi-srp/srp-list/srp-list-item.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-list-item.tsx
@@ -16,7 +16,7 @@ import { getIconSeedAddressByAccountGroupId } from '../../../../selectors/multic
 type SrpListItemProps = {
   accountId: AccountGroupId;
   accountName: string;
-  balance: string;
+  balance?: string;
 };
 
 export const SrpListItem = ({

--- a/ui/helpers/utils/account-group-balance.test.ts
+++ b/ui/helpers/utils/account-group-balance.test.ts
@@ -1,0 +1,57 @@
+import { getAccountGroupDisplayBalance } from './account-group-balance';
+
+describe('getAccountGroupDisplayBalance', () => {
+  const formatCurrency = jest.fn(
+    (value: number, currency: string) => `${currency}:${value}`,
+  );
+
+  beforeEach(() => {
+    formatCurrency.mockClear();
+  });
+
+  it('formats a non-zero balance', () => {
+    expect(
+      getAccountGroupDisplayBalance(
+        { totalBalanceInUserCurrency: 2400, userCurrency: 'usd' },
+        formatCurrency,
+      ),
+    ).toBe('usd:2400');
+    expect(formatCurrency).toHaveBeenCalledWith(2400, 'usd');
+  });
+
+  it('returns undefined when the group balance is missing', () => {
+    expect(
+      getAccountGroupDisplayBalance(undefined, formatCurrency),
+    ).toBeUndefined();
+    expect(formatCurrency).not.toHaveBeenCalled();
+  });
+
+  // An account group whose balance has not been fetched yet aggregates to 0,
+  // exactly like a genuinely empty one, so neither renders a balance.
+  it('returns undefined when the balance is zero', () => {
+    expect(
+      getAccountGroupDisplayBalance(
+        { totalBalanceInUserCurrency: 0, userCurrency: 'usd' },
+        formatCurrency,
+      ),
+    ).toBeUndefined();
+    expect(formatCurrency).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the balance is undefined', () => {
+    expect(
+      getAccountGroupDisplayBalance({ userCurrency: 'usd' }, formatCurrency),
+    ).toBeUndefined();
+    expect(formatCurrency).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the currency is missing', () => {
+    expect(
+      getAccountGroupDisplayBalance(
+        { totalBalanceInUserCurrency: 2400 },
+        formatCurrency,
+      ),
+    ).toBeUndefined();
+    expect(formatCurrency).not.toHaveBeenCalled();
+  });
+});

--- a/ui/helpers/utils/account-group-balance.test.ts
+++ b/ui/helpers/utils/account-group-balance.test.ts
@@ -1,57 +1,39 @@
 import { getAccountGroupDisplayBalance } from './account-group-balance';
 
 describe('getAccountGroupDisplayBalance', () => {
-  const formatCurrency = jest.fn(
-    (value: number, currency: string) => `${currency}:${value}`,
-  );
-
-  beforeEach(() => {
-    formatCurrency.mockClear();
-  });
-
-  it('formats a non-zero balance', () => {
+  it('returns the amount and currency for a non-zero balance', () => {
     expect(
-      getAccountGroupDisplayBalance(
-        { totalBalanceInUserCurrency: 2400, userCurrency: 'usd' },
-        formatCurrency,
-      ),
-    ).toBe('usd:2400');
-    expect(formatCurrency).toHaveBeenCalledWith(2400, 'usd');
+      getAccountGroupDisplayBalance({
+        totalBalanceInUserCurrency: 2400,
+        userCurrency: 'usd',
+      }),
+    ).toStrictEqual({ amount: 2400, currency: 'usd' });
   });
 
   it('returns undefined when the group balance is missing', () => {
-    expect(
-      getAccountGroupDisplayBalance(undefined, formatCurrency),
-    ).toBeUndefined();
-    expect(formatCurrency).not.toHaveBeenCalled();
+    expect(getAccountGroupDisplayBalance(undefined)).toBeUndefined();
   });
 
   // An account group whose balance has not been fetched yet aggregates to 0,
   // exactly like a genuinely empty one, so neither renders a balance.
   it('returns undefined when the balance is zero', () => {
     expect(
-      getAccountGroupDisplayBalance(
-        { totalBalanceInUserCurrency: 0, userCurrency: 'usd' },
-        formatCurrency,
-      ),
+      getAccountGroupDisplayBalance({
+        totalBalanceInUserCurrency: 0,
+        userCurrency: 'usd',
+      }),
     ).toBeUndefined();
-    expect(formatCurrency).not.toHaveBeenCalled();
   });
 
   it('returns undefined when the balance is undefined', () => {
     expect(
-      getAccountGroupDisplayBalance({ userCurrency: 'usd' }, formatCurrency),
+      getAccountGroupDisplayBalance({ userCurrency: 'usd' }),
     ).toBeUndefined();
-    expect(formatCurrency).not.toHaveBeenCalled();
   });
 
   it('returns undefined when the currency is missing', () => {
     expect(
-      getAccountGroupDisplayBalance(
-        { totalBalanceInUserCurrency: 2400 },
-        formatCurrency,
-      ),
+      getAccountGroupDisplayBalance({ totalBalanceInUserCurrency: 2400 }),
     ).toBeUndefined();
-    expect(formatCurrency).not.toHaveBeenCalled();
   });
 });

--- a/ui/helpers/utils/account-group-balance.ts
+++ b/ui/helpers/utils/account-group-balance.ts
@@ -1,0 +1,37 @@
+/**
+ * Shape of an aggregated account group balance, as produced by
+ * `selectBalanceForAllWallets`.
+ */
+type AccountGroupBalanceLike = {
+  totalBalanceInUserCurrency?: number;
+  userCurrency?: string;
+};
+
+/**
+ * Formats an account group's aggregated balance for display in an account cell,
+ * returning `undefined` when nothing should be rendered.
+ *
+ * Balances are only fetched eagerly for the selected account group — for
+ * performance, the rest are filled in lazily. An account group whose balance has
+ * not been fetched yet aggregates to `0`, exactly like a genuinely empty one, so
+ * the two are indistinguishable from the aggregated state. Showing "$0.00" for
+ * both makes users believe their funds are gone, so we render nothing until a
+ * non-zero balance is known. This mirrors `AccountCell` on mobile.
+ *
+ * @param groupBalance - The account group's aggregated balance, if present.
+ * @param formatCurrency - Currency formatter, e.g. `formatCurrencyWithMinThreshold`.
+ * @returns The formatted balance, or `undefined` when it should not be rendered.
+ */
+export function getAccountGroupDisplayBalance(
+  groupBalance: AccountGroupBalanceLike | undefined,
+  formatCurrency: (value: number, currency: string) => string,
+): string | undefined {
+  const total = groupBalance?.totalBalanceInUserCurrency;
+  const currency = groupBalance?.userCurrency;
+
+  if (!total || !currency) {
+    return undefined;
+  }
+
+  return formatCurrency(total, currency);
+}

--- a/ui/helpers/utils/account-group-balance.ts
+++ b/ui/helpers/utils/account-group-balance.ts
@@ -8,8 +8,16 @@ type AccountGroupBalanceLike = {
 };
 
 /**
- * Formats an account group's aggregated balance for display in an account cell,
- * returning `undefined` when nothing should be rendered.
+ * An account group balance that is known and worth rendering.
+ */
+type DisplayableAccountGroupBalance = {
+  amount: number;
+  currency: string;
+};
+
+/**
+ * Returns an account group's aggregated balance when it should be rendered in
+ * an account cell, and `undefined` when nothing should be rendered.
  *
  * Balances are only fetched eagerly for the selected account group — for
  * performance, the rest are filled in lazily. An account group whose balance has
@@ -18,20 +26,21 @@ type AccountGroupBalanceLike = {
  * both makes users believe their funds are gone, so we render nothing until a
  * non-zero balance is known. This mirrors `AccountCell` on mobile.
  *
+ * Formatting is left to the call site, which already has a currency formatter.
+ *
  * @param groupBalance - The account group's aggregated balance, if present.
- * @param formatCurrency - Currency formatter, e.g. `formatCurrencyWithMinThreshold`.
- * @returns The formatted balance, or `undefined` when it should not be rendered.
+ * @returns The amount and currency to format, or `undefined` when nothing
+ * should be rendered.
  */
 export function getAccountGroupDisplayBalance(
   groupBalance: AccountGroupBalanceLike | undefined,
-  formatCurrency: (value: number, currency: string) => string,
-): string | undefined {
-  const total = groupBalance?.totalBalanceInUserCurrency;
-  const currency = groupBalance?.userCurrency;
+): DisplayableAccountGroupBalance | undefined {
+  const { totalBalanceInUserCurrency: amount, userCurrency: currency } =
+    groupBalance ?? {};
 
-  if (!total || !currency) {
+  if (!amount || !currency) {
     return undefined;
   }
 
-  return formatCurrency(total, currency);
+  return { amount, currency };
 }

--- a/ui/hooks/multichain-accounts/useWalletBalance.ts
+++ b/ui/hooks/multichain-accounts/useWalletBalance.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { selectBalanceByWallet } from '../../selectors/assets';
+import { getAccountGroupDisplayBalance } from '../../helpers/utils/account-group-balance';
 import { useDisplayBalanceCalc } from './useAccountBalance';
 
 export function useSingleWalletDisplayBalance(walletId: string) {
@@ -21,20 +22,16 @@ export function useSingleWalletAccountsBalanceCallback(walletId: string) {
 
   const getDisplayBalance = useCallback(
     (groupId: string) => {
-      const balance = walletBalance.groups?.[groupId];
-      // A group whose balance has not been fetched yet aggregates to 0, exactly
-      // like a genuinely empty one, so return nothing rather than a misleading
-      // "$0.00". See `getAccountGroupDisplayBalance`.
-      if (!balance?.totalBalanceInUserCurrency) {
-        return undefined;
-      }
-
-      const displayBalance = displayBalanceCalc(
-        balance.totalBalanceInUserCurrency,
-        balance.userCurrency,
+      // Undefined when this group has no known balance yet, so nothing is
+      // rendered instead of a misleading "$0.00".
+      const groupBalance = getAccountGroupDisplayBalance(
+        walletBalance.groups?.[groupId],
       );
 
-      return displayBalance;
+      return (
+        groupBalance &&
+        displayBalanceCalc(groupBalance.amount, groupBalance.currency)
+      );
     },
     [walletBalance, displayBalanceCalc],
   );

--- a/ui/hooks/multichain-accounts/useWalletBalance.ts
+++ b/ui/hooks/multichain-accounts/useWalletBalance.ts
@@ -22,13 +22,16 @@ export function useSingleWalletAccountsBalanceCallback(walletId: string) {
   const getDisplayBalance = useCallback(
     (groupId: string) => {
       const balance = walletBalance.groups?.[groupId];
-      if (!balance) {
+      // A group whose balance has not been fetched yet aggregates to 0, exactly
+      // like a genuinely empty one, so return nothing rather than a misleading
+      // "$0.00". See `getAccountGroupDisplayBalance`.
+      if (!balance?.totalBalanceInUserCurrency) {
         return undefined;
       }
 
       const displayBalance = displayBalanceCalc(
-        balance?.totalBalanceInUserCurrency,
-        balance?.userCurrency,
+        balance.totalBalanceInUserCurrency,
+        balance.userCurrency,
       );
 
       return displayBalance;

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
@@ -147,12 +147,6 @@ exports[`MultichainConnectPage renders correctly 1`] = `
                   >
                     Test Account Group 1
                   </p>
-                  <p
-                    class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default truncate multichain-account-cell__account-balance"
-                    data-testid="balance-display-subtitle"
-                  >
-                    0.00
-                  </p>
                 </div>
               </div>
               <div
@@ -428,12 +422,6 @@ exports[`MultichainConnectPage renders with existing permissions correctly 1`] =
                   >
                     Test Account Group 1
                   </p>
-                  <p
-                    class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default truncate multichain-account-cell__account-balance"
-                    data-testid="balance-display-subtitle"
-                  >
-                    0.00
-                  </p>
                 </div>
               </div>
               <div
@@ -708,12 +696,6 @@ exports[`MultichainConnectPage renders with multichain origin request correctly 
                     data-testid="multichain-account-cell-name-Test Account Group 1"
                   >
                     Test Account Group 1
-                  </p>
-                  <p
-                    class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default truncate multichain-account-cell__account-balance"
-                    data-testid="balance-display-subtitle"
-                  >
-                    0.00
                   </p>
                 </div>
               </div>

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.tsx
@@ -74,6 +74,7 @@ import { MultichainEditAccountsPage } from '../../../components/multichain-accou
 import { getCaip25AccountIdsFromAccountGroupAndScope } from '../../../../shared/lib/multichain/scope-utils';
 import { selectBalanceForAllWallets } from '../../../selectors/assets';
 import { useFormatters } from '../../../hooks/useFormatters';
+import { getAccountGroupDisplayBalance } from '../../../helpers/utils/account-group-balance';
 import { AccountGroupWithInternalAccounts } from '../../../selectors/multichain-accounts/account-tree.types';
 import { getMultichainNetwork } from '../../../selectors/multichain';
 import { TrustSignalDisplayState } from '../../../hooks/useTrustSignals';
@@ -116,7 +117,7 @@ export enum MultichainAccountsConnectPageMode {
 type SingleAccountCellProps = {
   accountGroupId: AccountGroupObject['id'];
   accountName: string;
-  balance: string;
+  balance?: string;
   onEdit: () => void;
   privacyMode?: boolean;
 };
@@ -552,13 +553,14 @@ export const MultichainAccountsConnectPage = ({
     const account = accountGroup
       ? wallets?.[accountGroup.walletId]?.groups?.[accountGroupId]
       : undefined;
-    const balance = account?.totalBalanceInUserCurrency ?? 0;
-    const currency = account?.userCurrency ?? '';
 
     return {
       accountGroupId,
       accountName: accountGroup?.metadata.name ?? 'Unknown Account',
-      balance: formatCurrencyWithMinThreshold(balance, currency),
+      balance: getAccountGroupDisplayBalance(
+        account,
+        formatCurrencyWithMinThreshold,
+      ),
     };
   }, [
     selectedAccountGroupIds,

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.tsx
@@ -553,14 +553,19 @@ export const MultichainAccountsConnectPage = ({
     const account = accountGroup
       ? wallets?.[accountGroup.walletId]?.groups?.[accountGroupId]
       : undefined;
+    // Undefined when this group has no known balance yet, so the cell renders
+    // nothing instead of a misleading "$0.00".
+    const groupBalance = getAccountGroupDisplayBalance(account);
 
     return {
       accountGroupId,
       accountName: accountGroup?.metadata.name ?? 'Unknown Account',
-      balance: getAccountGroupDisplayBalance(
-        account,
-        formatCurrencyWithMinThreshold,
-      ),
+      balance:
+        groupBalance &&
+        formatCurrencyWithMinThreshold(
+          groupBalance.amount,
+          groupBalance.currency,
+        ),
     };
   }, [
     selectedAccountGroupIds,

--- a/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx
+++ b/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx
@@ -99,7 +99,7 @@ export const WalletDetailsPage = ({
           key={`multichain-account-cell-${group.id}`}
           accountId={group.id as AccountGroupId}
           accountName={group.metadata.name}
-          balance={walletAccountBalance(group.id) ?? ''}
+          balance={walletAccountBalance(group.id)}
           disableHoverEffect={true}
           privacyMode={privacyMode}
         />

--- a/ui/pages/settings/sync-accounts/components/wallet-selection-list.tsx
+++ b/ui/pages/settings/sync-accounts/components/wallet-selection-list.tsx
@@ -185,10 +185,15 @@ export const WalletSelectionList = ({
 
       // Undefined when this group has no known balance yet, so the cell renders
       // nothing instead of a misleading "$0.00".
-      const balance = getAccountGroupDisplayBalance(
+      const groupBalance = getAccountGroupDisplayBalance(
         allBalances?.wallets?.[item.walletId]?.groups?.[item.groupId],
-        formatCurrencyWithMinThreshold,
       );
+      const balance =
+        groupBalance &&
+        formatCurrencyWithMinThreshold(
+          groupBalance.amount,
+          groupBalance.currency,
+        );
 
       return (
         <MultichainAccountCell

--- a/ui/pages/settings/sync-accounts/components/wallet-selection-list.tsx
+++ b/ui/pages/settings/sync-accounts/components/wallet-selection-list.tsx
@@ -23,6 +23,7 @@ import {
   getShowDefaultAddressPreference,
 } from '../../../../selectors';
 import { useFormatters } from '../../../../hooks/useFormatters';
+import { getAccountGroupDisplayBalance } from '../../../../helpers/utils/account-group-balance';
 import { VirtualizedList } from '../../../../components/ui/virtualized-list/virtualized-list';
 
 type WalletGroupData =
@@ -182,17 +183,19 @@ export const WalletSelectionList = ({
         );
       }
 
-      const account =
-        allBalances?.wallets?.[item.walletId]?.groups?.[item.groupId];
-      const balance = account?.totalBalanceInUserCurrency ?? 0;
-      const currency = account?.userCurrency ?? '';
+      // Undefined when this group has no known balance yet, so the cell renders
+      // nothing instead of a misleading "$0.00".
+      const balance = getAccountGroupDisplayBalance(
+        allBalances?.wallets?.[item.walletId]?.groups?.[item.groupId],
+        formatCurrencyWithMinThreshold,
+      );
 
       return (
         <MultichainAccountCell
           accountId={item.groupId}
           accountName={item.groupData.metadata.name}
           accountNameString={item.groupData.metadata.name}
-          balance={formatCurrencyWithMinThreshold(balance, currency)}
+          balance={balance}
           selected={false}
           showDefaultAddress={isDefaultAddressEnabled && showDefaultAddress}
         />


### PR DESCRIPTION
## **Description**


1. What is the reason for the change?
- User have been complaining about showing a 0 balance in the accounts list when we have not fetched the balance for that account (example: https://x.com/viktorbunin/status/2090429711704858674?s=46). Showing `$0.00` in the row confuses users and scares them into thinking their accounts were drained.
- Mobile already addressed this issue by not rendering anything when the balance is null. 
2. What is the improvement/solution?
- Do not render anything when the balance is null
- when the account is selected, then we fetch the balance and update the row
- after an account gets selected once, we should then render the cached balance. 


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Do not render balance as zero in the accounts list when we have not fetched the balance. Leave the row empty instead. 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1316

## **Manual testing steps**

1. Download this build 
2. install the app
4. onboard by importing an SRP with multiple accounts and balances spread across those accounts
5. after onboarding, open the accounts list
6. the current selected account should show the balance, the other accounts should not have the balance rendered at all.
7. select another account with a balance.
8. the balance should update and the row in the accounts list should also update
9. navigate to other accounts and notice that the cached balances are still rendered in the accounts list
10. selecting an account that DOES have a zero balance should render `$0.0`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/f990fa57-649c-401b-a9b2-f29cf6e3ff1a


### **After**

<img width="420" height="895" alt="Screenshot 2026-08-20 at 4 26 34 PM" src="https://github.com/user-attachments/assets/df919bb5-b72e-414c-b3ad-df6441b8ab78" />

Mobile prod now: Now these clients match behaviour. 


<img width="300" height="600" alt="IMG_8731" src="https://github.com/user-attachments/assets/09557f99-ea38-4812-8a7a-3a3e4f451146" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widespread user-facing balance rendering logic; zero and unfetched balances are treated the same, so confirmed empty accounts also show no amount.
> 
> **Overview**
> Stops showing **$0.00** on multichain account rows when the aggregated balance is missing or still lazy-loaded, so users are not told their funds are gone before data is fetched (aligned with mobile).
> 
> Introduces **`getAccountGroupDisplayBalance`** and wires it through the account list, connect flow, wallet details, SRP list, address popover, and sync wallet picker. **`MultichainAccountCell`** now treats **`balance`** as optional and renders **no** `balance-display` element when it is empty or undefined.
> 
> E2E coverage adds **`checkMultichainAccountBalanceNotDisplayed`**, refactors wallet-scoped XPath via **`accountCellInWalletXPath`**, and updates specs that previously expected **$0.00** for unfetched accounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09d92b8b1db7967c55b1d9474923e66f2ca57ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->