### PR TITLE
chore(activity): revise row layout and transaction id type size

### DIFF
--- a/ui/components/app/transaction/transaction-id.tsx
+++ b/ui/components/app/transaction/transaction-id.tsx
@@ -32,14 +32,14 @@ export function TransactionId({ value }: TransactionIdProps) {
       onClick={() => handleCopy(value)}
       aria-label={t('copyTransactionId')}
       className={classnames(
-        'inline-flex items-center gap-1 rounded-full h-6 min-w-0 border-0 px-2 py-1',
+        'inline-flex items-center gap-1 rounded-full min-w-0 border-0 px-2 py-1',
         copied ? 'bg-success-muted' : 'bg-muted hover:bg-muted-hover',
       )}
       data-testid="transaction-id"
     >
       <Text
         ellipsis
-        variant={TextVariant.BodySm}
+        className="@compact:text-s-body-sm"
         fontWeight={FontWeight.Regular}
         color={copied ? TextColor.SuccessDefault : TextColor.TextDefault}
       >

--- a/ui/pages/details/components/shared.tsx
+++ b/ui/pages/details/components/shared.tsx
@@ -83,7 +83,7 @@ export function Row({
 
   return (
     <div
-      className="flex items-start justify-between gap-4 py-2"
+      className="flex items-center justify-between gap-4 min-h-8"
       data-testid={testId}
     >
       <Text
@@ -104,7 +104,11 @@ export function Row({
 }
 
 export function Section({ children }: Readonly<{ children: ReactNode }>) {
-  return <section className="py-2 empty:hidden">{children}</section>;
+  return (
+    <section className="flex flex-col gap-2 py-2 empty:hidden">
+      {children}
+    </section>
+  );
 }
 
 export function Footer({ children }: Readonly<{ children: ReactNode }>) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Updated the section and row layout to correctly distribute spacing and have consistent row height
- Updated the transaction ID type size 

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1320

## **Manual testing steps**

1. Open Activity and select a completed transaction with a transaction ID
2. Verify the Transaction ID text size matches the Date, Account, and Network metadata value text sizes.

## **Screenshots/Recordings**

### **Before**

[screenshots/recordings]

### **After**

<img width="216" height="266" alt="image" src="https://github.com/user-attachments/assets/4e0cfe3b-d828-4dbb-973d-e3d3fe87b575" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)