### PR TITLE
fix(ramps): align environment selection with build env

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -222,15 +222,6 @@ function setCITags() {
   }
 }
 
-/**
- * Tag reports with the build vocabulary that decides service routing.
- * This lets teams filter nightly events that still use the dev DSN.
- */
-function setBuildTags() {
-  Sentry.setTag('metamask.environment', METAMASK_ENVIRONMENT);
-  Sentry.setTag('metamask.build_type', METAMASK_BUILD_TYPE);
-}
-
 function getSentryEnvironment() {
   if (METAMASK_BUILD_TYPE === 'main') {
     return METAMASK_ENVIRONMENT;
@@ -293,7 +284,6 @@ function setSentryClient() {
   );
 
   setCITags();
-  setBuildTags();
 
   addDebugListeners();
 

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -222,6 +222,15 @@ function setCITags() {
   }
 }
 
+/**
+ * Tag reports with the build vocabulary that decides service routing.
+ * This lets teams filter nightly events that still use the dev DSN.
+ */
+function setBuildTags() {
+  Sentry.setTag('metamask.environment', METAMASK_ENVIRONMENT);
+  Sentry.setTag('metamask.build_type', METAMASK_BUILD_TYPE);
+}
+
 function getSentryEnvironment() {
   if (METAMASK_BUILD_TYPE === 'main') {
     return METAMASK_ENVIRONMENT;
@@ -284,6 +293,7 @@ function setSentryClient() {
   );
 
   setCITags();
+  setBuildTags();
 
   addDebugListeners();
 

--- a/shared/lib/ramps/environment.test.ts
+++ b/shared/lib/ramps/environment.test.ts
@@ -33,10 +33,10 @@ describe('getRampsEnvironment', () => {
   Object.entries(EXPECTED_RAMPS_ENVIRONMENT_BY_METAMASK_ENVIRONMENT).forEach(
     ([metamaskEnvironment, rampsEnvironment]) => {
       it(`maps METAMASK_ENVIRONMENT=${metamaskEnvironment} to ${rampsEnvironment} in main builds`, () => {
-      process.env.METAMASK_ENVIRONMENT = metamaskEnvironment;
-      process.env.METAMASK_BUILD_TYPE = 'main';
+        process.env.METAMASK_ENVIRONMENT = metamaskEnvironment;
+        process.env.METAMASK_BUILD_TYPE = 'main';
 
-      expect(getRampsEnvironment()).toBe(rampsEnvironment);
+        expect(getRampsEnvironment()).toBe(rampsEnvironment);
       });
     },
   );

--- a/shared/lib/ramps/environment.test.ts
+++ b/shared/lib/ramps/environment.test.ts
@@ -19,6 +19,8 @@ const EXPECTED_RAMPS_ENVIRONMENT_BY_METAMASK_ENVIRONMENT: Record<
   [ENVIRONMENT.TESTING]: RampsEnvironment.Staging,
 };
 
+const ENVIRONMENT_ALIASES = ['beta', 'dev', 'rc', 'test'];
+
 describe('getRampsEnvironment', () => {
   const originalEnv = process.env.METAMASK_ENVIRONMENT;
   const originalBuildType = process.env.METAMASK_BUILD_TYPE;
@@ -28,14 +30,14 @@ describe('getRampsEnvironment', () => {
     process.env.METAMASK_BUILD_TYPE = originalBuildType;
   });
 
-  // @ts-expect-error ESLint is misconfigured and not applying Jest types to this file
-  it.each(Object.entries(EXPECTED_RAMPS_ENVIRONMENT_BY_METAMASK_ENVIRONMENT))(
-    'maps METAMASK_ENVIRONMENT=%s to %s in main builds',
-    (metamaskEnvironment, rampsEnvironment) => {
+  Object.entries(EXPECTED_RAMPS_ENVIRONMENT_BY_METAMASK_ENVIRONMENT).forEach(
+    ([metamaskEnvironment, rampsEnvironment]) => {
+      it(`maps METAMASK_ENVIRONMENT=${metamaskEnvironment} to ${rampsEnvironment} in main builds`, () => {
       process.env.METAMASK_ENVIRONMENT = metamaskEnvironment;
       process.env.METAMASK_BUILD_TYPE = 'main';
 
       expect(getRampsEnvironment()).toBe(rampsEnvironment);
+      });
     },
   );
 
@@ -51,13 +53,11 @@ describe('getRampsEnvironment', () => {
     expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
   });
 
-  // @ts-expect-error ESLint is misconfigured and not applying Jest types to this file
-  it.each(['beta', 'dev', 'rc', 'test'])(
-    'returns Staging for remote-feature-flag environment alias "%s"',
-    (metamaskEnvironment) => {
+  ENVIRONMENT_ALIASES.forEach((metamaskEnvironment) => {
+    it(`returns Staging for remote-feature-flag environment alias "${metamaskEnvironment}"`, () => {
       process.env.METAMASK_ENVIRONMENT = metamaskEnvironment;
 
       expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
-    },
-  );
+    });
+  });
 });

--- a/shared/lib/ramps/environment.test.ts
+++ b/shared/lib/ramps/environment.test.ts
@@ -1,41 +1,48 @@
 import { RampsEnvironment } from '@metamask/ramps-controller';
+import {
+  ENVIRONMENT,
+  type MetaMaskBuildEnvironment,
+} from '../../constants/build';
 
 import { getRampsEnvironment } from './environment';
 
+const EXPECTED_RAMPS_ENVIRONMENT_BY_METAMASK_ENVIRONMENT: Record<
+  MetaMaskBuildEnvironment,
+  RampsEnvironment
+> = {
+  [ENVIRONMENT.DEVELOPMENT]: RampsEnvironment.Development,
+  [ENVIRONMENT.OTHER]: RampsEnvironment.Staging,
+  [ENVIRONMENT.PRODUCTION]: RampsEnvironment.Production,
+  [ENVIRONMENT.PULL_REQUEST]: RampsEnvironment.Staging,
+  [ENVIRONMENT.RELEASE_CANDIDATE]: RampsEnvironment.Production,
+  [ENVIRONMENT.STAGING]: RampsEnvironment.Production,
+  [ENVIRONMENT.TESTING]: RampsEnvironment.Staging,
+};
+
 describe('getRampsEnvironment', () => {
   const originalEnv = process.env.METAMASK_ENVIRONMENT;
+  const originalBuildType = process.env.METAMASK_BUILD_TYPE;
 
   afterEach(() => {
     process.env.METAMASK_ENVIRONMENT = originalEnv;
+    process.env.METAMASK_BUILD_TYPE = originalBuildType;
   });
 
-  it('returns Production for METAMASK_ENVIRONMENT=production', () => {
-    process.env.METAMASK_ENVIRONMENT = 'production';
-    expect(getRampsEnvironment()).toBe(RampsEnvironment.Production);
-  });
+  // @ts-expect-error ESLint is misconfigured and not applying Jest types to this file
+  it.each(Object.entries(EXPECTED_RAMPS_ENVIRONMENT_BY_METAMASK_ENVIRONMENT))(
+    'maps METAMASK_ENVIRONMENT=%s to %s in main builds',
+    (metamaskEnvironment, rampsEnvironment) => {
+      process.env.METAMASK_ENVIRONMENT = metamaskEnvironment;
+      process.env.METAMASK_BUILD_TYPE = 'main';
 
-  it('returns Production for METAMASK_ENVIRONMENT=beta', () => {
-    process.env.METAMASK_ENVIRONMENT = 'beta';
-    expect(getRampsEnvironment()).toBe(RampsEnvironment.Production);
-  });
+      expect(getRampsEnvironment()).toBe(rampsEnvironment);
+    },
+  );
 
-  it('returns Production for METAMASK_ENVIRONMENT=rc', () => {
-    process.env.METAMASK_ENVIRONMENT = 'rc';
-    expect(getRampsEnvironment()).toBe(RampsEnvironment.Production);
-  });
+  it('returns Staging for experimental staging builds', () => {
+    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.STAGING;
+    process.env.METAMASK_BUILD_TYPE = 'experimental';
 
-  it('returns Development for METAMASK_ENVIRONMENT=development', () => {
-    process.env.METAMASK_ENVIRONMENT = 'development';
-    expect(getRampsEnvironment()).toBe(RampsEnvironment.Development);
-  });
-
-  it('returns Development for METAMASK_ENVIRONMENT=dev', () => {
-    process.env.METAMASK_ENVIRONMENT = 'dev';
-    expect(getRampsEnvironment()).toBe(RampsEnvironment.Development);
-  });
-
-  it('returns Staging for METAMASK_ENVIRONMENT=testing', () => {
-    process.env.METAMASK_ENVIRONMENT = 'testing';
     expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
   });
 
@@ -43,4 +50,14 @@ describe('getRampsEnvironment', () => {
     delete process.env.METAMASK_ENVIRONMENT;
     expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
   });
+
+  // @ts-expect-error ESLint is misconfigured and not applying Jest types to this file
+  it.each(['beta', 'dev', 'rc', 'test'])(
+    'returns Staging for remote-feature-flag environment alias "%s"',
+    (metamaskEnvironment) => {
+      process.env.METAMASK_ENVIRONMENT = metamaskEnvironment;
+
+      expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
+    },
+  );
 });

--- a/shared/lib/ramps/environment.ts
+++ b/shared/lib/ramps/environment.ts
@@ -20,6 +20,9 @@ export function getRampsEnvironment(): RampsEnvironment {
     case ENVIRONMENT.RELEASE_CANDIDATE:
       return RampsEnvironment.Production;
     case ENVIRONMENT.STAGING:
+      // MetaMask's staging environment is used for nightly builds from main,
+      // which should use production Ramps. Experimental nightlies also use
+      // MetaMask's staging environment, but must use Ramps staging/UAT.
       return process.env.METAMASK_BUILD_TYPE === 'experimental'
         ? RampsEnvironment.Staging
         : RampsEnvironment.Production;

--- a/shared/lib/ramps/environment.ts
+++ b/shared/lib/ramps/environment.ts
@@ -1,4 +1,8 @@
 import { RampsEnvironment } from '@metamask/ramps-controller';
+import {
+  ENVIRONMENT,
+  type MetaMaskBuildEnvironment,
+} from '../../constants/build';
 
 /**
  * Determines the ramps API environment for the extension build.
@@ -9,17 +13,21 @@ import { RampsEnvironment } from '@metamask/ramps-controller';
  * @returns The ramps environment for API requests.
  */
 export function getRampsEnvironment(): RampsEnvironment {
-  const metamaskEnvironment = process.env.METAMASK_ENVIRONMENT;
+  const metamaskEnvironment = process.env
+    .METAMASK_ENVIRONMENT as MetaMaskBuildEnvironment;
   switch (metamaskEnvironment) {
-    case 'production':
-    case 'beta':
-    case 'rc':
+    case ENVIRONMENT.PRODUCTION:
+    case ENVIRONMENT.RELEASE_CANDIDATE:
       return RampsEnvironment.Production;
-    case 'development':
-    case 'dev':
+    case ENVIRONMENT.STAGING:
+      return process.env.METAMASK_BUILD_TYPE === 'experimental'
+        ? RampsEnvironment.Staging
+        : RampsEnvironment.Production;
+    case ENVIRONMENT.DEVELOPMENT:
       return RampsEnvironment.Development;
-    case 'test':
-    case 'testing':
+    case ENVIRONMENT.OTHER:
+    case ENVIRONMENT.PULL_REQUEST:
+    case ENVIRONMENT.TESTING:
     default:
       return RampsEnvironment.Staging;
   }

--- a/ui/helpers/utils/display-critical-error.test.ts
+++ b/ui/helpers/utils/display-critical-error.test.ts
@@ -33,6 +33,7 @@ process.env = {
   ...originalEnv,
   SENTRY_DSN: MOCK_SENTRY_DSN,
   SENTRY_DSN_DEV: MOCK_SENTRY_DSN_DEV,
+  METAMASK_BUILD_TYPE: 'main',
   METAMASK_ENVIRONMENT: 'development',
 };
 
@@ -263,6 +264,10 @@ describe('displayCriticalError', () => {
         level: 'error',
         message: MOCK_ERROR_MESSAGE,
         release: MOCK_RELEASE_VERSION,
+        tags: {
+          'metamask.build_type': 'main',
+          'metamask.environment': 'development',
+        },
         extra: {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           error_details: expect.any(Object), // Error object serialization varies by environment

--- a/ui/helpers/utils/display-critical-error.test.ts
+++ b/ui/helpers/utils/display-critical-error.test.ts
@@ -332,6 +332,97 @@ describe('displayCriticalError', () => {
     }
   });
 
+  it('adds fallback build tags when build environment variables are unset', async () => {
+    delete process.env.METAMASK_ENVIRONMENT;
+    delete process.env.METAMASK_BUILD_TYPE;
+
+    const error = new Error(MOCK_ERROR_MESSAGE);
+    const mockPort = createMockPort();
+
+    await expect(
+      displayCriticalErrorMessage(
+        container,
+        CriticalErrorTranslationKey.TroubleStarting,
+        error,
+        'en',
+        mockPort,
+        CriticalErrorType.Other,
+      ),
+    ).rejects.toThrow(error);
+
+    const restartButton = rootContainer.querySelector<HTMLButtonElement>(
+      '#critical-error-button',
+    );
+    const checkbox = rootContainer.querySelector<HTMLInputElement>(
+      '#critical-error-checkbox',
+    );
+
+    expect(restartButton).toBeTruthy();
+    expect(checkbox).toBeTruthy();
+    checkbox?.setAttribute('checked', 'true');
+    await act(async () => {
+      restartButton?.click();
+      await new Promise(setImmediate);
+    });
+
+    const requestBody = (fetch as jest.MockedFunction<typeof fetch>).mock
+      .calls[0][1]?.body as string;
+    const eventPayload = JSON.parse(requestBody.split('\n')[2]);
+    expect(eventPayload.tags).toEqual({
+      'metamask.environment': 'unknown',
+      'metamask.build_type': 'unknown',
+    });
+  });
+
+  it('allows error-specific tags to override build tags', async () => {
+    process.env.METAMASK_ENVIRONMENT = 'development';
+    process.env.METAMASK_BUILD_TYPE = 'main';
+
+    const error = Object.assign(new Error(MOCK_ERROR_MESSAGE), {
+      sentryTags: {
+        'metamask.environment': 'error-environment',
+        source: 'critical-error',
+      },
+    });
+    const mockPort = createMockPort();
+
+    await expect(
+      displayCriticalErrorMessage(
+        container,
+        CriticalErrorTranslationKey.TroubleStarting,
+        error,
+        'en',
+        mockPort,
+        CriticalErrorType.Other,
+      ),
+    ).rejects.toThrow(error);
+
+    const restartButton = rootContainer.querySelector<HTMLButtonElement>(
+      '#critical-error-button',
+    );
+    const checkbox = rootContainer.querySelector<HTMLInputElement>(
+      '#critical-error-checkbox',
+    );
+
+    expect(restartButton).toBeTruthy();
+    expect(checkbox).toBeTruthy();
+    checkbox?.setAttribute('checked', 'true');
+    await act(async () => {
+      restartButton?.click();
+      await new Promise(setImmediate);
+    });
+
+    const requestBody = (fetch as jest.MockedFunction<typeof fetch>).mock
+      .calls[0][1]?.body as string;
+    const eventPayload = JSON.parse(requestBody.split('\n')[2]);
+    expect(eventPayload.tags).toEqual({
+      'metamask.environment': 'error-environment',
+      'metamask.build_type': 'main',
+      source: 'critical-error',
+    });
+    expect(eventPayload.extra.error_details).not.toHaveProperty('sentryTags');
+  });
+
   it('still displays error and throws original error when notifying background fails', async () => {
     const port = {
       postMessage: jest.fn().mockImplementation(() => {

--- a/ui/helpers/utils/display-critical-error.ts
+++ b/ui/helpers/utils/display-critical-error.ts
@@ -76,6 +76,13 @@ function getSentryTarget() {
   return process.env.SENTRY_DSN;
 }
 
+function getBuildSentryTags(): Record<string, string> {
+  return {
+    'metamask.environment': process.env.METAMASK_ENVIRONMENT ?? 'unknown',
+    'metamask.build_type': process.env.METAMASK_BUILD_TYPE ?? 'unknown',
+  };
+}
+
 export enum CriticalErrorTranslationKey {
   TroubleStarting = 'troubleStarting',
   SomethingIsWrong = 'somethingIsWrong',
@@ -101,10 +108,14 @@ async function sendErrorToSentry(error: ErrorLike): Promise<void> {
     // Extract sentryTags from error object (if present)
     // Any error can define error.sentryTags to add searchable tags to Sentry
     const errorObj = error as Record<string, unknown>;
-    const sentryTags =
+    const errorSentryTags =
       errorObj?.sentryTags && typeof errorObj.sentryTags === 'object'
         ? (errorObj.sentryTags as Record<string, string>)
         : {};
+    const sentryTags = {
+      ...getBuildSentryTags(),
+      ...errorSentryTags,
+    };
 
     // Create error_details without sentryTags to avoid duplication
     // (sentryTags are sent as top-level tags)

--- a/ui/hooks/ramps/utils/getRampCallbackBaseUrl.test.ts
+++ b/ui/hooks/ramps/utils/getRampCallbackBaseUrl.test.ts
@@ -10,9 +10,11 @@ const DEVELOPMENT_CALLBACK =
 
 describe('getRampCallbackBaseUrl', () => {
   const originalEnv = process.env.METAMASK_ENVIRONMENT;
+  const originalBuildType = process.env.METAMASK_BUILD_TYPE;
 
   afterEach(() => {
     process.env.METAMASK_ENVIRONMENT = originalEnv;
+    process.env.METAMASK_BUILD_TYPE = originalBuildType;
   });
 
   it('returns the production URL for the production environment', () => {
@@ -30,8 +32,6 @@ describe('getRampCallbackBaseUrl', () => {
   for (const environment of [
     ENVIRONMENT.OTHER,
     ENVIRONMENT.PULL_REQUEST,
-    ENVIRONMENT.RELEASE_CANDIDATE,
-    ENVIRONMENT.STAGING,
     ENVIRONMENT.TESTING,
   ]) {
     it(`returns the staging URL for the ${environment} environment`, () => {
@@ -39,6 +39,27 @@ describe('getRampCallbackBaseUrl', () => {
       expect(getRampCallbackBaseUrl()).toBe(STAGING_CALLBACK);
     });
   }
+
+  it('returns the production URL for a main staging build', () => {
+    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.STAGING;
+    process.env.METAMASK_BUILD_TYPE = 'main';
+
+    expect(getRampCallbackBaseUrl()).toBe(PRODUCTION_CALLBACK);
+  });
+
+  it('returns the staging URL for an experimental staging build', () => {
+    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.STAGING;
+    process.env.METAMASK_BUILD_TYPE = 'experimental';
+
+    expect(getRampCallbackBaseUrl()).toBe(STAGING_CALLBACK);
+  });
+
+  it('returns the production URL for a release-candidate build', () => {
+    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.RELEASE_CANDIDATE;
+    process.env.METAMASK_BUILD_TYPE = 'main';
+
+    expect(getRampCallbackBaseUrl()).toBe(PRODUCTION_CALLBACK);
+  });
 
   it('returns the staging URL when METAMASK_ENVIRONMENT is unset', () => {
     delete process.env.METAMASK_ENVIRONMENT;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Fixes TRAM-3940 by making `getRampsEnvironment()` switch on the extension build system's `METAMASK_ENVIRONMENT` vocabulary instead of remote-feature-flag aliases.

The mapping now resolves:
- `production` and `release-candidate` to production ramps
- main `staging` nightly builds to production ramps
- experimental `staging` nightly builds to staging/UAT ramps
- `development` to development ramps
- `other`, `pull-request`, `testing`, and unknown values to staging/UAT ramps

This also tags Sentry reports with `metamask.environment` and `metamask.build_type` so nightly events that continue to use the dev DSN can be filtered by the build vocabulary involved in service routing.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TRAM-3940

## **Manual testing steps**

1. Build a main nightly-style extension with `METAMASK_ENVIRONMENT=staging` and `METAMASK_BUILD_TYPE=main`.
2. Open a ramps flow and verify ramps content/API traffic uses `https://on-ramp-content.api.cx.metamask.io`.
3. Build an experimental nightly-style extension with `METAMASK_ENVIRONMENT=staging` and `METAMASK_BUILD_TYPE=experimental`.
4. Open a ramps flow and verify ramps content/API traffic uses `https://on-ramp-content.uat-api.cx.metamask.io`.
5. Build or inspect a release-candidate build and verify ramps content/API traffic uses `https://on-ramp-content.api.cx.metamask.io`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91ba8d54-4b19-4ffa-9b63-b53c17cdcc57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91ba8d54-4b19-4ffa-9b63-b53c17cdcc57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

