### PR TITLE
test(confirmations): add gas sponsorship reserve-balance alert coverage

### DIFF
--- a/test/integration/confirmations/transactions/gas-sponsorship-alerts.test.tsx
+++ b/test/integration/confirmations/transactions/gas-sponsorship-alerts.test.tsx
@@ -216,13 +216,6 @@ describe('Gas sponsorship confirmation alerts', () => {
     expect(
       await screen.findByTestId('confirm-footer-button'),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText(
-        tEn('gasSponsorshipReserveBalanceWarning', ['10', 'MON']),
-      ),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(tEn('alertMinimumReserve')),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('inline-alert')).not.toBeInTheDocument();
   });
 });

--- a/test/integration/confirmations/transactions/gas-sponsorship-alerts.test.tsx
+++ b/test/integration/confirmations/transactions/gas-sponsorship-alerts.test.tsx
@@ -1,0 +1,228 @@
+import { ApprovalType } from '@metamask/controller-utils';
+import { fireEvent, screen } from '@testing-library/react';
+import nock from 'nock';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+import * as backgroundConnection from '../../../../ui/store/background-connection';
+import { tEn } from '../../../lib/i18n-helpers';
+import { integrationTestRender } from '../../../lib/render-helpers';
+import mockMetaMaskState from '../../data/integration-init-state.json';
+import { createMockImplementation, mock4byte } from '../../helpers';
+import { getUnapprovedContractInteractionTransaction } from './transactionDataHelpers';
+
+jest.mock('../../../../ui/store/background-connection', () => ({
+  ...jest.requireActual('../../../../ui/store/background-connection'),
+  submitRequestToBackground: jest.fn(),
+}));
+
+const mockedBackgroundConnection = jest.mocked(backgroundConnection);
+
+const backgroundConnectionMocked = {
+  onNotification: jest.fn(),
+};
+
+const pendingTransactionId = '48a75190-45ca-11ef-9001-f3886ec2397c';
+const pendingTransactionTime = new Date().getTime();
+
+const MONAD_NETWORK_CLIENT_ID = 'monad-mainnet';
+
+const MONAD_NETWORK_CONFIGURATION = {
+  chainId: CHAIN_IDS.MONAD,
+  rpcEndpoints: [
+    {
+      networkClientId: MONAD_NETWORK_CLIENT_ID,
+      url: 'https://monad-mainnet.infura.io/v3/{infuraProjectId}',
+      type: 'infura',
+    },
+  ],
+  defaultRpcEndpointIndex: 0,
+  blockExplorerUrls: ['https://monadscan.com'],
+  defaultBlockExplorerUrlIndex: 0,
+  name: 'Monad',
+  nativeCurrency: 'MON',
+};
+
+// Increased timeout: React 18's act() waits for ALL pending async work
+// (including Rive WASM loading) which can exceed the default 15s limit.
+jest.setTimeout(30_000);
+
+function getMonadSponsoredTransaction({
+  accountAddress,
+  isGasFeeSponsored,
+}: {
+  accountAddress: string;
+  isGasFeeSponsored: boolean;
+}) {
+  const transaction = getUnapprovedContractInteractionTransaction(
+    accountAddress,
+    pendingTransactionId,
+    pendingTransactionTime,
+  );
+
+  return {
+    ...transaction,
+    chainId: CHAIN_IDS.MONAD,
+    networkClientId: MONAD_NETWORK_CLIENT_ID,
+    isGasFeeSponsored,
+    simulationData: {
+      ...transaction.simulationData,
+      callTraceErrors: ['reserve balance violation'],
+    },
+  };
+}
+
+function getMetaMaskStateWithMonadSponsorshipTransaction({
+  accountAddress,
+  isGasFeeSponsored,
+}: {
+  accountAddress: string;
+  isGasFeeSponsored: boolean;
+}) {
+  const sepoliaAccounts = mockMetaMaskState.accountsByChainId['0xaa36a7'];
+
+  return {
+    ...mockMetaMaskState,
+    selectedNetworkClientId: MONAD_NETWORK_CLIENT_ID,
+    enabledNetworkMap: {
+      ...mockMetaMaskState.enabledNetworkMap,
+      eip155: {
+        ...mockMetaMaskState.enabledNetworkMap.eip155,
+        [CHAIN_IDS.MONAD]: true,
+      },
+    },
+    networkConfigurationsByChainId: {
+      ...mockMetaMaskState.networkConfigurationsByChainId,
+      [CHAIN_IDS.MONAD]: MONAD_NETWORK_CONFIGURATION,
+    },
+    accountsByChainId: {
+      ...mockMetaMaskState.accountsByChainId,
+      [CHAIN_IDS.MONAD]: sepoliaAccounts,
+    },
+    networksMetadata: {
+      ...mockMetaMaskState.networksMetadata,
+      [MONAD_NETWORK_CLIENT_ID]: {
+        EIPS: {
+          1559: true,
+        },
+        status: 'available',
+      },
+    },
+    pendingApprovals: {
+      [pendingTransactionId]: {
+        id: pendingTransactionId,
+        origin: 'origin',
+        time: pendingTransactionTime,
+        type: ApprovalType.Transaction,
+        requestData: {
+          txId: pendingTransactionId,
+        },
+        requestState: null,
+        expectsResult: false,
+      },
+    },
+    pendingApprovalCount: 1,
+    transactions: [
+      getMonadSponsoredTransaction({
+        accountAddress,
+        isGasFeeSponsored,
+      }),
+    ],
+  };
+}
+
+function setupSubmitRequestToBackgroundMocks() {
+  mockedBackgroundConnection.submitRequestToBackground.mockImplementation(
+    createMockImplementation({
+      isRelaySupported: true,
+      isSendBundleSupported: false,
+      getTokenStandardAndDetailsByChain: {
+        decimals: '4',
+      },
+    }),
+  );
+}
+
+describe('Gas sponsorship confirmation alerts', () => {
+  beforeAll(() => {
+    global.ethereumProvider = {
+      request: jest.fn(),
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    setupSubmitRequestToBackgroundMocks();
+    mock4byte('0x3b4b1381');
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  afterAll(() => {
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (global as any).ethereumProvider;
+  });
+
+  it('displays the reserve-balance warning when sponsorship simulation fails', async () => {
+    const account =
+      mockMetaMaskState.internalAccounts.accounts[
+        mockMetaMaskState.internalAccounts
+          .selectedAccount as keyof typeof mockMetaMaskState.internalAccounts.accounts
+      ];
+
+    await integrationTestRender({
+      preloadedState: getMetaMaskStateWithMonadSponsorshipTransaction({
+        accountAddress: account.address,
+        isGasFeeSponsored: false,
+      }),
+      backgroundConnection: backgroundConnectionMocked,
+    });
+
+    fireEvent.click(await screen.findByTestId('inline-alert'));
+
+    expect(await screen.findByTestId('alert-modal')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('alert-modal__selected-alert'),
+    ).toHaveTextContent(
+      tEn('gasSponsorshipReserveBalanceWarning', ['10', 'MON']),
+    );
+    expect(
+      await screen.findByText(tEn('alertMinimumReserve')),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('alert-modal-action-buy'),
+    ).toHaveTextContent(tEn('alertActionBuyWithNativeCurrency', ['MON']));
+    expect(await screen.findByTestId('confirm-footer-button')).toBeDisabled();
+  });
+
+  it('does not display the reserve-balance warning when the transaction is sponsored', async () => {
+    const account =
+      mockMetaMaskState.internalAccounts.accounts[
+        mockMetaMaskState.internalAccounts
+          .selectedAccount as keyof typeof mockMetaMaskState.internalAccounts.accounts
+      ];
+
+    await integrationTestRender({
+      preloadedState: getMetaMaskStateWithMonadSponsorshipTransaction({
+        accountAddress: account.address,
+        isGasFeeSponsored: true,
+      }),
+      backgroundConnection: backgroundConnectionMocked,
+    });
+
+    expect(
+      await screen.findByTestId('confirm-footer-button'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        tEn('gasSponsorshipReserveBalanceWarning', ['10', 'MON']),
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(tEn('alertMinimumReserve')),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/test/jest/console-baseline-integration.json
+++ b/test/jest/console-baseline-integration.json
@@ -73,6 +73,12 @@
       "error: Error: AggregateError": 1,
       "warn: ⚠️ React Router Future Flag": 1
     },
+    "test/integration/confirmations/transactions/gas-sponsorship-alerts.test.tsx": {
+      "Reselect: Identity function warnings": 1,
+      "Reselect: Input stability warnings": 5,
+      "error: Error: AggregateError": 1,
+      "warn: ⚠️ React Router Future Flag": 1
+    },
     "test/integration/confirmations/transactions/increase-allowance.test.tsx": {
       "Reselect: Identity function warnings": 1,
       "Reselect: Input stability warnings": 5,


### PR DESCRIPTION
## **Description**

Adds a confirmation integration test for the Monad gas sponsorship reserve-balance warning (WPN-1801).

The hook unit tests already cover when the alert is created. This test renders the confirmation and checks the user-visible state: the blocking reserve-balance warning when sponsorship fails (`isGasFeeSponsored: false` plus a `reserve balance violation` simulation error), and that the inline alert is absent when the transaction is already sponsored.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: WPN-1801

## **Manual testing steps**

This PR only adds an integration test. There is no user-facing product change.

To confirm the existing wallet behavior this test locks in:

1. On Monad, open a confirmation where gas sponsorship simulation fails with a reserve balance violation.
2. Open the estimated-fee inline alert and verify the reserve-balance warning (`Reserve balance is required`, 10 MON copy, Buy MON action) and that Confirm is disabled.
3. Open a confirmation that is already gas-sponsored and verify the reserve-balance inline alert is not shown.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Screenshots/Recordings**

Not applicable — test-only change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or confirmation UI logic modifications.
> 
> **Overview**
> Adds **integration test coverage** for Monad transaction confirmation **gas sponsorship reserve-balance alerts** (WPN-1801), without changing product code.
> 
> The new `gas-sponsorship-alerts.test.tsx` renders a pending contract interaction on Monad with simulation `callTraceErrors` including **reserve balance violation**. One case asserts that when **`isGasFeeSponsored` is false**, the inline alert opens a modal with the **`gasSponsorshipReserveBalanceWarning`** copy (10 MON), minimum-reserve text, a buy-with-MON action, and a **disabled** confirm button. The other case asserts that when **`isGasFeeSponsored` is true**, no inline alert appears while confirm remains available.
> 
> Test setup mirrors other confirmation integration tests (mock background connection, Monad network config, 30s timeout). **`console-baseline-integration.json`** is updated with expected console noise for the new file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c29cdf44d09a01124963572f6499163fb46e01db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->