### PR TITLE
ci: prevent cascading benchmark timeouts cp-13.46.0

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -77,6 +77,9 @@ jobs:
         run: .github/scripts/pin-geckodriver.sh
 
       - name: Run the benchmark
+        # Job timeouts propogate to later jobs, step timeouts just cause job failure.
+        # This must be set below the job timeout so that the job itself does not timeout.
+        timeout-minutes: 25
         id: run-benchmark
         run: >-
           ${{ matrix.pageType == 'startupPowerUserHome' && format('yarn test:e2e:benchmark --preset startupPowerUserHome --browserLoads 15 --pageLoads 7 --out test-artifacts/benchmarks/benchmark-{0}-{1}-startupPowerUserHome.json --retries 2', matrix.browser, matrix.buildType) || format('yarn test:e2e:benchmark --preset {2} --out test-artifacts/benchmarks/benchmark-{0}-{1}-{2}.json --retries 2', matrix.browser, matrix.buildType, matrix.pageType) }}
@@ -166,6 +169,9 @@ jobs:
           browsers: chromium
 
       - name: Run dapp page load benchmarks
+        # Job timeouts propogate to later jobs, step timeouts just cause job failure.
+        # This must be set below the job timeout so that the job itself does not timeout.
+        timeout-minutes: 25
         id: run-page-load
         run: yarn test:e2e:benchmark --preset=pageLoadBenchmark
 


### PR DESCRIPTION
## **Description**

This ensures that timed-out benchmarks don't cause later jobs (such as the status gate) to also timeout.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Extracted from #45670

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only timeout tweak in the benchmark workflow; no product, auth, or data-handling changes.
> 
> **Overview**
> Adds 25-minute **step** timeouts on the benchmark run steps so a hung run fails the step instead of hitting the 30-minute **job** timeout.
> 
> Job-level timeouts cancel downstream jobs (quality-gate, stats). Step timeouts only fail that job, so later jobs can still run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4f87f533d82526aab3f68d9843fe48094d832b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->