### PR TITLE
ci: use mocked requests for benchmarks on `main` and `release/*` cp-13.46.0

### DIFF
--- a/test/e2e/benchmarks/utils/mock-config.ts
+++ b/test/e2e/benchmarks/utils/mock-config.ts
@@ -7,17 +7,11 @@ import {
 /**
  * Check if mocked requests should be used for performance benchmarks.
  *
- * Uses GITHUB_REF_NAME (already available in CI) to determine mode:
- * - Push to main or release/* branches → use real server requests
- * - Everything else (PRs, local dev, etc.) → use mocked HTTP responses
- *
  * @returns true if mocks should be used, false for real server requests
  */
 export function shouldUseMockedRequests(): boolean {
-  const branch = process.env.GITHUB_REF_NAME || '';
-  const isMainOrRelease = branch === 'main' || branch.startsWith('release/');
-  // Use real server (no mocks) only for main/release/* branches
-  return !isMainOrRelease;
+  // TODO: Add a CI workflow that uses unmocked requests, or delete this dead code.
+  return true;
 }
 
 /**


### PR DESCRIPTION
## **Description**

We now use mocked requests in benchmarks run on the `main` branch and `release/*` branches. This should make the benchmark timeouts and flaky failures we've been seeing lately on these branches much less likely.

Originally our reason for using live API calls was to get more realistic timings for the API calls. However we're now getting these timings from production data instead, and we've modified mocks to add realistic delays. We don't need live calls for these jobs anymore.

I stopped short of deleting _all_ of the related code here because there is a draft PR that may restore live API call benchmark runs on a schedule (#45455). We should follow-up here to get that scheduled run merged or delete this dead code (I've left a comment to remind us).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI config for e2e benchmarks; no production or security-sensitive code. Benchmark numbers on main/release will no longer include live network latency.
> 
> **Overview**
> Performance benchmarks now always use mocked HTTP instead of live APIs on `main` and `release/*`. That should cut timeouts and flake from real-server calls; timings now come from production data and delayed mocks.
> 
> `shouldUseMockedRequests()` always returns `true`. The live-request branch is left in place with a TODO pending a scheduled unmocked workflow (or deletion).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc4c018eb7429827cbf79f168691aec19d7f81e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->