### PR TITLE
fix(activity): show token symbol on approval rows

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -174,26 +174,35 @@
   "activityEmptyNoFundsDescription": {
     "message": "Add funds to your wallet to get started."
   },
+  "activity_approveSpendingCapUnknownToken_failed_title": {
+    "message": "Approval failed"
+  },
+  "activity_approveSpendingCapUnknownToken_pending_title": {
+    "message": "Approving spending cap"
+  },
+  "activity_approveSpendingCapUnknownToken_success_title": {
+    "message": "Approved spending cap"
+  },
   "activity_approveSpendingCap_failed_description": {
     "message": "$1",
     "description": "$1 is the token symbol"
   },
   "activity_approveSpendingCap_failed_title": {
-    "message": "Approval failed"
+    "message": "$1 approval failed"
   },
   "activity_approveSpendingCap_pending_description": {
     "message": "$1",
     "description": "$1 is the token symbol"
   },
   "activity_approveSpendingCap_pending_title": {
-    "message": "Approving spending cap"
+    "message": "Approving $1 spending cap"
   },
   "activity_approveSpendingCap_success_description": {
     "message": "$1",
     "description": "$1 is the token symbol"
   },
   "activity_approveSpendingCap_success_title": {
-    "message": "Approved spending cap"
+    "message": "Approved $1 spending cap"
   },
   "activity_assetActivation_failed_description": {
     "message": "$1",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -174,26 +174,35 @@
   "activityEmptyNoFundsDescription": {
     "message": "Add funds to your wallet to get started."
   },
+  "activity_approveSpendingCapUnknownToken_failed_title": {
+    "message": "Approval failed"
+  },
+  "activity_approveSpendingCapUnknownToken_pending_title": {
+    "message": "Approving spending cap"
+  },
+  "activity_approveSpendingCapUnknownToken_success_title": {
+    "message": "Approved spending cap"
+  },
   "activity_approveSpendingCap_failed_description": {
     "message": "$1",
     "description": "$1 is the token symbol"
   },
   "activity_approveSpendingCap_failed_title": {
-    "message": "Approval failed"
+    "message": "$1 approval failed"
   },
   "activity_approveSpendingCap_pending_description": {
     "message": "$1",
     "description": "$1 is the token symbol"
   },
   "activity_approveSpendingCap_pending_title": {
-    "message": "Approving spending cap"
+    "message": "Approving $1 spending cap"
   },
   "activity_approveSpendingCap_success_description": {
     "message": "$1",
     "description": "$1 is the token symbol"
   },
   "activity_approveSpendingCap_success_title": {
-    "message": "Approved spending cap"
+    "message": "Approved $1 spending cap"
   },
   "activity_assetActivation_failed_description": {
     "message": "$1",

--- a/test/e2e/page-objects/flows/bridge.flow.ts
+++ b/test/e2e/page-objects/flows/bridge.flow.ts
@@ -54,7 +54,9 @@ export const verifySubmittedSwapTransaction = async ({
       confirmedTx: expectedTransactionsCount,
     });
     await activityTab.checkTxAction({
-      action: 'Approved spending cap',
+      action: expectedSrcToken
+        ? `Approved ${expectedSrcToken} spending cap`
+        : 'Approved spending cap',
       confirmedTx: expectedTransactionsCount,
       txIndex: 2,
     });

--- a/test/e2e/tests/bridge/swap-gasless.spec.ts
+++ b/test/e2e/tests/bridge/swap-gasless.spec.ts
@@ -79,7 +79,7 @@ describe('Gasless swap tests', function (this: Suite) {
           txIndex: 1,
         });
         await activityTab.checkTxAction({
-          action: 'Approved spending cap',
+          action: 'Approved USDC spending cap',
           confirmedTx: 0,
           txIndex: 2,
         });

--- a/ui/pages/activity/rows/useActivityRowContent.test.tsx
+++ b/ui/pages/activity/rows/useActivityRowContent.test.tsx
@@ -71,6 +71,39 @@ const buildActivity = (type: 'assetActivation' | 'assetDeactivation') =>
     },
   }) as unknown as ActivityListItem;
 
