### PR TITLE
fix(confirmations): use submitted gas for balance checks

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -609,7 +609,7 @@
       "React: Act warnings (component updates not wrapped)": 2
     },
     "ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts": {
-      "MetaMask: Background connection not initialized": 36
+      "MetaMask: Background connection not initialized": 40
     },
     "ui/pages/confirmations/components/confirm/info/info.test.tsx": {
       "MetaMask: Background connection not initialized": 61,
@@ -802,7 +802,7 @@
       "React: Act warnings (component updates not wrapped)": 1
     },
     "ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts": {
-      "MetaMask: Background connection not initialized": 36
+      "MetaMask: Background connection not initialized": 40
     },
     "ui/pages/confirmations/hooks/useSmartTransactionFeatureFlags.test.ts": {
       "Reselect: Identity function warnings": 1

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -276,7 +276,7 @@ describe('useFeeCalculations', () => {
     `);
   });
 
-  it('uses a max fee gas limit override without changing the estimated fee', () => {
+  it('uses txParams gas for balance checks without changing the estimated fee', () => {
     const transactionMeta = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
     }) as TransactionMeta;
@@ -286,7 +286,7 @@ describe('useFeeCalculations', () => {
     const { result } = renderHookWithConfirmContextProvider(
       () =>
         useFeeCalculations(transactionMeta, {
-          maxFeeGasLimit: '0xab77',
+          useBalanceCheckGasLimit: true,
         }),
       mockState,
     );
@@ -341,7 +341,7 @@ describe('useFeeCalculations', () => {
     expect(result.current.maxFeeNative).toBe('< 0.0001');
   });
 
-  it('returns the correct estimate if quoted swap is displayed in info', () => {
+  it('uses quoted gas for balance checks if a quoted swap is displayed', () => {
     jest.spyOn(DappSwapContext, 'useDappSwapContextOptional').mockReturnValue({
       selectedQuote: mockBridgeQuotes[0] as unknown as QuoteResponseV1,
       setSelectedQuote: jest.fn(),
@@ -356,7 +356,10 @@ describe('useFeeCalculations', () => {
     transactionMeta.layer1GasFee = '0x10000000000000';
 
     const { result } = renderHookWithConfirmContextProvider(
-      () => useFeeCalculations(transactionMeta),
+      () =>
+        useFeeCalculations(transactionMeta, {
+          useBalanceCheckGasLimit: true,
+        }),
       mockState,
     );
 

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -276,6 +276,25 @@ describe('useFeeCalculations', () => {
     `);
   });
 
