### PR TITLE
feat: show sub nav tabs for non-evm networks

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3436,6 +3436,9 @@
   "defiTabErrorTitle": {
     "message": "We could not load this page."
   },
+  "defiUnsupportedEmptyDescription": {
+    "message": "DeFi isn't supported on this network."
+  },
   "delete": {
     "message": "Delete"
   },
@@ -6042,6 +6045,9 @@
   },
   "nftTokenIdPlaceholder": {
     "message": "Enter the token id"
+  },
+  "nftUnsupportedEmptyDescription": {
+    "message": "NFTs aren't supported on this network."
   },
   "nftWarningContent": {
     "message": "You're granting access to $1, including any you might own in the future. The party on the other end can transfer these NFTs from your wallet at any time without asking you until you revoke this approval. $2",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3436,6 +3436,9 @@
   "defiTabErrorTitle": {
     "message": "We could not load this page."
   },
+  "defiUnsupportedEmptyDescription": {
+    "message": "DeFi isn't supported on this network."
+  },
   "delete": {
     "message": "Delete"
   },
@@ -6042,6 +6045,9 @@
   },
   "nftTokenIdPlaceholder": {
     "message": "Enter the token id"
+  },
+  "nftUnsupportedEmptyDescription": {
+    "message": "NFTs aren't supported on this network."
   },
   "nftWarningContent": {
     "message": "You're granting access to $1, including any you might own in the future. The party on the other end can transfer these NFTs from your wallet at any time without asking you until you revoke this approval. $2",

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -286,11 +286,6 @@
       "count": 1
     }
   },
