### PR TITLE
fix(money): earn on your crypto section renders on money account filled state ui

### DIFF
--- a/ui/pages/money/money-home-page.test.tsx
+++ b/ui/pages/money/money-home-page.test.tsx
@@ -192,6 +192,10 @@ describe('MoneyHomePage', () => {
     expect(
       screen.getByTestId('money-activity-placeholder'),
     ).toBeInTheDocument();
+    expect(screen.getByTestId('money-potential-earnings')).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.moneyEarnOnCrypto.message),
+    ).toBeInTheDocument();
     expect(
       screen.getByTestId('money-condensed-info-cards'),
     ).toBeInTheDocument();
@@ -215,9 +219,6 @@ describe('MoneyHomePage', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText(messages.moneyBenefits.message),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId('money-potential-earnings'),
     ).not.toBeInTheDocument();
     screen.getAllByRole('button').forEach((button) => {
       expect(button).toBeDisabled();
@@ -370,6 +371,7 @@ describe('MoneyHomePage', () => {
     expect(
       screen.getByTestId('money-activity-placeholder'),
     ).toBeInTheDocument();
+    expect(screen.getByTestId('money-potential-earnings')).toBeInTheDocument();
   });
 
   it('keeps a balance below the funded threshold in the empty state', () => {
@@ -477,6 +479,46 @@ describe('MoneyHomePage', () => {
   });
 
   it('previews eligible wallet assets using their existing balances', () => {
+    mockUseMoneyDepositTokens.mockReturnValue({
+      tokens: [
+        {
+          address: '0x0000000000000000000000000000000000000001',
+          chainId: '0x1',
+          decimals: 6,
+          image: 'usdc.png',
+          moneyFiatAmountUsd: 12,
+          secondary: '$12.00',
+          symbol: 'USDC',
+          title: 'USD Coin',
+          tokenFiatAmount: 12,
+        },
+      ],
+      isNoFeeToken: () => true,
+    });
+
+    renderWithLocalization(<MoneyHomePage />);
+
+    expect(screen.getByTestId('money-potential-earnings')).toBeInTheDocument();
+    expect(screen.getByText('USD Coin')).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.moneyEarnOnCryptoNoFee.message),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('money-potential-earnings-projection'),
+    ).toHaveTextContent('+$0.50');
+  });
+
+  it('previews eligible wallet assets on a funded Money account', () => {
+    mockUseMoneyAccountBalance.mockReturnValue({
+      apyDecimal: 0.042,
+      apyPercentFormatted: '4.2%',
+      isBalanceFetchError: false,
+      isBalanceLoading: false,
+      tokenTotal: new BigNumber('3475.45'),
+      totalFiatFormatted: '$3,475.45',
+      totalFiatRaw: '3475.45',
+      vaultApyQuery: { isLoading: false },
+    });
     mockUseMoneyDepositTokens.mockReturnValue({
       tokens: [
         {

--- a/ui/pages/money/money-home-page.tsx
+++ b/ui/pages/money/money-home-page.tsx
@@ -160,6 +160,14 @@ export function MoneyHomePage() {
       ? t('moneyBalanceUnavailable')
       : totalFiatFormatted;
   const apyDisplay = apyPercentFormatted;
+  const earnOnYourCryptoSection = (
+    <MoneyPotentialEarnings
+      tokens={depositTokens}
+      apyDecimal={apyDecimal}
+      isNoFeeToken={isNoFeeToken}
+      privacyMode={privacyMode}
+    />
+  );
 
   return (
     <main
@@ -272,6 +280,8 @@ export function MoneyHomePage() {
             ) : null}
             <MoneyActivityPlaceholder />
             <MoneySectionDivider />
+            {earnOnYourCryptoSection}
+            <MoneySectionDivider />
             <MoneyCondensedInfoCards />
           </>
         ) : (
@@ -310,12 +320,7 @@ export function MoneyHomePage() {
             <MoneyActivityPlaceholder />
 
             <MoneySectionDivider />
-            <MoneyPotentialEarnings
-              tokens={depositTokens}
-              apyDecimal={apyDecimal}
-              isNoFeeToken={isNoFeeToken}
-              privacyMode={privacyMode}
-            />
+            {earnOnYourCryptoSection}
 
             <MoneySectionDivider />
             <section className="px-4 py-3">


### PR DESCRIPTION
## **Description**

The “Earn on your crypto” section on Money Home was only mounted in the empty (unfunded) layout. Funded accounts never showed it, even though [#45603](https://github.com/MetaMask/metamask-extension/pull/45603) was meant to render it on Money Home in both states.

This change renders the same section on the filled layout, below Activity  and above the condensed info cards. Empty-state placement is unchanged. The Monthly/Lifetime Earnings block remains gated by `earnMoneyEarningSectionEnabled` and does not control this section.

## **Changelog**

CHANGELOG entry: Fixed Earn on your crypto not showing on funded Money Accounts

## **Related issues**

Follows: https://github.com/MetaMask/metamask-extension/pull/45603

## **Manual testing steps**

1. Enable `moneyEnableMoneyAccount` and open Money Home on an unfunded
   account (balance below $0.01).
2. Verify “Earn on your crypto” appears below Activity.
3. Open Money Home on a funded Money Account (filled state).
4. Verify “Earn on your crypto” still appears below Activity and above the
   condensed info cards, with eligible wallet assets listed when present.
5. If `earnMoneyEarningSectionEnabled` is off, verify Monthly/Lifetime
   Earnings is hidden and “Earn on your crypto” remains visible.
6. Enable privacy mode and verify balances and projections in the section
   are masked.

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="390" height="590" alt="Screenshot 2026-08-18 at 13 41 33" src="https://github.com/user-attachments/assets/223abb40-0587-4e08-ac92-3801861ef2b7" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/contributor-docs/blob/main/docs/labeling-guidelines.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout change on Money Home; no auth, data, or earnings-calculation logic is modified.
> 
> **Overview**
> Shows the **Earn on your crypto** (`MoneyPotentialEarnings`) block on funded Money Home, not only the empty/unfunded layout.
> 
> The same section is reused in both branches and sits below Activity (and above condensed info cards when funded). Monthly/Lifetime earnings stay gated by `earnMoneyEarningSectionEnabled`; this section does not. Tests now expect it in filled state, including eligible wallet-asset previews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45ac1d7a8ed9a4a65b6f6cc74a48b6461c2b0cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->