+  it('uses a max fee gas limit override without changing the estimated fee', () => {
+    const transactionMeta = genUnapprovedContractInteractionConfirmation({
+      address: CONTRACT_INTERACTION_SENDER_ADDRESS,
+    }) as TransactionMeta;
+
+    transactionMeta.gasUsed = toHex(37000);
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () =>
+        useFeeCalculations(transactionMeta, {
+          maxFeeGasLimit: '0xab77',
+        }),
+      mockState,
+    );
+
+    expect(result.current.estimatedFeeNativeHex).toBe('0x60183e087418');
+    expect(result.current.maxFeeHex).toBe('0x720087dcfc95');
+  });
+
   it('returns the correct estimate for a transaction with layer1GasFee', () => {
     const transactionMeta = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -41,6 +41,11 @@ const EMPTY_FEE = '';
 
 const MIN_NATIVE_FEE_THRESHOLD = 0.0001;
 
+type UseFeeCalculationsOptions = {
+  /** Gas limit used only to calculate the maximum fee. */
+  maxFeeGasLimit?: Hex;
+};
+
 const ETH_CONVERSION_RATE_FALLBACK_CHAIN_IDS = [
   CHAIN_IDS.SEPOLIA,
   CHAIN_IDS.LINEA_SEPOLIA,
@@ -95,7 +100,10 @@ function applySmallNativeFeeThreshold(nativeFee: string, hexFee: Hex): string {
   return nativeFee;
 }
 
-export function useFeeCalculations(transactionMeta: TransactionMeta) {
+export function useFeeCalculations(
+  transactionMeta: TransactionMeta,
+  { maxFeeGasLimit }: UseFeeCalculationsOptions = {},
+) {
   const currentCurrency = useSelector(getCurrentCurrency);
   const { chainId } = transactionMeta;
   const fiatFormatter = useFiatFormatter();
@@ -235,12 +243,13 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
         supportsEIP1559
           ? (decimalToHex(maxFeePerGas) as Hex)
           : (gasPrice as Hex),
-        optimizedGasLimit as Hex,
+        maxFeeGasLimit ?? optimizedGasLimit,
       ),
     ) as Hex;
   }, [
     gasPrice,
     layer1GasFee,
+    maxFeeGasLimit,
     maxFeePerGas,
     optimizedGasLimit,
     supportsEIP1559,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -42,8 +42,8 @@ const EMPTY_FEE = '';
 const MIN_NATIVE_FEE_THRESHOLD = 0.0001;
 
 type UseFeeCalculationsOptions = {
-  /** Gas limit used only to calculate the maximum fee. */
-  maxFeeGasLimit?: Hex;
+  /** Whether the maximum fee should use the gas limits submitted on confirm. */
+  useBalanceCheckGasLimit?: boolean;
 };
 
 const ETH_CONVERSION_RATE_FALLBACK_CHAIN_IDS = [
@@ -102,7 +102,7 @@ function applySmallNativeFeeThreshold(nativeFee: string, hexFee: Hex): string {
 
 export function useFeeCalculations(
   transactionMeta: TransactionMeta,
-  { maxFeeGasLimit }: UseFeeCalculationsOptions = {},
+  { useBalanceCheckGasLimit }: UseFeeCalculationsOptions = {},
 ) {
   const currentCurrency = useSelector(getCurrentCurrency);
   const { chainId } = transactionMeta;
@@ -128,6 +128,11 @@ export function useFeeCalculations(
 
   const { gasLimit: optimizedGasLimit, quotedGasLimit } =
     useTransactionGasLimit(transactionMeta);
+  const gasLimitForMaxFee = useBalanceCheckGasLimit
+    ? (quotedGasLimit ??
+      (transactionMeta.txParams?.gas as Hex | undefined) ??
+      optimizedGasLimit)
+    : optimizedGasLimit;
 
   const getFeesFromHex = useCallback(
     (hexFee: Hex) => {
@@ -243,15 +248,14 @@ export function useFeeCalculations(
         supportsEIP1559
           ? (decimalToHex(maxFeePerGas) as Hex)
           : (gasPrice as Hex),
-        maxFeeGasLimit ?? optimizedGasLimit,
+        gasLimitForMaxFee,
       ),
     ) as Hex;
   }, [
+    gasLimitForMaxFee,
     gasPrice,
     layer1GasFee,
-    maxFeeGasLimit,
     maxFeePerGas,
-    optimizedGasLimit,
     supportsEIP1559,
   ]);
 

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
@@ -107,6 +107,28 @@ describe('useHasInsufficientBalance', () => {
     expect(result.isNativeBalanceKnown).toBe(true);
   });
 
+  it('uses submitted gas limit instead of simulation gas for balance check', () => {
+    const transaction = {
+      ...TRANSACTION_MOCK,
+      gasUsed: '0xe429',
+      gasLimitNoBuffer: '0xf807',
+      txParams: {
+        ...TRANSACTION_MOCK.txParams,
+        value: '0x0',
+        gas: '0x1740a',
+        maxFeePerGas: '0x83fdd112',
+      },
+    } as TransactionMeta;
+
+    const result = runHook({
+      balance: 167208508861377,
+      currentConfirmation: transaction,
+      transaction,
+    });
+
+    expect(result.hasInsufficientBalance).toBe(true);
+  });
+
   it('sums nested transaction values correctly', () => {
     const BATCH_TRANSACTION_MOCK = {
       ...TRANSACTION_MOCK,

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -49,9 +49,7 @@ export function useHasInsufficientBalance(): {
     currentConfirmation?.txParams
       ? currentConfirmation
       : ({ txParams: {} } as TransactionMeta),
-    {
-      maxFeeGasLimit: currentConfirmation?.txParams?.gas as Hex | undefined,
-    },
+    { useBalanceCheckGasLimit: true },
   );
 
   const { nativeCurrencySymbol } = useNativeCurrencySymbol(chainId);

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -49,6 +49,9 @@ export function useHasInsufficientBalance(): {
     currentConfirmation?.txParams
       ? currentConfirmation
       : ({ txParams: {} } as TransactionMeta),
+    {
+      maxFeeGasLimit: currentConfirmation?.txParams?.gas as Hex | undefined,
+    },
   );
 
   const { nativeCurrencySymbol } = useNativeCurrencySymbol(chainId);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Context

The confirmation flow calculates realistic fee estimates using simulation-oriented gas limits such as `gasUsed` or `gasLimitNoBuffer`. The transaction submitted to the network can retain a larger buffered `txParams.gas` limit. MetaMask-selected dapp swap quotes are a special case because confirmation can submit both approval and trade transactions using the quote's gas limits.

### Problem

The insufficient-balance guard reused the display-oriented maximum fee. When the native balance covered the simulated fee but not `txParams.gas × maxFeePerGas`, MetaMask omitted the blocking alert and allowed the RPC to reject the transaction for insufficient funds.

### Solution

Use safety-specific gas-limit selection for the maximum fee used by `useHasInsufficientBalance`. It prefers the combined approval and trade gas for a selected MetaMask swap quote, otherwise uses the submitted `txParams.gas`. Display consumers continue using the optimized simulation gas limit.

### Implementation notes

- Quoted swaps retain combined approval-plus-trade gas precedence because those transaction details are applied on confirmation.
- Ordinary EIP-1559 and legacy transactions use their submitted gas limit for the balance check.
- EIP-1559 and legacy fee-price selection remains unchanged.
- Layer 1 fees remain additive.
- Missing submitted gas falls back to the existing optimized gas limit.
- Focused tests reproduce the reported balance boundary, cover quoted-swap precedence, and confirm estimated fee displays remain unchanged.

## **Changelog**

CHANGELOG entry: Fixed an issue that allowed transactions to be submitted when the native balance could not cover the maximum network fee.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1762

## **Manual testing steps**

1. On Ethereum Mainnet, prepare an account whose ETH balance covers the simulated gas cost but not the maximum cost calculated with the submitted buffered gas limit.
2. Start a USDT transfer and open its confirmation.
3. Verify the displayed network-fee estimate still uses the optimized simulation estimate.
4. Verify a blocking insufficient-ETH alert appears before submission and prevents the transaction from reaching the RPC.
5. Increase the ETH balance above the submitted transaction's maximum gas cost and verify the alert clears.
6. Repeat with a dapp swap where a MetaMask quote includes approval and trade transactions, and verify the balance check accounts for both quoted gas limits.

## **Local validation**

- `npx jest --no-watchman ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts`
- `yarn lint:changed:fix`
- `yarn lint:changed`
- `yarn lint:tsc`

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmation fee math and the insufficient-balance gate, so a wrong gas-limit choice could block valid txs or still allow underfunded ones. Display estimates are unchanged.
> 
> **Overview**
> Stops confirmations from allowing submit when native balance covers the *simulated* max fee but not the *submitted* `txParams.gas × maxFeePerGas` (or quoted swap gas). The RPC then used to reject with insufficient funds.
> 
> `useFeeCalculations` now takes `useBalanceCheckGasLimit`. When set, max fee uses quoted swap gas if present, else submitted `txParams.gas`, else the existing optimized/simulation limit. Displayed estimated fees still use simulation gas. `useHasInsufficientBalance` opts into this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3161fb5a01d9183ce9379f6229d3dcba7a377de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->