-  "ui/components/multichain-accounts/permissions/multichain-edit-networks-page/multichain-edit-networks-page.tsx": {
-    "react-hooks/exhaustive-deps": {
-      "count": 2
-    }
-  },
   "ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.tsx": {
     "react-hooks/set-state-in-effect": {
       "count": 1

--- a/ui/components/app/assets/defi-list/cells/defi-empty-state.test.tsx
+++ b/ui/components/app/assets/defi-list/cells/defi-empty-state.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
+import mockState from '../../../../../../test/data/mock-state.json';
+import { ThemeType } from '../../../../../../shared/constants/preferences';
+import { DeFiEmptyStateMessage } from './defi-empty-state';
+
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../../../hooks/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: jest.fn(() => ({
+      addCategory: jest.fn().mockReturnThis(),
+      addProperties: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({}),
+    })),
+  }),
+}));
+
+describe('DeFiEmptyStateMessage', () => {
+  const mockStore = configureMockStore([thunk]);
+  let store: ReturnType<typeof mockStore>;
+
+  const renderComponent = (stateOverride = {}) => {
+    store = mockStore({ ...mockState, ...stateOverride });
+    return renderWithProvider(<DeFiEmptyStateMessage />, store);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the default empty state with correct test id', () => {
+    renderComponent();
+    expect(screen.getByTestId('defi-tab-empty-state')).toBeInTheDocument();
+  });
+
+  it('renders explore DeFi button', () => {
+    renderComponent();
+    expect(
+      screen.getByRole('button', { name: messages.exploreDefi.message }),
+    ).toBeInTheDocument();
+  });
+
+  it('opens portfolio when explore DeFi button is clicked', () => {
+    const openTabSpy = jest.spyOn(global.platform, 'openTab');
+    renderComponent();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: messages.exploreDefi.message }),
+    );
+
+    expect(openTabSpy).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalled();
+  });
+
+  it('renders light theme icon by default', () => {
+    renderComponent();
+
+    const image = screen.getByAltText('DeFi');
+    expect(image).toHaveAttribute('src', '/images/empty-state-defi-light.png');
+  });
+
+  it('renders dark theme icon when theme is dark', () => {
+    renderComponent({
+      metamask: {
+        ...mockState.metamask,
+        theme: ThemeType.dark,
+      },
+    });
+
+    const image = screen.getByAltText('DeFi');
+    expect(image).toHaveAttribute('src', '/images/empty-state-defi-dark.png');
+  });
+
+  describe('when a non-EVM network is selected', () => {
+    const nonEvmNetworkState = {
+      metamask: {
+        ...mockState.metamask,
+        isEvmSelected: false,
+      },
+    };
+
+    it('renders the unsupported empty state', () => {
+      renderComponent(nonEvmNetworkState);
+
+      expect(
+        screen.getByTestId('defi-tab-unsupported-empty-state'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('defi-tab-empty-state'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render explore DeFi button', () => {
+      renderComponent(nonEvmNetworkState);
+
+      expect(
+        screen.queryByRole('button', { name: messages.exploreDefi.message }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/components/app/assets/defi-list/cells/defi-empty-state.tsx
+++ b/ui/components/app/assets/defi-list/cells/defi-empty-state.tsx
@@ -15,11 +15,38 @@ import {
   getAnalyticsId,
   getConsentDecisionMade,
   getOptedIn,
+  getIsEvmMultichainNetworkSelected,
 } from '../../../../../selectors';
 
-export const DeFiEmptyStateMessage = () => {
+const EMPTY_STATE_CLASSNAME = 'mx-auto mt-5 mb-6 max-w-48';
+
+const DeFiEmptyStateIcon = () => {
   const t = useI18nContext();
   const theme = useTheme();
+
+  const defiIcon =
+    theme === ThemeType.dark
+      ? '/images/empty-state-defi-dark.png'
+      : '/images/empty-state-defi-light.png';
+
+  return <img src={defiIcon} alt={t('defi')} width={72} height={72} />;
+};
+
+export const DeFiUnsupportedEmptyStateMessage = () => {
+  const t = useI18nContext();
+
+  return (
+    <TabEmptyState
+      icon={<DeFiEmptyStateIcon />}
+      description={t('defiUnsupportedEmptyDescription')}
+      data-testid="defi-tab-unsupported-empty-state"
+      className={EMPTY_STATE_CLASSNAME}
+    />
+  );
+};
+
+const DeFiDefaultEmptyStateMessage = () => {
+  const t = useI18nContext();
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   const analyticsId = useSelector(getAnalyticsId);
@@ -54,19 +81,24 @@ export const DeFiEmptyStateMessage = () => {
     trackEvent,
   ]);
 
-  const defiIcon =
-    theme === ThemeType.dark
-      ? '/images/empty-state-defi-dark.png'
-      : '/images/empty-state-defi-light.png';
-
   return (
     <TabEmptyState
-      icon={<img src={defiIcon} alt={t('defi')} width={72} height={72} />}
+      icon={<DeFiEmptyStateIcon />}
       description={t('defiEmptyDescription')}
       actionButtonText={t('exploreDefi')}
       onAction={handleExploreDefi}
       data-testid="defi-tab-empty-state"
-      className="mx-auto mt-5 mb-6 max-w-48"
+      className={EMPTY_STATE_CLASSNAME}
     />
   );
+};
+
+export const DeFiEmptyStateMessage = () => {
+  const isEvmNetworkSelected = useSelector(getIsEvmMultichainNetworkSelected);
+
+  if (!isEvmNetworkSelected) {
+    return <DeFiUnsupportedEmptyStateMessage />;
+  }
+
+  return <DeFiDefaultEmptyStateMessage />;
 };

--- a/ui/components/app/assets/nfts/nft-empty-state/index.ts
+++ b/ui/components/app/assets/nfts/nft-empty-state/index.ts
@@ -1,2 +1,1 @@
-export { NftEmptyState } from './nft-empty-state';
-export type { NftEmptyStateProps } from './nft-empty-state';
+export { NftEmptyState, NftUnsupportedEmptyState } from './nft-empty-state';

--- a/ui/components/app/assets/nfts/nft-empty-state/index.ts
+++ b/ui/components/app/assets/nfts/nft-empty-state/index.ts
@@ -1,1 +1,0 @@
-export { NftEmptyState, NftUnsupportedEmptyState } from './nft-empty-state';

--- a/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.test.tsx
+++ b/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.test.tsx
@@ -13,9 +13,9 @@ describe('NftEmptyState', () => {
   const mockStore = configureMockStore([thunk]);
   let store: ReturnType<typeof mockStore>;
 
-  const renderComponent = (props = {}, stateOverride = {}) => {
+  const renderComponent = (stateOverride = {}) => {
     store = mockStore({ ...mockState, ...stateOverride });
-    return renderWithProvider(<NftEmptyState {...props} />, store);
+    return renderWithProvider(<NftEmptyState />, store);
   };
 
   beforeEach(() => {
@@ -39,14 +39,6 @@ describe('NftEmptyState', () => {
     expect(
       screen.getByRole('button', { name: messages.importNFT.message }),
     ).toBeInTheDocument();
-  });
-
-  it('should apply custom className when provided', () => {
-    const customClassName = 'custom-test-class';
-    renderComponent({ className: customClassName });
-
-    const emptyState = screen.getByTestId('nft-tab-empty-state');
-    expect(emptyState).toHaveClass(customClassName);
   });
 
   it('should dispatch showImportNftsModal when import button is clicked', () => {
@@ -76,9 +68,37 @@ describe('NftEmptyState', () => {
       },
     };
 
-    renderComponent({}, darkThemeState);
+    renderComponent(darkThemeState);
 
     const image = screen.getByAltText('NFTs');
     expect(image).toHaveAttribute('src', './images/empty-state-nfts-dark.png');
+  });
+
+  describe('when a non-EVM network is selected', () => {
+    const nonEvmNetworkState = {
+      metamask: {
+        ...mockState.metamask,
+        isEvmSelected: false,
+      },
+    };
+
+    it('should render the unsupported empty state', () => {
+      renderComponent(nonEvmNetworkState);
+
+      expect(
+        screen.getByTestId('nft-tab-unsupported-empty-state'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('nft-tab-empty-state'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not render import button', () => {
+      renderComponent(nonEvmNetworkState);
+
+      expect(
+        screen.queryByRole('button', { name: messages.importNFT.message }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.tsx
+++ b/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.tsx
@@ -1,10 +1,9 @@
 import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { twMerge } from '@metamask/design-system-react';
 import { ThemeType } from '../../../../../../shared/constants/preferences';
 import { TabEmptyState } from '../../../../ui/tab-empty-state';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { getTheme } from '../../../../../selectors';
+import { getTheme, getIsEvmMultichainNetworkSelected } from '../../../../../selectors';
 import { useAnalytics } from '../../../../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,
@@ -13,21 +12,37 @@ import {
 import { showImportNftsModal } from '../../../../../store/actions';
 import { useDispatch } from '../../../../../store/hooks';
 
-export type NftEmptyStateProps = {
-  className?: string;
-};
+const EMPTY_STATE_CLASSNAME = 'mx-auto mt-5 mb-6 max-w-64';
 
-export const NftEmptyState = ({ className }: NftEmptyStateProps) => {
+const NftEmptyStateIcon = () => {
   const t = useI18nContext();
   const theme = useSelector(getTheme);
-  const { trackEvent, createEventBuilder } = useAnalytics();
-  const dispatch = useDispatch();
 
-  // Theme-aware icon
   const nftIcon =
     theme === ThemeType.dark
       ? './images/empty-state-nfts-dark.png'
       : './images/empty-state-nfts-light.png';
+
+  return <img src={nftIcon} alt={t('nfts')} width={72} height={72} />;
+};
+
+export const NftUnsupportedEmptyState = () => {
+  const t = useI18nContext();
+
+  return (
+    <TabEmptyState
+      icon={<NftEmptyStateIcon />}
+      description={t('nftUnsupportedEmptyDescription')}
+      data-testid="nft-tab-unsupported-empty-state"
+      className={EMPTY_STATE_CLASSNAME}
+    />
+  );
+};
+
+const NftDefaultEmptyState = () => {
+  const t = useI18nContext();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const dispatch = useDispatch();
 
   const handleImportNfts = useCallback(() => {
     dispatch(showImportNftsModal({}));
@@ -43,12 +58,22 @@ export const NftEmptyState = ({ className }: NftEmptyStateProps) => {
 
   return (
     <TabEmptyState
-      icon={<img src={nftIcon} alt={t('nfts')} width={72} height={72} />}
+      icon={<NftEmptyStateIcon />}
       description={t('nftEmptyDescription')}
       actionButtonText={t('importNFT')}
       onAction={handleImportNfts}
       data-testid="nft-tab-empty-state"
-      className={twMerge('max-w-64', className)}
+      className={EMPTY_STATE_CLASSNAME}
     />
   );
+};
+
+export const NftEmptyState = () => {
+  const isEvmNetworkSelected = useSelector(getIsEvmMultichainNetworkSelected);
+
+  if (!isEvmNetworkSelected) {
+    return <NftUnsupportedEmptyState />;
+  }
+
+  return <NftDefaultEmptyState />;
 };

--- a/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.tsx
+++ b/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.tsx
@@ -3,7 +3,10 @@ import { useSelector } from 'react-redux';
 import { ThemeType } from '../../../../../../shared/constants/preferences';
 import { TabEmptyState } from '../../../../ui/tab-empty-state';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { getTheme, getIsEvmMultichainNetworkSelected } from '../../../../../selectors';
+import {
+  getTheme,
+  getIsEvmMultichainNetworkSelected,
+} from '../../../../../selectors';
 import { useAnalytics } from '../../../../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,

--- a/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
+++ b/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
@@ -18,7 +18,7 @@ import { ASSET_ROUTE } from '../../../../../helpers/constants/routes';
 import NftGrid from '../nft-grid/nft-grid';
 import { sortAssets } from '../../util/sort';
 import AssetListControlBar from '../../asset-list/asset-list-control-bar';
-import { NftEmptyState } from '../nft-empty-state';
+import { NftEmptyState } from '../nft-empty-state/nft-empty-state';
 import { transitionForward } from '../../../../ui/transition';
 import { useScreenViewedEvent } from '../../../../../hooks/useScreenViewedEvent';
 import {

--- a/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
+++ b/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
@@ -87,7 +87,7 @@ export default function NftsTab({
             />
           </Box>
         ) : (
-          <NftEmptyState className="mx-auto mt-5 mb-6" />
+          <NftEmptyState />
         )}
       </Box>
     </>

--- a/ui/components/multichain/account-overview/account-overview-eth.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-eth.test.tsx
@@ -38,7 +38,10 @@ jest.mock('react-redux', () => {
   };
 });
 
-const render = (props: AccountOverviewEthProps) => {
+const render = (
+  props: AccountOverviewEthProps,
+  stateOverrides: Record<string, unknown> = {},
+) => {
   const store = configureStore({
     activeTab: mockState.activeTab,
     metamask: {
@@ -51,6 +54,7 @@ const render = (props: AccountOverviewEthProps) => {
           [CHAIN_IDS.LINEA_MAINNET]: true,
         },
       },
+      ...stateOverrides,
     },
   });
 
@@ -83,6 +87,27 @@ describe('AccountOverviewEth', () => {
     expect(queryByTestId('account-overview__nfts-tab')).toBeInTheDocument();
     expect(queryByTestId('account-overview__activity-tab')).toBeInTheDocument();
     expect(queryByTestId('account-overview__defi-tab')).toBeInTheDocument();
+  });
+
+  it('hides the DeFi tab when DeFi positions are disabled', () => {
+    const { queryByTestId } = render(
+      {
+        setBasicFunctionalityModalOpen: jest.fn(),
+        onSupportLinkClick: jest.fn(),
+      },
+      {
+        remoteFeatureFlags: {
+          assetsDefiPositionsEnabled: false,
+        },
+      },
+    );
+
+    expect(queryByTestId('account-overview__asset-tab')).toBeInTheDocument();
+    expect(queryByTestId('account-overview__nfts-tab')).toBeInTheDocument();
+    expect(queryByTestId('account-overview__activity-tab')).toBeInTheDocument();
+    expect(
+      queryByTestId('account-overview__defi-tab'),
+    ).not.toBeInTheDocument();
   });
 
   describe('when the bottom nav bar is shown', () => {

--- a/ui/components/multichain/account-overview/account-overview-eth.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-eth.test.tsx
@@ -105,9 +105,7 @@ describe('AccountOverviewEth', () => {
     expect(queryByTestId('account-overview__asset-tab')).toBeInTheDocument();
     expect(queryByTestId('account-overview__nfts-tab')).toBeInTheDocument();
     expect(queryByTestId('account-overview__activity-tab')).toBeInTheDocument();
-    expect(
-      queryByTestId('account-overview__defi-tab'),
-    ).not.toBeInTheDocument();
+    expect(queryByTestId('account-overview__defi-tab')).not.toBeInTheDocument();
   });
 
   describe('when the bottom nav bar is shown', () => {

--- a/ui/components/multichain/account-overview/account-overview-eth.tsx
+++ b/ui/components/multichain/account-overview/account-overview-eth.tsx
@@ -1,22 +1,13 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { EthOverview } from '../../app/wallet-overview';
-import { getIsDefiPositionsEnabled } from '../../../selectors';
 import { AccountOverviewLayout } from './account-overview-layout';
 import { AccountOverviewCommonProps } from './common';
 
 export type AccountOverviewEthProps = AccountOverviewCommonProps;
 
 export const AccountOverviewEth = (props: AccountOverviewEthProps) => {
-  const defiPositionsEnabled = useSelector(getIsDefiPositionsEnabled);
   return (
-    <AccountOverviewLayout
-      showTokens={true}
-      showNfts={true}
-      showDefi={defiPositionsEnabled}
-      showActivity={true}
-      {...props}
-    >
+    <AccountOverviewLayout {...props}>
       {<EthOverview />}
     </AccountOverviewLayout>
   );

--- a/ui/components/multichain/account-overview/account-overview-eth.tsx
+++ b/ui/components/multichain/account-overview/account-overview-eth.tsx
@@ -7,8 +7,6 @@ export type AccountOverviewEthProps = AccountOverviewCommonProps;
 
 export const AccountOverviewEth = (props: AccountOverviewEthProps) => {
   return (
-    <AccountOverviewLayout {...props}>
-      {<EthOverview />}
-    </AccountOverviewLayout>
+    <AccountOverviewLayout {...props}>{<EthOverview />}</AccountOverviewLayout>
   );
 };

--- a/ui/components/multichain/account-overview/account-overview-non-evm.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-non-evm.test.tsx
@@ -71,6 +71,19 @@ const render = (
   );
 };
 
+const expectStandardTabs = (
+  queryByTestId: (id: string) => HTMLElement | null,
+) => {
+  expect(queryByTestId('account-overview__asset-tab')).toBeInTheDocument();
+  expect(queryByTestId('account-overview__nfts-tab')).toBeInTheDocument();
+  expect(queryByTestId('account-overview__activity-tab')).toBeInTheDocument();
+};
+
+const expectAllTabs = (queryByTestId: (id: string) => HTMLElement | null) => {
+  expectStandardTabs(queryByTestId);
+  expect(queryByTestId('account-overview__defi-tab')).toBeInTheDocument();
+};
+
 describe('AccountOverviewBtc', () => {
   beforeEach(() => {
     setBackgroundConnection({
@@ -79,23 +92,14 @@ describe('AccountOverviewBtc', () => {
   });
 
   describe('when no EVM networks are enabled', () => {
-    it('shows only Tokens and Activity tabs', () => {
+    it('shows all tabs', () => {
       const { queryByTestId } = render(defaultProps, {
         enabledNetworkMap: {
           eip155: {},
         },
       });
 
-      expect(queryByTestId('account-overview__asset-tab')).toBeInTheDocument();
-      expect(
-        queryByTestId('account-overview__nfts-tab'),
-      ).not.toBeInTheDocument();
-      expect(
-        queryByTestId('account-overview__activity-tab'),
-      ).toBeInTheDocument();
-      expect(
-        queryByTestId('account-overview__defi-tab'),
-      ).not.toBeInTheDocument();
+      expectAllTabs(queryByTestId);
     });
 
     it('shows tokens links', () => {
@@ -115,7 +119,7 @@ describe('AccountOverviewBtc', () => {
   });
 
   describe('when EVM networks are enabled', () => {
-    it('shows Tokens, NFTs, and Activity tabs when DeFi is disabled', () => {
+    it('hides the DeFi tab when DeFi positions are disabled', () => {
       const { queryByTestId } = render(defaultProps, {
         enabledNetworkMap: {
           eip155: {
@@ -127,77 +131,7 @@ describe('AccountOverviewBtc', () => {
           assetsDefiPositionsEnabled: false,
         },
       });
-
-      expect(queryByTestId('account-overview__asset-tab')).toBeInTheDocument();
-      expect(queryByTestId('account-overview__nfts-tab')).toBeInTheDocument();
-      expect(
-        queryByTestId('account-overview__activity-tab'),
-      ).toBeInTheDocument();
-      expect(
-        queryByTestId('account-overview__defi-tab'),
-      ).not.toBeInTheDocument();
-    });
-
-    it('shows all tabs including DeFi when DeFi positions are enabled', () => {
-      const { queryByTestId } = render(defaultProps, {
-        enabledNetworkMap: {
-          eip155: {
-            [CHAIN_IDS.MAINNET]: true,
-            [CHAIN_IDS.LINEA_MAINNET]: true,
-          },
-        },
-        remoteFeatureFlags: {
-          assetsDefiPositionsEnabled: true,
-        },
-      });
-
-      expect(queryByTestId('account-overview__asset-tab')).toBeInTheDocument();
-      expect(queryByTestId('account-overview__nfts-tab')).toBeInTheDocument();
-      expect(
-        queryByTestId('account-overview__activity-tab'),
-      ).toBeInTheDocument();
-      expect(queryByTestId('account-overview__defi-tab')).toBeInTheDocument();
-    });
-
-    it('shows NFTs and Activity tabs even when only one EVM network is enabled', () => {
-      const { queryByTestId } = render(defaultProps, {
-        enabledNetworkMap: {
-          eip155: {
-            [CHAIN_IDS.MAINNET]: true,
-            [CHAIN_IDS.LINEA_MAINNET]: false,
-          },
-        },
-      });
-
-      expect(queryByTestId('account-overview__asset-tab')).toBeInTheDocument();
-      expect(queryByTestId('account-overview__nfts-tab')).toBeInTheDocument();
-      expect(
-        queryByTestId('account-overview__activity-tab'),
-      ).toBeInTheDocument();
-    });
-  });
-
-  describe('when switching between network types', () => {
-    it('hides NFTs and DeFi tabs when all EVM networks are disabled', () => {
-      const { queryByTestId } = render(defaultProps, {
-        enabledNetworkMap: {
-          eip155: {
-            [CHAIN_IDS.MAINNET]: false,
-            [CHAIN_IDS.LINEA_MAINNET]: false,
-          },
-          solana: {
-            'solana:mainnet': true,
-          },
-        },
-      });
-
-      expect(queryByTestId('account-overview__asset-tab')).toBeInTheDocument();
-      expect(
-        queryByTestId('account-overview__nfts-tab'),
-      ).not.toBeInTheDocument();
-      expect(
-        queryByTestId('account-overview__activity-tab'),
-      ).toBeInTheDocument();
+      expectStandardTabs(queryByTestId);
       expect(
         queryByTestId('account-overview__defi-tab'),
       ).not.toBeInTheDocument();

--- a/ui/components/multichain/account-overview/account-overview-non-evm.tsx
+++ b/ui/components/multichain/account-overview/account-overview-non-evm.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { NonEvmOverview } from '../../app/wallet-overview';
-import {
-  getIsDefiPositionsEnabled,
-  getHasAnyEvmNetworkEnabled,
-} from '../../../selectors';
 import { AccountOverviewLayout } from './account-overview-layout';
 import { AccountOverviewCommonProps } from './common';
 
@@ -13,18 +8,8 @@ export type AccountOverviewNonEvmProps = AccountOverviewCommonProps;
 export const AccountOverviewNonEvm = ({
   ...props
 }: AccountOverviewNonEvmProps) => {
-  const defiPositionsEnabled = useSelector(getIsDefiPositionsEnabled);
-  const hasAnyEvmNetworkEnabled = useSelector(getHasAnyEvmNetworkEnabled);
-
   return (
-    <AccountOverviewLayout
-      showTokens={true}
-      showTokensLinks={true}
-      showNfts={hasAnyEvmNetworkEnabled}
-      showDefi={hasAnyEvmNetworkEnabled && defiPositionsEnabled}
-      showActivity={true}
-      {...props}
-    >
+    <AccountOverviewLayout showTokensLinks={true} {...props}>
       <NonEvmOverview />
     </AccountOverviewLayout>
   );

--- a/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
@@ -84,13 +84,11 @@ describe('AccountOverviewTabs - Perps tab New badge (TAT-3382)', () => {
     variantFlag,
     perpsTabBadgeSeen = false,
     perpsAvailable = true,
-    showTokens = true,
     route,
   }: {
     variantFlag?: { name: string };
     perpsTabBadgeSeen?: boolean;
     perpsAvailable?: boolean;
-    showTokens?: boolean;
     route?: string;
   }) => {
     const store = configureStore({
@@ -111,9 +109,6 @@ describe('AccountOverviewTabs - Perps tab New badge (TAT-3382)', () => {
 
     return renderWithProvider(
       <AccountOverviewTabs
-        showTokens={showTokens}
-        showNfts={false}
-        showActivity={false}
         setBasicFunctionalityModalOpen={jest.fn()}
         onSupportLinkClick={jest.fn()}
       />,
@@ -307,9 +302,6 @@ describe('AccountOverviewTabs - TokenBalancesPoller', () => {
 
     renderWithProvider(
       <AccountOverviewTabs
-        showTokens={true}
-        showNfts={false}
-        showActivity={false}
         setBasicFunctionalityModalOpen={jest.fn()}
         onSupportLinkClick={jest.fn()}
       />,

--- a/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
@@ -177,19 +177,6 @@ describe('AccountOverviewTabs - Perps tab New badge (TAT-3382)', () => {
     expect(setPerpsTabBadgeSeen).not.toHaveBeenCalled();
   });
 
-  it('persists the dismissal when Perps is the clamped active tab (active tab hidden)', () => {
-    // Tokens is hidden but activeTabKey points at the now-hidden Tokens tab, so
-    // Tabs clamps the rendered active tab to the first one (Perps). The badge
-    // must still be marked seen even though no tab click occurs.
-    renderTabs({
-      variantFlag: { name: 'treatment' },
-      showTokens: false,
-      route: '/?tab=tokens',
-    });
-
-    expect(setPerpsTabBadgeSeen).toHaveBeenCalledWith(true);
-  });
-
   it('does not mark the badge seen while Perps is unavailable, even when it is the active tab', () => {
     // Treatment + ?tab=perps but the Perps experience is unavailable: the badge
     // is never rendered, so it must not be persisted as seen (otherwise it would

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -25,6 +25,7 @@ import { useSafeChains } from '../networks-form/use-safe-chains';
 import {
   getDefaultHomeActiveTabName,
   getEnabledChainIds,
+  getIsDefiPositionsEnabled,
 } from '../../../selectors';
 import {
   getIsPerpsExperienceAvailable,
@@ -56,11 +57,11 @@ import { ScreenViewedEntryPoint } from '../../../../shared/constants/metametrics
 import { AccountOverviewCommonProps } from './common';
 
 export type AccountOverviewTabsProps = AccountOverviewCommonProps & {
-  showTokens: boolean;
   showTokensLinks?: boolean;
-  showNfts: boolean;
-  showActivity: boolean;
+  showTokens?: boolean;
+  showNfts?: boolean;
   showDefi?: boolean;
+  showActivity?: boolean;
 };
 
 /**
@@ -83,11 +84,11 @@ const TokenBalancesPoller = ({ chainIds }: { chainIds: Hex[] }) => {
 };
 
 export const AccountOverviewTabs = ({
-  showTokens,
   showTokensLinks,
-  showNfts,
-  showActivity,
-  showDefi,
+  showTokens = true,
+  showNfts = true,
+  showDefi = true,
+  showActivity = true,
 }: AccountOverviewTabsProps) => {
   const persistedTab = useSelector(getDefaultHomeActiveTabName);
   const [urlTab, setActiveTabKey] = useTabState();
@@ -110,6 +111,7 @@ export const AccountOverviewTabs = ({
   const dispatch = useDispatch();
   const selectedChainIds = useSelector(getEnabledChainIds);
   const prefetchTransactions = usePrefetchTransactions();
+  const defiPositionsEnabled = useSelector(getIsDefiPositionsEnabled);
 
   const perpsTabBadgeSeen = useSelector(getPerpsTabBadgeSeen);
   const isPerpsExperienceAvailable = useSelector(getIsPerpsExperienceAvailable);
@@ -141,7 +143,7 @@ export const AccountOverviewTabs = ({
     ...(isPerpsExperienceAvailable && !showBottomNav
       ? [AccountOverviewTabKey.Perps]
       : []),
-    ...(showDefi ? [AccountOverviewTabKey.DeFi] : []),
+    ...(showDefi && defiPositionsEnabled ? [AccountOverviewTabKey.DeFi] : []),
     ...(showNfts ? [AccountOverviewTabKey.Nfts] : []),
     ...(showActivity && !showBottomNav ? [AccountOverviewTabKey.Activity] : []),
   ]);
@@ -284,7 +286,7 @@ export const AccountOverviewTabs = ({
           </Tab>
         )}
 
-        {showDefi && (
+        {showDefi && defiPositionsEnabled && (
           <Tab
             name={t('defi')}
             tabKey={AccountOverviewTabKey.DeFi}


### PR DESCRIPTION
## **Description**

Previously, the home page NFTs and DeFi tabs were hidden on some networks and account types (e.g. non-EVM accounts without any EVM networks enabled). 

This PR always shows the Tokens and NFTs tabs on supported account types, and shows the DeFi tab when the `assetsDefiPositionsEnabled` feature flag is on. Unsupported account types (`account-overview-unknown`) still only show Activity, unchanged from before.

When a user opens the NFTs or DeFi tab while a non-EVM network is selected, they now see a dedicated unsupported empty state ("NFTs/DeFi aren't supported on this network.") instead of the default import/explore empty states.

## **Changelog**

CHANGELOG entry: Reinstate showing DeFi and NFTs tabs on the home page with specific empty states when viewing a non-EVM network.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/45321

## **Manual testing steps**

2. On an EVM account (e.g. Ethereum) with Mainnet selected, open the home page and confirm **Tokens**, **NFTs**, and **DeFi** (if feature flag enabled) tabs are all visible.
3. Switch the network picker to a non-EVM network (e.g. Solana).
4. Open the **NFTs** tab and confirm the unsupported empty state is shown with no Import button.
5. Open the **DeFi** tab and confirm the unsupported empty state is shown with no Explore DeFi button.
6. Switch back to an EVM network and confirm both tabs show the default empty states with their action buttons.

## **Screenshots/Recordings**

### **Before**

https://github.com/MetaMask/metamask-extension/issues/45321

### **After**

<img width="453" height="351" alt="image" src="https://github.com/user-attachments/assets/1168e35a-5d46-4428-855d-6242c03a06fa" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tab visibility and empty-state copy; no auth, funds, or data-handling changes. Unknown account types still hide NFT/DeFi.
> 
> **Overview**
> Always shows Tokens, NFTs, and (when the DeFi feature flag is on) DeFi tabs on EVM and non-EVM home overviews, instead of hiding NFTs/DeFi when no EVM network is enabled.
> 
> Tab visibility is now defaulted in `AccountOverviewTabs` and gated there for DeFi via `assetsDefiPositionsEnabled`. ETH and non-EVM overviews no longer pass per-network show flags. Unknown account types still only show Activity.
> 
> On a non-EVM selected network, NFT and DeFi empty states now say the feature isn’t supported and omit Import / Explore actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47c46960a48a784491d0e393601c88263d6eda2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->