### PR TITLE
fix(activity): show spending cap amounts in detail headers

### DIFF
--- a/ui/pages/details/components/token-header.tsx
+++ b/ui/pages/details/components/token-header.tsx
@@ -5,7 +5,13 @@ import { ActivityAvatar } from '../../../components/app/activity-list-item-avata
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTokensData } from '../../../hooks/useTokensData';
 
-export const TokenHeader = ({ token }: { token?: TokenAmount }) => {
+export const TokenHeader = ({
+  token,
+  amount,
+}: {
+  token?: TokenAmount;
+  amount?: string;
+}) => {
   const t = useI18nContext();
   const tokenAssetId = token?.assetId;
   const tokensByAssetId = useTokensData(tokenAssetId ? [tokenAssetId] : []);
@@ -14,12 +20,13 @@ export const TokenHeader = ({ token }: { token?: TokenAmount }) => {
     : undefined;
   const tokenLabel =
     token?.symbol ?? tokenMetadata?.symbol ?? tokenMetadata?.name ?? t('token');
+  const headerLabel = amount ? `${amount} ${tokenLabel}` : tokenLabel;
 
   return (
     <div className="flex items-center gap-2 py-4">
       <ActivityAvatar tokens={[token?.assetId]} />
 
-      <Text variant="heading-lg">{tokenLabel}</Text>
+      <Text variant="heading-lg">{headerLabel}</Text>
     </div>
   );
 };

--- a/ui/pages/details/templates/approval-details.test.tsx
+++ b/ui/pages/details/templates/approval-details.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { ActivityListItem } from '../../../../shared/lib/activity/types';
+import { ApprovalDetails } from './approval-details';
+
+jest.mock('../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string) =>
+    ({ token: 'Token', unlimited: 'Unlimited' })[key] ?? key,
+}));
+
+jest.mock('../../../hooks/useFormatters', () => ({
+  useFormatters: () => ({
+    formatToken: (
+      value: `${number}`,
+      symbol: string,
+      options: Intl.NumberFormatOptions,
+    ) =>
+      `${new Intl.NumberFormat('en-US', options).format(Number(value))} ${symbol}`,
+  }),
+}));
+
+jest.mock('../../../hooks/useTokensData', () => ({
+  useTokensData: () => ({}),
+}));
+
+jest.mock('../../../components/app/activity-list-item-avatar', () => ({
+  ActivityAvatar: () => <div data-testid="activity-avatar" />,
+}));
+
+jest.mock('../components/sections', () => ({
+  MetadataSection: () => <div data-testid="metadata-section" />,
+}));
+
+jest.mock('../components/amounts-section', () => ({
+  FeesRows: () => <div data-testid="fees-rows" />,
+  TotalAmountRow: () => <div data-testid="total-amount-row" />,
+}));
+
+jest.mock('../components/shared', () => ({
+  Footer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="footer">{children}</div>
+  ),
+  Section: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="section">{children}</div>
+  ),
+}));
+
+jest.mock('../components/block-explorer-button', () => ({
+  BlockExplorerButton: () => <div data-testid="block-explorer-button" />,
+}));
+
+type ApprovalItem = Extract<
+  ActivityListItem,
+  {
+    type: 'approveSpendingCap' | 'increaseSpendingCap' | 'revokeSpendingCap';
+  }
+>;
+
+const usdtAssetId = 'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7';
+
+function buildItem(
+  type: ApprovalItem['type'],
+  amount: string | undefined,
+): ApprovalItem {
+  return {
+    type,
+    chainId: 'eip155:1',
+    status: 'success',
+    timestamp: 1716367781000,
+    hash: '0x123',
+    data: {
+      from: '0x1111111111111111111111111111111111111111',
+      token: {
+        amount,
+        assetId: usdtAssetId,
+        decimals: 6,
+        direction: 'out',
+        symbol: 'USDT',
+      },
+    },
+  };
+}
+
+const mappedAmountTypes = [
+  'approveSpendingCap',
+  'increaseSpendingCap',
+] as const;
+
+describe('ApprovalDetails', () => {
+  for (const type of mappedAmountTypes) {
+    it(`renders the mapped amount for ${type} activity`, () => {
+      const { getByText } = render(
+        <ApprovalDetails item={buildItem(type, '50000000000')} />,
+      );
+
+      expect(getByText('50,000 USDT')).toBeInTheDocument();
+    });
+  }
+
+  it('renders Unlimited when the mapped approval omits its unlimited amount', () => {
+    const { getByText } = render(
+      <ApprovalDetails item={buildItem('approveSpendingCap', undefined)} />,
+    );
+
+    expect(getByText('Unlimited USDT')).toBeInTheDocument();
+  });
+
+  it('renders 0 for revoke activity regardless of its mapped token amount', () => {
+    const { getByText } = render(
+      <ApprovalDetails item={buildItem('revokeSpendingCap', '50000000000')} />,
+    );
+
+    expect(getByText('0 USDT')).toBeInTheDocument();
+  });
+});

