### PR TITLE
feat(perps): support $ and % amount input when partially closing a position

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7222,8 +7222,14 @@
   "perpsCloseAmountInPercent": {
     "message": "%"
   },
+  "perpsCloseAmountInPercentLabel": {
+    "message": "Enter close amount as a percentage of your position"
+  },
   "perpsCloseAmountInUsd": {
     "message": "$"
+  },
+  "perpsCloseAmountInUsdLabel": {
+    "message": "Enter close amount in US dollars"
   },
   "perpsCloseLimitPriceOutsideOracleBand": {
     "message": "Price can't be more than 95% away from the market price"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7216,6 +7216,15 @@
   "perpsCloseAmount": {
     "message": "Close amount"
   },
+  "perpsCloseAmountCappedAtPosition": {
+    "message": "Close amount capped at your position value."
+  },
+  "perpsCloseAmountInPercent": {
+    "message": "%"
+  },
+  "perpsCloseAmountInUsd": {
+    "message": "$"
+  },
   "perpsCloseLimitPriceOutsideOracleBand": {
     "message": "Price can't be more than 95% away from the market price"
   },
@@ -7227,6 +7236,9 @@
   },
   "perpsClosePartialMinNotional": {
     "message": "Partial closes must be at least $1 in USD value. Increase the close amount or close the full position."
+  },
+  "perpsClosePercentCappedAtMax": {
+    "message": "Close percentage capped at 100%."
   },
   "perpsClosePosition": {
     "message": "Close position"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7216,6 +7216,21 @@
   "perpsCloseAmount": {
     "message": "Close amount"
   },
+  "perpsCloseAmountCappedAtPosition": {
+    "message": "Close amount capped at your position value."
+  },
+  "perpsCloseAmountInPercent": {
+    "message": "%"
+  },
+  "perpsCloseAmountInPercentLabel": {
+    "message": "Enter close amount as a percentage of your position"
+  },
+  "perpsCloseAmountInUsd": {
+    "message": "$"
+  },
+  "perpsCloseAmountInUsdLabel": {
+    "message": "Enter close amount in US dollars"
+  },
   "perpsCloseLimitPriceOutsideOracleBand": {
     "message": "Price can't be more than 95% away from the market price"
   },
@@ -7227,6 +7242,9 @@
   },
   "perpsClosePartialMinNotional": {
     "message": "Partial closes must be at least $1 in USD value. Increase the close amount or close the full position."
+  },
+  "perpsClosePercentCappedAtMax": {
+    "message": "Close percentage capped at 100%."
   },
   "perpsClosePosition": {
     "message": "Close position"

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -239,16 +239,20 @@
       "React: Act warnings (component updates not wrapped)": 36
     },
     "ui/components/app/perps/close-position/close-position-modal.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 8
+      "React: Act warnings (component updates not wrapped)": 175
     },
     "ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 24,
       "React: componentWill* lifecycle deprecations": 1
     },
+    "ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx": {
+      "React: Act warnings (component updates not wrapped)": 205
+    },
     "ui/components/app/perps/order-entry/components/leverage-slider/leverage-slider.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 1
     },
     "ui/components/app/perps/order-entry/order-entry.test.tsx": {
+      "React: Act warnings (component updates not wrapped)": 13,
       "React: componentWill* lifecycle deprecations": 1
     },
     "ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.test.tsx": {

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -239,20 +239,16 @@
       "React: Act warnings (component updates not wrapped)": 36
     },
     "ui/components/app/perps/close-position/close-position-modal.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 175
+      "React: Act warnings (component updates not wrapped)": 8
     },
     "ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 24,
       "React: componentWill* lifecycle deprecations": 1
     },