+const tokenContractAddress = '0x1234567890abcdef1234567890abcdef12345678';
+const usdcAssetId = `eip155:1/erc20:${tokenContractAddress}`;
+
+const buildSpendingCapActivity = ({
+  type = 'approveSpendingCap',
+  status = 'success',
+  symbol = 'USDC',
+}: {
+  type?: 'approveSpendingCap' | 'increaseSpendingCap' | 'revokeSpendingCap';
+  status?: 'pending' | 'success';
+  symbol?: string;
+} = {}) =>
+  ({
+    type,
+    chainId: 'eip155:1',
+    status,
+    timestamp: 1,
+    hash: '0xabc',
+    data: {
+      from: '0x2222222222222222222222222222222222222222',
+      token: {
+        direction: 'out',
+        symbol,
+        assetId: usdcAssetId,
+      },
+    },
+  }) as ActivityListItem;
+
+const unchangedTitleCases = [
+  ['increaseSpendingCap', 'activity_increaseSpendingCap_success_title'],
+  ['revokeSpendingCap', 'activity_revokeSpendingCap_success_title'],
+] as const;
+
 describe('useActivityRowContent', () => {
   beforeEach(() => {
     mockGetDisplayName.mockImplementation((address?: string) =>
@@ -343,4 +376,81 @@ describe('useActivityRowContent', () => {
       'activity_receive_success_description|Bob',
     );
   });
+
+  it('includes the token symbol in pending approve titles', () => {
+    const { result } = renderHookWithProvider(() =>
+      useActivityRowContent(buildSpendingCapActivity({ status: 'pending' })),
+    );
+
+    expect(result.current?.title.props.children).toBe(
+      'activity_approveSpendingCap_pending_title|USDC',
+    );
+  });
+
+  it('includes the token symbol in successful approve titles', () => {
+    const { result } = renderHookWithProvider(() =>
+      useActivityRowContent(buildSpendingCapActivity()),
+    );
+
+    expect(result.current?.title.props.children).toBe(
+      'activity_approveSpendingCap_success_title|USDC',
+    );
+  });
+
+  it('shows the approved token contract name in the subtitle', () => {
+    mockGetDisplayName.mockReturnValue('USD Coin');
+
+    const { result } = renderHookWithProvider(() =>
+      useActivityRowContent(buildSpendingCapActivity()),
+    );
+
+    expect(mockGetDisplayName).toHaveBeenCalledWith(tokenContractAddress);
+    expect(result.current?.subtitle).toBe(
+      'activity_contractInteraction_success_description|USD Coin',
+    );
+  });
+
+  it('falls back to the truncated contract address in the subtitle', () => {
+    mockGetDisplayName.mockReturnValue('0x12345...45678');
+
+    const { result } = renderHookWithProvider(() =>
+      useActivityRowContent(buildSpendingCapActivity()),
+    );
+
+    expect(result.current?.subtitle).toBe(
+      'activity_contractInteraction_success_description|0x12345...45678',
+    );
+  });
+
+  it('uses a title without a symbol for an approve that has no token symbol', () => {
+    const { result } = renderHookWithProvider(() =>
+      useActivityRowContent(buildSpendingCapActivity({ symbol: '' })),
+    );
+
+    expect(result.current.title.props.children).toBe(
+      'activity_approveSpendingCapUnknownToken_success_title',
+    );
+  });
+
+  it('uses a title without a symbol for a pending approve that has no token symbol', () => {
+    const { result } = renderHookWithProvider(() =>
+      useActivityRowContent(
+        buildSpendingCapActivity({ status: 'pending', symbol: '' }),
+      ),
+    );
+
+    expect(result.current.title.props.children).toBe(
+      'activity_approveSpendingCapUnknownToken_pending_title',
+    );
+  });
+
+  for (const [type, expectedTitle] of unchangedTitleCases) {
+    it(`keeps the ${type} title unchanged`, () => {
+      const { result } = renderHookWithProvider(() =>
+        useActivityRowContent(buildSpendingCapActivity({ type })),
+      );
+
+      expect(result.current?.title.props.children).toBe(expectedTitle);
+    });
+  }
 });

--- a/ui/pages/activity/rows/useActivityRowContent.tsx
+++ b/ui/pages/activity/rows/useActivityRowContent.tsx
@@ -1,7 +1,12 @@
 import React, { type ReactNode } from 'react';
 import cn from 'clsx';
 import type { CaipAssetType, CaipChainId } from '@metamask/utils';
-import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
+import {
+  isCaipAssetType,
+  KnownCaipNamespace,
+  parseCaipAssetType,
+  parseCaipChainId,
+} from '@metamask/utils';
 import { NETWORK_TO_NAME_MAP } from '../../../../shared/constants/network';
 import { MULTICHAIN_NETWORK_TO_NICKNAME } from '../../../../shared/constants/multichain/networks';
 import { getChainIdFromAssetId } from '../../../../shared/lib/asset-utils';
@@ -32,6 +37,12 @@ type ActivityContent = {
   avatarTokens: ActivityListItemAvatarTokens;
 };
 
+const approveUnknownTokenTitleKeys: Record<string, string> = {
+  pending: 'activity_approveSpendingCapUnknownToken_pending_title',
+  success: 'activity_approveSpendingCapUnknownToken_success_title',
+  failed: 'activity_approveSpendingCapUnknownToken_failed_title',
+};
+
 function getChainDisplay(caipChainId: CaipChainId) {
   const { namespace } = parseCaipChainId(caipChainId);
   const chainId =
@@ -59,7 +70,6 @@ export function useActivityRowContent(activity: ActivityRowProps['data']) {
     type: activity.type,
     status: activity.status,
   });
-
   const getContent = (): ActivityContent => {
     switch (activity.type) {
       case 'send':
@@ -291,11 +301,32 @@ export function useActivityRowContent(activity: ActivityRowProps['data']) {
       case 'increaseSpendingCap':
       case 'revokeSpendingCap': {
         const { token } = activity.data;
+        const isApprove = activity.type === 'approveSpendingCap';
+        const contractAddress =
+          isApprove && token?.assetId && isCaipAssetType(token.assetId)
+            ? parseCaipAssetType(token.assetId).assetReference
+            : undefined;
+        const contractDisplayName = isApprove
+          ? formatDisplayName(contractAddress)
+          : '';
+        const symbol = token?.symbol;
+        // NFT and unwatched-token approvals reach the list without a symbol,
+        // so they use titles that read correctly without one.
+        const approveTitleKey = symbol
+          ? labelKeys.title.key
+          : (approveUnknownTokenTitleKeys[activity.status] ??
+            labelKeys.title.key);
 
         return {
           avatarTokens: [token?.assetId],
-          title: t(labelKeys.title.key),
-          subtitle: t(labelKeys.description.key, [token?.symbol ?? '']),
+          title: isApprove
+            ? t(approveTitleKey, symbol ? [symbol] : undefined)
+            : t(labelKeys.title.key),
+          subtitle: isApprove
+            ? t(`activity_contractInteraction_${activity.status}_description`, [
+                contractDisplayName,
+              ])
+            : t(labelKeys.description.key, [token?.symbol ?? '']),
           primaryAmount: token?.amount
             ? formatTokenAmount(token, { showPlus: false })
             : undefined,

--- a/ui/pages/details/components/header.test.tsx
+++ b/ui/pages/details/components/header.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { ActivityListItem } from '../../../../shared/lib/activity/types';
+import { Header } from './header';
+
+jest.mock('../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string, substitutions?: string[]) =>
+    substitutions ? `${key}|${substitutions.join(',')}` : key,
+}));
+
+const buildApproval = (status: 'pending' | 'success', symbol = 'USDC') =>
+  ({
+    type: 'approveSpendingCap',
+    chainId: 'eip155:1',
+    status,
+    timestamp: 1,
+    hash: '0xabc',
+    data: {
+      token: {
+        direction: 'out',
+        symbol,
+      },
+    },
+  }) as ActivityListItem;
+
+const approveTitleCases = [
+  ['pending', 'activity_approveSpendingCap_pending_title|USDC'],
+  ['success', 'activity_approveSpendingCap_success_title|USDC'],
+] as const;
+
+describe('Header', () => {
+  for (const [status, expectedTitle] of approveTitleCases) {
+    it(`includes the token symbol in the ${status} approve title`, () => {
+      const { getByText } = render(
+        <Header item={buildApproval(status)} onBack={jest.fn()} />,
+      );
+
+      expect(getByText(expectedTitle)).toBeInTheDocument();
+    });
+  }
+
+  it('uses a title without a symbol when the approval has no token symbol', () => {
+    const { getByText } = render(
+      <Header item={buildApproval('success', '')} onBack={jest.fn()} />,
+    );
+
+    expect(
+      getByText('activity_approveSpendingCapUnknownToken_success_title'),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/pages/details/components/header.tsx
+++ b/ui/pages/details/components/header.tsx
@@ -84,6 +84,21 @@ function getTitleConfig(item: ActivityListItem | undefined) {
         args: getDefinedArgs(item.data.token?.symbol),
       };
     }
+    case 'approveSpendingCap': {
+      const symbol = item.data.token?.symbol;
+
+      if (!symbol) {
+        return {
+          key: `activity_approveSpendingCapUnknownToken_${item.status}_title`,
+          args: undefined,
+        };
+      }
+
+      return {
+        key,
+        args: getDefinedArgs(symbol),
+      };
+    }
     default:
       return { key, args: [''] };
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Approve spending cap activity rows did not identify the approved token or contract clearly. This change includes the token symbol in pending, successful, and failed approval titles, shows the approved token contract name with the existing truncated-address fallback, hides approval rows without a token symbol, and keeps the details header aligned with the list title. Increase and revoke spending cap titles are unchanged; approval amount work remains scoped to CEUX-1321.

## **Changelog**

CHANGELOG entry: Fixed approve spending cap activity rows to show token symbols and contract names

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1322

## **Manual testing steps**

1. Run the extension and connect a dapp that can request an ERC-20 spending approval for a known token such as USDC.
2. Submit the approval and open Activity while it is pending.
3. Verify the row title reads `Approving USDC spending cap` and the subtitle reads `With {contract name}` or uses the truncated token contract address when no name is available.
4. Wait for the approval to succeed and verify the row title reads `Approved USDC spending cap`.
5. Open the activity details and verify its header matches the list title and status tense.
6. Verify existing increase and revoke spending cap activity titles remain unchanged.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Not included; this draft was prepared without running a build or visual test session.

### **After**

Not included; this draft was prepared without running a build or visual test session.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)