### PR TITLE
test: fix flaky test responsive send network toast overlay

### DIFF
--- a/test/e2e/page-objects/components/tx-toast-notification.ts
+++ b/test/e2e/page-objects/components/tx-toast-notification.ts
@@ -5,6 +5,9 @@ import { Driver } from '../../webdriver/driver';
  *
  */
 export class TxToastNotification {
+  private readonly anyTransactionToast =
+    '[data-testid="transaction-submitted-toast"], [data-testid="transaction-confirmed-toast"], [data-testid="transaction-failed-toast"]';
+
   private readonly closeButton = '[aria-label="Close"]';
 
   protected driver: Driver;
@@ -34,5 +37,10 @@ export class TxToastNotification {
   async closeToastNotification(): Promise<void> {
     // The toast auto-dismisses after a few seconds, so use clickElementSafe to avoid race conditions.
     await this.driver.clickElementSafe(this.closeButton, 5_000);
+  }
+
+  async waitForToastNotification(): Promise<void> {
+    console.log('Waiting for transaction toast notification');
+    await this.driver.waitForSelector(this.anyTransactionToast);
   }
 }

--- a/test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts
+++ b/test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts
@@ -157,7 +157,7 @@ describe('MetaMask Responsive UI', function (this: Suite) {
         await homePage.checkPageIsLoaded();
 
         const txToast = new TxToastNotification(driver);
-        await txToast.checkTxSubmittedToast();
+        await txToast.waitForToastNotification();
         await txToast.closeToastNotification();
 
         await switchToNetworkFromNetworkSelect(driver, 'Localhost 8545');

--- a/test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts
+++ b/test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts
@@ -16,6 +16,7 @@ import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { PAGES } from '../../webdriver/driver';
 import { getProductionRemoteFlagApiResponse } from '../../feature-flags';
 import SetupPasskeyPage from '../../page-objects/pages/onboarding/setup-passkey-page';
+import { TxToastNotification } from '../../page-objects/components/tx-toast-notification';
 
 const FEATURE_FLAGS_URL = 'https://client-config.api.cx.metamask.io/v1/flags';
 
@@ -154,6 +155,10 @@ describe('MetaMask Responsive UI', function (this: Suite) {
         });
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
+
+        const txToast = new TxToastNotification(driver);
+        await txToast.checkTxSubmittedToast();
+        await txToast.closeToastNotification();
 
         await switchToNetworkFromNetworkSelect(driver, 'Localhost 8545');
 


### PR DESCRIPTION
## **Description**

Stabilizes flaky E2E test "Send Transaction from responsive window" (`test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts`).

**Root cause:**

- The test sends 1 ETH from the small responsive window, then returns to Home.
- Confirming the send shows a "Transaction submitted" toast at the bottom of the screen.
- That toast has a full-area link over it, so the whole toast is clickable.
- Next, the test opens the Select network list and tries to click Localhost 8545.
- On the small window, the toast sits on top of the lower network rows.
- The click hits the toast link instead of Localhost 8545, and the test fails.

**Solution:**

- Wait until the submitted toast is on screen, so the test does not race past it.
- Close the toast before opening the network list, so nothing covers Localhost 8545.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Build a test build: `yarn build:test`
2. Run the flaky test:
   ```
   SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts --debug --leave-running
   ```
3. Confirm the send completes, the submitted toast is dismissed, Localhost 8545 can be selected, and Activity shows `-1 ETH`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E-only test helper and spec timing change; no production or security impact.
> 
> **Overview**
> Fixes a flake in the responsive “Send Transaction” E2E where the post-send toast overlay sat on top of Localhost 8545 in the network list.
> 
> Adds `waitForToastNotification()` on `TxToastNotification` (any submitted/confirmed/failed toast) and dismisses the toast before opening the network selector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5499ffcc3135e6ba5eafcceec8ef03f6d4677840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->