### PR TITLE
test(e2e): add shared fixture session helper

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -2295,12 +2295,24 @@ initOrRestoreBackground().catch((error) => {
   log.error('initOrRestoreBackground failed', error);
 });
 
+/* istanbul ignore next: test-only E2E control path */
+async function resetFixtureStateForTest() {
+  await evacuate();
+  await persistenceManager.reset({ initializeStore: false });
+}
+
+/* istanbul ignore next: test-only E2E control path */
 if (process.env.IN_TEST) {
+  const { setFixtureStateResetHandler } =
+    // Use `require` to make it easier to exclude this test code from the Browserify build.
+    // eslint-disable-next-line n/global-require
+    require('../../test/e2e/background-socket/socket-background-to-mocha');
+  setFixtureStateResetHandler(resetFixtureStateForTest);
   // listen for test messages from the background
-  // maintenance note: if you can't find any tests containing 'STOP_PERSISTENCE'
-  // you can remove this, and probably the evacuate function in app\scripts\lib\safe-reload.ts too.
   browser.runtime.onMessage.addListener(async (message, _sender) => {
     if (message.type === 'STOP_PERSISTENCE') {
+      // Maintenance note: if no tests contain 'STOP_PERSISTENCE',
+      // remove this message branch. Only remove `evacuate` if it is otherwise unused.
       await evacuate();
       return { status: 'PERSISTENCE_STOPPED' };
     }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -2304,7 +2304,7 @@ async function resetFixtureStateForTest() {
 /* istanbul ignore next: test-only E2E control path */
 if (process.env.IN_TEST) {
   const { setFixtureStateResetHandler } =
-    // Use `require` to make it easier to exclude this test code from the Browserify build.
+    // Load conditionally so this test-only code is excluded from production builds and policies.
     // eslint-disable-next-line n/global-require
     require('../../test/e2e/background-socket/socket-background-to-mocha');
   setFixtureStateResetHandler(resetFixtureStateForTest);

--- a/shared/lib/stores/base-store.ts
+++ b/shared/lib/stores/base-store.ts
@@ -39,6 +39,13 @@ export type MetaMaskStorageStructure = {
   meta?: MetaData;
 };
 
+export type StoreResetOptions = {
+  /**
+   * Whether fixture-backed stores should reinitialize themselves after reset.
+   */
+  initialize?: boolean;
+};
+
 /**
  * The BaseStore class is an abstract class designed to be extended by other
  * classes that implement the abstract methods `set` and `get`. This class
@@ -64,5 +71,5 @@ export type BaseStore = {
 
   get: () => Promise<MetaMaskStorageStructure | null>;
 
-  reset: () => Promise<void>;
+  reset: (options?: StoreResetOptions) => Promise<void>;
 };

--- a/shared/lib/stores/extension-store.ts
+++ b/shared/lib/stores/extension-store.ts
@@ -5,6 +5,7 @@ import type {
   MetaMaskStorageStructure,
   BaseStore,
   MetaData,
+  StoreResetOptions,
 } from './base-store';
 
 const { sentry } = globalThis;
@@ -185,14 +186,17 @@ export default class ExtensionStore implements BaseStore {
   /**
    * Removes all keys contained in the manifest from the `local` extension
    * storage area.
+   *
+   * @param _options - Ignored by ExtensionStore; accepted for BaseStore compatibility.
    */
-  async reset(): Promise<void> {
+  async reset(_options?: StoreResetOptions): Promise<void> {
     if (!this.isSupported) {
       throw new Error(
         'MetaMask - cannot persist state to local store as this browser does not support this action',
       );
     }
     const { local } = browser.storage;
-    return await local.remove(['manifest', ...this.#manifest]);
+    await local.remove(['manifest', ...this.#manifest]);
+    this.#manifest.clear();
   }
 }

--- a/shared/lib/stores/fixture-extension-store.test.ts
+++ b/shared/lib/stores/fixture-extension-store.test.ts
@@ -29,6 +29,10 @@ jest.mock('webextension-polyfill', () => {
       this.#state = value;
     }
 
+    async remove() {
+      this.#state = null;
+    }
+
     async clear() {
       this.#state = null;
     }
@@ -183,6 +187,37 @@ describe('FixtureExtensionStore', () => {
         data: { appState: { test: true } },
         meta: { version: 10 },
       });
+    });
+  });
+
+  describe('reset', () => {
+    it('reinitializes fixture state by default', async () => {
+      const nextState = {
+        data: { config: { hello: 'world' } },
+        meta: { version: 2 },
+      };
+      setMockFixtureServerReply(MOCK_STATE);
+      const store = new FixtureExtensionStore({ initialize: true });
+      await store.get();
+      setMockFixtureServerReply(nextState);
+
+      await store.reset();
+      const result = await store.get();
+
+      expect(result).toStrictEqual(nextState);
+    });
+
+    it('can reset storage without reinitializing fixture state', async () => {
+      setMockFixtureServerReply(MOCK_STATE);
+      const store = new FixtureExtensionStore({ initialize: true });
+      await store.get();
+      const interceptor = mockFixtureServerInterceptor().reply(200, MOCK_STATE);
+
+      await store.reset({ initialize: false });
+      const result = await store.get();
+
+      expect(result).toBe(null);
+      expect(interceptor.isDone()).toBe(false);
     });
   });
 

--- a/shared/lib/stores/fixture-extension-store.ts
+++ b/shared/lib/stores/fixture-extension-store.ts
@@ -5,7 +5,7 @@ import { getManifestFlags } from '../manifestFlags';
 import { PLATFORM_FIREFOX } from '../../constants/app';
 import { getBrowserName } from '../browser-runtime.utils';
 import ExtensionStore from './extension-store';
-import type { MetaMaskStorageStructure } from './base-store';
+import type { MetaMaskStorageStructure, StoreResetOptions } from './base-store';
 import {
   STORAGE_SERVICE_INDEXED_DB_NAME,
   STORAGE_SERVICE_INDEXED_DB_VERSION,
@@ -165,10 +165,17 @@ export class FixtureExtensionStore extends ExtensionStore {
     return super.set(data);
   }
 
-  async reset(): Promise<void> {
+  async reset({ initialize = true }: StoreResetOptions = {}): Promise<void> {
     this.#initialized = false;
     await super.reset();
-    this.#initializing = this.#init();
-    await this.#initializing;
+
+    if (initialize) {
+      this.#initializing = this.#init();
+      await this.#initializing;
+      return;
+    }
+
+    this.#initializing = Promise.resolve();
+    this.#initialized = true;
   }
 }

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -1142,6 +1142,20 @@ describe('PersistenceManager', () => {
     });
   });
 
+  describe('reset', () => {
+    it('initializes the local store by default', async () => {
+      await manager.reset();
+
+      expect(mockStoreReset).toHaveBeenCalledWith({ initialize: true });
+    });
+
+    it('can skip local store initialization', async () => {
+      await manager.reset({ initializeStore: false });
+
+      expect(mockStoreReset).toHaveBeenCalledWith({ initialize: false });
+    });
+  });
+
   describe('Locks', () => {
     it('should acquire a lock when setting state', async () => {
       manager.storageKind = 'data';

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -109,6 +109,9 @@ function delay(ms: number, signal?: AbortSignal): Promise<boolean> {
   });
 }
 
+export type PersistenceManagerResetOptions = {
+  initializeStore?: boolean;
+};
 /**
  * Checks whether IndexedDB mutations are blocked, as can happen for Firefox
  * extensions in private browsing mode.
@@ -1020,15 +1023,18 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
    * Resets the local store and the backup database. This method is used to
    * clear the state and metadata, effectively resetting the application to
    * its initial state.
+   *
+   * @param options - Reset behavior options.
+   * @param options.initializeStore - Whether the local store should initialize after reset.
    */
-  async reset() {
+  async reset({ initializeStore = true }: PersistenceManagerResetOptions = {}) {
     this.#supersedeWriteRetry();
     await navigator.locks.request(
       STATE_LOCK,
       { mode: 'exclusive' },
       async () => {
         await Promise.all([
-          this.#localStore.reset(),
+          this.#localStore.reset({ initialize: initializeStore }),
           await this.#backupDb?.reset(),
         ]);
         this.#backup = undefined;

--- a/test/e2e/background-socket/server-mocha-to-background.ts
+++ b/test/e2e/background-socket/server-mocha-to-background.ts
@@ -6,6 +6,8 @@ import {
   WindowProperties,
 } from './types';
 
+const RESPONSE_TIMEOUT_MS = 30_000;
+
 /**
  * This singleton class runs on the Mocha/Selenium test.
  * It's used to communicate from the Mocha/Selenium test to the Extension background script (service worker in MV3).
@@ -15,9 +17,13 @@ class ServerMochaToBackground {
 
   private ws: WebSocket | null = null;
 
+  private connectionVersion = 0;
+
   private eventEmitter;
 
   constructor() {
+    this.eventEmitter = new events.EventEmitter<ServerMochaEventEmitterType>();
+
     this.server = new WebSocketServer({ port: 8111 });
 
     console.debug('ServerMochaToBackground created');
@@ -32,8 +38,10 @@ class ServerMochaToBackground {
       }
 
       this.ws = ws;
+      this.connectionVersion += 1;
 
       console.debug('ServerMochaToBackground got a client connection');
+      this.eventEmitter.emit('connection');
 
       ws.onmessage = (ev: MessageEvent) => {
         let message: MessageType;
@@ -56,8 +64,6 @@ class ServerMochaToBackground {
         console.debug('ServerMochaToBackground disconnected from client');
       };
     });
-
-    this.eventEmitter = new events.EventEmitter<ServerMochaEventEmitterType>();
   }
 
   // This function is never explicitly called, but in the future it could be
@@ -80,8 +86,17 @@ class ServerMochaToBackground {
 
   // Handle messages received from the Extension background script (service worker in MV3)
   private receivedMessage(message: MessageType) {
-    if (message.command === 'openTabs' && message.tabs) {
-      this.eventEmitter.emit('openTabs', message.tabs);
+    if (message.command === 'openTabs') {
+      this.eventEmitter.emit('openTabs', message.tabs ?? []);
+    } else if (message.command === 'fixtureStateReset') {
+      this.eventEmitter.emit('fixtureStateReset');
+    } else if (message.command === 'fixtureStateResetError') {
+      const error = new Error(message.error);
+      if (this.eventEmitter.listenerCount('error') > 0) {
+        this.eventEmitter.emit('error', error);
+      } else {
+        throw error;
+      }
     } else if (message.command === 'notFound') {
       const error = new Error(
         `No window found by background script with ${message.property}: ${message.value}`,
@@ -97,6 +112,80 @@ class ServerMochaToBackground {
   // This is not used in the current code, but could be used in the future
   queryTabs(tabTitle: string) {
     this.send({ command: 'queryTabs', title: tabTitle });
+  }
+
+  getConnectionVersion() {
+    return this.connectionVersion;
+  }
+
+  async resetFixtureState({
+    reloadServiceWorker = true,
+    waitForReconnect = true,
+  }: { reloadServiceWorker?: boolean; waitForReconnect?: boolean } = {}) {
+    const { connectionVersion } = this;
+
+    this.send({
+      command: 'resetFixtureState',
+      reloadServiceWorker,
+    });
+
+    await this.waitForFixtureStateResetResponse();
+    if (reloadServiceWorker && waitForReconnect) {
+      await this.waitForConnectionAfter(connectionVersion);
+    }
+  }
+
+  async waitForConnectionAfter(connectionVersion: number) {
+    if (this.connectionVersion > connectionVersion) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const { eventEmitter } = this;
+      const getConnectionVersion = () => this.connectionVersion;
+      const timeoutRef: { id?: ReturnType<typeof setTimeout> } = {};
+
+      function onConnection() {
+        if (getConnectionVersion() > connectionVersion) {
+          eventEmitter.removeListener('connection', onConnection);
+          clearTimeout(timeoutRef.id);
+          resolve();
+        }
+      }
+
+      timeoutRef.id = setTimeout(() => {
+        eventEmitter.removeListener('connection', onConnection);
+        reject(new Error('Timed out waiting for background socket reconnect'));
+      }, RESPONSE_TIMEOUT_MS);
+
+      eventEmitter.on('connection', onConnection);
+    });
+  }
+
+  async waitForFixtureStateResetResponse() {
+    return new Promise<void>((resolve, reject) => {
+      const { eventEmitter } = this;
+      const timeoutId = setTimeout(() => {
+        eventEmitter.removeListener('error', onError);
+        eventEmitter.removeListener('fixtureStateReset', onResponse);
+        reject(new Error('Timed out waiting for fixture state reset response'));
+      }, RESPONSE_TIMEOUT_MS);
+
+      function onResponse() {
+        eventEmitter.removeListener('error', onError);
+        clearTimeout(timeoutId);
+        resolve();
+      }
+
+      function onError(error: Error) {
+        eventEmitter.removeListener('fixtureStateReset', onResponse);
+        clearTimeout(timeoutId);
+        reject(error);
+      }
+
+      eventEmitter.once('error', onError);
+      eventEmitter.once('fixtureStateReset', onResponse);
+    });
   }
 
   // Sends the message to the Extension, and waits for a response

--- a/test/e2e/background-socket/socket-background-to-mocha.ts
+++ b/test/e2e/background-socket/socket-background-to-mocha.ts
@@ -3,6 +3,8 @@ import { isManifestV3 } from '../../../shared/lib/mv3.utils';
 import { handleQrSyncSimulateMessage } from '../helpers/qr-sync/qr-sync-e2e-bridge';
 import { MessageType, WindowProperties } from './types';
 
+type FixtureStateResetHandler = () => Promise<void>;
+
 /**
  * This singleton class runs on the Extension background script (service worker in MV3).
  * It's used to communicate from the Extension background script to the Mocha/Selenium test.
@@ -11,6 +13,8 @@ import { MessageType, WindowProperties } from './types';
  */
 class SocketBackgroundToMocha {
   private client: WebSocket;
+
+  private fixtureStateResetHandler?: FixtureStateResetHandler;
 
   constructor() {
     this.client = new WebSocket('ws://localhost:8111');
@@ -125,15 +129,47 @@ class SocketBackgroundToMocha {
       const tabs = await this.queryTabs({ title: message.title });
       log.debug('SocketBackgroundToMocha sending tabs:', tabs);
       this.send({ command: 'openTabs', tabs: this.cleanTabs(tabs) });
-    } else if (
-      message.command === 'waitUntilWindowWithProperty' &&
-      message.property &&
-      message.value
-    ) {
-      this.waitUntilWindowWithProperty(message.property, message.value);
+    } else if (message.command === 'waitUntilWindowWithProperty') {
+      if (message.property && message.value) {
+        this.waitUntilWindowWithProperty(message.property, message.value);
+      }
     } else if (message.command === 'qrSyncSimulate') {
       handleQrSyncSimulateMessage(message);
+    } else if (message.command === 'resetFixtureState') {
+      await this.resetFixtureState(message.reloadServiceWorker ?? false);
     }
+  }
+
+  private async resetFixtureState(reloadServiceWorker: boolean) {
+    if (!this.fixtureStateResetHandler) {
+      this.send({
+        command: 'fixtureStateResetError',
+        error: 'Fixture state reset handler is not registered',
+      });
+      return;
+    }
+
+    try {
+      await this.fixtureStateResetHandler();
+      this.send({
+        command: 'fixtureStateReset',
+      });
+
+      if (reloadServiceWorker) {
+        globalThis.setTimeout(() => {
+          chrome.runtime.reload();
+        }, 0);
+      }
+    } catch (error) {
+      this.send({
+        command: 'fixtureStateResetError',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  setFixtureStateResetHandler(handler: FixtureStateResetHandler) {
+    this.fixtureStateResetHandler = handler;
   }
 }
 
@@ -146,6 +182,10 @@ export function getSocketBackgroundToMocha() {
   }
 
   return _socketBackgroundToMocha;
+}
+
+export function setFixtureStateResetHandler(handler: FixtureStateResetHandler) {
+  getSocketBackgroundToMocha().setFixtureStateResetHandler(handler);
 }
 
 function startSocketBackgroundToMocha() {

--- a/test/e2e/background-socket/types.ts
+++ b/test/e2e/background-socket/types.ts
@@ -9,13 +9,18 @@ export type MessageType = {
     | 'notFound'
     | 'queryTabs'
     | 'waitUntilWindowWithProperty'
-    | 'qrSyncSimulate';
+    | 'qrSyncSimulate'
+    | 'fixtureStateReset'
+    | 'fixtureStateResetError'
+    | 'resetFixtureState';
   tabs?: chrome.tabs.Tab[];
   title?: string;
   property?: WindowProperties;
   value?: string;
   action?: QrSyncSimulatorAction;
   params?: SimulatorParams;
+  error?: string;
+  reloadServiceWorker?: boolean;
 };
 
 export type Handle = {
@@ -27,7 +32,8 @@ export type Handle = {
 export type WindowProperties = 'title' | 'url';
 
 export type ServerMochaEventEmitterType = {
+  connection: [];
   error: [error: Error];
+  fixtureStateReset: [];
   openTabs: [openTabs: chrome.tabs.Tab[]];
-  notFound: [openTabs: chrome.tabs.Tab[]];
 };

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -620,6 +620,7 @@ async function withFixtures(options, testSuite) {
       bundlerServer,
       contractRegistry,
       driver: effectiveDriver,
+      fixtureServer,
       localNodes,
       mockedEndpoint,
       mockServer,

--- a/test/e2e/helpers/fixture-session.test.ts
+++ b/test/e2e/helpers/fixture-session.test.ts
@@ -31,10 +31,7 @@ jest.mock('../helpers', () => ({
   ),
 }));
 
-type MochaHook = (
-  title: string,
-  callback: () => void | Promise<void>,
-) => void;
+type MochaHook = (title: string, callback: () => void | Promise<void>) => void;
 
 function wrapJestHook(
   jestHook: (callback: () => void | Promise<void>) => void,
@@ -56,10 +53,11 @@ const runnerContext: RunnerContext = {
   driver: {} as Driver,
 };
 
-const runFixtures: FixtureSessionRunner<RunnerOptions, RunnerContext> =
-  jest.fn(async (_options, testSuite) => {
+const runFixtures: FixtureSessionRunner<RunnerOptions, RunnerContext> = jest.fn(
+  async (_options, testSuite) => {
     await testSuite(runnerContext);
-  });
+  },
+);
 
 const fixtureOptions: RunnerOptions = {
   customOption: 'custom-option',

--- a/test/e2e/helpers/fixture-session.test.ts
+++ b/test/e2e/helpers/fixture-session.test.ts
@@ -1,0 +1,94 @@
+import type { Driver } from '../webdriver/driver';
+import {
+  configureFixtureSession,
+  type FixtureSessionRunner,
+} from './fixture-session';
+
+type RunnerOptions = {
+  customOption: string;
+  fixtures: unknown;
+};
+
+type RunnerContext = {
+  customContext: string;
+  driver: Driver;
+};
+
+jest.mock('../helpers', () => ({
+  withFixtures: jest.fn(
+    async (
+      _options: unknown,
+      testSuite: (context: { driver: Driver }) => Promise<void>,
+    ) => {
+      await testSuite({
+        driver: {
+          getAllWindowHandles: jest.fn().mockResolvedValue(['main']),
+          getCurrentWindowHandle: jest.fn().mockResolvedValue('main'),
+          openNewURL: jest.fn().mockResolvedValue(undefined),
+        } as unknown as Driver,
+      });
+    },
+  ),
+}));
+
+type MochaHook = (
+  title: string,
+  callback: () => void | Promise<void>,
+) => void;
+
+function wrapJestHook(
+  jestHook: (callback: () => void | Promise<void>) => void,
+): MochaHook {
+  return (_title, callback) => jestHook(callback);
+}
+
+const mochaHooks = globalThis as unknown as Record<
+  'after' | 'afterEach' | 'before' | 'beforeEach',
+  MochaHook
+>;
+mochaHooks.after = wrapJestHook(afterAll);
+mochaHooks.afterEach = wrapJestHook(globalThis.afterEach);
+mochaHooks.before = wrapJestHook(beforeAll);
+mochaHooks.beforeEach = wrapJestHook(globalThis.beforeEach);
+
+const runnerContext: RunnerContext = {
+  customContext: 'runner-context',
+  driver: {} as Driver,
+};
+
+const runFixtures: FixtureSessionRunner<RunnerOptions, RunnerContext> =
+  jest.fn(async (_options, testSuite) => {
+    await testSuite(runnerContext);
+  });
+
+const fixtureOptions: RunnerOptions = {
+  customOption: 'custom-option',
+  fixtures: { fixture: 'value' },
+};
+
+configureFixtureSession<RunnerOptions, RunnerContext>(
+  'custom fixture session runner',
+  {
+    ...fixtureOptions,
+    failFast: true,
+    navigateAfterEach: false,
+    resetAfterEach: false,
+    runFixtures,
+  },
+  ({ getFixtures }) => {
+    it('starts the shared session with the injected runner', () => {
+      expect(runFixtures).toHaveBeenCalledTimes(1);
+      expect(runFixtures).toHaveBeenCalledWith(
+        {
+          ...fixtureOptions,
+          title: 'custom fixture session runner',
+        },
+        expect.any(Function),
+      );
+    });
+
+    it('exposes the injected runner context', () => {
+      expect(getFixtures()).toBe(runnerContext);
+    });
+  },
+);

--- a/test/e2e/helpers/fixture-session.ts
+++ b/test/e2e/helpers/fixture-session.ts
@@ -12,17 +12,52 @@ type FixtureSessionContext = Parameters<WithFixturesTestSuite>[0] & {
 };
 
 /**
- * Options accepted by the shared fixture-session runner.
+ * Options accepted by the default (plain `withFixtures`) runner. Wrappers
+ * with richer option shapes (e.g. `withTronFixtures`, whose `testSpecificMock`
+ * takes a second `context` argument and whose `fixtures` is optional) pass
+ * their own `TRunnerOptions` to `configureFixtureSession` instead of this
+ * default.
  */
-type FixtureSessionOptions = WithFixturesOptions & {
+type BaseFixtureSessionRunnerOptions = WithFixturesOptions & {
   fixtures: unknown;
-  resetAfterEach?: boolean;
   testSpecificMock?: (mockServer: Mockttp) => unknown | Promise<unknown>;
 };
 
-export type FixtureSessionAccessors = {
+/**
+ * Fixture runner used to start the shared session. Generic so wrappers with
+ * richer option/context shapes (e.g. `withTronFixtures`) can be plugged in
+ * via `runFixtures` without casting: `TRunnerOptions` is whatever options the
+ * runner itself expects, and `TRunnerContext` is the context it hands to the
+ * test suite callback.
+ */
+export type FixtureSessionRunner<
+  TRunnerOptions extends object = BaseFixtureSessionRunnerOptions,
+  TRunnerContext extends { driver: Driver } = FixtureSessionContext,
+> = (
+  options: TRunnerOptions,
+  testSuite: (context: TRunnerContext) => Promise<void> | void,
+) => Promise<void>;
+
+export type FixtureSessionOptions<
+  TRunnerOptions extends object = BaseFixtureSessionRunnerOptions,
+  TRunnerContext extends { driver: Driver } = FixtureSessionContext,
+> = TRunnerOptions & {
+  // When true, skip the remaining tests in the suite after the first test
+  // failure (fail-fast). Defaults to false.
+  failFast?: boolean;
+  // When false, the between-test afterEach neither closes auxiliary windows
+  // nor navigates to about:blank. Defaults to true (current behavior).
+  navigateAfterEach?: boolean;
+  resetAfterEach?: boolean;
+  // Fixture runner that starts the shared session. Defaults to `withFixtures`.
+  runFixtures?: FixtureSessionRunner<TRunnerOptions, TRunnerContext>;
+};
+
+export type FixtureSessionAccessors<
+  TRunnerContext extends { driver: Driver } = FixtureSessionContext,
+> = {
   getDriver: () => Driver;
-  getFixtures: () => FixtureSessionContext;
+  getFixtures: () => TRunnerContext;
 };
 
 const OFFSCREEN_PAGE_PATH = '/offscreen.html';
@@ -201,25 +236,30 @@ async function resetSharedFixtureSession(fixtureContext: {
  * across all tests in the suite to reduce repeated E2E setup cost.
  *
  * @param suiteTitle - The Mocha suite title for the shared-session tests.
- * @param fixtureOptions - The `withFixtures` options used to start the shared
- * session, plus the `resetAfterEach` behavior flag.
+ * @param fixtureOptions - The fixture-runner options used to start the shared
+ * session, plus the session behavior flags (`resetAfterEach`, `failFast`,
+ * `navigateAfterEach`, `runFixtures`).
  * @param defineSuite - Callback that defines the suite's tests and hooks using
  * the shared driver and fixture accessors.
  */
-export function configureFixtureSession(
+export function configureFixtureSession<
+  TRunnerOptions extends object = BaseFixtureSessionRunnerOptions,
+  TRunnerContext extends { driver: Driver } = FixtureSessionContext,
+>(
   suiteTitle: string,
-  fixtureOptions: FixtureSessionOptions,
-  defineSuite: (accessors: FixtureSessionAccessors) => void,
+  fixtureOptions: FixtureSessionOptions<TRunnerOptions, TRunnerContext>,
+  defineSuite: (accessors: FixtureSessionAccessors<TRunnerContext>) => void,
 ): void {
   const sharedSuite = describe(suiteTitle, function () {
-    const fixtureSetup = createDeferredPromise<FixtureSessionContext>();
+    const fixtureSetup = createDeferredPromise<TRunnerContext>();
     const suiteFinished = createDeferredPromise<void>();
 
+    let firstTestFailureError: Error | undefined;
     let fixturePromise: Promise<void> | undefined;
-    let fixtures: FixtureSessionContext | undefined;
+    let fixtures: TRunnerContext | undefined;
     let sessionPoisonedError: Error | undefined;
 
-    const getFixtures = (): FixtureSessionContext => {
+    const getFixtures = (): TRunnerContext => {
       if (!fixtures) {
         throw new Error(
           'Fixture session is not ready yet; call getDriver()/getFixtures() only inside test or hook bodies after the shared fixture session `before` hook has run.',
@@ -234,16 +274,28 @@ export function configureFixtureSession(
     };
 
     before('Set up shared fixture session', async function () {
-      const { resetAfterEach: _resetAfterEach, ...withFixturesOptions } =
-        fixtureOptions;
+      const {
+        failFast: _failFast,
+        navigateAfterEach: _navigateAfterEach,
+        resetAfterEach: _resetAfterEach,
+        // The default runner only matches `TRunnerOptions`/`TRunnerContext`
+        // when the caller uses the default type parameters (plain
+        // `withFixtures`); callers that pass their own `TRunnerOptions` (e.g.
+        // Tron's `withTronFixtures`) always supply their own `runFixtures`.
+        runFixtures = withFixtures as unknown as FixtureSessionRunner<
+          TRunnerOptions,
+          TRunnerContext
+        >,
+        ...withFixturesOptions
+      } = fixtureOptions;
       const { title } = withFixturesOptions as { title?: string };
       const options = {
         ...withFixturesOptions,
         title: title ?? suiteTitle,
-      };
+      } as TRunnerOptions;
 
-      fixturePromise = withFixtures(options, async (fixtureContext) => {
-        fixtures = fixtureContext as FixtureSessionContext;
+      fixturePromise = runFixtures(options, async (fixtureContext) => {
+        fixtures = fixtureContext;
         fixtureSetup.resolve(fixtures);
         await suiteFinished.promise;
       });
@@ -261,6 +313,10 @@ export function configureFixtureSession(
           `Shared fixture session is no longer reusable because reset failed: ${sessionPoisonedError.message}`,
         );
       }
+
+      if ((fixtureOptions.failFast ?? false) && firstTestFailureError) {
+        this.skip();
+      }
     });
 
     defineSuite({ getDriver, getFixtures });
@@ -270,7 +326,19 @@ export function configureFixtureSession(
     afterEach(
       'Reset shared fixture session state between tests',
       async function () {
+        if (this.currentTest?.state === 'failed' && !firstTestFailureError) {
+          firstTestFailureError =
+            this.currentTest.err ??
+            new Error(`Test failed: ${this.currentTest.fullTitle()}`);
+        }
+
         if (sessionPoisonedError) {
+          return;
+        }
+
+        const resetAfterEach = fixtureOptions.resetAfterEach ?? true;
+        const navigateAfterEach = fixtureOptions.navigateAfterEach ?? true;
+        if (!resetAfterEach && !navigateAfterEach) {
           return;
         }
 
@@ -279,15 +347,17 @@ export function configureFixtureSession(
           const { driver } = fixtureContext;
 
           if (
-            (fixtureOptions.resetAfterEach ?? true) &&
+            resetAfterEach &&
             this.currentTest &&
             shouldResetSharedFixtureSession(sharedSuite, this.currentTest)
           ) {
             await resetSharedFixtureSession(fixtureContext);
           }
 
-          await closeAuxiliaryWindows(driver);
-          await driver.openNewURL('about:blank');
+          if (navigateAfterEach) {
+            await closeAuxiliaryWindows(driver);
+            await driver.openNewURL('about:blank');
+          }
         } catch (error) {
           sessionPoisonedError =
             error instanceof Error ? error : new Error(String(error));

--- a/test/e2e/helpers/fixture-session.ts
+++ b/test/e2e/helpers/fixture-session.ts
@@ -1,0 +1,307 @@
+import { createDeferredPromise } from '@metamask/utils';
+import type { Mockttp } from 'mockttp';
+import { getServerMochaToBackground } from '../background-socket/server-mocha-to-background';
+import type { Driver } from '../webdriver/driver';
+import { withFixtures } from '../helpers';
+
+type WithFixturesOptions = Parameters<typeof withFixtures>[0];
+type WithFixturesTestSuite = Parameters<typeof withFixtures>[1];
+
+type FixtureSessionContext = Parameters<WithFixturesTestSuite>[0] & {
+  driver: Driver;
+};
+
+/**
+ * Options accepted by the shared fixture-session runner.
+ */
+type FixtureSessionOptions = WithFixturesOptions & {
+  fixtures: unknown;
+  resetAfterEach?: boolean;
+  testSpecificMock?: (mockServer: Mockttp) => unknown | Promise<unknown>;
+};
+
+export type FixtureSessionAccessors = {
+  getDriver: () => Driver;
+  getFixtures: () => FixtureSessionContext;
+};
+
+const OFFSCREEN_PAGE_PATH = '/offscreen.html';
+const CHROME_EXTENSION_PROTOCOL = 'chrome-extension://';
+
+function getRunnableTests(suite: Mocha.Suite): Mocha.Test[] {
+  return [
+    ...suite.tests.filter((test) => !test.pending),
+    ...suite.suites.flatMap(getRunnableTests),
+  ];
+}
+
+function hasNextRunnableTest(
+  sharedSuite: Mocha.Suite,
+  currentTest: Mocha.Test,
+): boolean {
+  const runnableTests = getRunnableTests(sharedSuite);
+  const currentTestIndex = runnableTests.indexOf(currentTest);
+
+  return currentTestIndex < runnableTests.length - 1;
+}
+
+function shouldResetSharedFixtureSession(
+  sharedSuite: Mocha.Suite,
+  currentTest: Mocha.Test,
+): boolean {
+  return (
+    currentTest.state === 'failed' ||
+    hasNextRunnableTest(sharedSuite, currentTest)
+  );
+}
+
+async function getReloadSurvivorWindow(driver: Driver): Promise<string> {
+  const currentWindow = await driver.getCurrentWindowHandle();
+  const currentUrl = await driver.getCurrentUrl().catch((error) => {
+    console.warn(
+      'getReloadSurvivorWindow: failed to read the current window URL; ' +
+        'falling back to treating it as a non-extension page.',
+      error,
+    );
+    return '';
+  });
+
+  if (!currentUrl.startsWith(driver.extensionUrl)) {
+    return currentWindow;
+  }
+
+  const survivorWindow = await driver.openNewPage('about:blank');
+  await driver.switchToWindow(currentWindow);
+  return survivorWindow;
+}
+
+async function sendChromeDevToolsCommand(
+  driver: Driver,
+  command: string,
+  params: Record<string, unknown> = {},
+): Promise<void> {
+  const seleniumDriver = driver.driver as {
+    sendAndGetDevToolsCommand?: (
+      commandName: string,
+      commandParams?: Record<string, unknown>,
+    ) => Promise<unknown>;
+  };
+
+  if (!seleniumDriver.sendAndGetDevToolsCommand) {
+    throw new Error('Chrome DevTools Protocol is not available.');
+  }
+
+  await seleniumDriver.sendAndGetDevToolsCommand(command, params);
+}
+
+async function restartChromeServiceWorker(driver: Driver): Promise<void> {
+  const scopeURL = driver.extensionUrl.endsWith('/')
+    ? driver.extensionUrl
+    : `${driver.extensionUrl}/`;
+  const backgroundSocket = getServerMochaToBackground();
+  const connectionVersion = backgroundSocket.getConnectionVersion();
+
+  await sendChromeDevToolsCommand(driver, 'ServiceWorker.enable');
+  await sendChromeDevToolsCommand(driver, 'ServiceWorker.stopAllWorkers');
+  await sendChromeDevToolsCommand(driver, 'ServiceWorker.startWorker', {
+    scopeURL,
+  });
+  await backgroundSocket.waitForConnectionAfter(connectionVersion);
+  // The tab that was active before the restart may hold a message port or
+  // other reference tied to the now-dead service worker instance. Open a
+  // fresh, neutral tab so the session has a live, non-extension page to
+  // continue from instead of a stale extension page.
+  await driver.openNewPage('about:blank');
+}
+
+/**
+ * Closes any user-visible auxiliary tabs/windows that were opened during a
+ * shared-session test, while preserving the current tab and the MV3 offscreen
+ * page.
+ *
+ * @param driver - The active shared-session driver.
+ */
+async function closeAuxiliaryWindows(driver: Driver): Promise<void> {
+  const currentHandle = await driver.getCurrentWindowHandle();
+  const windowHandles = await driver.getAllWindowHandles();
+  const offscreenPageUrl = `${driver.extensionUrl}${OFFSCREEN_PAGE_PATH}`;
+
+  for (const handle of windowHandles) {
+    if (handle === currentHandle) {
+      continue;
+    }
+
+    try {
+      await driver.switchToWindow(handle);
+      // Match the MV3 offscreen page by URL (available immediately via
+      // `getCurrentUrl()`) rather than by title: reading the title requires
+      // the document to have rendered, so a transiently empty title could
+      // misidentify - and close - the offscreen page, poisoning the session.
+      const url = await driver.getCurrentUrl();
+      if (url !== offscreenPageUrl) {
+        await driver.closeWindow();
+      }
+    } catch (error) {
+      // Best-effort cleanup: log so a systemic failure (e.g. every handle
+      // erroring) isn't silently invisible, but don't fail the suite over a
+      // handle that disappeared during cleanup.
+      console.warn(
+        `closeAuxiliaryWindows: failed to inspect/close window handle ${handle}.`,
+        error,
+      );
+    } finally {
+      await driver.switchToWindow(currentHandle);
+    }
+  }
+}
+
+/**
+ * Resets the shared-session extension back to the baseline fixture state
+ * without rebuilding the entire E2E environment.
+ *
+ * @param fixtureContext - The active shared-session fixture context.
+ * @param fixtureContext.driver - The active shared-session driver.
+ */
+async function resetSharedFixtureSession(fixtureContext: {
+  driver: Driver;
+}): Promise<void> {
+  const { driver } = fixtureContext;
+  const canRestartWithCdp = driver.extensionUrl.startsWith(
+    CHROME_EXTENSION_PROTOCOL,
+  );
+
+  if (canRestartWithCdp) {
+    await getServerMochaToBackground().resetFixtureState({
+      reloadServiceWorker: false,
+      waitForReconnect: false,
+    });
+    await restartChromeServiceWorker(driver);
+    return;
+  }
+
+  const survivorWindow = await getReloadSurvivorWindow(driver);
+  await getServerMochaToBackground().resetFixtureState({
+    reloadServiceWorker: true,
+    waitForReconnect: true,
+  });
+
+  await driver.switchToWindow(survivorWindow);
+  if (process.env.SELENIUM_BROWSER === 'firefox') {
+    await driver.openNewPage('about:blank');
+  }
+
+  await driver.waitForExtensionStart({
+    waitForControllers: false,
+    waitForLoadingLogoToDisappear: false,
+  });
+}
+
+/**
+ * Defines a suite that reuses a single browser/extension fixture session
+ * across all tests in the suite to reduce repeated E2E setup cost.
+ *
+ * @param suiteTitle - The Mocha suite title for the shared-session tests.
+ * @param fixtureOptions - The `withFixtures` options used to start the shared
+ * session, plus the `resetAfterEach` behavior flag.
+ * @param defineSuite - Callback that defines the suite's tests and hooks using
+ * the shared driver and fixture accessors.
+ */
+export function configureFixtureSession(
+  suiteTitle: string,
+  fixtureOptions: FixtureSessionOptions,
+  defineSuite: (accessors: FixtureSessionAccessors) => void,
+): void {
+  const sharedSuite = describe(suiteTitle, function () {
+    const fixtureSetup = createDeferredPromise<FixtureSessionContext>();
+    const suiteFinished = createDeferredPromise<void>();
+
+    let fixturePromise: Promise<void> | undefined;
+    let fixtures: FixtureSessionContext | undefined;
+    let sessionPoisonedError: Error | undefined;
+
+    const getFixtures = (): FixtureSessionContext => {
+      if (!fixtures) {
+        throw new Error(
+          'Fixture session is not ready yet; call getDriver()/getFixtures() only inside test or hook bodies after the shared fixture session `before` hook has run.',
+        );
+      }
+
+      return fixtures;
+    };
+
+    const getDriver = (): Driver => {
+      return getFixtures().driver;
+    };
+
+    before('Set up shared fixture session', async function () {
+      const { resetAfterEach: _resetAfterEach, ...withFixturesOptions } =
+        fixtureOptions;
+      const { title } = withFixturesOptions as { title?: string };
+      const options = {
+        ...withFixturesOptions,
+        title: title ?? suiteTitle,
+      };
+
+      fixturePromise = withFixtures(options, async (fixtureContext) => {
+        fixtures = fixtureContext as FixtureSessionContext;
+        fixtureSetup.resolve(fixtures);
+        await suiteFinished.promise;
+      });
+
+      fixturePromise.catch((error: unknown) => {
+        fixtureSetup.reject(error);
+      });
+
+      await fixtureSetup.promise;
+    });
+
+    beforeEach('Ensure shared fixture session is reusable', function () {
+      if (sessionPoisonedError) {
+        throw new Error(
+          `Shared fixture session is no longer reusable because reset failed: ${sessionPoisonedError.message}`,
+        );
+      }
+    });
+
+    defineSuite({ getDriver, getFixtures });
+
+    // Register shared cleanup after the suite so suite-specific teardown can
+    // still access the active session before we reset or shut it down.
+    afterEach(
+      'Reset shared fixture session state between tests',
+      async function () {
+        if (sessionPoisonedError) {
+          return;
+        }
+
+        try {
+          const fixtureContext = getFixtures();
+          const { driver } = fixtureContext;
+
+          if (
+            (fixtureOptions.resetAfterEach ?? true) &&
+            this.currentTest &&
+            shouldResetSharedFixtureSession(sharedSuite, this.currentTest)
+          ) {
+            await resetSharedFixtureSession(fixtureContext);
+          }
+
+          await closeAuxiliaryWindows(driver);
+          await driver.openNewURL('about:blank');
+        } catch (error) {
+          sessionPoisonedError =
+            error instanceof Error ? error : new Error(String(error));
+          suiteFinished.resolve();
+          throw sessionPoisonedError;
+        }
+      },
+    );
+
+    after('Shut down shared fixture session', async function () {
+      suiteFinished.resolve();
+      if (fixturePromise) {
+        await fixturePromise;
+      }
+    });
+  });
+}

--- a/test/e2e/page-objects/pages/vault/critical-error-page.ts
+++ b/test/e2e/page-objects/pages/vault/critical-error-page.ts
@@ -1,6 +1,5 @@
 import { until } from 'selenium-webdriver';
-import { Driver, PAGES } from '../../../webdriver/driver';
-import { WINDOW_TITLES } from '../../../constants';
+import { Driver } from '../../../webdriver/driver';
 
 /**
  * Fatal startup failure UI when MetaMask cannot boot normally.
@@ -174,22 +173,11 @@ class CriticalErrorPage {
     waitForLoadingLogoToDisappear?: boolean;
   } = {}): Promise<void> {
     console.log('Wait for critical error page after extension reload');
-    await this.driver.waitUntil(
-      async () => {
-        await this.driver.navigate(PAGES.HOME, { waitForControllers: false });
-        const title = await this.driver.driver.getTitle();
-        // the browser will return an error message for our UI's HOME page until
-        // the extension has restarted
-        return title === WINDOW_TITLES.ExtensionInFullScreenView;
-      },
-      // reload and check title as quickly as possible
-      { interval: 100, timeout: timeoutMs },
-    );
-    if (waitForLoadingLogoToDisappear) {
-      await this.driver.assertElementNotPresent('.loading-logo', {
-        timeout: 10000,
-      });
-    }
+    await this.driver.waitForExtensionStart({
+      timeout: timeoutMs,
+      waitForControllers: false,
+      waitForLoadingLogoToDisappear,
+    });
   }
 }
 

--- a/test/e2e/tests/state-persistence/helpers.ts
+++ b/test/e2e/tests/state-persistence/helpers.ts
@@ -1,8 +1,6 @@
 import assert from 'node:assert/strict';
 import { STORAGE_KEY_PREFIX } from '@metamask/storage-service';
-import { WINDOW_TITLES } from '../../constants';
-import HomePage from '../../page-objects/pages/home/homepage';
-import { Driver, PAGES } from '../../webdriver/driver';
+import { Driver } from '../../webdriver/driver';
 
 export type DataStorage = {
   meta: {
@@ -67,21 +65,7 @@ export const pausePersistence = async (
  * @param driver - WebDriver instance.
  */
 async function waitForRestart(driver: Driver): Promise<void> {
-  await driver.waitUntil(
-    async () => {
-      await driver.navigate(PAGES.HOME, { waitForControllers: false });
-      const title = await driver.driver.getTitle();
-      // the browser will return an error message for our UI's HOME page until
-      // the extension has restarted
-      return title === WINDOW_TITLES.ExtensionInFullScreenView;
-    },
-    // reload and check title as quickly a possible
-    { interval: 100, timeout: 10000 },
-  );
-
-  await driver.waitForControllersLoaded();
-  const homePage = new HomePage(driver);
-  await homePage.waitForLoadingLogoToDisappear();
+  await driver.waitForExtensionStart();
 }
 
 /**

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -29,6 +29,7 @@ const PAGES = {
   POPUP: 'popup',
   SIDEPANEL: 'sidepanel',
 };
+const EXTENSION_FULL_SCREEN_TITLE = 'MetaMask';
 
 /**
  * Temporary workaround to patch selenium's element handle API with methods
@@ -1350,6 +1351,58 @@ class Driver {
       until.elementLocated(this.buildLocator('.controller-loaded')),
       timeout,
     );
+  }
+
+  /**
+   * Waits for the extension UI to become available on the home page.
+   *
+   * This is useful after actions that temporarily make the extension
+   * unavailable, such as `runtime.reload()`, background recovery flows, or
+   * shared fixture session resets. This method only waits for startup to
+   * complete; it does not trigger the restart itself.
+   *
+   * @param {object} [options] - Options.
+   * @param {number} [options.timeout] - The maximum time in milliseconds to
+   * wait for the extension to become reachable. Defaults to the driver's
+   * timeout.
+   * @param {boolean} [options.waitForControllers] - Whether to wait for the
+   * controller-loaded marker after the extension page is reachable. Defaults
+   * to true.
+   * @param {boolean} [options.waitForLoadingLogoToDisappear] - Whether to wait
+   * for the loading logo to disappear. Defaults to true.
+   * @returns {Promise<void>} A promise that resolves once the extension home
+   * page satisfies the requested readiness checks.
+   */
+  async waitForExtensionStart({
+    timeout = this.timeout,
+    waitForControllers = true,
+    waitForLoadingLogoToDisappear = true,
+  } = {}) {
+    await this.waitUntil(
+      async () => {
+        try {
+          await this.navigate(PAGES.HOME, { waitForControllers: false });
+          const title = await this.driver.getTitle();
+          // The browser may briefly show an error page for `home.html` until
+          // the extension has finished starting again.
+          return title === EXTENSION_FULL_SCREEN_TITLE;
+        } catch {
+          return false;
+        }
+      },
+      {
+        interval: 100,
+        timeout,
+      },
+    );
+
+    if (waitForControllers) {
+      await this.waitForControllersLoaded(timeout);
+    }
+
+    if (waitForLoadingLogoToDisappear) {
+      await this.assertElementNotPresent('.loading-logo', { timeout });
+    }
   }
 
   /**


### PR DESCRIPTION
## **Description**

All credits go to @davidmurdoch for the original PR [here](https://github.com/MetaMask/metamask-extension/pull/42470).

Adds a shared E2E fixture-session helper following the reset-by-default contract from [ADR 0005: Shared E2E Fixture Sessions for Browser Extension E2E Tests](https://github.com/MetaMask/decisions/blob/main/decisions/extension/0005-e2e-test-shared-fixture-session.md).

The helper starts one `withFixtures` session for an eligible suite and exposes `getDriver()` / `getFixtures()` accessors. By default it resets fixture-backed persistence after each test, then restarts the background context before the next test. Chrome/MV3 uses CDP `ServiceWorker.stopAllWorkers` + `ServiceWorker.startWorker`; non-CDP browsers fall back to `browser.runtime.reload()`. This keeps service-worker/module state to one worker lifetime per test without paying for full browser teardown.

The fixture reset skips reinitializing fixture state in the worker that is about to be restarted; the fresh worker loads the fixture state normally on startup. This avoids one redundant fixture-server fetch per reset while preserving a real background restart.

This is #42470 rebased onto latest main and split in two: this PR contains the helper and supporting infrastructure; the phishing spec migration follows in a stacked PR. On top of the rebase it also incorporates review fixes (timeout/listener cleanup in the background-socket response wait, `reset({ initialize })` threading in the fixture store) and refactors `state-persistence/helpers.ts#waitForRestart` to reuse the new `driver.waitForExtensionStart()`.

Part of the WPN-1881 stack:
1. **test(e2e): add shared fixture session helper** (this PR)
2. `WPN-1881-phishing-shared-fixture-session`
3. `WPN-1881-tron-shared-session-infra`, then six parallel Tron suite refactors

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: [WPN-1881](https://consensys.atlassian.net/browse/WPN-1881), supersedes #42470 (first half)

## **Manual testing steps**

1. `yarn test:unit shared/lib/stores/fixture-extension-store.test.ts shared/lib/stores/persistence-manager.test.ts`
2. Run any suite migrated in the stacked PRs (e.g. the phishing redirect spec) and confirm one browser session is reused across tests.
3. Full E2E CI should stay green — no existing suite behavior changes until a suite opts in via `configureFixtureSession`.

## **Screenshots/Recordings**

Not applicable (test infrastructure).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[WPN-1881]: https://consensyssoftware.atlassian.net/browse/WPN-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