-    "ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 205
-    },
     "ui/components/app/perps/order-entry/components/leverage-slider/leverage-slider.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 1
     },
     "ui/components/app/perps/order-entry/order-entry.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 13,
       "React: componentWill* lifecycle deprecations": 1
     },
     "ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.test.tsx": {

--- a/ui/components/app/perps/close-position/close-position-modal.test.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.test.tsx
@@ -473,6 +473,7 @@ describe('ClosePositionModal', () => {
 
   describe('close amount input modes', () => {
     it('submits the token quantity equivalent to a typed dollar amount', async () => {
+      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -488,8 +489,9 @@ describe('ClosePositionModal', () => {
         screen.getByTestId('close-amount-value'),
       ).getByRole('textbox');
       // Half of the 2.5 ETH position at 2,900 is 3,625 USD.
-      fireEvent.change(usdInput, { target: { value: '3625' } });
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await user.clear(usdInput);
+      await user.type(usdInput, '3625');
+      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -500,6 +502,7 @@ describe('ClosePositionModal', () => {
     });
 
     it('submits the token quantity equivalent to a typed percentage', async () => {
+      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -511,12 +514,13 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
       const percentInput = within(
         screen.getByTestId('close-amount-percent'),
       ).getByRole('textbox');
-      fireEvent.change(percentInput, { target: { value: '50' } });
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await user.clear(percentInput);
+      await user.type(percentInput, '50');
+      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -527,6 +531,7 @@ describe('ClosePositionModal', () => {
     });
 
     it('caps a dollar amount above the position at a full close', async () => {
+      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -541,13 +546,14 @@ describe('ClosePositionModal', () => {
       const usdInput = within(
         screen.getByTestId('close-amount-value'),
       ).getByRole('textbox');
-      fireEvent.change(usdInput, { target: { value: '999999' } });
+      await user.clear(usdInput);
+      await user.type(usdInput, '999999');
 
       expect(
         screen.getByTestId('close-amount-over-close-error'),
       ).toBeInTheDocument();
 
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalled();
@@ -558,6 +564,7 @@ describe('ClosePositionModal', () => {
     });
 
     it('caps a percentage above 100 at a full close', async () => {
+      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -569,17 +576,18 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
       const percentInput = within(
         screen.getByTestId('close-amount-percent'),
       ).getByRole('textbox');
-      fireEvent.change(percentInput, { target: { value: '150' } });
+      await user.clear(percentInput);
+      await user.type(percentInput, '150');
 
       expect(
         screen.getByTestId('close-amount-over-close-error'),
       ).toBeInTheDocument();
 
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalled();
@@ -589,6 +597,7 @@ describe('ClosePositionModal', () => {
     });
 
     it('reports the percentage input method on the close request', async () => {
+      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -600,12 +609,13 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
       const percentInput = within(
         screen.getByTestId('close-amount-percent'),
       ).getByRole('textbox');
-      fireEvent.change(percentInput, { target: { value: '50' } });
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await user.clear(percentInput);
+      await user.type(percentInput, '50');
+      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -622,6 +632,7 @@ describe('ClosePositionModal', () => {
     });
 
     it('reports the keypad input method for a typed dollar amount', async () => {
+      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -636,8 +647,9 @@ describe('ClosePositionModal', () => {
       const usdInput = within(
         screen.getByTestId('close-amount-value'),
       ).getByRole('textbox');
-      fireEvent.change(usdInput, { target: { value: '3625' } });
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await user.clear(usdInput);
+      await user.type(usdInput, '3625');
+      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -654,6 +666,7 @@ describe('ClosePositionModal', () => {
     });
 
     it('reports the slider input method when the slider sets the amount', async () => {
+      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -669,7 +682,7 @@ describe('ClosePositionModal', () => {
         screen.getByTestId('close-amount-slider-pct-100'),
       ).getByRole('slider');
       fireEvent.change(slider, { target: { value: '50' } });
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -686,6 +699,7 @@ describe('ClosePositionModal', () => {
     });
 
     it('reports the default input method when the amount is untouched', async () => {
+      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -697,7 +711,7 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(

--- a/ui/components/app/perps/close-position/close-position-modal.test.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.test.tsx
@@ -221,6 +221,24 @@ jest.mock('../perps-toast', () => ({
   }),
 }));
 
+/**
+ * Runs realistic user interactions with their React updates contained.
+ *
+ * `userEvent` resolves between keystrokes, so the re-renders it triggers land
+ * outside React's test scope and are reported as act warnings. Wrapping the
+ * whole interaction keeps the realistic input behaviour without adding noise.
+ *
+ * @param interact - Callback issuing the userEvent calls.
+ */
+const interactAs = async (
+  interact: (user: ReturnType<typeof userEvent.setup>) => Promise<void>,
+) => {
+  const user = userEvent.setup();
+  await act(async () => {
+    await interact(user);
+  });
+};
+
 const mockStore = configureStore({
   metamask: {
     ...mockState.metamask,
@@ -488,8 +506,13 @@ describe('ClosePositionModal', () => {
         screen.getByTestId('close-amount-value'),
       ).getByRole('textbox');
       // Half of the 2.5 ETH position at 2,900 is 3,625 USD.
-      fireEvent.change(usdInput, { target: { value: '3625' } });
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await interactAs(async (user) => {
+        await user.clear(usdInput);
+        await user.paste('3625');
+      });
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -511,12 +534,19 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
       const percentInput = within(
         screen.getByTestId('close-amount-percent'),
       ).getByRole('textbox');
-      fireEvent.change(percentInput, { target: { value: '50' } });
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await interactAs(async (user) => {
+        await user.clear(percentInput);
+        await user.paste('50');
+      });
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -541,13 +571,18 @@ describe('ClosePositionModal', () => {
       const usdInput = within(
         screen.getByTestId('close-amount-value'),
       ).getByRole('textbox');
-      fireEvent.change(usdInput, { target: { value: '999999' } });
+      await interactAs(async (user) => {
+        await user.clear(usdInput);
+        await user.paste('999999');
+      });
 
       expect(
         screen.getByTestId('close-amount-over-close-error'),
       ).toBeInTheDocument();
 
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalled();
@@ -569,17 +604,24 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
       const percentInput = within(
         screen.getByTestId('close-amount-percent'),
       ).getByRole('textbox');
-      fireEvent.change(percentInput, { target: { value: '150' } });
+      await interactAs(async (user) => {
+        await user.clear(percentInput);
+        await user.paste('150');
+      });
 
       expect(
         screen.getByTestId('close-amount-over-close-error'),
       ).toBeInTheDocument();
 
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalled();
@@ -600,12 +642,19 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
       const percentInput = within(
         screen.getByTestId('close-amount-percent'),
       ).getByRole('textbox');
-      fireEvent.change(percentInput, { target: { value: '50' } });
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await interactAs(async (user) => {
+        await user.clear(percentInput);
+        await user.paste('50');
+      });
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -636,8 +685,13 @@ describe('ClosePositionModal', () => {
       const usdInput = within(
         screen.getByTestId('close-amount-value'),
       ).getByRole('textbox');
-      fireEvent.change(usdInput, { target: { value: '3625' } });
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await interactAs(async (user) => {
+        await user.clear(usdInput);
+        await user.paste('3625');
+      });
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -669,7 +723,9 @@ describe('ClosePositionModal', () => {
         screen.getByTestId('close-amount-slider-pct-100'),
       ).getByRole('slider');
       fireEvent.change(slider, { target: { value: '50' } });
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -697,7 +753,9 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(

--- a/ui/components/app/perps/close-position/close-position-modal.test.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.test.tsx
@@ -556,6 +556,73 @@ describe('ClosePositionModal', () => {
       });
     });
 
+    it('never sends the whole position size on a partial close', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={45000}
+          sizeDecimals={4}
+        />,
+        mockStore,
+      );
+
+      const usdInput = within(
+        screen.getByTestId('close-amount-value'),
+      ).getByRole('textbox');
+      // A hair under the 112,500 position. Rounding the size to 4 decimals
+      // formats 99.99999% of 2.5 as "2.5000", so without a floor this partial
+      // close would carry the trader's entire position.
+      await interactAs(async (user) => {
+        await user.clear(usdInput);
+        await user.paste('112499.995');
+      });
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalled();
+      });
+      const [, [request]] = mockSubmitRequestToBackground.mock.calls[0];
+      expect(request.size).toBe('2.4999');
+      expect(Number.parseFloat(request.size)).toBeLessThan(
+        Math.abs(Number.parseFloat(basePosition.size)),
+      );
+    });
+
+    it('leaves an ordinary partial size untouched', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={45000}
+          sizeDecimals={4}
+        />,
+        mockStore,
+      );
+
+      const usdInput = within(
+        screen.getByTestId('close-amount-value'),
+      ).getByRole('textbox');
+      await interactAs(async (user) => {
+        await user.clear(usdInput);
+        await user.paste('56250');
+      });
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'perpsClosePosition',
+          [expect.objectContaining({ size: '1.2500' })],
+        );
+      });
+    });
+
     it('caps a dollar amount above the position at a full close', async () => {
       renderWithProvider(
         <ClosePositionModal

--- a/ui/components/app/perps/close-position/close-position-modal.test.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.test.tsx
@@ -471,6 +471,249 @@ describe('ClosePositionModal', () => {
     });
   });
 
+  describe('close amount input modes', () => {
+    it('submits the token quantity equivalent to a typed dollar amount', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+          sizeDecimals={4}
+        />,
+        mockStore,
+      );
+
+      const usdInput = within(
+        screen.getByTestId('close-amount-value'),
+      ).getByRole('textbox');
+      // Half of the 2.5 ETH position at 2,900 is 3,625 USD.
+      fireEvent.change(usdInput, { target: { value: '3625' } });
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'perpsClosePosition',
+          [expect.objectContaining({ size: '1.2500' })],
+        );
+      });
+    });
+
+    it('submits the token quantity equivalent to a typed percentage', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+          sizeDecimals={4}
+        />,
+        mockStore,
+      );
+
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      const percentInput = within(
+        screen.getByTestId('close-amount-percent'),
+      ).getByRole('textbox');
+      fireEvent.change(percentInput, { target: { value: '50' } });
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'perpsClosePosition',
+          [expect.objectContaining({ size: '1.2500' })],
+        );
+      });
+    });
+
+    it('caps a dollar amount above the position at a full close', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+          sizeDecimals={4}
+        />,
+        mockStore,
+      );
+
+      const usdInput = within(
+        screen.getByTestId('close-amount-value'),
+      ).getByRole('textbox');
+      fireEvent.change(usdInput, { target: { value: '999999' } });
+
+      expect(
+        screen.getByTestId('close-amount-over-close-error'),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalled();
+      });
+      // A full close omits size entirely, so no over-sized order can be sent.
+      const [, [request]] = mockSubmitRequestToBackground.mock.calls[0];
+      expect(request.size).toBeUndefined();
+    });
+
+    it('caps a percentage above 100 at a full close', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+          sizeDecimals={4}
+        />,
+        mockStore,
+      );
+
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      const percentInput = within(
+        screen.getByTestId('close-amount-percent'),
+      ).getByRole('textbox');
+      fireEvent.change(percentInput, { target: { value: '150' } });
+
+      expect(
+        screen.getByTestId('close-amount-over-close-error'),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalled();
+      });
+      const [, [request]] = mockSubmitRequestToBackground.mock.calls[0];
+      expect(request.size).toBeUndefined();
+    });
+
+    it('reports the percentage input method on the close request', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+          sizeDecimals={4}
+        />,
+        mockStore,
+      );
+
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      const percentInput = within(
+        screen.getByTestId('close-amount-percent'),
+      ).getByRole('textbox');
+      fireEvent.change(percentInput, { target: { value: '50' } });
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'perpsClosePosition',
+          [
+            expect.objectContaining({
+              trackingData: expect.objectContaining({
+                inputMethod: 'percentage',
+              }),
+            }),
+          ],
+        );
+      });
+    });
+
+    it('reports the keypad input method for a typed dollar amount', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+          sizeDecimals={4}
+        />,
+        mockStore,
+      );
+
+      const usdInput = within(
+        screen.getByTestId('close-amount-value'),
+      ).getByRole('textbox');
+      fireEvent.change(usdInput, { target: { value: '3625' } });
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'perpsClosePosition',
+          [
+            expect.objectContaining({
+              trackingData: expect.objectContaining({
+                inputMethod: 'keypad',
+              }),
+            }),
+          ],
+        );
+      });
+    });
+
+    it('reports the slider input method when the slider sets the amount', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+          sizeDecimals={4}
+        />,
+        mockStore,
+      );
+
+      const slider = within(
+        screen.getByTestId('close-amount-slider-pct-100'),
+      ).getByRole('slider');
+      fireEvent.change(slider, { target: { value: '50' } });
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'perpsClosePosition',
+          [
+            expect.objectContaining({
+              trackingData: expect.objectContaining({
+                inputMethod: 'slider',
+              }),
+            }),
+          ],
+        );
+      });
+    });
+
+    it('reports the default input method when the amount is untouched', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+          sizeDecimals={4}
+        />,
+        mockStore,
+      );
+
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'perpsClosePosition',
+          [
+            expect.objectContaining({
+              trackingData: expect.objectContaining({
+                inputMethod: 'default',
+              }),
+            }),
+          ],
+        );
+      });
+    });
+  });
+
   describe('auto-focus', () => {
     it('auto-focuses the Close Position submit button on mount', async () => {
       renderWithProvider(

--- a/ui/components/app/perps/close-position/close-position-modal.test.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.test.tsx
@@ -473,7 +473,6 @@ describe('ClosePositionModal', () => {
 
   describe('close amount input modes', () => {
     it('submits the token quantity equivalent to a typed dollar amount', async () => {
-      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -489,9 +488,8 @@ describe('ClosePositionModal', () => {
         screen.getByTestId('close-amount-value'),
       ).getByRole('textbox');
       // Half of the 2.5 ETH position at 2,900 is 3,625 USD.
-      await user.clear(usdInput);
-      await user.type(usdInput, '3625');
-      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
+      fireEvent.change(usdInput, { target: { value: '3625' } });
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -502,7 +500,6 @@ describe('ClosePositionModal', () => {
     });
 
     it('submits the token quantity equivalent to a typed percentage', async () => {
-      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -514,13 +511,12 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
       const percentInput = within(
         screen.getByTestId('close-amount-percent'),
       ).getByRole('textbox');
-      await user.clear(percentInput);
-      await user.type(percentInput, '50');
-      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
+      fireEvent.change(percentInput, { target: { value: '50' } });
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -531,7 +527,6 @@ describe('ClosePositionModal', () => {
     });
 
     it('caps a dollar amount above the position at a full close', async () => {
-      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -546,14 +541,13 @@ describe('ClosePositionModal', () => {
       const usdInput = within(
         screen.getByTestId('close-amount-value'),
       ).getByRole('textbox');
-      await user.clear(usdInput);
-      await user.type(usdInput, '999999');
+      fireEvent.change(usdInput, { target: { value: '999999' } });
 
       expect(
         screen.getByTestId('close-amount-over-close-error'),
       ).toBeInTheDocument();
 
-      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalled();
@@ -564,7 +558,6 @@ describe('ClosePositionModal', () => {
     });
 
     it('caps a percentage above 100 at a full close', async () => {
-      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -576,18 +569,17 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
       const percentInput = within(
         screen.getByTestId('close-amount-percent'),
       ).getByRole('textbox');
-      await user.clear(percentInput);
-      await user.type(percentInput, '150');
+      fireEvent.change(percentInput, { target: { value: '150' } });
 
       expect(
         screen.getByTestId('close-amount-over-close-error'),
       ).toBeInTheDocument();
 
-      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalled();
@@ -597,7 +589,6 @@ describe('ClosePositionModal', () => {
     });
 
     it('reports the percentage input method on the close request', async () => {
-      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -609,13 +600,12 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
       const percentInput = within(
         screen.getByTestId('close-amount-percent'),
       ).getByRole('textbox');
-      await user.clear(percentInput);
-      await user.type(percentInput, '50');
-      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
+      fireEvent.change(percentInput, { target: { value: '50' } });
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -632,7 +622,6 @@ describe('ClosePositionModal', () => {
     });
 
     it('reports the keypad input method for a typed dollar amount', async () => {
-      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -647,9 +636,8 @@ describe('ClosePositionModal', () => {
       const usdInput = within(
         screen.getByTestId('close-amount-value'),
       ).getByRole('textbox');
-      await user.clear(usdInput);
-      await user.type(usdInput, '3625');
-      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
+      fireEvent.change(usdInput, { target: { value: '3625' } });
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -666,7 +654,6 @@ describe('ClosePositionModal', () => {
     });
 
     it('reports the slider input method when the slider sets the amount', async () => {
-      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -682,7 +669,7 @@ describe('ClosePositionModal', () => {
         screen.getByTestId('close-amount-slider-pct-100'),
       ).getByRole('slider');
       fireEvent.change(slider, { target: { value: '50' } });
-      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -699,7 +686,6 @@ describe('ClosePositionModal', () => {
     });
 
     it('reports the default input method when the amount is untouched', async () => {
-      const user = userEvent.setup();
       renderWithProvider(
         <ClosePositionModal
           isOpen
@@ -711,7 +697,7 @@ describe('ClosePositionModal', () => {
         mockStore,
       );
 
-      await user.click(screen.getByTestId('perps-close-position-modal-submit'));
+      fireEvent.click(screen.getByTestId('perps-close-position-modal-submit'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(

--- a/ui/components/app/perps/close-position/close-position-modal.test.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.test.tsx
@@ -592,6 +592,71 @@ describe('ClosePositionModal', () => {
       );
     });
 
+    it('sends a full close when the size floor would reach zero', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={{ ...basePosition, size: '1' }}
+          currentPrice={50000}
+          sizeDecimals={0}
+        />,
+        mockStore,
+      );
+
+      const usdInput = within(
+        screen.getByTestId('close-amount-value'),
+      ).getByRole('textbox');
+      // A 1-unit position on an integer-size market: the smallest step is the
+      // whole position, so stepping back off a rounded-up size lands on zero.
+      await interactAs(async (user) => {
+        await user.clear(usdInput);
+        await user.paste('49999.99');
+      });
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalled();
+      });
+      const [, [request]] = mockSubmitRequestToBackground.mock.calls[0];
+      // Omitting size is the full-close shape. A "0" size is a no-op the venue
+      // rejects, which is worse than the rounded-up size it replaced.
+      expect(request.size).toBeUndefined();
+    });
+
+    it('still floors a partial size on a market with room to step back', async () => {
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={{ ...basePosition, size: '5' }}
+          currentPrice={50000}
+          sizeDecimals={0}
+        />,
+        mockStore,
+      );
+
+      const usdInput = within(
+        screen.getByTestId('close-amount-value'),
+      ).getByRole('textbox');
+      await interactAs(async (user) => {
+        await user.clear(usdInput);
+        await user.paste('249999.99');
+      });
+      await interactAs((user) =>
+        user.click(screen.getByTestId('perps-close-position-modal-submit')),
+      );
+
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'perpsClosePosition',
+          [expect.objectContaining({ size: '4' })],
+        );
+      });
+    });
+
     it('leaves an ordinary partial size untouched', async () => {
       renderWithProvider(
         <ClosePositionModal

--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -131,19 +131,29 @@ const buildCloseRequestParams = ({
     sizeDecimals === undefined
       ? closeSize.toString()
       : closeSize.toFixed(sizeDecimals);
-  const size =
+  const roundsOntoWholePosition =
     isPartialClose &&
     sizeDecimals !== undefined &&
-    Number.parseFloat(roundedSize) >= positionSize
-      ? Math.max(positionSize - 10 ** -sizeDecimals, 0).toFixed(sizeDecimals)
-      : roundedSize;
+    Number.parseFloat(roundedSize) >= positionSize;
+  const flooredSize =
+    sizeDecimals === undefined
+      ? roundedSize
+      : (positionSize - 10 ** -sizeDecimals).toFixed(sizeDecimals);
+  // On a market whose smallest step is the position itself — a 1-unit position
+  // on an integer-size market — stepping back lands on zero, which the venue
+  // rejects or treats as a no-op. The trader asked for all but a rounding
+  // sliver, so send it as the full close it effectively is.
+  const closesWholePosition =
+    roundsOntoWholePosition && Number.parseFloat(flooredSize) <= 0;
+  const size = roundsOntoWholePosition ? flooredSize : roundedSize;
+  const includeSize = isPartialClose && !closesWholePosition;
 
   if (orderType === 'limit') {
     return {
       symbol,
       orderType: 'limit',
       price: limitPrice,
-      ...(isPartialClose ? { size } : {}),
+      ...(includeSize ? { size } : {}),
       position,
     };
   }
@@ -152,7 +162,7 @@ const buildCloseRequestParams = ({
     symbol,
     orderType: 'market',
     currentPrice,
-    ...(isPartialClose ? { size } : {}),
+    ...(includeSize ? { size } : {}),
     position,
   };
 };

--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -25,6 +25,7 @@ import {
 } from '@metamask/design-system-react';
 import type {
   ClosePositionParams,
+  InputMethod,
   OrderType,
 } from '@metamask/perps-controller';
 import {
@@ -365,6 +366,11 @@ export const ClosePositionModal = ({
   const getAbandonProperties = useRef(() => latestAbandonPropsRef.current);
   const hasConfirmedCloseRef = useRef(false);
 
+  // Which control the trader last used to set the close amount. Mirrors mobile:
+  // a ref (not state) so recording it never re-renders the form, last-touched
+  // wins, and it rides `trackingData` to the controller's close event.
+  const inputMethodRef = useRef<InputMethod>('default');
+
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
   if (isOpen !== prevIsOpen) {
     setPrevIsOpen(isOpen);
@@ -383,6 +389,7 @@ export const ClosePositionModal = ({
   useEffect(() => {
     if (isOpen) {
       hasConfirmedCloseRef.current = false;
+      inputMethodRef.current = 'default';
     }
   }, [isOpen]);
 
@@ -681,6 +688,7 @@ export const ClosePositionModal = ({
           vipTier,
           vipDiscount: metamaskFeeRateDiscountPercentage,
           hlFeeRate: protocolFeeRate,
+          inputMethod: inputMethodRef.current,
         });
         const result = await submitRequestToBackground<{
           success: boolean;
@@ -779,6 +787,10 @@ export const ClosePositionModal = ({
     setError(null);
   }, []);
 
+  const handleInputMethodChange = useCallback((inputMethod: InputMethod) => {
+    inputMethodRef.current = inputMethod;
+  }, []);
+
   const handleOrderTypeChange = useCallback(
     (orderType: OrderType) => {
       setSelectedOrderType(orderType);
@@ -850,6 +862,7 @@ export const ClosePositionModal = ({
                 asset={displayName}
                 currentPrice={effectivePrice}
                 sizeDecimals={sizeDecimals}
+                onInputMethodChange={handleInputMethodChange}
               />
 
               {isPartialCloseBelowMinNotional ? (

--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -108,6 +108,7 @@ const buildCloseRequestParams = ({
   currentPrice,
   isPartialClose,
   closeSize,
+  positionSize,
   sizeDecimals,
   orderType,
   limitPrice,
@@ -117,15 +118,25 @@ const buildCloseRequestParams = ({
   currentPrice: number;
   isPartialClose: boolean;
   closeSize: number;
+  positionSize: number;
   sizeDecimals?: number;
   orderType: OrderType;
   limitPrice?: string;
   position: Position;
 }): ClosePositionParams => {
-  const size =
+  // Round-half-up can lift a partial size onto the whole position — closing
+  // 99.999% of 2.5 at 4 decimals formats as "2.5000". A partial close must stay
+  // strictly under the position, so step the last decimal back when it does.
+  const roundedSize =
     sizeDecimals === undefined
       ? closeSize.toString()
       : closeSize.toFixed(sizeDecimals);
+  const size =
+    isPartialClose &&
+    sizeDecimals !== undefined &&
+    Number.parseFloat(roundedSize) >= positionSize
+      ? Math.max(positionSize - 10 ** -sizeDecimals, 0).toFixed(sizeDecimals)
+      : roundedSize;
 
   if (orderType === 'limit') {
     return {
@@ -674,6 +685,7 @@ export const ClosePositionModal = ({
           currentPrice,
           isPartialClose,
           closeSize,
+          positionSize,
           sizeDecimals,
           orderType: effectiveOrderType,
           limitPrice:
@@ -765,6 +777,7 @@ export const ClosePositionModal = ({
     isPartialClose,
     position,
     closeSize,
+    positionSize,
     displayName,
     t,
     formatNumber,

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithProvider } from '../../../../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../../../../test/lib/i18n-helpers';
 import configureStore from '../../../../../../store/store';
@@ -11,6 +12,24 @@ const mockStore = configureStore({
     ...mockState.metamask,
   },
 });
+
+/**
+ * Runs realistic user interactions with their React updates contained.
+ *
+ * `userEvent` resolves between keystrokes, so the re-renders it triggers land
+ * outside React's test scope and are reported as act warnings. Wrapping the
+ * whole interaction keeps the realistic input behaviour without adding noise.
+ *
+ * @param interact - Callback issuing the userEvent calls.
+ */
+const interactAs = async (
+  interact: (user: ReturnType<typeof userEvent.setup>) => Promise<void>,
+) => {
+  const user = userEvent.setup();
+  await act(async () => {
+    await interact(user);
+  });
+};
 
 describe('CloseAmountSection', () => {
   const defaultProps = {
@@ -149,10 +168,12 @@ describe('CloseAmountSection', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('swaps the field to a percent input when percent mode is selected', () => {
+    it('swaps the field to a percent input when percent mode is selected', async () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       expect(screen.getByTestId('close-amount-unit')).toHaveTextContent(
         messages.perpsCloseAmountInPercent.message,
@@ -165,7 +186,7 @@ describe('CloseAmountSection', () => {
   });
 
   describe('dollar amount entry', () => {
-    it('converts a typed dollar amount to the equivalent close percentage', () => {
+    it('converts a typed dollar amount to the equivalent close percentage', async () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -178,13 +199,16 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '56250' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('56250');
+      });
 
       // 56,250 of a 112,500 position (2.5 BTC at 45,000) is half of it.
       expect(onClosePercentChange).toHaveBeenCalledWith(50);
     });
 
-    it('converts a quarter-position dollar amount to 25 percent', () => {
+    it('converts a quarter-position dollar amount to 25 percent', async () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -197,12 +221,15 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '28125' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('28125');
+      });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(25);
     });
 
-    it('reports keypad as the input method for a typed dollar amount', () => {
+    it('reports keypad as the input method for a typed dollar amount', async () => {
       const onInputMethodChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -215,59 +242,70 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '56250' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('56250');
+      });
 
       expect(onInputMethodChange).toHaveBeenCalledWith('keypad');
     });
   });
 
   describe('percent amount entry', () => {
-    const renderInPercentMode = (props = {}) => {
+    const renderInPercentMode = async (props = {}) => {
       const result = renderWithProvider(
         <CloseAmountSection {...defaultProps} {...props} />,
         mockStore,
       );
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
       return result;
     };
 
-    it('commits a typed percentage', () => {
+    it('commits a typed percentage', async () => {
       const onClosePercentChange = jest.fn();
-      renderInPercentMode({ onClosePercentChange });
+      await renderInPercentMode({ onClosePercentChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '50' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('50');
+      });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(50);
     });
 
-    it('commits a quarter close from a typed percentage', () => {
+    it('commits a quarter close from a typed percentage', async () => {
       const onClosePercentChange = jest.fn();
-      renderInPercentMode({ onClosePercentChange });
+      await renderInPercentMode({ onClosePercentChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '25' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('25');
+      });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(25);
     });
 
-    it('treats an emptied percent field as closing nothing', () => {
+    it('treats an emptied percent field as closing nothing', async () => {
       const onClosePercentChange = jest.fn();
-      renderInPercentMode({ onClosePercentChange });
+      await renderInPercentMode({ onClosePercentChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '' } });
+      await interactAs((user) => user.clear(input));
 
       expect(onClosePercentChange).toHaveBeenCalledWith(0);
     });
 
-    it('leaves the field empty while the trader clears it to retype', () => {
+    it('leaves the field empty while the trader clears it to retype', async () => {
       const ControlledHarness = () => {
         const [percent, setPercent] = React.useState(100);
         return (
@@ -279,37 +317,44 @@ describe('CloseAmountSection', () => {
         );
       };
       renderWithProvider(<ControlledHarness />, mockStore);
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '' } });
+      await interactAs((user) => user.clear(input));
 
       expect(input.value).toBe('');
     });
 
-    it('reports percentage as the input method for a typed percentage', () => {
+    it('reports percentage as the input method for a typed percentage', async () => {
       const onInputMethodChange = jest.fn();
-      renderInPercentMode({ onInputMethodChange });
+      await renderInPercentMode({ onInputMethodChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '50' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('50');
+      });
 
       expect(onInputMethodChange).toHaveBeenCalledWith('percentage');
     });
 
-    it('reports percentage, not max, for a typed full close', () => {
+    it('reports percentage, not max, for a typed full close', async () => {
       const onInputMethodChange = jest.fn();
-      renderInPercentMode({ onInputMethodChange, closePercent: 25 });
+      await renderInPercentMode({ onInputMethodChange, closePercent: 25 });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '100' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('100');
+      });
 
       // Mobile reserves 'max' for an explicit Max button, which this screen has
       // no equivalent of, so inferring it from 100 would diverge the funnel.
@@ -319,7 +364,7 @@ describe('CloseAmountSection', () => {
   });
 
   describe('over-close protection', () => {
-    it('caps a dollar amount above the position value and explains the cap', () => {
+    it('caps a dollar amount above the position value and explains the cap', async () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -332,7 +377,10 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '999999' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('999999');
+      });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(100);
       expect(
@@ -340,19 +388,22 @@ describe('CloseAmountSection', () => {
       ).toHaveTextContent(messages.perpsCloseAmountCappedAtPosition.message);
     });
 
-    it('shows the capped dollar amount in the field rather than the typed one', () => {
+    it('shows the capped dollar amount in the field rather than the typed one', async () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '999999' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('999999');
+      });
 
       // 2.5 BTC at 45,000 is a 112,500 position.
       expect(input.value).toBe('112500');
     });
 
-    it('caps a percentage above 100 and explains the cap', () => {
+    it('caps a percentage above 100 and explains the cap', async () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -361,12 +412,17 @@ describe('CloseAmountSection', () => {
         />,
         mockStore,
       );
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '150' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('150');
+      });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(100);
       expect(
@@ -374,21 +430,25 @@ describe('CloseAmountSection', () => {
       ).toHaveTextContent(messages.perpsClosePercentCappedAtMax.message);
     });
 
-    it('shows the capped percentage in the field rather than the typed one', () => {
+    it('shows the capped percentage in the field rather than the typed one', async () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '150' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('150');
+      });
 
       // Matches the dollar field, which caps in place on the same keystroke.
       expect(input.value).toBe('100');
     });
 
-    it('never commits more than the whole position', () => {
+    it('never commits more than the whole position', async () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -397,18 +457,23 @@ describe('CloseAmountSection', () => {
         />,
         mockStore,
       );
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '150' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('150');
+      });
 
       const committed = onClosePercentChange.mock.calls.map(([value]) => value);
       expect(Math.max(...committed)).toBe(100);
     });
 
-    it('caps a dollar amount too large to hold in a number', () => {
+    it('caps a dollar amount too large to hold in a number', async () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -421,8 +486,10 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '9'.repeat(320) } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('9'.repeat(320));
+      });
 
       // Overflows to Infinity, which still means "more than the position".
       // Committing 0 here would show a 100% cap while closing nothing.
@@ -432,7 +499,7 @@ describe('CloseAmountSection', () => {
       ).toBeInTheDocument();
     });
 
-    it('caps a percentage too large to hold in a number', () => {
+    it('caps a percentage too large to hold in a number', async () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -441,26 +508,38 @@ describe('CloseAmountSection', () => {
         />,
         mockStore,
       );
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '9'.repeat(320) } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('9'.repeat(320));
+      });
 
       expect(onClosePercentChange).toHaveBeenLastCalledWith(100);
     });
 
-    it('clears the cap message once an amount that fits is entered', () => {
+    it('clears the cap message once an amount that fits is entered', async () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '150' } });
-      fireEvent.change(input, { target: { value: '40' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('150');
+      });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('40');
+      });
 
       expect(
         screen.queryByTestId('close-amount-over-close-error'),
@@ -469,7 +548,7 @@ describe('CloseAmountSection', () => {
   });
 
   describe('unusable market data', () => {
-    it('closes nothing when the position has no value', () => {
+    it('closes nothing when the position has no value', async () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -483,13 +562,16 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '500' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('500');
+      });
 
       // A typed amount must never leave a stale percentage behind it.
       expect(onClosePercentChange).toHaveBeenCalledWith(0);
     });
 
-    it('closes nothing while only a decimal point has been typed', () => {
+    it('closes nothing while only a decimal point has been typed', async () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -502,14 +584,17 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '.' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('.');
+      });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(0);
     });
   });
 
   describe('cross-unit precision', () => {
-    it('commits a dollar amount at the precision the percent field shows', () => {
+    it('closes exactly the dollar amount the trader typed', async () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -523,16 +608,20 @@ describe('CloseAmountSection', () => {
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
       // 1,000 of a 112,500 position is 0.888…%, not a whole percent.
-      fireEvent.change(input, { target: { value: '1000' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('1000');
+      });
 
       const [committed] = onClosePercentChange.mock.calls.at(-1) as [number];
-      // Rounded to the two decimals the percent field renders, so the committed
-      // value is always the one on screen. Whole-percent rounding would move the
-      // typed dollar amount by cents; this keeps it under a hundredth of one.
-      expect(committed).toBe(0.89);
+      // Deliberately un-rounded. A percentage step is worth more the larger the
+      // position — 0.01% of this 112,500 position is $11.25 — so rounding here
+      // would close more than the typed 1,000.
+      expect(committed).toBe((1000 / 112500) * 100);
+      expect((112500 * committed) / 100).toBeCloseTo(1000, 10);
     });
 
-    it('lets the trader edit a fractional percentage the field is showing', () => {
+    it('lets the trader edit a fractional percentage the field is showing', async () => {
       const ControlledHarness = () => {
         const [percent, setPercent] = React.useState(100);
         return (
@@ -548,20 +637,27 @@ describe('CloseAmountSection', () => {
       const usdInput = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(usdInput, { target: { value: '1000' } });
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs(async (user) => {
+        await user.clear(usdInput);
+        await user.paste('1000');
+      });
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       const percentInput = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
       // The field displays 0.89, so a decimal edit of it must be accepted.
-      fireEvent.focus(percentInput);
-      fireEvent.change(percentInput, { target: { value: '0.5' } });
+      await interactAs(async (user) => {
+        await user.clear(percentInput);
+        await user.paste('0.5');
+      });
 
       expect(percentInput.value).toBe('0.5');
     });
 
-    it('commits the same percentage the field shows after blur', () => {
+    it('commits the same percentage the field shows after blur', async () => {
       let committed = 100;
       const ControlledHarness = () => {
         const [percent, setPercent] = React.useState(100);
@@ -575,13 +671,17 @@ describe('CloseAmountSection', () => {
         );
       };
       renderWithProvider(<ControlledHarness />, mockStore);
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '99.999' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('99.999');
+      });
       fireEvent.blur(input);
 
       // The field can only render two decimals, so committing 99.999 would show
@@ -590,7 +690,7 @@ describe('CloseAmountSection', () => {
       expect(committed).toBe(100);
     });
 
-    it('keeps a percentage within the displayed precision intact', () => {
+    it('keeps a percentage within the displayed precision intact', async () => {
       let committed = 100;
       const ControlledHarness = () => {
         const [percent, setPercent] = React.useState(100);
@@ -604,20 +704,24 @@ describe('CloseAmountSection', () => {
         );
       };
       renderWithProvider(<ControlledHarness />, mockStore);
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '12.34' } });
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('12.34');
+      });
       fireEvent.blur(input);
 
       expect(input.value).toBe('12.34');
       expect(committed).toBe(12.34);
     });
 
-    it('shows a fractional percentage in the percent field rather than rounding it away', () => {
+    it('shows a fractional percentage in the percent field rather than rounding it away', async () => {
       const ControlledHarness = () => {
         const [percent, setPercent] = React.useState(100);
         return (
@@ -633,8 +737,13 @@ describe('CloseAmountSection', () => {
       const usdInput = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(usdInput, { target: { value: '1000' } });
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs(async (user) => {
+        await user.clear(usdInput);
+        await user.paste('1000');
+      });
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       const percentInput = screen
         .getByTestId('close-amount-percent')
@@ -670,10 +779,12 @@ describe('CloseAmountSection', () => {
       );
     });
 
-    it('moves the pressed state to percent when percent mode is selected', () => {
+    it('moves the pressed state to percent when percent mode is selected', async () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await interactAs((user) =>
+        user.click(screen.getByTestId('close-amount-mode-percent')),
+      );
 
       expect(screen.getByTestId('close-amount-mode-percent')).toHaveAttribute(
         'aria-pressed',

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithProvider } from '../../../../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../../../../test/lib/i18n-helpers';
 import configureStore from '../../../../../../store/store';
@@ -149,10 +150,11 @@ describe('CloseAmountSection', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('swaps the field to a percent input when percent mode is selected', () => {
+    it('swaps the field to a percent input when percent mode is selected', async () => {
+      const user = userEvent.setup();
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
 
       expect(screen.getByTestId('close-amount-unit')).toHaveTextContent(
         messages.perpsCloseAmountInPercent.message,
@@ -165,7 +167,8 @@ describe('CloseAmountSection', () => {
   });
 
   describe('dollar amount entry', () => {
-    it('converts a typed dollar amount to the equivalent close percentage', () => {
+    it('converts a typed dollar amount to the equivalent close percentage', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -178,13 +181,15 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '56250' } });
+      await user.clear(input);
+      await user.paste('56250');
 
       // 56,250 of a 112,500 position (2.5 BTC at 45,000) is half of it.
       expect(onClosePercentChange).toHaveBeenCalledWith(50);
     });
 
-    it('converts a quarter-position dollar amount to 25 percent', () => {
+    it('converts a quarter-position dollar amount to 25 percent', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -197,12 +202,14 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '28125' } });
+      await user.clear(input);
+      await user.paste('28125');
 
       expect(onClosePercentChange).toHaveBeenCalledWith(25);
     });
 
-    it('reports keypad as the input method for a typed dollar amount', () => {
+    it('reports keypad as the input method for a typed dollar amount', async () => {
+      const user = userEvent.setup();
       const onInputMethodChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -215,59 +222,69 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '56250' } });
+      await user.clear(input);
+      await user.paste('56250');
 
       expect(onInputMethodChange).toHaveBeenCalledWith('keypad');
     });
   });
 
   describe('percent amount entry', () => {
-    const renderInPercentMode = (props = {}) => {
+    const renderInPercentMode = async (
+      user: ReturnType<typeof userEvent.setup>,
+      props = {},
+    ) => {
       const result = renderWithProvider(
         <CloseAmountSection {...defaultProps} {...props} />,
         mockStore,
       );
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
       return result;
     };
 
-    it('commits a typed percentage', () => {
+    it('commits a typed percentage', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
-      renderInPercentMode({ onClosePercentChange });
+      await renderInPercentMode(user, { onClosePercentChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '50' } });
+      await user.clear(input);
+      await user.paste('50');
 
       expect(onClosePercentChange).toHaveBeenCalledWith(50);
     });
 
-    it('commits a quarter close from a typed percentage', () => {
+    it('commits a quarter close from a typed percentage', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
-      renderInPercentMode({ onClosePercentChange });
+      await renderInPercentMode(user, { onClosePercentChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '25' } });
+      await user.clear(input);
+      await user.paste('25');
 
       expect(onClosePercentChange).toHaveBeenCalledWith(25);
     });
 
-    it('treats an emptied percent field as closing nothing', () => {
+    it('treats an emptied percent field as closing nothing', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
-      renderInPercentMode({ onClosePercentChange });
+      await renderInPercentMode(user, { onClosePercentChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '' } });
+      await user.clear(input);
 
       expect(onClosePercentChange).toHaveBeenCalledWith(0);
     });
 
-    it('leaves the field empty while the trader clears it to retype', () => {
+    it('leaves the field empty while the trader clears it to retype', async () => {
+      const user = userEvent.setup();
       const ControlledHarness = () => {
         const [percent, setPercent] = React.useState(100);
         return (
@@ -279,37 +296,43 @@ describe('CloseAmountSection', () => {
         );
       };
       renderWithProvider(<ControlledHarness />, mockStore);
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '' } });
+      await user.clear(input);
 
       expect(input.value).toBe('');
     });
 
-    it('reports percentage as the input method for a typed percentage', () => {
+    it('reports percentage as the input method for a typed percentage', async () => {
+      const user = userEvent.setup();
       const onInputMethodChange = jest.fn();
-      renderInPercentMode({ onInputMethodChange });
+      await renderInPercentMode(user, { onInputMethodChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '50' } });
+      await user.clear(input);
+      await user.paste('50');
 
       expect(onInputMethodChange).toHaveBeenCalledWith('percentage');
     });
 
-    it('reports percentage, not max, for a typed full close', () => {
+    it('reports percentage, not max, for a typed full close', async () => {
+      const user = userEvent.setup();
       const onInputMethodChange = jest.fn();
-      renderInPercentMode({ onInputMethodChange, closePercent: 25 });
+      await renderInPercentMode(user, {
+        onInputMethodChange,
+        closePercent: 25,
+      });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '100' } });
+      await user.clear(input);
+      await user.paste('100');
 
       // Mobile reserves 'max' for an explicit Max button, which this screen has
       // no equivalent of, so inferring it from 100 would diverge the funnel.
@@ -319,7 +342,8 @@ describe('CloseAmountSection', () => {
   });
 
   describe('over-close protection', () => {
-    it('caps a dollar amount above the position value and explains the cap', () => {
+    it('caps a dollar amount above the position value and explains the cap', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -332,7 +356,8 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '999999' } });
+      await user.clear(input);
+      await user.paste('999999');
 
       expect(onClosePercentChange).toHaveBeenCalledWith(100);
       expect(
@@ -340,19 +365,22 @@ describe('CloseAmountSection', () => {
       ).toHaveTextContent(messages.perpsCloseAmountCappedAtPosition.message);
     });
 
-    it('shows the capped dollar amount in the field rather than the typed one', () => {
+    it('shows the capped dollar amount in the field rather than the typed one', async () => {
+      const user = userEvent.setup();
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '999999' } });
+      await user.clear(input);
+      await user.paste('999999');
 
       // 2.5 BTC at 45,000 is a 112,500 position.
       expect(input.value).toBe('112500');
     });
 
-    it('caps a percentage above 100 and explains the cap', () => {
+    it('caps a percentage above 100 and explains the cap', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -361,12 +389,13 @@ describe('CloseAmountSection', () => {
         />,
         mockStore,
       );
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '150' } });
+      await user.clear(input);
+      await user.paste('150');
 
       expect(onClosePercentChange).toHaveBeenCalledWith(100);
       expect(
@@ -374,21 +403,23 @@ describe('CloseAmountSection', () => {
       ).toHaveTextContent(messages.perpsClosePercentCappedAtMax.message);
     });
 
-    it('shows the capped percentage in the field rather than the typed one', () => {
+    it('shows the capped percentage in the field rather than the typed one', async () => {
+      const user = userEvent.setup();
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '150' } });
+      await user.clear(input);
+      await user.paste('150');
 
       // Matches the dollar field, which caps in place on the same keystroke.
       expect(input.value).toBe('100');
     });
 
-    it('never commits more than the whole position', () => {
+    it('never commits more than the whole position', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -397,26 +428,76 @@ describe('CloseAmountSection', () => {
         />,
         mockStore,
       );
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '150' } });
+      await user.clear(input);
+      await user.paste('150');
 
       const committed = onClosePercentChange.mock.calls.map(([value]) => value);
       expect(Math.max(...committed)).toBe(100);
     });
 
-    it('clears the cap message once an amount that fits is entered', () => {
-      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+    it('caps a dollar amount too large to hold in a number', async () => {
+      const user = userEvent.setup();
+      const onClosePercentChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          onClosePercentChange={onClosePercentChange}
+        />,
+        mockStore,
+      );
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      await user.clear(input);
+      await user.paste('9'.repeat(320));
+
+      // Overflows to Infinity, which still means "more than the position".
+      // Committing 0 here would show a 100% cap while closing nothing.
+      expect(onClosePercentChange).toHaveBeenLastCalledWith(100);
+      expect(
+        screen.getByTestId('close-amount-over-close-error'),
+      ).toBeInTheDocument();
+    });
+
+    it('caps a percentage too large to hold in a number', async () => {
+      const user = userEvent.setup();
+      const onClosePercentChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          onClosePercentChange={onClosePercentChange}
+        />,
+        mockStore,
+      );
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '150' } });
-      fireEvent.change(input, { target: { value: '40' } });
+      await user.clear(input);
+      await user.paste('9'.repeat(320));
+
+      expect(onClosePercentChange).toHaveBeenLastCalledWith(100);
+    });
+
+    it('clears the cap message once an amount that fits is entered', async () => {
+      const user = userEvent.setup();
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      await user.clear(input);
+      await user.paste('150');
+      await user.clear(input);
+      await user.paste('40');
 
       expect(
         screen.queryByTestId('close-amount-over-close-error'),
@@ -425,7 +506,8 @@ describe('CloseAmountSection', () => {
   });
 
   describe('unusable market data', () => {
-    it('closes nothing when the position has no value', () => {
+    it('closes nothing when the position has no value', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -439,13 +521,15 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '500' } });
+      await user.clear(input);
+      await user.paste('500');
 
       // A typed amount must never leave a stale percentage behind it.
       expect(onClosePercentChange).toHaveBeenCalledWith(0);
     });
 
-    it('closes nothing while only a decimal point has been typed', () => {
+    it('closes nothing while only a decimal point has been typed', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -458,14 +542,16 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(input, { target: { value: '.' } });
+      await user.clear(input);
+      await user.paste('.');
 
       expect(onClosePercentChange).toHaveBeenCalledWith(0);
     });
   });
 
   describe('cross-unit precision', () => {
-    it('keeps the exact percentage a dollar amount resolves to', () => {
+    it('keeps the exact percentage a dollar amount resolves to', async () => {
+      const user = userEvent.setup();
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -479,13 +565,15 @@ describe('CloseAmountSection', () => {
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
       // 1,000 of a 112,500 position is 0.888…%, not a whole percent.
-      fireEvent.change(input, { target: { value: '1000' } });
+      await user.clear(input);
+      await user.paste('1000');
 
       const [committed] = onClosePercentChange.mock.calls.at(-1) as [number];
       expect(committed).toBeCloseTo((1000 / 112500) * 100, 10);
     });
 
-    it('shows a fractional percentage in the percent field rather than rounding it away', () => {
+    it('lets the trader edit a fractional percentage the field is showing', async () => {
+      const user = userEvent.setup();
       const ControlledHarness = () => {
         const [percent, setPercent] = React.useState(100);
         return (
@@ -501,8 +589,40 @@ describe('CloseAmountSection', () => {
       const usdInput = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(usdInput, { target: { value: '1000' } });
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.clear(usdInput);
+      await user.type(usdInput, '1000');
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
+
+      const percentInput = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      // The field displays 0.89, so a decimal edit of it must be accepted.
+      await user.clear(percentInput);
+      await user.type(percentInput, '0.5');
+
+      expect(percentInput.value).toBe('0.5');
+    });
+
+    it('shows a fractional percentage in the percent field rather than rounding it away', async () => {
+      const user = userEvent.setup();
+      const ControlledHarness = () => {
+        const [percent, setPercent] = React.useState(100);
+        return (
+          <CloseAmountSection
+            {...defaultProps}
+            closePercent={percent}
+            onClosePercentChange={setPercent}
+          />
+        );
+      };
+      renderWithProvider(<ControlledHarness />, mockStore);
+
+      const usdInput = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      await user.clear(usdInput);
+      await user.paste('1000');
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
 
       const percentInput = screen
         .getByTestId('close-amount-percent')
@@ -538,10 +658,11 @@ describe('CloseAmountSection', () => {
       );
     });
 
-    it('moves the pressed state to percent when percent mode is selected', () => {
+    it('moves the pressed state to percent when percent mode is selected', async () => {
+      const user = userEvent.setup();
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
 
       expect(screen.getByTestId('close-amount-mode-percent')).toHaveAttribute(
         'aria-pressed',

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../../../../test/lib/i18n-helpers';
 import configureStore from '../../../../../../store/store';
@@ -150,11 +149,10 @@ describe('CloseAmountSection', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('swaps the field to a percent input when percent mode is selected', async () => {
-      const user = userEvent.setup();
+    it('swaps the field to a percent input when percent mode is selected', () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       expect(screen.getByTestId('close-amount-unit')).toHaveTextContent(
         messages.perpsCloseAmountInPercent.message,
@@ -167,8 +165,7 @@ describe('CloseAmountSection', () => {
   });
 
   describe('dollar amount entry', () => {
-    it('converts a typed dollar amount to the equivalent close percentage', async () => {
-      const user = userEvent.setup();
+    it('converts a typed dollar amount to the equivalent close percentage', () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -181,15 +178,13 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('56250');
+      fireEvent.change(input, { target: { value: '56250' } });
 
       // 56,250 of a 112,500 position (2.5 BTC at 45,000) is half of it.
       expect(onClosePercentChange).toHaveBeenCalledWith(50);
     });
 
-    it('converts a quarter-position dollar amount to 25 percent', async () => {
-      const user = userEvent.setup();
+    it('converts a quarter-position dollar amount to 25 percent', () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -202,14 +197,12 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('28125');
+      fireEvent.change(input, { target: { value: '28125' } });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(25);
     });
 
-    it('reports keypad as the input method for a typed dollar amount', async () => {
-      const user = userEvent.setup();
+    it('reports keypad as the input method for a typed dollar amount', () => {
       const onInputMethodChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -222,69 +215,59 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('56250');
+      fireEvent.change(input, { target: { value: '56250' } });
 
       expect(onInputMethodChange).toHaveBeenCalledWith('keypad');
     });
   });
 
   describe('percent amount entry', () => {
-    const renderInPercentMode = async (
-      user: ReturnType<typeof userEvent.setup>,
-      props = {},
-    ) => {
+    const renderInPercentMode = (props = {}) => {
       const result = renderWithProvider(
         <CloseAmountSection {...defaultProps} {...props} />,
         mockStore,
       );
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
       return result;
     };
 
-    it('commits a typed percentage', async () => {
-      const user = userEvent.setup();
+    it('commits a typed percentage', () => {
       const onClosePercentChange = jest.fn();
-      await renderInPercentMode(user, { onClosePercentChange });
+      renderInPercentMode({ onClosePercentChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('50');
+      fireEvent.change(input, { target: { value: '50' } });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(50);
     });
 
-    it('commits a quarter close from a typed percentage', async () => {
-      const user = userEvent.setup();
+    it('commits a quarter close from a typed percentage', () => {
       const onClosePercentChange = jest.fn();
-      await renderInPercentMode(user, { onClosePercentChange });
+      renderInPercentMode({ onClosePercentChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('25');
+      fireEvent.change(input, { target: { value: '25' } });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(25);
     });
 
-    it('treats an emptied percent field as closing nothing', async () => {
-      const user = userEvent.setup();
+    it('treats an emptied percent field as closing nothing', () => {
       const onClosePercentChange = jest.fn();
-      await renderInPercentMode(user, { onClosePercentChange });
+      renderInPercentMode({ onClosePercentChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
+      fireEvent.change(input, { target: { value: '' } });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(0);
     });
 
-    it('leaves the field empty while the trader clears it to retype', async () => {
-      const user = userEvent.setup();
+    it('leaves the field empty while the trader clears it to retype', () => {
       const ControlledHarness = () => {
         const [percent, setPercent] = React.useState(100);
         return (
@@ -296,43 +279,37 @@ describe('CloseAmountSection', () => {
         );
       };
       renderWithProvider(<ControlledHarness />, mockStore);
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '' } });
 
       expect(input.value).toBe('');
     });
 
-    it('reports percentage as the input method for a typed percentage', async () => {
-      const user = userEvent.setup();
+    it('reports percentage as the input method for a typed percentage', () => {
       const onInputMethodChange = jest.fn();
-      await renderInPercentMode(user, { onInputMethodChange });
+      renderInPercentMode({ onInputMethodChange });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('50');
+      fireEvent.change(input, { target: { value: '50' } });
 
       expect(onInputMethodChange).toHaveBeenCalledWith('percentage');
     });
 
-    it('reports percentage, not max, for a typed full close', async () => {
-      const user = userEvent.setup();
+    it('reports percentage, not max, for a typed full close', () => {
       const onInputMethodChange = jest.fn();
-      await renderInPercentMode(user, {
-        onInputMethodChange,
-        closePercent: 25,
-      });
+      renderInPercentMode({ onInputMethodChange, closePercent: 25 });
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('100');
+      fireEvent.change(input, { target: { value: '100' } });
 
       // Mobile reserves 'max' for an explicit Max button, which this screen has
       // no equivalent of, so inferring it from 100 would diverge the funnel.
@@ -342,8 +319,7 @@ describe('CloseAmountSection', () => {
   });
 
   describe('over-close protection', () => {
-    it('caps a dollar amount above the position value and explains the cap', async () => {
-      const user = userEvent.setup();
+    it('caps a dollar amount above the position value and explains the cap', () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -356,8 +332,7 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('999999');
+      fireEvent.change(input, { target: { value: '999999' } });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(100);
       expect(
@@ -365,22 +340,19 @@ describe('CloseAmountSection', () => {
       ).toHaveTextContent(messages.perpsCloseAmountCappedAtPosition.message);
     });
 
-    it('shows the capped dollar amount in the field rather than the typed one', async () => {
-      const user = userEvent.setup();
+    it('shows the capped dollar amount in the field rather than the typed one', () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('999999');
+      fireEvent.change(input, { target: { value: '999999' } });
 
       // 2.5 BTC at 45,000 is a 112,500 position.
       expect(input.value).toBe('112500');
     });
 
-    it('caps a percentage above 100 and explains the cap', async () => {
-      const user = userEvent.setup();
+    it('caps a percentage above 100 and explains the cap', () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -389,13 +361,12 @@ describe('CloseAmountSection', () => {
         />,
         mockStore,
       );
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('150');
+      fireEvent.change(input, { target: { value: '150' } });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(100);
       expect(
@@ -403,23 +374,21 @@ describe('CloseAmountSection', () => {
       ).toHaveTextContent(messages.perpsClosePercentCappedAtMax.message);
     });
 
-    it('shows the capped percentage in the field rather than the typed one', async () => {
-      const user = userEvent.setup();
+    it('shows the capped percentage in the field rather than the typed one', () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('150');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '150' } });
 
       // Matches the dollar field, which caps in place on the same keystroke.
       expect(input.value).toBe('100');
     });
 
-    it('never commits more than the whole position', async () => {
-      const user = userEvent.setup();
+    it('never commits more than the whole position', () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -428,20 +397,18 @@ describe('CloseAmountSection', () => {
         />,
         mockStore,
       );
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('150');
+      fireEvent.change(input, { target: { value: '150' } });
 
       const committed = onClosePercentChange.mock.calls.map(([value]) => value);
       expect(Math.max(...committed)).toBe(100);
     });
 
-    it('caps a dollar amount too large to hold in a number', async () => {
-      const user = userEvent.setup();
+    it('caps a dollar amount too large to hold in a number', () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -454,8 +421,8 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('9'.repeat(320));
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '9'.repeat(320) } });
 
       // Overflows to Infinity, which still means "more than the position".
       // Committing 0 here would show a 100% cap while closing nothing.
@@ -465,8 +432,7 @@ describe('CloseAmountSection', () => {
       ).toBeInTheDocument();
     });
 
-    it('caps a percentage too large to hold in a number', async () => {
-      const user = userEvent.setup();
+    it('caps a percentage too large to hold in a number', () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -475,29 +441,26 @@ describe('CloseAmountSection', () => {
         />,
         mockStore,
       );
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('9'.repeat(320));
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '9'.repeat(320) } });
 
       expect(onClosePercentChange).toHaveBeenLastCalledWith(100);
     });
 
-    it('clears the cap message once an amount that fits is entered', async () => {
-      const user = userEvent.setup();
+    it('clears the cap message once an amount that fits is entered', () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       const input = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('150');
-      await user.clear(input);
-      await user.paste('40');
+      fireEvent.change(input, { target: { value: '150' } });
+      fireEvent.change(input, { target: { value: '40' } });
 
       expect(
         screen.queryByTestId('close-amount-over-close-error'),
@@ -506,8 +469,7 @@ describe('CloseAmountSection', () => {
   });
 
   describe('unusable market data', () => {
-    it('closes nothing when the position has no value', async () => {
-      const user = userEvent.setup();
+    it('closes nothing when the position has no value', () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -521,15 +483,13 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('500');
+      fireEvent.change(input, { target: { value: '500' } });
 
       // A typed amount must never leave a stale percentage behind it.
       expect(onClosePercentChange).toHaveBeenCalledWith(0);
     });
 
-    it('closes nothing while only a decimal point has been typed', async () => {
-      const user = userEvent.setup();
+    it('closes nothing while only a decimal point has been typed', () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -542,16 +502,14 @@ describe('CloseAmountSection', () => {
       const input = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(input);
-      await user.paste('.');
+      fireEvent.change(input, { target: { value: '.' } });
 
       expect(onClosePercentChange).toHaveBeenCalledWith(0);
     });
   });
 
   describe('cross-unit precision', () => {
-    it('keeps the exact percentage a dollar amount resolves to', async () => {
-      const user = userEvent.setup();
+    it('commits a dollar amount at the precision the percent field shows', () => {
       const onClosePercentChange = jest.fn();
       renderWithProvider(
         <CloseAmountSection
@@ -565,15 +523,16 @@ describe('CloseAmountSection', () => {
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
       // 1,000 of a 112,500 position is 0.888…%, not a whole percent.
-      await user.clear(input);
-      await user.paste('1000');
+      fireEvent.change(input, { target: { value: '1000' } });
 
       const [committed] = onClosePercentChange.mock.calls.at(-1) as [number];
-      expect(committed).toBeCloseTo((1000 / 112500) * 100, 10);
+      // Rounded to the two decimals the percent field renders, so the committed
+      // value is always the one on screen. Whole-percent rounding would move the
+      // typed dollar amount by cents; this keeps it under a hundredth of one.
+      expect(committed).toBe(0.89);
     });
 
-    it('lets the trader edit a fractional percentage the field is showing', async () => {
-      const user = userEvent.setup();
+    it('lets the trader edit a fractional percentage the field is showing', () => {
       const ControlledHarness = () => {
         const [percent, setPercent] = React.useState(100);
         return (
@@ -589,22 +548,76 @@ describe('CloseAmountSection', () => {
       const usdInput = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(usdInput);
-      await user.type(usdInput, '1000');
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.change(usdInput, { target: { value: '1000' } });
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       const percentInput = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
       // The field displays 0.89, so a decimal edit of it must be accepted.
-      await user.clear(percentInput);
-      await user.type(percentInput, '0.5');
+      fireEvent.focus(percentInput);
+      fireEvent.change(percentInput, { target: { value: '0.5' } });
 
       expect(percentInput.value).toBe('0.5');
     });
 
-    it('shows a fractional percentage in the percent field rather than rounding it away', async () => {
-      const user = userEvent.setup();
+    it('commits the same percentage the field shows after blur', () => {
+      let committed = 100;
+      const ControlledHarness = () => {
+        const [percent, setPercent] = React.useState(100);
+        committed = percent;
+        return (
+          <CloseAmountSection
+            {...defaultProps}
+            closePercent={percent}
+            onClosePercentChange={setPercent}
+          />
+        );
+      };
+      renderWithProvider(<ControlledHarness />, mockStore);
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '99.999' } });
+      fireEvent.blur(input);
+
+      // The field can only render two decimals, so committing 99.999 would show
+      // "100" while leaving a sliver of the position open.
+      expect(input.value).toBe('100');
+      expect(committed).toBe(100);
+    });
+
+    it('keeps a percentage within the displayed precision intact', () => {
+      let committed = 100;
+      const ControlledHarness = () => {
+        const [percent, setPercent] = React.useState(100);
+        committed = percent;
+        return (
+          <CloseAmountSection
+            {...defaultProps}
+            closePercent={percent}
+            onClosePercentChange={setPercent}
+          />
+        );
+      };
+      renderWithProvider(<ControlledHarness />, mockStore);
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '12.34' } });
+      fireEvent.blur(input);
+
+      expect(input.value).toBe('12.34');
+      expect(committed).toBe(12.34);
+    });
+
+    it('shows a fractional percentage in the percent field rather than rounding it away', () => {
       const ControlledHarness = () => {
         const [percent, setPercent] = React.useState(100);
         return (
@@ -620,9 +633,8 @@ describe('CloseAmountSection', () => {
       const usdInput = screen
         .getByTestId('close-amount-value')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(usdInput);
-      await user.paste('1000');
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.change(usdInput, { target: { value: '1000' } });
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       const percentInput = screen
         .getByTestId('close-amount-percent')
@@ -658,11 +670,10 @@ describe('CloseAmountSection', () => {
       );
     });
 
-    it('moves the pressed state to percent when percent mode is selected', async () => {
-      const user = userEvent.setup();
+    it('moves the pressed state to percent when percent mode is selected', () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       expect(screen.getByTestId('close-amount-mode-percent')).toHaveAttribute(
         'aria-pressed',

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
@@ -229,6 +229,36 @@ describe('CloseAmountSection', () => {
       expect(onClosePercentChange).toHaveBeenCalledWith(25);
     });
 
+    it('limits a typed dollar amount to whole cents', async () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      // Matches mobile, which slices the decimal part to two digits rather than
+      // rounding it, so the committed percentage reflects what was entered.
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('1234.5678');
+      });
+
+      expect(input.value).toBe('1234.56');
+    });
+
+    it('keeps a trailing decimal point while the trader is still typing', async () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      await interactAs(async (user) => {
+        await user.clear(input);
+        await user.paste('12.');
+      });
+
+      expect(input.value).toBe('12.');
+    });
+
     it('reports keypad as the input method for a typed dollar amount', async () => {
       const onInputMethodChange = jest.fn();
       renderWithProvider(

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
@@ -140,7 +140,9 @@ describe('CloseAmountSection', () => {
     it('starts in dollar mode', () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
-      expect(screen.getByTestId('close-amount-unit')).toHaveTextContent('$');
+      expect(screen.getByTestId('close-amount-unit')).toHaveTextContent(
+        messages.perpsCloseAmountInUsd.message,
+      );
       expect(screen.getByTestId('close-amount-value')).toBeInTheDocument();
       expect(
         screen.queryByTestId('close-amount-percent'),
@@ -152,7 +154,9 @@ describe('CloseAmountSection', () => {
 
       fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
-      expect(screen.getByTestId('close-amount-unit')).toHaveTextContent('%');
+      expect(screen.getByTestId('close-amount-unit')).toHaveTextContent(
+        messages.perpsCloseAmountInPercent.message,
+      );
       expect(screen.getByTestId('close-amount-percent')).toBeInTheDocument();
       expect(
         screen.queryByTestId('close-amount-value'),
@@ -298,7 +302,7 @@ describe('CloseAmountSection', () => {
       expect(onInputMethodChange).toHaveBeenCalledWith('percentage');
     });
 
-    it('reports max as the input method for a full close', () => {
+    it('reports percentage, not max, for a typed full close', () => {
       const onInputMethodChange = jest.fn();
       renderInPercentMode({ onInputMethodChange, closePercent: 25 });
 
@@ -307,7 +311,10 @@ describe('CloseAmountSection', () => {
         .querySelector('input') as HTMLInputElement;
       fireEvent.change(input, { target: { value: '100' } });
 
-      expect(onInputMethodChange).toHaveBeenCalledWith('max');
+      // Mobile reserves 'max' for an explicit Max button, which this screen has
+      // no equivalent of, so inferring it from 100 would diverge the funnel.
+      expect(onInputMethodChange).toHaveBeenCalledWith('percentage');
+      expect(onInputMethodChange).not.toHaveBeenCalledWith('max');
     });
   });
 
@@ -365,6 +372,20 @@ describe('CloseAmountSection', () => {
       expect(
         screen.getByTestId('close-amount-over-close-error'),
       ).toHaveTextContent(messages.perpsClosePercentCappedAtMax.message);
+    });
+
+    it('shows the capped percentage in the field rather than the typed one', () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '150' } });
+
+      // Matches the dollar field, which caps in place on the same keystroke.
+      expect(input.value).toBe('100');
     });
 
     it('never commits more than the whole position', () => {
@@ -491,34 +512,43 @@ describe('CloseAmountSection', () => {
   });
 
   describe('mode selector accessibility', () => {
-    it('exposes the modes as a radio group with the active unit checked', () => {
+    it('names each mode for screen readers rather than relying on the glyph', () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
-      expect(screen.getByTestId('close-amount-mode-selector')).toHaveAttribute(
-        'role',
-        'radiogroup',
-      );
       expect(screen.getByTestId('close-amount-mode-usd')).toHaveAttribute(
-        'aria-checked',
+        'aria-label',
+        messages.perpsCloseAmountInUsdLabel.message,
+      );
+      expect(screen.getByTestId('close-amount-mode-percent')).toHaveAttribute(
+        'aria-label',
+        messages.perpsCloseAmountInPercentLabel.message,
+      );
+    });
+
+    it('marks the active unit as pressed', () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+
+      expect(screen.getByTestId('close-amount-mode-usd')).toHaveAttribute(
+        'aria-pressed',
         'true',
       );
       expect(screen.getByTestId('close-amount-mode-percent')).toHaveAttribute(
-        'aria-checked',
+        'aria-pressed',
         'false',
       );
     });
 
-    it('moves the checked state to percent when percent mode is selected', () => {
+    it('moves the pressed state to percent when percent mode is selected', () => {
       renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
 
       fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
 
       expect(screen.getByTestId('close-amount-mode-percent')).toHaveAttribute(
-        'aria-checked',
+        'aria-pressed',
         'true',
       );
       expect(screen.getByTestId('close-amount-mode-usd')).toHaveAttribute(
-        'aria-checked',
+        'aria-pressed',
         'false',
       );
     });

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../../../../test/lib/i18n-helpers';
 import configureStore from '../../../../../../store/store';
@@ -121,6 +121,406 @@ describe('CloseAmountSection', () => {
 
       const btcElements = screen.getAllByText(/2\.5.*BTC/u);
       expect(btcElements.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('input mode selector', () => {
+    it('offers a dollar mode, a percent mode, and the slider', () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+
+      expect(screen.getByTestId('close-amount-mode-usd')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('close-amount-mode-percent'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('close-amount-slider-pct-100'),
+      ).toBeInTheDocument();
+    });
+
+    it('starts in dollar mode', () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+
+      expect(screen.getByTestId('close-amount-unit')).toHaveTextContent('$');
+      expect(screen.getByTestId('close-amount-value')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('close-amount-percent'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('swaps the field to a percent input when percent mode is selected', () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+
+      expect(screen.getByTestId('close-amount-unit')).toHaveTextContent('%');
+      expect(screen.getByTestId('close-amount-percent')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('close-amount-value'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('dollar amount entry', () => {
+    it('converts a typed dollar amount to the equivalent close percentage', () => {
+      const onClosePercentChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          onClosePercentChange={onClosePercentChange}
+        />,
+        mockStore,
+      );
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '56250' } });
+
+      // 56,250 of a 112,500 position (2.5 BTC at 45,000) is half of it.
+      expect(onClosePercentChange).toHaveBeenCalledWith(50);
+    });
+
+    it('converts a quarter-position dollar amount to 25 percent', () => {
+      const onClosePercentChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          onClosePercentChange={onClosePercentChange}
+        />,
+        mockStore,
+      );
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '28125' } });
+
+      expect(onClosePercentChange).toHaveBeenCalledWith(25);
+    });
+
+    it('reports keypad as the input method for a typed dollar amount', () => {
+      const onInputMethodChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          onInputMethodChange={onInputMethodChange}
+        />,
+        mockStore,
+      );
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '56250' } });
+
+      expect(onInputMethodChange).toHaveBeenCalledWith('keypad');
+    });
+  });
+
+  describe('percent amount entry', () => {
+    const renderInPercentMode = (props = {}) => {
+      const result = renderWithProvider(
+        <CloseAmountSection {...defaultProps} {...props} />,
+        mockStore,
+      );
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      return result;
+    };
+
+    it('commits a typed percentage', () => {
+      const onClosePercentChange = jest.fn();
+      renderInPercentMode({ onClosePercentChange });
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '50' } });
+
+      expect(onClosePercentChange).toHaveBeenCalledWith(50);
+    });
+
+    it('commits a quarter close from a typed percentage', () => {
+      const onClosePercentChange = jest.fn();
+      renderInPercentMode({ onClosePercentChange });
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '25' } });
+
+      expect(onClosePercentChange).toHaveBeenCalledWith(25);
+    });
+
+    it('treats an emptied percent field as closing nothing', () => {
+      const onClosePercentChange = jest.fn();
+      renderInPercentMode({ onClosePercentChange });
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '' } });
+
+      expect(onClosePercentChange).toHaveBeenCalledWith(0);
+    });
+
+    it('leaves the field empty while the trader clears it to retype', () => {
+      const ControlledHarness = () => {
+        const [percent, setPercent] = React.useState(100);
+        return (
+          <CloseAmountSection
+            {...defaultProps}
+            closePercent={percent}
+            onClosePercentChange={setPercent}
+          />
+        );
+      };
+      renderWithProvider(<ControlledHarness />, mockStore);
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '' } });
+
+      expect(input.value).toBe('');
+    });
+
+    it('reports percentage as the input method for a typed percentage', () => {
+      const onInputMethodChange = jest.fn();
+      renderInPercentMode({ onInputMethodChange });
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '50' } });
+
+      expect(onInputMethodChange).toHaveBeenCalledWith('percentage');
+    });
+
+    it('reports max as the input method for a full close', () => {
+      const onInputMethodChange = jest.fn();
+      renderInPercentMode({ onInputMethodChange, closePercent: 25 });
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '100' } });
+
+      expect(onInputMethodChange).toHaveBeenCalledWith('max');
+    });
+  });
+
+  describe('over-close protection', () => {
+    it('caps a dollar amount above the position value and explains the cap', () => {
+      const onClosePercentChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          onClosePercentChange={onClosePercentChange}
+        />,
+        mockStore,
+      );
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '999999' } });
+
+      expect(onClosePercentChange).toHaveBeenCalledWith(100);
+      expect(
+        screen.getByTestId('close-amount-over-close-error'),
+      ).toHaveTextContent(messages.perpsCloseAmountCappedAtPosition.message);
+    });
+
+    it('shows the capped dollar amount in the field rather than the typed one', () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '999999' } });
+
+      // 2.5 BTC at 45,000 is a 112,500 position.
+      expect(input.value).toBe('112500');
+    });
+
+    it('caps a percentage above 100 and explains the cap', () => {
+      const onClosePercentChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          onClosePercentChange={onClosePercentChange}
+        />,
+        mockStore,
+      );
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '150' } });
+
+      expect(onClosePercentChange).toHaveBeenCalledWith(100);
+      expect(
+        screen.getByTestId('close-amount-over-close-error'),
+      ).toHaveTextContent(messages.perpsClosePercentCappedAtMax.message);
+    });
+
+    it('never commits more than the whole position', () => {
+      const onClosePercentChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          onClosePercentChange={onClosePercentChange}
+        />,
+        mockStore,
+      );
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '150' } });
+
+      const committed = onClosePercentChange.mock.calls.map(([value]) => value);
+      expect(Math.max(...committed)).toBe(100);
+    });
+
+    it('clears the cap message once an amount that fits is entered', () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+
+      const input = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '150' } });
+      fireEvent.change(input, { target: { value: '40' } });
+
+      expect(
+        screen.queryByTestId('close-amount-over-close-error'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('unusable market data', () => {
+    it('closes nothing when the position has no value', () => {
+      const onClosePercentChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          currentPrice={0}
+          onClosePercentChange={onClosePercentChange}
+        />,
+        mockStore,
+      );
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '500' } });
+
+      // A typed amount must never leave a stale percentage behind it.
+      expect(onClosePercentChange).toHaveBeenCalledWith(0);
+    });
+
+    it('closes nothing while only a decimal point has been typed', () => {
+      const onClosePercentChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          onClosePercentChange={onClosePercentChange}
+        />,
+        mockStore,
+      );
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '.' } });
+
+      expect(onClosePercentChange).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('cross-unit precision', () => {
+    it('keeps the exact percentage a dollar amount resolves to', () => {
+      const onClosePercentChange = jest.fn();
+      renderWithProvider(
+        <CloseAmountSection
+          {...defaultProps}
+          onClosePercentChange={onClosePercentChange}
+        />,
+        mockStore,
+      );
+
+      const input = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      // 1,000 of a 112,500 position is 0.888…%, not a whole percent.
+      fireEvent.change(input, { target: { value: '1000' } });
+
+      const [committed] = onClosePercentChange.mock.calls.at(-1) as [number];
+      expect(committed).toBeCloseTo((1000 / 112500) * 100, 10);
+    });
+
+    it('shows a fractional percentage in the percent field rather than rounding it away', () => {
+      const ControlledHarness = () => {
+        const [percent, setPercent] = React.useState(100);
+        return (
+          <CloseAmountSection
+            {...defaultProps}
+            closePercent={percent}
+            onClosePercentChange={setPercent}
+          />
+        );
+      };
+      renderWithProvider(<ControlledHarness />, mockStore);
+
+      const usdInput = screen
+        .getByTestId('close-amount-value')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(usdInput, { target: { value: '1000' } });
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+
+      const percentInput = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      expect(percentInput.value).toBe('0.89');
+    });
+  });
+
+  describe('mode selector accessibility', () => {
+    it('exposes the modes as a radio group with the active unit checked', () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+
+      expect(screen.getByTestId('close-amount-mode-selector')).toHaveAttribute(
+        'role',
+        'radiogroup',
+      );
+      expect(screen.getByTestId('close-amount-mode-usd')).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+      expect(screen.getByTestId('close-amount-mode-percent')).toHaveAttribute(
+        'aria-checked',
+        'false',
+      );
+    });
+
+    it('moves the checked state to percent when percent mode is selected', () => {
+      renderWithProvider(<CloseAmountSection {...defaultProps} />, mockStore);
+
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+
+      expect(screen.getByTestId('close-amount-mode-percent')).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+      expect(screen.getByTestId('close-amount-mode-usd')).toHaveAttribute(
+        'aria-checked',
+        'false',
+      );
     });
   });
 

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
@@ -77,6 +77,24 @@ const clampClosePercent = (percent: number): number => {
 const formatPercentForInput = (percent: number): string =>
   formatNumberForInput(percent, PERCENT_INPUT_DECIMALS);
 
+/** Scale used to round a percentage to the precision the field renders. */
+const PERCENT_PRECISION_SCALE = 10 ** PERCENT_INPUT_DECIMALS;
+
+/**
+ * Rounds a percentage to the precision the percent field displays.
+ *
+ * Keeping the committed value and the rendered value at the same precision
+ * means the trader never reads a number the position does not actually match —
+ * e.g. a 99.999% close rendering as "100" while a sliver stays open.
+ *
+ * @param percent - The raw percentage.
+ * @returns The percentage rounded to the displayed precision.
+ */
+const roundToPercentPrecision = (percent: number): number =>
+  Number.isFinite(percent)
+    ? Math.round(percent * PERCENT_PRECISION_SCALE) / PERCENT_PRECISION_SCALE
+    : percent;
+
 /**
  * CloseAmountSection - Section for selecting how much of a position to close
  *
@@ -185,11 +203,14 @@ export const CloseAmountSection = ({
           ? formatNumberForInput(totalNotionalUsd, USD_INPUT_DECIMALS)
           : value,
       );
-      // Deliberately NOT rounded to a whole percent: the trader asked to close
-      // an exact dollar amount, and on a small position one percentage point is
-      // several cents. The percent field renders this faithfully.
+      // Rounded to the precision the percent field renders, not to a whole
+      // percent: whole-percent rounding moves a typed dollar amount by several
+      // cents on a small position, while this keeps it within a hundredth of a
+      // cent and guarantees the committed value is the one displayed.
       onClosePercentChange(
-        clampClosePercent((parsed / totalNotionalUsd) * 100),
+        clampClosePercent(
+          roundToPercentPrecision((parsed / totalNotionalUsd) * 100),
+        ),
       );
     },
     [totalNotionalUsd, onClosePercentChange, onInputMethodChange],
@@ -240,7 +261,10 @@ export const CloseAmountSection = ({
       setPercentInputValue(
         exceedsMax ? formatPercentForInput(MAX_CLOSE_PERCENT) : value,
       );
-      commitPercent(clampClosePercent(parsed));
+      // Commit only the precision the field can show. Otherwise a typed 99.999
+      // renders as "100" once blurred while a 0.001% sliver of the position
+      // stays open — the trader would read that as a full close.
+      commitPercent(clampClosePercent(roundToPercentPrecision(parsed)));
     },
     [commitPercent],
   );

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
@@ -24,11 +24,7 @@ import { PerpsSlider } from '../../../perps-slider';
 import { getDisplaySymbol } from '../../../utils';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import type { CloseAmountSectionProps } from '../../order-entry.types';
-import {
-  isUnsignedDecimalInput,
-  isDigitsOnlyInput,
-  formatNumberForInput,
-} from '../../utils';
+import { isUnsignedDecimalInput, formatNumberForInput } from '../../utils';
 
 /** Fixed width (rem) for the close-% chip so the slider row layout stays stable as digits change */
 const CLOSE_PERCENT_CHIP_WIDTH_REM = 4.75;
@@ -52,11 +48,16 @@ type CloseAmountUnit = 'usd' | 'percent';
 /**
  * Clamps a close percentage into the closable range.
  *
+ * `Infinity` is treated as an over-close rather than as "no amount": a pasted
+ * value long enough to overflow a double still means the trader asked for more
+ * than the position holds, and returning 0 there would show a 100% cap while
+ * committing nothing. Only a genuine non-number falls back to 0.
+ *
  * @param percent - Raw percentage, possibly out of range or non-finite.
  * @returns The percentage constrained to 0-100, or 0 when not a number.
  */
 const clampClosePercent = (percent: number): number => {
-  if (!Number.isFinite(percent)) {
+  if (Number.isNaN(percent)) {
     return 0;
   }
   return Math.min(MAX_CLOSE_PERCENT, Math.max(0, percent));
@@ -215,17 +216,22 @@ export const CloseAmountSection = ({
 
   const handlePercentInputChange = useCallback(
     ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
-      if (!(value === '' || isDigitsOnlyInput(value))) {
+      // Decimals are accepted, not just digits: a percentage derived from a
+      // typed dollar amount is shown with fractional precision, so the trader
+      // has to be able to edit the value the field is actually displaying.
+      if (!(value === '' || isUnsignedDecimalInput(value))) {
         return;
       }
-      if (value === '') {
+
+      const parsed = Number.parseFloat(value);
+      if (Number.isNaN(parsed)) {
+        // '' and a lone '.' are both "no amount chosen yet".
         setPercentInputValue(value);
         setDidExceedPosition(false);
         commitPercent(0);
         return;
       }
 
-      const parsed = Number.parseInt(value, 10);
       const exceedsMax = parsed > MAX_CLOSE_PERCENT;
       setDidExceedPosition(exceedsMax);
       // Show the capped percentage straight away rather than the typed one, so
@@ -361,7 +367,7 @@ export const CloseAmountSection = ({
             isPercentUnit ? 'close-amount-percent' : 'close-amount-value'
           }
           inputProps={{
-            inputMode: isPercentUnit ? 'numeric' : 'decimal',
+            inputMode: 'decimal',
           }}
           startAccessory={
             <Text

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
@@ -10,6 +10,9 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
   BoxAlignItems,
+  Button,
+  ButtonSize,
+  ButtonVariant,
 } from '@metamask/design-system-react';
 import { formatPositionSize } from '../../../../../../../shared/lib/perps-formatters';
 import {
@@ -21,13 +24,66 @@ import { PerpsSlider } from '../../../perps-slider';
 import { getDisplaySymbol } from '../../../utils';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import type { CloseAmountSectionProps } from '../../order-entry.types';
-import { isUnsignedDecimalInput, formatNumberForInput } from '../../utils';
+import {
+  isUnsignedDecimalInput,
+  isDigitsOnlyInput,
+  formatNumberForInput,
+} from '../../utils';
 
 /** Fixed width (rem) for the close-% chip so the slider row layout stays stable as digits change */
 const CLOSE_PERCENT_CHIP_WIDTH_REM = 4.75;
 
+/** Largest share of a position a single close can take. */
+const MAX_CLOSE_PERCENT = 100;
+
+/** Fractional digits used for the USD close amount, matching mobile. */
+const USD_INPUT_DECIMALS = 2;
+
+/** Fractional digits kept when a dollar amount resolves to a partial percent. */
+const PERCENT_INPUT_DECIMALS = 2;
+
+/**
+ * Which unit the trader types the close amount in. The slider is always
+ * available alongside whichever unit is selected, so these two values plus the
+ * slider make up the three input modes.
+ */
+type CloseAmountUnit = 'usd' | 'percent';
+
+/**
+ * Clamps a close percentage into the closable range.
+ *
+ * @param percent - Raw percentage, possibly out of range or non-finite.
+ * @returns The percentage constrained to 0-100, or 0 when not a number.
+ */
+const clampClosePercent = (percent: number): number => {
+  if (!Number.isFinite(percent)) {
+    return 0;
+  }
+  return Math.min(MAX_CLOSE_PERCENT, Math.max(0, percent));
+};
+
+/**
+ * Renders a close percentage for the percent field.
+ *
+ * A percentage derived from a typed dollar amount is rarely whole, and on a
+ * small position one percentage point is worth several cents, so the fraction
+ * is kept rather than rounded away. Whole percentages — every value the slider
+ * and the percent field itself produce — still render without a decimal tail.
+ *
+ * @param percent - The committed close percentage.
+ * @returns The percentage as editable field text.
+ */
+const formatPercentForInput = (percent: number): string =>
+  formatNumberForInput(percent, PERCENT_INPUT_DECIMALS);
+
 /**
  * CloseAmountSection - Section for selecting how much of a position to close
+ *
+ * The trader picks the amount in one of three ways: the slider, a USD notional
+ * amount, or a percentage of the position. USD and percent share a single field
+ * whose unit is chosen by the `$` / `%` selector; the slider is always visible.
+ * `closePercent` stays the single source of truth for every mode, so an amount
+ * entered in one unit is immediately reflected in the others.
  *
  * @param props - Component props
  * @param props.positionSize - Total position size (absolute value); labeled "Available to close"
@@ -36,6 +92,7 @@ const CLOSE_PERCENT_CHIP_WIDTH_REM = 4.75;
  * @param props.asset - Asset symbol for display
  * @param props.currentPrice - Current asset price for USD calculation
  * @param props.sizeDecimals - Market size decimals for controller-based size formatting
+ * @param props.onInputMethodChange - Reports which control the trader used, for analytics
  */
 export const CloseAmountSection = ({
   positionSize,
@@ -44,6 +101,7 @@ export const CloseAmountSection = ({
   asset,
   currentPrice,
   sizeDecimals,
+  onInputMethodChange,
 }: CloseAmountSectionProps) => {
   const t = useI18nContext();
 
@@ -55,50 +113,168 @@ export const CloseAmountSection = ({
     [totalNotionalUsd, closePercent],
   );
 
+  const [unit, setUnit] = useState<CloseAmountUnit>('usd');
   const [rawInput, setRawInput] = useState('');
   const [isUsdInputFocused, setIsUsdInputFocused] = useState(false);
+  const [percentInputValue, setPercentInputValue] = useState(() =>
+    formatPercentForInput(closePercent),
+  );
+  // Set when the trader asks for more than the position holds. Cleared as soon
+  // as they enter an amount that fits, so it only ever describes the value
+  // currently in the field.
+  const [didExceedPosition, setDidExceedPosition] = useState(false);
+
+  const isPercentUnit = unit === 'percent';
 
   const displayValue = useMemo(
-    () => formatNumberForInput(closeValueUsd, 2),
+    () => formatNumberForInput(closeValueUsd, USD_INPUT_DECIMALS),
     [closeValueUsd],
+  );
+
+  // Keep the percent field in step with slider drags and USD entry without an
+  // effect, so the displayed value never lags a render behind `closePercent`.
+  // Skipped while the trader is typing, so clearing the field to retype does
+  // not immediately snap it back to "0".
+  const [isEditingPercent, setIsEditingPercent] = useState(false);
+  const [prevClosePercent, setPrevClosePercent] = useState(closePercent);
+  if (closePercent !== prevClosePercent) {
+    setPrevClosePercent(closePercent);
+    if (!isEditingPercent) {
+      setPercentInputValue(formatPercentForInput(closePercent));
+    }
+  }
+
+  const commitPercent = useCallback(
+    (percent: number) => {
+      onClosePercentChange(percent);
+      onInputMethodChange?.(
+        percent >= MAX_CLOSE_PERCENT ? 'max' : 'percentage',
+      );
+    },
+    [onClosePercentChange, onInputMethodChange],
   );
 
   const handleUsdInputChange = useCallback(
     ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
-      if (value === '' || isUnsignedDecimalInput(value)) {
-        setRawInput(value);
-
-        const parsed = Number.parseFloat(value);
-        if (!Number.isNaN(parsed) && totalNotionalUsd > 0) {
-          const newPercent = Math.min(
-            100,
-            Math.max(0, (parsed / totalNotionalUsd) * 100),
-          );
-          onClosePercentChange(newPercent);
-        } else if (value === '' || value === '0') {
-          onClosePercentChange(0);
-        }
+      if (!(value === '' || isUnsignedDecimalInput(value))) {
+        return;
       }
+      onInputMethodChange?.('keypad');
+
+      const parsed = Number.parseFloat(value);
+      // `''`, `'.'` and a zero-valued position all mean "no amount chosen".
+      // Committing 0 here keeps the field and `closePercent` in agreement; a
+      // partially typed value must never leave a stale percentage behind it.
+      if (Number.isNaN(parsed) || totalNotionalUsd <= 0) {
+        setRawInput(value);
+        setDidExceedPosition(false);
+        onClosePercentChange(0);
+        return;
+      }
+
+      // Cap rather than reject: an over-close can never reach submission, and
+      // the message below tells the trader why the value changed.
+      const exceedsPosition = parsed > totalNotionalUsd;
+      setDidExceedPosition(exceedsPosition);
+      // Show the capped amount straight away rather than the typed one, so the
+      // field agrees with the slider, the summary, and the cap message.
+      setRawInput(
+        exceedsPosition
+          ? formatNumberForInput(totalNotionalUsd, USD_INPUT_DECIMALS)
+          : value,
+      );
+      // Deliberately NOT rounded to a whole percent: the trader asked to close
+      // an exact dollar amount, and on a small position one percentage point is
+      // several cents. The percent field renders this faithfully.
+      onClosePercentChange(
+        clampClosePercent((parsed / totalNotionalUsd) * 100),
+      );
     },
-    [totalNotionalUsd, onClosePercentChange],
+    [totalNotionalUsd, onClosePercentChange, onInputMethodChange],
   );
 
-  const handleUsdInputFocus = useCallback(() => {
-    setIsUsdInputFocused(true);
-    setRawInput(formatNumberForInput(closeValueUsd, 2));
-  }, [closeValueUsd]);
+  const handleUsdInputFocus = useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      setIsUsdInputFocused(true);
+      setRawInput(formatNumberForInput(closeValueUsd, USD_INPUT_DECIMALS));
+      // The field is pre-filled with the whole position value, so select it the
+      // way AmountInput does: typing replaces it instead of appending digits to
+      // it and asking for an accidental over-close.
+      event.target.select();
+    },
+    [closeValueUsd],
+  );
 
   const handleUsdInputBlur = useCallback(() => {
     setIsUsdInputFocused(false);
+    // The capped percentage is the source of truth; re-deriving the field from
+    // it replaces an over-typed amount with the amount actually being closed.
+    setRawInput('');
   }, []);
+
+  const handlePercentInputChange = useCallback(
+    ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
+      if (!(value === '' || isDigitsOnlyInput(value))) {
+        return;
+      }
+      setPercentInputValue(value);
+
+      if (value === '') {
+        setDidExceedPosition(false);
+        commitPercent(0);
+        return;
+      }
+
+      const parsed = Number.parseInt(value, 10);
+      setDidExceedPosition(parsed > MAX_CLOSE_PERCENT);
+      commitPercent(clampClosePercent(parsed));
+    },
+    [commitPercent],
+  );
+
+  const handlePercentInputFocus = useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      setIsEditingPercent(true);
+      event.target.select();
+    },
+    [],
+  );
+
+  const handlePercentInputBlur = useCallback(() => {
+    setIsEditingPercent(false);
+    // Snap the field back to the percentage actually committed, so a typed
+    // "150" is left showing the "100" that will be closed.
+    setPercentInputValue(formatPercentForInput(closePercent));
+  }, [closePercent]);
 
   const handleSliderChange = useCallback(
     (_event: Event, value: number | number[]) => {
       const percent = Array.isArray(value) ? value[0] : value;
+      setDidExceedPosition(false);
       onClosePercentChange(percent);
+      onInputMethodChange?.(percent >= MAX_CLOSE_PERCENT ? 'max' : 'slider');
     },
-    [onClosePercentChange],
+    [onClosePercentChange, onInputMethodChange],
   );
+
+  const handleSelectUsdUnit = useCallback(() => {
+    setUnit('usd');
+    setDidExceedPosition(false);
+  }, []);
+
+  const handleSelectPercentUnit = useCallback(() => {
+    setUnit('percent');
+    setDidExceedPosition(false);
+  }, []);
+
+  // While the USD field has focus the trader's own draft is shown, including an
+  // empty one; otherwise the field re-derives from the committed percentage.
+  const usdFieldValue = isUsdInputFocused ? rawInput : displayValue;
+  const fieldValue = isPercentUnit ? percentInputValue : usdFieldValue;
+
+  const overCloseMessage = isPercentUnit
+    ? t('perpsClosePercentCappedAtMax')
+    : t('perpsCloseAmountCappedAtPosition');
 
   return (
     <Box flexDirection={BoxFlexDirection.Column} gap={3}>
@@ -116,31 +292,90 @@ export const CloseAmountSection = ({
       </Box>
 
       <Box flexDirection={BoxFlexDirection.Column} gap={2}>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {t('perpsCloseAmount')}
-        </Text>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+          alignItems={BoxAlignItems.Center}
+        >
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('perpsCloseAmount')}
+          </Text>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={1}
+            role="radiogroup"
+            aria-label={t('perpsCloseAmount')}
+            data-testid="close-amount-mode-selector"
+          >
+            <Button
+              size={ButtonSize.Sm}
+              variant={
+                isPercentUnit ? ButtonVariant.Tertiary : ButtonVariant.Secondary
+              }
+              type="button"
+              onClick={handleSelectUsdUnit}
+              role="radio"
+              aria-checked={!isPercentUnit}
+              data-testid="close-amount-mode-usd"
+            >
+              {t('perpsCloseAmountInUsd')}
+            </Button>
+            <Button
+              size={ButtonSize.Sm}
+              variant={
+                isPercentUnit ? ButtonVariant.Secondary : ButtonVariant.Tertiary
+              }
+              type="button"
+              onClick={handleSelectPercentUnit}
+              role="radio"
+              aria-checked={isPercentUnit}
+              data-testid="close-amount-mode-percent"
+            >
+              {t('perpsCloseAmountInPercent')}
+            </Button>
+          </Box>
+        </Box>
         <TextField
           size={TextFieldSize.Md}
-          value={isUsdInputFocused ? rawInput : displayValue}
-          onChange={handleUsdInputChange}
-          onFocus={handleUsdInputFocus}
-          onBlur={handleUsdInputBlur}
-          placeholder="0.00"
+          value={fieldValue}
+          onChange={
+            isPercentUnit ? handlePercentInputChange : handleUsdInputChange
+          }
+          onFocus={
+            isPercentUnit ? handlePercentInputFocus : handleUsdInputFocus
+          }
+          onBlur={isPercentUnit ? handlePercentInputBlur : handleUsdInputBlur}
+          placeholder={isPercentUnit ? '0' : '0.00'}
           borderRadius={BorderRadius.MD}
           borderWidth={0}
           backgroundColor={BackgroundColor.backgroundMuted}
           className="w-full"
-          data-testid="close-amount-value"
-          inputProps={{ inputMode: 'decimal' }}
+          data-testid={
+            isPercentUnit ? 'close-amount-percent' : 'close-amount-value'
+          }
+          inputProps={{
+            inputMode: isPercentUnit ? 'numeric' : 'decimal',
+          }}
           startAccessory={
             <Text
               variant={TextVariant.BodyMd}
               color={TextColor.TextAlternative}
+              data-testid="close-amount-unit"
             >
-              $
+              {isPercentUnit ? '%' : '$'}
             </Text>
           }
         />
+        {didExceedPosition ? (
+          <Text
+            variant={TextVariant.BodyXs}
+            color={TextColor.ErrorDefault}
+            data-testid="close-amount-over-close-error"
+          >
+            {overCloseMessage}
+          </Text>
+        ) : null}
       </Box>
 
       <Box
@@ -155,7 +390,7 @@ export const CloseAmountSection = ({
         >
           <PerpsSlider
             min={0}
-            max={100}
+            max={MAX_CLOSE_PERCENT}
             step={1}
             value={closePercent}
             onChange={handleSliderChange}

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
@@ -203,14 +203,14 @@ export const CloseAmountSection = ({
           ? formatNumberForInput(totalNotionalUsd, USD_INPUT_DECIMALS)
           : value,
       );
-      // Rounded to the precision the percent field renders, not to a whole
-      // percent: whole-percent rounding moves a typed dollar amount by several
-      // cents on a small position, while this keeps it within a hundredth of a
-      // cent and guarantees the committed value is the one displayed.
+      // Kept exact, deliberately un-rounded. The trader asked to close a precise
+      // dollar amount, and a percentage step is worth more the larger the
+      // position: 0.01% of a $112,500 position is $11.25, so rounding here would
+      // silently close more than was typed. The dollar field remains the source
+      // of truth for what it shows; the percent field, which can only render two
+      // decimals, is the approximation.
       onClosePercentChange(
-        clampClosePercent(
-          roundToPercentPrecision((parsed / totalNotionalUsd) * 100),
-        ),
+        clampClosePercent((parsed / totalNotionalUsd) * 100),
       );
     },
     [totalNotionalUsd, onClosePercentChange, onInputMethodChange],

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
@@ -147,9 +147,10 @@ export const CloseAmountSection = ({
   const commitPercent = useCallback(
     (percent: number) => {
       onClosePercentChange(percent);
-      onInputMethodChange?.(
-        percent >= MAX_CLOSE_PERCENT ? 'max' : 'percentage',
-      );
+      // Always 'percentage', never 'max': mobile reserves 'max' for an explicit
+      // Max button, which this screen has no equivalent of. Inferring it from a
+      // typed 100 would label these events differently across platforms.
+      onInputMethodChange?.('percentage');
     },
     [onClosePercentChange, onInputMethodChange],
   );
@@ -217,16 +218,22 @@ export const CloseAmountSection = ({
       if (!(value === '' || isDigitsOnlyInput(value))) {
         return;
       }
-      setPercentInputValue(value);
-
       if (value === '') {
+        setPercentInputValue(value);
         setDidExceedPosition(false);
         commitPercent(0);
         return;
       }
 
       const parsed = Number.parseInt(value, 10);
-      setDidExceedPosition(parsed > MAX_CLOSE_PERCENT);
+      const exceedsMax = parsed > MAX_CLOSE_PERCENT;
+      setDidExceedPosition(exceedsMax);
+      // Show the capped percentage straight away rather than the typed one, so
+      // the field agrees with the slider and the cap message — the same moment
+      // the dollar field caps at the position value.
+      setPercentInputValue(
+        exceedsMax ? formatPercentForInput(MAX_CLOSE_PERCENT) : value,
+      );
       commitPercent(clampClosePercent(parsed));
     },
     [commitPercent],
@@ -252,7 +259,8 @@ export const CloseAmountSection = ({
       const percent = Array.isArray(value) ? value[0] : value;
       setDidExceedPosition(false);
       onClosePercentChange(percent);
-      onInputMethodChange?.(percent >= MAX_CLOSE_PERCENT ? 'max' : 'slider');
+      // Unconditionally 'slider', matching mobile — see commitPercent on 'max'.
+      onInputMethodChange?.('slider');
     },
     [onClosePercentChange, onInputMethodChange],
   );
@@ -304,8 +312,6 @@ export const CloseAmountSection = ({
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
             gap={1}
-            role="radiogroup"
-            aria-label={t('perpsCloseAmount')}
             data-testid="close-amount-mode-selector"
           >
             <Button
@@ -315,8 +321,8 @@ export const CloseAmountSection = ({
               }
               type="button"
               onClick={handleSelectUsdUnit}
-              role="radio"
-              aria-checked={!isPercentUnit}
+              aria-pressed={!isPercentUnit}
+              aria-label={t('perpsCloseAmountInUsdLabel')}
               data-testid="close-amount-mode-usd"
             >
               {t('perpsCloseAmountInUsd')}
@@ -328,8 +334,8 @@ export const CloseAmountSection = ({
               }
               type="button"
               onClick={handleSelectPercentUnit}
-              role="radio"
-              aria-checked={isPercentUnit}
+              aria-pressed={isPercentUnit}
+              aria-label={t('perpsCloseAmountInPercentLabel')}
               data-testid="close-amount-mode-percent"
             >
               {t('perpsCloseAmountInPercent')}
@@ -415,7 +421,7 @@ export const CloseAmountSection = ({
             textAlign={TextAlign.Center}
             style={{ width: '100%', fontVariantNumeric: 'tabular-nums' }}
           >
-            {Math.round(closePercent)} %
+            {formatPercentForInput(closePercent)} %
           </Text>
         </Box>
       </Box>

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
@@ -77,6 +77,29 @@ const clampClosePercent = (percent: number): number => {
 const formatPercentForInput = (percent: number): string =>
   formatNumberForInput(percent, PERCENT_INPUT_DECIMALS);
 
+/**
+ * Truncates a typed dollar amount to whole cents.
+ *
+ * Mirrors mobile's keypad handling: the fractional part is cut rather than
+ * rounded, and a trailing "." is preserved so an in-progress "2." survives.
+ * Cutting at the input keeps the committed percentage exact for what was
+ * actually entered, instead of rounding the derived percentage afterwards.
+ *
+ * @param value - The raw field text.
+ * @returns The text limited to two decimal places.
+ */
+const truncateToUsdCents = (value: string): string => {
+  const separatorIndex = value.indexOf('.');
+  if (separatorIndex === -1) {
+    return value;
+  }
+  const integerPart = value.slice(0, separatorIndex);
+  const decimalPart = value.slice(separatorIndex + 1);
+  return decimalPart.length === 0
+    ? `${integerPart}.`
+    : `${integerPart}.${decimalPart.slice(0, USD_INPUT_DECIMALS)}`;
+};
+
 /** Scale used to round a percentage to the precision the field renders. */
 const PERCENT_PRECISION_SCALE = 10 ** PERCENT_INPUT_DECIMALS;
 
@@ -181,12 +204,17 @@ export const CloseAmountSection = ({
       }
       onInputMethodChange?.('keypad');
 
-      const parsed = Number.parseFloat(value);
+      // Constrain the entry to cents, matching mobile. Without this a sub-cent
+      // amount just under the position — 112,499.995 of 112,500 — stays a
+      // "partial" close while its size rounds up to the whole position, sending
+      // a partial order for everything the trader holds.
+      const truncatedValue = truncateToUsdCents(value);
+      const parsed = Number.parseFloat(truncatedValue);
       // `''`, `'.'` and a zero-valued position all mean "no amount chosen".
       // Committing 0 here keeps the field and `closePercent` in agreement; a
       // partially typed value must never leave a stale percentage behind it.
       if (Number.isNaN(parsed) || totalNotionalUsd <= 0) {
-        setRawInput(value);
+        setRawInput(truncatedValue);
         setDidExceedPosition(false);
         onClosePercentChange(0);
         return;
@@ -201,7 +229,7 @@ export const CloseAmountSection = ({
       setRawInput(
         exceedsPosition
           ? formatNumberForInput(totalNotionalUsd, USD_INPUT_DECIMALS)
-          : value,
+          : truncatedValue,
       );
       // Kept exact, deliberately un-rounded. The trader asked to close a precise
       // dollar amount, and a percentage step is worth more the larger the

--- a/ui/components/app/perps/order-entry/order-entry.test.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.test.tsx
@@ -1,4 +1,5 @@
-import { screen, fireEvent } from '@testing-library/react';
+import { act, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import mockState from '../../../../../test/data/mock-state.json';
@@ -407,7 +408,8 @@ describe('OrderEntry', () => {
       );
     });
 
-    it('reports the input method the trader used to size the close', () => {
+    it('reports the input method the trader used to size the close', async () => {
+      const user = userEvent.setup();
       const onInputMethodChange = jest.fn();
       renderWithProvider(
         <OrderEntry
@@ -419,11 +421,16 @@ describe('OrderEntry', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
+      await act(async () => {
+        await user.click(screen.getByTestId('close-amount-mode-percent'));
+      });
       const percentInput = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      fireEvent.change(percentInput, { target: { value: '50' } });
+      await act(async () => {
+        await user.clear(percentInput);
+        await user.type(percentInput, '50');
+      });
 
       // Without the forward in the close branch this route reports nothing and
       // every close from it is attributed to 'default'.

--- a/ui/components/app/perps/order-entry/order-entry.test.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.test.tsx
@@ -1,5 +1,4 @@
 import { screen, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import mockState from '../../../../../test/data/mock-state.json';
@@ -408,8 +407,7 @@ describe('OrderEntry', () => {
       );
     });
 
-    it('reports the input method the trader used to size the close', async () => {
-      const user = userEvent.setup();
+    it('reports the input method the trader used to size the close', () => {
       const onInputMethodChange = jest.fn();
       renderWithProvider(
         <OrderEntry
@@ -421,12 +419,11 @@ describe('OrderEntry', () => {
         mockStore,
       );
 
-      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      fireEvent.click(screen.getByTestId('close-amount-mode-percent'));
       const percentInput = screen
         .getByTestId('close-amount-percent')
         .querySelector('input') as HTMLInputElement;
-      await user.clear(percentInput);
-      await user.type(percentInput, '50');
+      fireEvent.change(percentInput, { target: { value: '50' } });
 
       // Without the forward in the close branch this route reports nothing and
       // every close from it is attributed to 'default'.

--- a/ui/components/app/perps/order-entry/order-entry.test.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.test.tsx
@@ -1,4 +1,5 @@
 import { screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import mockState from '../../../../../test/data/mock-state.json';
@@ -405,6 +406,31 @@ describe('OrderEntry', () => {
       expect(screen.getByTestId('order-entry-submit-button')).toHaveTextContent(
         'Close short',
       );
+    });
+
+    it('reports the input method the trader used to size the close', async () => {
+      const user = userEvent.setup();
+      const onInputMethodChange = jest.fn();
+      renderWithProvider(
+        <OrderEntry
+          {...defaultProps}
+          mode="close"
+          existingPosition={existingPosition}
+          onInputMethodChange={onInputMethodChange}
+        />,
+        mockStore,
+      );
+
+      await user.click(screen.getByTestId('close-amount-mode-percent'));
+      const percentInput = screen
+        .getByTestId('close-amount-percent')
+        .querySelector('input') as HTMLInputElement;
+      await user.clear(percentInput);
+      await user.type(percentInput, '50');
+
+      // Without the forward in the close branch this route reports nothing and
+      // every close from it is attributed to 'default'.
+      expect(onInputMethodChange).toHaveBeenCalledWith('percentage');
     });
 
     it('shows CloseAmountSection in close mode', () => {

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -292,6 +292,7 @@ export const OrderEntry = ({
             positionSize={positionSize}
             closePercent={closePercent}
             onClosePercentChange={handleClosePercentChange}
+            onInputMethodChange={onInputMethodChange}
             asset={asset}
             currentPrice={currentPrice}
             sizeDecimals={sizeDecimals}

--- a/ui/components/app/perps/order-entry/order-entry.types.ts
+++ b/ui/components/app/perps/order-entry/order-entry.types.ts
@@ -312,4 +312,9 @@ export type CloseAmountSectionProps = {
   currentPrice: number;
   /** Market size decimals for controller-based position-size formatting */
   sizeDecimals?: number;
+  /**
+   * Callback when the user changes the close amount via a specific input
+   * control (keypad/slider/percentage/max), for analytics attribution.
+   */
+  onInputMethodChange?: (inputMethod: InputMethod) => void;
 };

--- a/ui/hooks/perps/usePerpsAttribution.test.ts
+++ b/ui/hooks/perps/usePerpsAttribution.test.ts
@@ -46,6 +46,33 @@ describe('usePerpsAttribution', () => {
     });
   });
 
+  it('carries the input method that produced the amount', () => {
+    const { result } = renderHook(() => usePerpsAttribution(), { wrapper });
+
+    const trackingData = result.current.buildTrackingData({
+      totalFee: 1.5,
+      marketPrice: 3000,
+      vipTier: null,
+      vipDiscount: undefined,
+      inputMethod: 'percentage',
+    });
+
+    expect(trackingData.inputMethod).toBe('percentage');
+  });
+
+  it('omits the input method when the caller does not report one', () => {
+    const { result } = renderHook(() => usePerpsAttribution(), { wrapper });
+
+    const trackingData = result.current.buildTrackingData({
+      totalFee: 1.5,
+      marketPrice: 3000,
+      vipTier: null,
+      vipDiscount: undefined,
+    });
+
+    expect(trackingData).not.toHaveProperty('inputMethod');
+  });
+
   it('builds TP/SL tracking data with flow attribution', () => {
     const { result } = renderHook(() => usePerpsAttribution(), { wrapper });
 

--- a/ui/hooks/perps/usePerpsAttribution.ts
+++ b/ui/hooks/perps/usePerpsAttribution.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import type {
+  InputMethod,
   TPSLTrackingData,
   TrackingData,
 } from '@metamask/perps-controller';
@@ -14,6 +15,7 @@ type BuildTrackingDataInput = {
   vipDiscount: number | undefined;
   hlFeeRate?: number;
   tradeAction?: PerpsTradeAction;
+  inputMethod?: InputMethod;
 };
 
 /**
@@ -33,6 +35,7 @@ export function usePerpsAttribution() {
       vipDiscount,
       hlFeeRate,
       tradeAction,
+      inputMethod,
     }: BuildTrackingDataInput): TrackingData => ({
       totalFee,
       ...(metamaskFee === undefined ? {} : { metamaskFee }),
@@ -40,6 +43,7 @@ export function usePerpsAttribution() {
       ...(vipTier === null ? {} : { vipTier }),
       ...(vipDiscount === undefined ? {} : { vipDiscount }),
       ...(hlFeeRate === undefined ? {} : { hlFeeRate }),
+      ...(inputMethod === undefined ? {} : { inputMethod }),
       // The controller only emits the transaction `action` property when
       // `trackingData.tradeAction` is set, and forwards the value verbatim. Its
       // `TradeAction` type currently lists only create/increase, but flips are


### PR DESCRIPTION
## **Description**

The partial close screen now accepts the close amount as a dollar notional or as a percentage of the position, selected with a `$` / `%` control next to **Close amount**. The slider remains available as the third mode, and all three drive the same underlying close percentage, so switching units re-expresses the same amount rather than resetting it.

Entering more than the position holds — dollars above the position value, or a percentage above 100 — is capped at a full close and explained inline, so an over-sized close order cannot be built. Which control was used is reported on the close submission via the perps controller's existing `trackingData.inputMethod`.

Note: the ticket describes the current flow as slider-only. That was out of date — a `$` field already existed and the `%` was a read-only chip (see the Before screenshot). This adds the typed percent mode, the explicit selector, over-close protection, and the instrumentation.

## **Changelog**

CHANGELOG entry: Added dollar and percentage amount entry when partially closing a perps position

## **Related issues**

Fixes: [TAT-2857](https://consensyssoftware.atlassian.net/browse/TAT-2857)

## **Manual testing steps**

1. Open a perps position, then go to its market screen and choose **Modify → Reduce exposure**.
2. Confirm **Close amount** shows a `$` / `%` selector and a slider.
3. In `$` mode, type an amount below the position value — the slider and the Margin / Fees / You'll receive summary update to match.
4. Switch to `%` and type `50` — the slider moves to 50% and the summary halves. Switch back to `$` to see the equivalent dollar amount.
5. Type a dollar amount larger than the position value — it is capped at the position value and "Close amount capped at your position value." appears.
6. Switch to `%` and type `150` — it is capped at 100% and "Close percentage capped at 100%." appears.
7. Confirm a close in either mode and check the submitted size matches the amount shown.

Close amount now takes a $ or a % as well as the slider, and an over-close in either unit is capped with an explanation.

<table>
<tr><td align="center" valign="top" width="50%"><strong>Before: close amount had a $ field, a slider, and a read-only percent chip — no way to type a percentage</strong><br/><img src="Before Close Amount Section" alt="Before: close amount had a $ field, a slider, and a read-only percent chip — no way to type a percentage" width="320" /></td><td align="center" valign="top" width="50%"><strong>After: a $ / % selector sits beside Close amount, with the slider still available as the third mode</strong><br/><img src="After Ac1 Three Input Modes" alt="After: a $ / % selector sits beside Close amount, with the slider still available as the third mode" width="320" /></td></tr>
<tr><td align="center" valign="top" width="50%"><strong>Typing $6 sizes the close at 49% and halves the margin and payout</strong><br/><img src="After Ac2 Usd Amount" alt="Typing $6 sizes the close at 49% and halves the margin and payout" width="320" /></td><td align="center" valign="top" width="50%"><strong>Typing 50% sizes the close at half the position</strong><br/><img src="After Ac3 Percent Amount" alt="Typing 50% sizes the close at half the position" width="320" /></td></tr>
<tr><td align="center" valign="top" width="50%"><strong>A $ amount above the position is capped at the position value with an explanation, so the order cannot over-close</strong><br/><img src="After Ac4 Usd Capped" alt="A $ amount above the position is capped at the position value with an explanation, so the order cannot over-close" width="320" /></td><td align="center" valign="top" width="50%"><strong>A percentage above 100 is capped at 100% with an explanation, so the order cannot over-close</strong><br/><img src="After Ac5 Percent Capped" alt="A percentage above 100 is capped at 100% with an explanation, so the order cannot over-close" width="320" /></td></tr>
</table>

**Video**
Full validation run: all three input modes, both conversions, and both over-close caps.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

Ran against a live ETH position: **pass, 42/42 nodes**. All five acceptance criteria are bound to `ac<N>-` nodes; reverting the component change fails the run at `ac1-wait-percent-mode`.

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "TAT-2857 — dollar and percent amount input when partially closing a position",
  "description": "Proves the partial close screen offers slider, dollar, and percent input modes; that a typed dollar amount and a typed percentage each resolve to the matching share of the position; and that an over-close in either unit is capped with a message so no over-sized order can be submitted.",
  "workflow": {
    "entry": "gate-unlock",
    "nodes": {
      "gate-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "intent": "Unlock the wallet so the perps position is reachable",
        "next": "setup-open-market"
      },
      "setup-open-market": {
        "action": "ui.navigate",
        "hash": "#/perps/market/ETH",
        "timeout_ms": 30000,
        "intent": "Show the ETH market where the trader manages their open position",
        "next": "setup-settle-market"
      },
      "setup-wait-position": {
        "action": "ui.wait_for",
        "test_id": "perps-position-size-value",
        "expected": "visible",
        "timeout_ms": 45000,
        "intent": "Confirm the trader holds a live ETH position to close",
        "next": "setup-settle-before-press"
      },
      "setup-open-modify-menu": {
        "action": "ui.press",
        "test_id": "perps-modify-cta-button",
        "timeout_ms": 15000,
        "intent": "Open the position management choices offered on the ETH position",
        "next": "setup-settle-menu"
      },
      "setup-wait-menu": {
        "action": "ui.wait_for",
        "test_id": "perps-modify-menu-reduce-exposure",
        "expected": "visible",
        "timeout_ms": 30000,
        "intent": "Confirm the reduce-exposure choice is offered to the trader",
        "next": "setup-open-reduce"
      },
      "setup-open-reduce": {
        "action": "ui.press",
        "test_id": "perps-modify-menu-reduce-exposure",
        "timeout_ms": 15000,
        "intent": "Enter the partial close flow for the ETH position",
        "next": "setup-settle-modal"
      },
      "setup-wait-modal": {
        "action": "ui.wait_for",
        "test_id": "perps-close-position-asset-symbol",
        "expected": "visible",
        "timeout_ms": 20000,
        "intent": "Confirm the partial close screen is showing the market being closed",
        "next": "ac1-wait-usd-mode"
      },
      "ac1-wait-usd-mode": {
        "action": "ui.wait_for",
        "test_id": "close-amount-mode-usd",
        "expected": "visible",
        "timeout_ms": 15000,
        "intent": "AC1: the trader is offered a dollar input mode",
        "next": "ac1-wait-percent-mode"
      },
      "ac1-wait-percent-mode": {
        "action": "ui.wait_for",
        "test_id": "close-amount-mode-percent",
        "expected": "visible",
        "timeout_ms": 15000,
        "intent": "AC1: the trader is offered a percent input mode",
        "next": "ac1-wait-slider"
      },
      "ac1-wait-slider": {
        "action": "ui.wait_for",
        "test_id": "close-amount-slider-pct-100",
        "expected": "visible",
        "timeout_ms": 15000,
        "intent": "AC1: the trader is offered the slider input mode alongside the two typed units",
        "next": "ac1-kill-capture-orphans"
      },
      "ac1-kill-capture-orphans": {
        "action": "command",
        "cmd": "pkill -9 -f 'capture-helper' || true",
        "intent": "Clear capture-helper orphans so the screenshot comes from capture-helper",
        "next": "ac1-screenshot-modes"
      },
      "ac1-screenshot-modes": {
        "action": "ui.screenshot",
        "label": "AC1: close amount offers a $ mode, a % mode, and the slider",
        "intent": "AC1: show the trader all three ways of sizing a partial close on one screen",
        "next": "ac2-enter-usd-amount"
      },
      "ac2-enter-usd-amount": {
        "action": "ui.set_input",
        "value": "6",
        "timeout_ms": 15000,
        "intent": "AC2: the trader sizes the close by typing a dollar amount",
        "next": "ac2-assert-slider-moved",
        "selector": "[data-testid=\"close-amount-value\"] input"
      },
      "ac2-assert-slider-moved": {
        "action": "ui.wait_for",
        "selector": "[data-testid^=\"close-amount-slider-pct-\"]:not([data-testid=\"close-amount-slider-pct-100\"])",
        "expected": "visible",
        "timeout_ms": 15000,
        "intent": "AC2: the typed dollar amount resolves to a partial share of the position, not the whole position",
        "next": "ac2-kill-capture-orphans"
      },
      "ac2-kill-capture-orphans": {
        "action": "command",
        "cmd": "pkill -9 -f 'capture-helper' || true",
        "intent": "Clear capture-helper orphans so the screenshot comes from capture-helper",
        "next": "ac2-screenshot-usd"
      },
      "ac2-screenshot-usd": {
        "action": "ui.screenshot",
        "label": "AC2: a typed $ amount sizes the close and updates the order summary",
        "intent": "AC2: show the dollar amount the trader typed driving the close size and summary",
        "next": "ac3-switch-to-percent"
      },
      "ac3-switch-to-percent": {
        "action": "ui.press",
        "test_id": "close-amount-mode-percent",
        "timeout_ms": 15000,
        "intent": "AC3: the trader switches to sizing the close as a percentage",
        "next": "ac3-enter-percent"
      },
      "ac3-enter-percent": {
        "action": "ui.set_input",
        "value": "50",
        "timeout_ms": 15000,
        "intent": "AC3: the trader asks to close half of the position",
        "next": "ac3-assert-half",
        "selector": "[data-testid=\"close-amount-percent\"] input"
      },
      "ac3-assert-half": {
        "action": "ui.wait_for",
        "test_id": "close-amount-slider-pct-50",
        "expected": "visible",
        "timeout_ms": 15000,
        "intent": "AC3: entering 50 percent sizes the close at half the position",
        "next": "ac3-kill-capture-orphans"
      },
      "ac3-kill-capture-orphans": {
        "action": "command",
        "cmd": "pkill -9 -f 'capture-helper' || true",
        "intent": "Clear capture-helper orphans so the screenshot comes from capture-helper",
        "next": "ac3-screenshot-percent"
      },
      "ac3-screenshot-percent": {
        "action": "ui.screenshot",
        "label": "AC3: entering 50% closes half the position",
        "intent": "AC3: show a typed percentage sizing the close at half the position",
        "next": "ac5-enter-over-percent"
      },
      "ac5-enter-over-percent": {
        "action": "ui.set_input",
        "value": "150",
        "timeout_ms": 15000,
        "intent": "AC5: the trader asks to close more of the position than they hold",
        "next": "ac5-assert-capped",
        "selector": "[data-testid=\"close-amount-percent\"] input"
      },
      "ac5-assert-capped": {
        "action": "ui.wait_for",
        "test_id": "close-amount-slider-pct-100",
        "expected": "visible",
        "timeout_ms": 15000,
        "intent": "AC5: an over-100 percent request is capped at closing the whole position, so no over-sized order can be built",
        "next": "ac5-assert-message"
      },
      "ac5-assert-message": {
        "action": "ui.wait_for",
        "test_id": "close-amount-over-close-error",
        "expected": "visible",
        "timeout_ms": 15000,
        "intent": "AC5: the trader is told their percentage was capped",
        "next": "ac5-kill-capture-orphans"
      },
      "ac5-kill-capture-orphans": {
        "action": "command",
        "cmd": "pkill -9 -f 'capture-helper' || true",
        "intent": "Clear capture-helper orphans so the screenshot comes from capture-helper",
        "next": "ac5-screenshot-percent-cap"
      },
      "ac5-screenshot-percent-cap": {
        "action": "ui.screenshot",
        "label": "AC5: entering 150% is capped at 100% with an explanation",
        "intent": "AC5: show the capped percentage and the message explaining the cap",
        "next": "ac4-switch-to-usd"
      },
      "ac4-switch-to-usd": {
        "action": "ui.press",
        "test_id": "close-amount-mode-usd",
        "timeout_ms": 15000,
        "intent": "AC4: the trader switches back to sizing the close in dollars",
        "next": "ac4-settle-usd"
      },
      "ac4-assert-capped": {
        "action": "ui.wait_for",
        "test_id": "close-amount-slider-pct-100",
        "expected": "visible",
        "timeout_ms": 15000,
        "intent": "AC4: a dollar amount above the position notional is capped at closing the whole position, so no over-sized order can be built",
        "next": "ac4-assert-message"
      },
      "ac4-assert-message": {
        "action": "ui.wait_for",
        "test_id": "close-amount-over-close-error",
        "expected": "visible",
        "timeout_ms": 15000,
        "intent": "AC4: the trader is told their dollar amount was capped at the position value",
        "next": "ac4-kill-capture-orphans"
      },
      "ac4-kill-capture-orphans": {
        "action": "command",
        "cmd": "pkill -9 -f 'capture-helper' || true",
        "intent": "Clear capture-helper orphans so the screenshot comes from capture-helper",
        "next": "ac4-screenshot-usd-cap"
      },
      "ac4-screenshot-usd-cap": {
        "action": "ui.screenshot",
        "label": "AC4: a $ amount above the position value is capped with an explanation",
        "intent": "AC4: show the capped dollar amount and the message explaining the cap",
        "next": "ac6-run-instrumentation-tests"
      },
      "ac6-run-instrumentation-tests": {
        "action": "command",
        "cmd": "yarn jest ui/components/app/perps/close-position/close-position-modal.test.tsx ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx ui/hooks/perps/usePerpsAttribution.test.ts --no-coverage -t 'input method|not max'",
        "timeout_ms": 600000,
        "intent": "Instrumentation: run the tests that pin which input mode is reported on a close",
        "next": "ac6-assert-tests-passed"
      },
      "ac6-assert-tests-passed": {
        "action": "assert_output",
        "node": "ac6-run-instrumentation-tests",
        "contains": "9 passed",
        "intent": "Instrumentation: confirm every input-mode attribution case actually ran and passed",
        "next": "teardown-close-modal",
        "stream": "stderr"
      },
      "teardown-close-modal": {
        "action": "ui.press",
        "test_id": "perps-close-position-back-button",
        "timeout_ms": 15000,
        "intent": "Leave the partial close screen without submitting, so the position is unchanged for the next run",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      },
      "setup-settle-menu": {
        "action": "wait",
        "duration_ms": 1000,
        "intent": "Let the position management popover finish opening before choosing from it",
        "next": "setup-wait-menu"
      },
      "setup-settle-modal": {
        "action": "wait",
        "duration_ms": 1000,
        "intent": "Let the partial close screen finish opening before reading its controls",
        "next": "setup-wait-modal"
      },
      "setup-settle-market": {
        "action": "wait",
        "duration_ms": 6000,
        "intent": "Let the market screen finish loading the live position before reading it",
        "next": "setup-scroll-to-position"
      },
      "setup-scroll-to-position": {
        "action": "ui.scroll",
        "test_id": "perps-position-size-value",
        "scroll_into_view": true,
        "timeout_ms": 30000,
        "intent": "A trader reviews their open position details before deciding how much of it to close",
        "next": "setup-wait-position"
      },
      "setup-settle-before-press": {
        "action": "wait",
        "duration_ms": 2000,
        "intent": "Let the live position figures stop updating so the trader’s next click is not lost mid-render",
        "next": "setup-open-modify-menu"
      },
      "ac4-enter-over-usd": {
        "action": "ui.set_input",
        "selector": "[data-testid=\"close-amount-value\"] input",
        "value": "99.99",
        "timeout_ms": 15000,
        "intent": "AC4: the trader asks to close more dollars than the position is worth",
        "next": "ac4-assert-capped"
      },
      "ac4-settle-usd": {
        "action": "wait",
        "duration_ms": 800,
        "intent": "Let the dollar field re-derive from the current close percentage before it is typed into",
        "next": "ac4-enter-over-usd"
      }
    }
  }
}
```

</details>

Close amount now takes a $ or a % as well as the slider, and an over-close in either unit is capped with an explanation.

<table>
<tr><td align="center" valign="top" width="50%"><strong>Before: close amount had a $ field, a slider, and a read-only percent chip — no way to type a percentage</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/45700/before-close-amount-section.png?sha=08b92446c65e6896" alt="Before: close amount had a $ field, a slider, and a read-only percent chip — no way to type a percentage" width="320" /></td><td align="center" valign="top" width="50%"><strong>After: a $ / % selector sits beside Close amount, with the slider still available as the third mode</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/45700/after-ac1-three-input-modes.png?sha=2a4ffa39d54a5ead" alt="After: a $ / % selector sits beside Close amount, with the slider still available as the third mode" width="320" /></td></tr>
<tr><td align="center" valign="top" width="50%"><strong>Typing $6 sizes the close at 49% and halves the margin and payout</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/45700/after-ac2-usd-amount.png?sha=5c8bed066e1c1d12" alt="Typing $6 sizes the close at 49% and halves the margin and payout" width="320" /></td><td align="center" valign="top" width="50%"><strong>Typing 50% sizes the close at half the position</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/45700/after-ac3-percent-amount.png?sha=ba717ac979039c48" alt="Typing 50% sizes the close at half the position" width="320" /></td></tr>
<tr><td align="center" valign="top" width="50%"><strong>A $ amount above the position is capped at the position value with an explanation, so the order cannot over-close</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/45700/after-ac4-usd-capped.png?sha=13ae7420fdd15af1" alt="A $ amount above the position is capped at the position value with an explanation, so the order cannot over-close" width="320" /></td><td align="center" valign="top" width="50%"><strong>A percentage above 100 is capped at 100% with an explanation, so the order cannot over-close</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/45700/after-ac5-percent-capped.png?sha=65860e8f9849f821" alt="A percentage above 100 is capped at 100% with an explanation, so the order cannot over-close" width="320" /></td></tr>
</table>


[TAT-2857]: https://consensyssoftware.atlassian.net/browse/TAT-2857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how close order size is computed and submitted (rounding/flooring and full-close omission). A bug here could close more or less of a live position than the trader intended.
> 
> **Overview**
> Lets traders size a partial perps close in **USD or percent** (plus the existing slider), with all three modes sharing one `closePercent`. Over-close amounts are **capped at the full position** and explained inline so an oversized order cannot be built.
> 
> `buildCloseRequestParams` now **floors a rounded-up partial size** so it never equals the whole position (or omits `size` for a true full close when stepping back would hit zero). Close submissions also send `trackingData.inputMethod` (`keypad` / `percentage` / `slider` / `default`) to match mobile attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f09eecf09afeebde0e6ac5cc81c32586dab46b69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->