### PR TITLE
feat(stellar): add stellar snap + block stellar from trending list if stellar snap is not "on"

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -121,6 +121,7 @@ ignores:
   - '@metamask/bitcoin-wallet-snap'
   - '@metamask/solana-wallet-snap'
   - '@metamask/tron-wallet-snap'
+  - '@metamask/stellar-wallet-snap'
   - '@metamask/institutional-wallet-snap'
   - '@metamask/gator-permissions-snap'
   - '@metamask/permissions-kernel-snap'

--- a/app/scripts/constants/snaps.ts
+++ b/app/scripts/constants/snaps.ts
@@ -16,6 +16,11 @@ export const PREINSTALLED_SNAPS_URLS = [
     import.meta.url,
   ),
   new URL(
+    '@metamask/stellar-wallet-snap/dist/preinstalled-snap.json',
+    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
+    import.meta.url,
+  ),
+  new URL(
     '@metamask/permissions-kernel-snap/dist/preinstalled-snap.json',
     // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,

--- a/app/scripts/messenger-client-init/assets/network-enablement-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/network-enablement-controller-init.ts
@@ -10,6 +10,7 @@ import {
   SolAccountType,
   SolScope,
   TrxScope,
+  XlmScope,
 } from '@metamask/keyring-api';
 import {
   CaipChainId,
@@ -115,6 +116,7 @@ const generateDefaultNetworkEnablementControllerState = (
   const enabledMultichainNetworks: string[] = [SolScope.Mainnet];
   enabledMultichainNetworks.push(BtcScope.Mainnet);
   enabledMultichainNetworks.push(TrxScope.Mainnet);
+  enabledMultichainNetworks.push(XlmScope.Pubnet);
 
   return {
     enabledNetworkMap: {

--- a/app/scripts/messenger-client-init/messengers/accounts/multichain-account-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/multichain-account-service-messenger.ts
@@ -3,7 +3,10 @@ import {
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
-import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import {
+  RemoteFeatureFlagControllerGetStateAction,
+  RemoteFeatureFlagControllerStateChangeEvent,
+} from '@metamask/remote-feature-flag-controller';
 import type { MultichainAccountServiceMessenger } from '@metamask/multichain-account-service';
 import {
   PreferencesControllerGetStateAction,
@@ -60,7 +63,9 @@ type AllowedInitializationActions =
   | PreferencesControllerGetStateAction
   | RemoteFeatureFlagControllerGetStateAction;
 
-type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
+type AllowedInitializationEvents =
+  | PreferencesControllerStateChangeEvent
+  | RemoteFeatureFlagControllerStateChangeEvent;
 
 export type MultichainAccountServiceInitMessenger = ReturnType<
   typeof getMultichainAccountServiceInitMessenger
@@ -94,7 +99,10 @@ export function getMultichainAccountServiceInitMessenger(
       'PreferencesController:getState',
       'RemoteFeatureFlagController:getState',
     ],
-    events: ['PreferencesController:stateChange'],
+    events: [
+      'PreferencesController:stateChange',
+      'RemoteFeatureFlagController:stateChange',
+    ],
   });
   return serviceInitMessenger;
 }

--- a/app/scripts/messenger-client-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-account-service-init.test.ts
@@ -1,4 +1,5 @@
 import {
+  AccountProviderWrapper,
   MultichainAccountService,
   MultichainAccountServiceMessenger,
 } from '@metamask/multichain-account-service';
@@ -8,6 +9,7 @@ import {
   Messenger,
   MockAnyNamespace,
 } from '@metamask/messenger';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
 import {
@@ -22,7 +24,9 @@ jest.mock('@metamask/multichain-account-service');
 
 const PREFERENCES_STATE = { useExternalServices: false };
 
-function buildInitRequestMock(): jest.Mocked<
+function buildInitRequestMock(
+  remoteFeatureFlags: Record<string, unknown> = {},
+): jest.Mocked<
   MessengerClientInitRequest<
     MultichainAccountServiceMessenger,
     MultichainAccountServiceInitMessenger
@@ -30,13 +34,22 @@ function buildInitRequestMock(): jest.Mocked<
 > {
   const baseControllerMessenger = new Messenger<
     MockAnyNamespace,
-    PreferencesControllerGetStateAction | ActionConstraint,
+    | PreferencesControllerGetStateAction
+    | RemoteFeatureFlagControllerGetStateAction
+    | ActionConstraint,
     never
   >({ namespace: MOCK_ANY_NAMESPACE });
 
   baseControllerMessenger.registerActionHandler(
     'PreferencesController:getState',
     jest.fn().mockReturnValue(PREFERENCES_STATE),
+  );
+
+  baseControllerMessenger.registerActionHandler(
+    'RemoteFeatureFlagController:getState',
+    jest.fn().mockReturnValue({
+      remoteFeatureFlags,
+    }),
   );
 
   return {
@@ -83,6 +96,7 @@ describe('MultichainAccountServiceInit', () => {
 
       expect(multichainAccountServiceClassMock).toHaveBeenCalledWith({
         messenger: requestMock.controllerMessenger,
+        providers: [expect.any(AccountProviderWrapper)],
         providerConfigs: expect.any(Object),
         config: expect.any(Object),
         ensureOnboardingComplete: requestMock.ensureOnboardingComplete,
@@ -191,5 +205,114 @@ describe('MultichainAccountServiceInit', () => {
 
       expect(setBasicFunctionalitySpy).not.toHaveBeenCalled();
     });
+  });
+
+  describe('Stellar provider', () => {
+    const mockSetEnabled = jest.fn();
+    const mockXlmProvider = {
+      setEnabled: mockSetEnabled,
+    } as unknown as AccountProviderWrapper;
+
+    function getSubscriptionHandler(
+      subscribeSpy: jest.SpyInstance,
+      eventName: string,
+    ) {
+      const handler = subscribeSpy.mock.calls.find(
+        (call) => call[0] === eventName,
+      )?.[1];
+      expect(handler).toBeDefined();
+      return handler as (payload: unknown) => unknown;
+    }
+
+    beforeEach(() => {
+      jest
+        .mocked(AccountProviderWrapper)
+        .mockImplementation(() => mockXlmProvider);
+    });
+
+    it('calls RemoteFeatureFlagController:getState during init', () => {
+      const requestMock = buildInitRequestMock();
+      const callSpy = jest.spyOn(
+        requestMock.initMessenger,
+        'call',
+      ) as jest.Mock;
+
+      MultichainAccountServiceInit(requestMock);
+
+      expect(callSpy).toHaveBeenCalledWith(
+        'RemoteFeatureFlagController:getState',
+      );
+    });
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([true, false])(
+      'sets XLM provider enabled to %s based on stellarAccounts feature flag',
+      (enabled: boolean) => {
+        MultichainAccountServiceInit(
+          buildInitRequestMock({ stellarAccounts: enabled }),
+        );
+
+        expect(mockSetEnabled).toHaveBeenCalledWith(enabled);
+      },
+    );
+
+    it('subscribes to RemoteFeatureFlagController:stateChange on initMessenger', () => {
+      const requestMock = buildInitRequestMock();
+      const subscribeSpy = jest.spyOn(requestMock.initMessenger, 'subscribe');
+
+      MultichainAccountServiceInit(requestMock);
+
+      expect(subscribeSpy).toHaveBeenCalledWith(
+        'RemoteFeatureFlagController:stateChange',
+        expect.any(Function),
+      );
+    });
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      { initial: false, next: true, setEnabledCalls: 1, alignCalls: 1 },
+      { initial: true, next: false, setEnabledCalls: 0, alignCalls: 0 },
+      { initial: false, next: false, setEnabledCalls: 0, alignCalls: 0 },
+      { initial: true, next: true, setEnabledCalls: 0, alignCalls: 0 },
+    ])(
+      'when feature flag goes from $initial to $next, setEnabled=$setEnabledCalls alignWallets=$alignCalls',
+      async ({
+        initial,
+        next,
+        setEnabledCalls,
+        alignCalls,
+      }: {
+        initial: boolean;
+        next: boolean;
+        setEnabledCalls: number;
+        alignCalls: number;
+      }) => {
+        const requestMock = buildInitRequestMock({
+          stellarAccounts: initial,
+        });
+        const subscribeSpy = jest.spyOn(requestMock.initMessenger, 'subscribe');
+
+        const result = MultichainAccountServiceInit(requestMock);
+        const alignWalletsSpy = jest
+          .spyOn(result.messengerClient, 'alignWallets')
+          .mockResolvedValue(undefined as never);
+
+        mockSetEnabled.mockClear();
+
+        const handler = getSubscriptionHandler(
+          subscribeSpy,
+          'RemoteFeatureFlagController:stateChange',
+        );
+
+        await handler({
+          remoteFeatureFlags: {
+            stellarAccounts: next,
+          },
+        });
+
+        expect(mockSetEnabled).toHaveBeenCalledTimes(setEnabledCalls);
+        expect(alignWalletsSpy).toHaveBeenCalledTimes(alignCalls);
+      },
+    );
   });
 });

--- a/app/scripts/messenger-client-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-account-service-init.ts
@@ -4,10 +4,13 @@ import {
   SOL_ACCOUNT_PROVIDER_NAME,
   TRX_ACCOUNT_PROVIDER_NAME,
   BTC_ACCOUNT_PROVIDER_NAME,
+  AccountProviderWrapper,
+  XlmAccountProvider,
 } from '@metamask/multichain-account-service';
 import { MessengerClientInitFunction } from '../types';
 import { MultichainAccountServiceInitMessenger } from '../messengers/accounts';
 import { previousValueComparator } from '../../lib/util';
+import { isMultichainFeatureEnabled } from '../../../../shared/lib/multichain-feature-flags';
 import { trace } from '../../../../shared/lib/trace';
 
 /**
@@ -43,8 +46,26 @@ export const MultichainAccountServiceInit: MessengerClientInitFunction<
     },
   };
 
+  const xlmProvider = new AccountProviderWrapper(
+    controllerMessenger,
+    new XlmAccountProvider(controllerMessenger, snapAccountProviderConfig),
+  );
+
+  // initialize Stellar provider based on feature flag
+  const initialRemoteFeatureFlagsState = initMessenger.call(
+    'RemoteFeatureFlagController:getState',
+  );
+
+  const initialStellarEnabled = isMultichainFeatureEnabled(
+    initialRemoteFeatureFlagsState?.remoteFeatureFlags?.stellarAccounts,
+  );
+  xlmProvider.setEnabled(initialStellarEnabled);
+
   const messengerClient = new MultichainAccountService({
     messenger: controllerMessenger,
+    // TODO: Once stellar is officially supported,
+    // move it to the providers array via `XLM_ACCOUNT_PROVIDER_NAME`.
+    providers: [xlmProvider],
     providerConfigs: {
       [SOL_ACCOUNT_PROVIDER_NAME]: snapAccountProviderConfig,
       [BTC_ACCOUNT_PROVIDER_NAME]: snapAccountProviderConfig,
@@ -79,6 +100,35 @@ export const MultichainAccountServiceInit: MessengerClientInitFunction<
 
       return true;
     }, preferencesState),
+  );
+
+  // Subscribe to feature flag changes to enable Stellar provider.
+  initMessenger.subscribe(
+    'RemoteFeatureFlagController:stateChange',
+    previousValueComparator((prevState, currState) => {
+      const prevStellarEnabled = isMultichainFeatureEnabled(
+        prevState?.remoteFeatureFlags?.stellarAccounts,
+      );
+      const currStellarEnabled = isMultichainFeatureEnabled(
+        currState?.remoteFeatureFlags?.stellarAccounts,
+      );
+
+      // Only handle the case when Stellar provider is enabled.
+      if (prevStellarEnabled !== currStellarEnabled && currStellarEnabled) {
+        xlmProvider.setEnabled(currStellarEnabled);
+
+        // Trigger wallet alignment when Stellar accounts are enabled
+        // This will create Stellar accounts for existing wallets
+        messengerClient.alignWallets().catch((error) => {
+          console.error(
+            'Failed to align wallets after enabling Stellar provider:',
+            error,
+          );
+        });
+      }
+
+      return true;
+    }, initialRemoteFeatureFlagsState),
   );
 
   return {

--- a/package.json
+++ b/package.json
@@ -483,6 +483,7 @@
     "@metamask/snaps-utils": "^12.5.0",
     "@metamask/solana-wallet-snap": "^2.10.0",
     "@metamask/solana-wallet-standard": "^1.0.0",
+    "@metamask/stellar-wallet-snap": "0.1.0",
     "@metamask/storage-service": "^1.0.0",
     "@metamask/subscription-controller": "^7.0.0",
     "@metamask/transaction-controller": "^69.5.1",

--- a/shared/lib/accounts/snaps.ts
+++ b/shared/lib/accounts/snaps.ts
@@ -7,6 +7,7 @@ import {
 import { SnapKeyringBuilderMessenger } from '../../../app/scripts/lib/snap-keyring/types';
 import { SOLANA_WALLET_SNAP_ID } from './solana-wallet-snap';
 import { BITCOIN_WALLET_SNAP_ID } from './bitcoin-wallet-snap';
+import { STELLAR_WALLET_SNAP_ID } from './stellar-wallet-snap';
 import { TRON_WALLET_SNAP_ID } from './tron-wallet-snap';
 
 /**
@@ -21,6 +22,7 @@ const WHITELISTED_SNAPS = [
   BITCOIN_WALLET_SNAP_ID,
   SOLANA_WALLET_SNAP_ID,
   TRON_WALLET_SNAP_ID,
+  STELLAR_WALLET_SNAP_ID,
 ];
 
 /**

--- a/shared/lib/snaps/snaps.ts
+++ b/shared/lib/snaps/snaps.ts
@@ -19,6 +19,7 @@ export const PREINSTALLED_SNAPS = [
   'npm:@metamask/bitcoin-wallet-snap',
   'npm:@metamask/solana-wallet-snap',
   'npm:@metamask/tron-wallet-snap',
+  'npm:@metamask/stellar-wallet-snap',
   'npm:@metamask/permissions-kernel-snap',
   'npm:@metamask/gator-permissions-snap',
 ];

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -1057,7 +1057,8 @@
       "referrals": {
         "asterdex": {},
         "gmx": {},
-        "hyperliquid": {}
+        "hyperliquid": {},
+        "variational": {}
       },
       "securityAlertsEnabled": true,
       "showSidePanelMigrationToast": false,
@@ -1266,6 +1267,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 222
+    "version": 223
   }
 }

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -179,7 +179,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 222,
+      "currentMigrationVersion": 223,
       "firstTimeInfo": {},
       "previousAppVersion": "",
       "previousMigrationVersion": 0

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -179,7 +179,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 223,
+      "currentMigrationVersion": 222,
       "firstTimeInfo": {},
       "previousAppVersion": "",
       "previousMigrationVersion": 0
@@ -1057,8 +1057,7 @@
       "referrals": {
         "asterdex": {},
         "gmx": {},
-        "hyperliquid": {},
-        "variational": {}
+        "hyperliquid": {}
       },
       "securityAlertsEnabled": true,
       "showSidePanelMigrationToast": false,
@@ -1214,6 +1213,7 @@
         "npm:@metamask/message-signing-snap": "mainnet",
         "npm:@metamask/permissions-kernel-snap": "mainnet",
         "npm:@metamask/solana-wallet-snap": "mainnet",
+        "npm:@metamask/stellar-wallet-snap": "mainnet",
         "npm:@metamask/tron-wallet-snap": "mainnet"
       }
     },
@@ -1266,6 +1266,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 223
+    "version": 222
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -49,7 +49,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 222,
+      "currentMigrationVersion": 223,
       "firstTimeInfo": {
         "date": 0,
         "version": "13.17.0"

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -2046,7 +2046,8 @@
       "referrals": {
         "asterdex": {},
         "gmx": {},
-        "hyperliquid": {}
+        "hyperliquid": {},
+        "variational": {}
       },
       "securityAlertsEnabled": true,
       "showSidePanelMigrationToast": false,
@@ -2257,6 +2258,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 222
+    "version": 223
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -49,7 +49,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 223,
+      "currentMigrationVersion": 222,
       "firstTimeInfo": {
         "date": 0,
         "version": "13.17.0"
@@ -545,7 +545,7 @@
           "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": false
         },
         "stellar": {
-          "stellar:pubnet": false,
+          "stellar:pubnet": true,
           "stellar:testnet": false
         },
         "tron": {
@@ -2046,8 +2046,7 @@
       "referrals": {
         "asterdex": {},
         "gmx": {},
-        "hyperliquid": {},
-        "variational": {}
+        "hyperliquid": {}
       },
       "securityAlertsEnabled": true,
       "showSidePanelMigrationToast": false,
@@ -2130,6 +2129,7 @@
         "npm:@metamask/message-signing-snap": "mainnet",
         "npm:@metamask/permissions-kernel-snap": "mainnet",
         "npm:@metamask/solana-wallet-snap": "mainnet",
+        "npm:@metamask/stellar-wallet-snap": "mainnet",
         "npm:@metamask/tron-wallet-snap": "mainnet"
       }
     },
@@ -2257,6 +2257,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 223
+    "version": 222
   }
 }

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -482,6 +482,28 @@
         "schedule": "string",
         "scheduledAt": "string",
         "snapId": "string"
+      },
+      "cronjob-npm:@metamask/stellar-wallet-snap-0": {
+        "date": "string",
+        "id": "string",
+        "recurring": "boolean",
+        "request": {
+          "method": "string"
+        },
+        "schedule": "string",
+        "scheduledAt": "string",
+        "snapId": "string"
+      },
+      "cronjob-npm:@metamask/stellar-wallet-snap-1": {
+        "date": "string",
+        "id": "string",
+        "recurring": "boolean",
+        "request": {
+          "method": "string"
+        },
+        "schedule": "string",
+        "scheduledAt": "string",
+        "snapId": "string"
       }
     },
     "fcmToken": "string",
@@ -975,8 +997,7 @@
     "referrals": {
       "asterdex": {},
       "gmx": {},
-      "hyperliquid": {},
-      "variational": {}
+      "hyperliquid": {}
     },
     "region": "string",
     "requests": {
@@ -1172,6 +1193,15 @@
         "version": "string"
       },
       "npm:@metamask/tron-wallet-snap": {
+        "extensionId": "null",
+        "iconUrl": "null",
+        "name": "string",
+        "origin": "string",
+        "subjectType": "string",
+        "svgIcon": "string",
+        "version": "string"
+      },
+      "npm:@metamask/stellar-wallet-snap": {
         "extensionId": "null",
         "iconUrl": "null",
         "name": "string",

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -997,7 +997,8 @@
     "referrals": {
       "asterdex": {},
       "gmx": {},
-      "hyperliquid": {}
+      "hyperliquid": {},
+      "variational": {}
     },
     "region": "string",
     "requests": {

--- a/ui/hooks/discover-search/constants.ts
+++ b/ui/hooks/discover-search/constants.ts
@@ -22,6 +22,7 @@ export const DISCOVER_SEARCH_CHAIN_IDS: CaipChainId[] = [
   toEvmCaipChainId(CHAIN_IDS.ZKSYNC_ERA),
   toEvmCaipChainId(CHAIN_IDS.ROBINHOOD_CHAIN),
   TrxScope.Mainnet,
+  MultichainNetworks.STELLAR,
 ];
 
 /** RWA / tokenized stocks default chains. */

--- a/ui/hooks/discover-search/useDiscoverCryptoSearch.test.tsx
+++ b/ui/hooks/discover-search/useDiscoverCryptoSearch.test.tsx
@@ -1,16 +1,23 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { getTrendingTokens, searchTokens } from '@metamask/assets-controllers';
 
 import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
+import { DISCOVER_SEARCH_CHAIN_IDS } from './constants';
 import { useDiscoverCryptoSearch } from './useDiscoverCryptoSearch';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
 
 jest.mock('@metamask/assets-controllers', () => ({
   getTrendingTokens: jest.fn(),
   searchTokens: jest.fn(),
 }));
 
+const mockUseSelector = jest.mocked(useSelector);
 const mockGetTrendingTokens = jest.mocked(getTrendingTokens);
 const mockSearchTokens = jest.mocked(searchTokens);
 
@@ -34,6 +41,7 @@ describe('useDiscoverCryptoSearch', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSelector.mockReturnValue(false);
     mockGetTrendingTokens.mockResolvedValue([]);
   });
 
@@ -68,6 +76,42 @@ describe('useDiscoverCryptoSearch', () => {
     expect(mockSearchTokens).not.toHaveBeenCalled();
     expect(result.current.data).toHaveLength(1);
     expect(result.current.data[0].symbol).toBe('ETH');
+  });
+
+  it('includes Stellar in trending chain IDs when Stellar support is enabled', async () => {
+    mockUseSelector.mockReturnValue(true);
+    mockGetTrendingTokens.mockResolvedValue([]);
+
+    const { result } = renderHook(
+      () => useDiscoverCryptoSearch({ query: '' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGetTrendingTokens.mock.calls[0][0].chainIds).toContain(
+      MultichainNetworks.STELLAR,
+    );
+  });
+
+  it('excludes Stellar in trending chain IDs when Stellar support is off', async () => {
+    mockUseSelector.mockReturnValue(false);
+    mockGetTrendingTokens.mockResolvedValue([]);
+
+    const { result } = renderHook(
+      () => useDiscoverCryptoSearch({ query: '' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGetTrendingTokens.mock.calls[0][0].chainIds).not.toContain(
+      MultichainNetworks.STELLAR,
+    );
   });
 
   it('searches tokens when query is present', async () => {

--- a/ui/hooks/discover-search/useDiscoverCryptoSearch.ts
+++ b/ui/hooks/discover-search/useDiscoverCryptoSearch.ts
@@ -1,10 +1,15 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import {
   getTrendingTokens,
   searchTokens,
   type TrendingAsset,
 } from '@metamask/assets-controllers';
+import type { CaipChainId } from '@metamask/utils';
 
+import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
+import { getIsStellarSupportEnabled } from '../../selectors/multichain/feature-flags';
 import {
   DISCOVER_SEARCH_CHAIN_IDS,
   DISCOVER_SEARCH_GC_TIME_MS,
@@ -79,6 +84,26 @@ const dedupeByAssetId = (assets: TrendingAsset[]): TrendingAsset[] => {
 };
 
 /**
+ * Chain IDs for Discover crypto trending / search, excluding blocked chains
+ * when they are not live (e.g. Stellar support is not enabled).
+ * Mirrors mobile's `useTrendingChainIds`.
+ */
+const useDiscoverSearchChainIds = (): CaipChainId[] => {
+  const isStellarSupportEnabled = useSelector(getIsStellarSupportEnabled);
+
+  return useMemo((): CaipChainId[] => {
+    const blockList = new Set<CaipChainId>();
+    if (!isStellarSupportEnabled) {
+      blockList.add(MultichainNetworks.STELLAR);
+    }
+
+    return DISCOVER_SEARCH_CHAIN_IDS.filter(
+      (chainId) => !blockList.has(chainId),
+    );
+  }, [isStellarSupportEnabled]);
+};
+
+/**
  * Crypto Discover feed: trending when query is empty, market-data search otherwise.
  * @param options0
  * @param options0.query
@@ -90,17 +115,18 @@ export const useDiscoverCryptoSearch = ({
 }: UseDiscoverCryptoSearchOptions): UseDiscoverCryptoSearchResult => {
   const trimmedQuery = query.trim();
   const isSearch = trimmedQuery.length > 0;
+  const chainIds = useDiscoverSearchChainIds();
 
   const trendingQuery = useQuery<TrendingAsset[], Error>({
     queryKey: [
       ...DISCOVER_SEARCH_QUERY_KEY_ROOT,
       'crypto',
       'trending',
-      DISCOVER_SEARCH_CHAIN_IDS,
+      chainIds,
     ] as const,
     queryFn: async (): Promise<TrendingAsset[]> =>
       getTrendingTokens({
-        chainIds: DISCOVER_SEARCH_CHAIN_IDS,
+        chainIds,
         sort: 'h24_trending',
         minLiquidity: 200_000,
         minVolume24hUsd: 1_000_000,
@@ -117,23 +143,19 @@ export const useDiscoverCryptoSearch = ({
       'crypto',
       'search',
       trimmedQuery,
-      DISCOVER_SEARCH_CHAIN_IDS,
+      chainIds,
     ] as const,
     queryFn: async ({
       pageParam,
     }: {
       pageParam?: string;
     }): Promise<CryptoSearchPage> => {
-      const response = await searchTokens(
-        DISCOVER_SEARCH_CHAIN_IDS,
-        trimmedQuery,
-        {
-          limit: DISCOVER_SEARCH_PAGE_SIZE,
-          after: pageParam,
-          includeMarketData: true,
-          includeTokenSecurityData: true,
-        },
-      );
+      const response = await searchTokens(chainIds, trimmedQuery, {
+        limit: DISCOVER_SEARCH_PAGE_SIZE,
+        after: pageParam,
+        includeMarketData: true,
+        includeTokenSecurityData: true,
+      });
 
       if (response.error) {
         throw new Error(response.error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8653,6 +8653,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/stellar-wallet-snap@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@metamask/stellar-wallet-snap@npm:0.1.0"
+  checksum: 10/373cebc4af1b95e3a9228b0ce2bea79fb71d6d61f86abb03f3160ed040469392307d4f932fe0189b13d555d729c14205eaad20ab6957ab6291888a4c00a3cc6e
+  languageName: node
+  linkType: hard
+
 "@metamask/storage-service@npm:^1.0.0, @metamask/storage-service@npm:^1.0.2":
   version: 1.0.2
   resolution: "@metamask/storage-service@npm:1.0.2"
@@ -33323,6 +33330,7 @@ __metadata:
     "@metamask/solana-test-validator-up": "npm:^1.0.0"
     "@metamask/solana-wallet-snap": "npm:^2.10.0"
     "@metamask/solana-wallet-standard": "npm:^1.0.0"
+    "@metamask/stellar-wallet-snap": "npm:0.1.0"
     "@metamask/storage-service": "npm:^1.0.0"
     "@metamask/subscription-controller": "npm:^7.0.0"
     "@metamask/superstruct": "npm:^3.2.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR is adding the implementation for Stellar SNAP
while most of the side component already shipped


PRs:
- https://github.com/MetaMask/metamask-extension/pull/44192
- https://github.com/MetaMask/metamask-extension/pull/45133
- https://github.com/MetaMask/metamask-extension/pull/45219
- https://github.com/MetaMask/metamask-extension/pull/45263
- https://github.com/MetaMask/metamask-extension/pull/44193
- https://github.com/MetaMask/metamask-extension/pull/45075
- https://github.com/MetaMask/metamask-extension/pull/44200

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Stellar SNAP

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

When FF is off
https://www.loom.com/share/de37057d00cd48caa1010ff072470a6b

When FF is on
https://www.loom.com/share/715bb4593d81468d94664c4b34c5cba9

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new preinstalled keyring snap and account-creation path, but it is feature-flagged and follows existing Solana/Tron/Bitcoin patterns.
> 
> **Overview**
> Adds the preinstalled `@metamask/stellar-wallet-snap` and wires Stellar into multichain accounts, gated by the `stellarAccounts` remote feature flag.
> 
> The snap is registered as a preinstalled/whitelisted wallet snap. `MultichainAccountService` now wraps an `XlmAccountProvider`, enables it from the flag, and on flag-on transitions calls `alignWallets` to create Stellar accounts. Stellar pubnet is enabled by default in network enablement.
> 
> Discover crypto search/trending includes Stellar only when Stellar support is on. E2E fixtures and state-log schemas are updated for the new snap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 223d2170c30a3f2391577639c078ed5078ce1fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->