### PR TITLE
revert(confirmations): disable enforced simulations for wallet transactions

### DIFF
--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -150,56 +150,23 @@ describe('enforced-simulations', () => {
       ).toBe(true);
     });
 
-    for (const { description, origin } of [
-      { description: 'no origin', origin: undefined },
-      { description: 'the MetaMask origin', origin: ORIGIN_METAMASK },
-    ]) {
-      describe(`with a wallet-initiated transaction using ${description}`, () => {
-        it('returns true when all conditions are met', () => {
-          expect(
-            isEnforcedSimulationsEligible(
-              { ...BASE_TRANSACTION_META, origin },
-              buildState(ResultType.Benign),
-            ),
-          ).toBe(true);
-        });
+    it('returns false when origin is undefined', () => {
+      expect(
+        isEnforcedSimulationsEligible(
+          { ...BASE_TRANSACTION_META, origin: undefined },
+          buildState(ResultType.Benign),
+        ),
+      ).toBe(false);
+    });
 
-        it('returns false when the chain is unsupported', () => {
-          expect(
-            isEnforcedSimulationsEligible(
-              {
-                ...BASE_TRANSACTION_META,
-                origin,
-                chainId: UNSUPPORTED_CHAIN_ID,
-              },
-              buildState(ResultType.Benign),
-            ),
-          ).toBe(false);
-        });
-
-        it('returns true when there are no balance changes', () => {
-          expect(
-            isEnforcedSimulationsEligible(
-              {
-                ...BASE_TRANSACTION_META,
-                origin,
-                simulationData: { tokenBalanceChanges: [] },
-              },
-              buildState(ResultType.Benign),
-            ),
-          ).toBe(true);
-        });
-
-        it('returns false when the recipient is trusted', () => {
-          expect(
-            isEnforcedSimulationsEligible(
-              { ...BASE_TRANSACTION_META, origin },
-              buildState(ResultType.Trusted),
-            ),
-          ).toBe(false);
-        });
-      });
-    }
+    it('returns false when origin is MetaMask internal', () => {
+      expect(
+        isEnforcedSimulationsEligible(
+          { ...BASE_TRANSACTION_META, origin: ORIGIN_METAMASK },
+          buildState(ResultType.Benign),
+        ),
+      ).toBe(false);
+    });
 
     it('returns false when chain is not in eip7702 supported chains', () => {
       expect(
@@ -959,13 +926,13 @@ describe('enforced-simulations', () => {
         ).toBe(true);
       });
 
-      it('returns true when origin is MetaMask internal', () => {
+      it('still returns false when origin is MetaMask internal', () => {
         expect(
           isEnforcedSimulationsEligible(
             { ...BASE_TRANSACTION_META, origin: ORIGIN_METAMASK },
             buildState(ResultType.Trusted),
           ),
-        ).toBe(true);
+        ).toBe(false);
       });
 
       it('is ignored when value is not the string "true"', () => {

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -2,6 +2,7 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
@@ -145,7 +146,11 @@ export function isEnforcedSimulationsEligible(
   transactionMeta: TransactionMeta,
   state: EnforcedSimulationsState,
 ): boolean {
-  const { chainId, simulationData, type } = transactionMeta;
+  const { chainId, origin, simulationData, type } = transactionMeta;
+
+  if (!origin || origin === ORIGIN_METAMASK) {
+    return false;
+  }
 
   if (
     !state.eip7702SupportedChains?.some(


### PR DESCRIPTION
## **Description**

Reverts #45278, restoring the origin eligibility gate for enforced simulations. Wallet-initiated transactions with no origin or the internal MetaMask origin are again ineligible, while the newer chain, simulation-completion, transaction-type, internal-account, and trust-signal eligibility behavior remains unchanged.

## **Changelog**

CHANGELOG entry: Stopped enforced simulations from running for wallet-initiated transactions

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Start MetaMask with the `confirmations_enforced_simulations` remote feature enabled, using an EIP-7702-supported account and network.
2. Initiate a Send transaction from inside MetaMask to an untrusted recipient.
3. Continue to the confirmation and verify that enforced simulations are not applied to the wallet-initiated transaction.
4. Initiate an equivalent transaction from a connected dapp and verify that it remains eligible for enforced simulations.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation-path eligibility for enforced simulations. Scope is a small origin gate, but it affects which transactions get extra simulation enforcement.
> 
> **Overview**
> Restores the origin gate on `isEnforcedSimulationsEligible` so wallet-initiated transactions are no longer eligible for enforced simulations.
> 
> If `origin` is missing or is `ORIGIN_METAMASK`, eligibility now returns false immediately—including when `FORCE_ENFORCED_SIMULATIONS` is set. Dapp-originated txs keep the existing chain, simulation, type, and trust-signal checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5524ba09caf9a273fca651f22ec78f6282482b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->