--- a/ui/pages/details/templates/approval-details.tsx
+++ b/ui/pages/details/templates/approval-details.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import type { ActivityListItem } from '../../../../shared/lib/activity/types';
+import { getHumanReadableTokenAmount } from '../../../../shared/lib/activity/fiat';
+import { useFormatters } from '../../../hooks/useFormatters';
+import { useI18nContext } from '../../../hooks/useI18nContext';
 import { FeesRows, TotalAmountRow } from '../components/amounts-section';
 import { Footer, Section } from '../components/shared';
 import { BlockExplorerButton } from '../components/block-explorer-button';
 import { MetadataSection } from '../components/sections';
 import { TokenHeader } from '../components/token-header';
+
+const maximumFractionDigits = 8;
 
 export function ApprovalDetails({
   item,
@@ -16,10 +21,32 @@ export function ApprovalDetails({
     }
   >;
 }) {
+  const t = useI18nContext();
+  const { formatToken } = useFormatters();
+  const { token } = item.data;
+  const humanAmount = token ? getHumanReadableTokenAmount(token) : undefined;
+
+  let amount: string | undefined;
+  if (token) {
+    if (item.type === 'revokeSpendingCap') {
+      amount = '0';
+    } else if (
+      token.amount === undefined ||
+      token.amount === null ||
+      token.amount === ''
+    ) {
+      amount = t('unlimited');
+    } else if (humanAmount !== undefined) {
+      amount = formatToken(humanAmount as `${number}`, '', {
+        maximumFractionDigits,
+      }).trim();
+    }
+  }
+
   return (
     <div className="flex grow flex-col">
       <div className="divide-y divide-border-muted">
-        <TokenHeader token={item.data.token} />
+        <TokenHeader token={token} amount={amount} />
         <MetadataSection item={item} />
         <Section>
           <FeesRows item={item} />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Spending cap activity details only showed the token symbol in the header. This change formats source-mapped approval and increase amounts in the header, displays unlimited approvals as `Unlimited`, and displays revocations as `0` while keeping local activity mapping limited to activity classification.

## **Changelog**

CHANGELOG entry: Added spending cap amounts to approval, increase, and revoke activity detail headers

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1321

## **Manual testing steps**

1. Run the extension, approve a finite ERC-20 spending cap, wait for the indexed activity data to load, and open the activity details.
2. Verify the header shows the localized approval amount followed by the token symbol.
3. Approve an unlimited spending cap and verify the details header shows `Unlimited` followed by the token symbol.
4. Increase a spending cap and verify the details header shows the increase amount followed by the token symbol.
5. Revoke a spending cap and verify the details header shows `0` followed by the token symbol.

## **Screenshots/Recordings**

Screenshots were not captured because the extension build and visual verification were excluded from this task.

### **Before**

Not captured.

### **After**

Not captured.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)