### PR TITLE
chore(assets-controller): delegate AccountActivityService:transactionUpdated for v15

### DIFF
--- a/app/scripts/messenger-client-init/messengers/assets/assets-controller-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/assets-controller-messenger.test.ts
@@ -38,6 +38,7 @@ const ASSETS_CONTROLLER_DELEGATED_EVENTS = [
   'TransactionController:unapprovedTransactionAdded',
   'AccountActivityService:balanceUpdated',
   'AccountActivityService:statusChanged',
+  'AccountActivityService:transactionUpdated',
   'RemoteFeatureFlagController:stateChange',
 ] as const;
 

--- a/app/scripts/messenger-client-init/messengers/assets/assets-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/assets-controller-messenger.ts
@@ -89,6 +89,9 @@ export function getAssetsControllerMessenger(
       // Real-time post-tx balances + per-chain connectivity (AccountActivityService WS path)
       'AccountActivityService:balanceUpdated',
       'AccountActivityService:statusChanged',
+      // Correlates a confirmed tx with its WS push to skip a redundant Accounts
+      // API call (see AssetsController post-tx WS dedup in @metamask/assets-controller v15)
+      'AccountActivityService:transactionUpdated',
       'RemoteFeatureFlagController:stateChange',
     ],
   });


### PR DESCRIPTION
## **Description**

`@metamask/assets-controller` v15 adds a breaking change: it now listens for `AccountActivityService:transactionUpdated` to skip redundant Accounts API balance refetches after a transaction is confirmed when the WebSocket already delivered the update.

Extension uses a scoped `AssetsController` messenger with an explicit delegation list, so this event must be delegated or `AssetsController` will never receive it and will always fall back to the API call.

This PR adds that delegation (and updates the delegated-events test list). The `@metamask/assets-controller` package bump to v15 will follow once it is published — see MetaMask/core#9940.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3910

Refs: MetaMask/core#9940

## **Manual testing steps**

N/A — messenger wiring only. End-to-end verification depends on bumping `@metamask/assets-controller` to v15 once published; after that, confirm a transaction on a WS-active chain does not trigger a redundant Accounts API balance refetch when the WebSocket already updated balances.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.