### PR TITLE
chore: upgrade design system packages (v61.0.0)

### DIFF
--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -1192,6 +1192,7 @@
     },
     "@metamask/design-system-react": {
       "globals": {
+        "ResizeObserver": true,
         "console.warn": true,
         "document.addEventListener": true,
         "document.body": true,

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -1192,6 +1192,7 @@
     },
     "@metamask/design-system-react": {
       "globals": {
+        "ResizeObserver": true,
         "console.warn": true,
         "document.addEventListener": true,
         "document.body": true,

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -1192,6 +1192,7 @@
     },
     "@metamask/design-system-react": {
       "globals": {
+        "ResizeObserver": true,
         "console.warn": true,
         "document.addEventListener": true,
         "document.body": true,

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -1192,6 +1192,7 @@
     },
     "@metamask/design-system-react": {
       "globals": {
+        "ResizeObserver": true,
         "console.warn": true,
         "document.addEventListener": true,
         "document.body": true,

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -1278,6 +1278,7 @@
     },
     "@metamask/design-system-react": {
       "globals": {
+        "ResizeObserver": true,
         "console.warn": true,
         "document.addEventListener": true,
         "document.body": true,

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -1278,6 +1278,7 @@
     },
     "@metamask/design-system-react": {
       "globals": {
+        "ResizeObserver": true,
         "console.warn": true,
         "document.addEventListener": true,
         "document.body": true,

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -1278,6 +1278,7 @@
     },
     "@metamask/design-system-react": {
       "globals": {
+        "ResizeObserver": true,
         "console.warn": true,
         "document.addEventListener": true,
         "document.body": true,

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -1278,6 +1278,7 @@
     },
     "@metamask/design-system-react": {
       "globals": {
+        "ResizeObserver": true,
         "console.warn": true,
         "document.addEventListener": true,
         "document.body": true,

--- a/package.json
+++ b/package.json
@@ -393,7 +393,7 @@
     "@metamask/delegation-controller": "^3.0.2",
     "@metamask/delegation-core": "^2.0.0",
     "@metamask/delegation-deployments": "^1.3.0",
-    "@metamask/design-system-react": "^0.36.0",
+    "@metamask/design-system-react": "^0.37.0",
     "@metamask/design-system-tailwind-preset": "^0.11.0",
     "@metamask/design-tokens": "^9.0.0",
     "@metamask/dummy-package": "workspace:*",

--- a/ui/components/multichain/avatar-group/avatar-group.tsx
+++ b/ui/components/multichain/avatar-group/avatar-group.tsx
@@ -24,6 +24,13 @@ import {
 } from '../../component-library/avatar-network';
 import { AvatarGroupProps, AvatarType } from './avatar-group.types';
 
+/**
+ * @deprecated This component is deprecated and will be removed in a future release.
+ * Please use the AvatarGroup component from @metamask/design-system-react instead.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#avatargroup-component | Migration Guide}
+ * @see {@link https://metamask.github.io/metamask-design-system/?path=/docs/react-components-avatargroup--docs | Storybook Documentation}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/tree/main/packages/design-system-react/src/components/AvatarGroup | Component Source}
+ */
 export const AvatarGroup = ({
   className = '',
   limit = 4,

--- a/ui/components/multichain/avatar-group/avatar-group.tsx
+++ b/ui/components/multichain/avatar-group/avatar-group.tsx
@@ -25,11 +25,17 @@ import {
 import { AvatarGroupProps, AvatarType } from './avatar-group.types';
 
 /**
- * @deprecated This component is deprecated and will be removed in a future release.
- * Please use the AvatarGroup component from @metamask/design-system-react instead.
+ * @param options0
+ * @param options0.className
+ * @param options0.limit
+ * @param options0.members
+ * @param options0.size
+ * @param options0.avatarType
+ * @param options0.isTagOverlay
+ * @param options0.variant
+ * @deprecated Please update your code to use `AvatarGroup` from `@metamask/design-system-react`.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#avatargroup-component | Migration Guide}
  * @see {@link https://metamask.github.io/metamask-design-system/?path=/docs/react-components-avatargroup--docs | Storybook Documentation}
- * @see {@link https://github.com/MetaMask/metamask-design-system/tree/main/packages/design-system-react/src/components/AvatarGroup | Component Source}
  */
 export const AvatarGroup = ({
   className = '',

--- a/ui/pages/bridge/prepare/components/__snapshots__/bridge-alert-banner-list.test.tsx.snap
+++ b/ui/pages/bridge/prepare/components/__snapshots__/bridge-alert-banner-list.test.tsx.snap
@@ -212,7 +212,7 @@ exports[`BridgeAlertBannerList should render the no-quotes alert when no quotes 
   data-testid="bridge-banner-alerts"
 >
   <div
-    class="flex flex-row gap-4 items-start pt-3 pr-4 pb-3 pl-4 bg-error-muted rounded-xl"
+    class="flex flex-row gap-4 items-center pt-3 pr-4 pb-3 pl-4 bg-error-muted rounded-xl"
     data-testid="bridge-no-quotes"
   >
     <svg
@@ -254,7 +254,7 @@ exports[`BridgeAlertBannerList should render the no-quotes alert when reason is 
   data-testid="bridge-banner-alerts"
 >
   <div
-    class="flex flex-row gap-4 items-start pt-3 pr-4 pb-3 pl-4 bg-error-muted rounded-xl"
+    class="flex flex-row gap-4 items-center pt-3 pr-4 pb-3 pl-4 bg-error-muted rounded-xl"
     data-testid="bridge-no-quotes"
   >
     <svg

--- a/ui/pages/bridge/prepare/components/__snapshots__/bridge-alert-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/components/__snapshots__/bridge-alert-modal.test.tsx.snap
@@ -247,7 +247,7 @@ exports[`BridgeAlertModal quote-card should render alert banner when there is a 
               class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
             />
             <div
-              class="flex flex-row gap-4 items-start pt-3 pr-4 pb-3 pl-4 bg-error-muted rounded-xl"
+              class="flex flex-row gap-4 items-center pt-3 pr-4 pb-3 pl-4 bg-error-muted rounded-xl"
               data-testid="bridge-alert-modal-banner"
             >
               <svg
@@ -632,7 +632,7 @@ exports[`BridgeAlertModal submit-cta should disable the submit button when submi
               class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
             />
             <div
-              class="flex flex-row gap-4 items-start pt-3 pr-4 pb-3 pl-4 bg-error-muted rounded-xl"
+              class="flex flex-row gap-4 items-center pt-3 pr-4 pb-3 pl-4 bg-error-muted rounded-xl"
               data-testid="bridge-alert-modal-banner"
             >
               <svg
@@ -866,7 +866,7 @@ exports[`BridgeAlertModal submit-cta should render when there is a price impact 
               class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
             />
             <div
-              class="flex flex-row gap-4 items-start pt-3 pr-4 pb-3 pl-4 bg-error-muted rounded-xl"
+              class="flex flex-row gap-4 items-center pt-3 pr-4 pb-3 pl-4 bg-error-muted rounded-xl"
               data-testid="bridge-alert-modal-banner"
             >
               <svg

--- a/ui/pages/create-password-form/__snapshots__/create-password-form.test.tsx.snap
+++ b/ui/pages/create-password-form/__snapshots__/create-password-form.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`CreatePasswordForm renders match snapshot 1`] = `
           >
             <input
               aria-invalid="false"
-              class="peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform enabled:active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default disabled:cursor-not-allowed bg-default enabled:hover:bg-default-hover enabled:active:bg-default-pressed border-default"
+              class="peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform enabled:active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default disabled:cursor-not-allowed bg-transparent enabled:hover:bg-hover enabled:active:bg-pressed border-default"
               id="create-password-terms"
               type="checkbox"
             />

--- a/ui/pages/onboarding-flow/create-password/__snapshots__/create-password.test.tsx.snap
+++ b/ui/pages/onboarding-flow/create-password/__snapshots__/create-password.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`Onboarding Create Password Render should match snapshot 1`] = `
             >
               <input
                 aria-invalid="false"
-                class="peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform enabled:active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default disabled:cursor-not-allowed bg-default enabled:hover:bg-default-hover enabled:active:bg-default-pressed border-default"
+                class="peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform enabled:active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default disabled:cursor-not-allowed bg-transparent enabled:hover:bg-hover enabled:active:bg-pressed border-default"
                 id="create-password-terms"
                 type="checkbox"
               />

--- a/ui/pages/onboarding-flow/metametrics/__snapshots__/metametrics.test.tsx.snap
+++ b/ui/pages/onboarding-flow/metametrics/__snapshots__/metametrics.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`Onboarding Metametrics Component renders match snapshot 1`] = `
         >
           <input
             aria-invalid="false"
-            class="peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform enabled:active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default disabled:cursor-not-allowed bg-default enabled:hover:bg-default-hover enabled:active:bg-default-pressed border-default"
+            class="peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform enabled:active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default disabled:cursor-not-allowed bg-transparent enabled:hover:bg-hover enabled:active:bg-pressed border-default"
             id="metametrics-datacollection-opt-in"
             type="checkbox"
           />
@@ -232,7 +232,7 @@ exports[`Onboarding Metametrics Component renders match snapshot after new polic
         >
           <input
             aria-invalid="false"
-            class="peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform enabled:active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default disabled:cursor-not-allowed bg-default enabled:hover:bg-default-hover enabled:active:bg-default-pressed border-default"
+            class="peer size-6 shrink-0 cursor-pointer appearance-none rounded border-2 p-0 transition-transform enabled:active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default disabled:cursor-not-allowed bg-transparent enabled:hover:bg-hover enabled:active:bg-pressed border-default"
             id="metametrics-datacollection-opt-in"
             type="checkbox"
           />

--- a/yarn.lock
+++ b/yarn.lock
@@ -6360,9 +6360,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react@npm:^0.36.0":
-  version: 0.36.0
-  resolution: "@metamask/design-system-react@npm:0.36.0"
+"@metamask/design-system-react@npm:^0.37.0":
+  version: 0.37.0
+  resolution: "@metamask/design-system-react@npm:0.37.0"
   dependencies:
     "@floating-ui/react-dom": "npm:^2.1.2"
     "@metamask/design-system-shared": "npm:^0.33.0"
@@ -6377,7 +6377,7 @@ __metadata:
     "@metamask/utils": ^11.11.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/2f4a6d43ca33c5db7c3a9bedbf0520f70f23279b0bd65115d65f899ead8c8a37b400bd2fbafe942f2108cf063d0a66933b03aef09c7c94ccd3d1620869c06b55
+  checksum: 10/7481ff773df061b1004eb30f9896106e74c327bcbc4d4235b70d517a227de36443cc97293a5513e131cfb08ee6609367f8ad4b27eb4cff3b339fa6a3d17e4718
   languageName: node
   linkType: hard
 
@@ -33221,7 +33221,7 @@ __metadata:
     "@metamask/delegation-controller": "npm:^3.0.2"
     "@metamask/delegation-core": "npm:^2.0.0"
     "@metamask/delegation-deployments": "npm:^1.3.0"
-    "@metamask/design-system-react": "npm:^0.36.0"
+    "@metamask/design-system-react": "npm:^0.37.0"
     "@metamask/design-system-shared": "npm:^0.33.0"
     "@metamask/design-system-tailwind-preset": "npm:^0.11.0"
     "@metamask/design-tokens": "npm:^9.0.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Upgrades design system packages to align with the [v61.0.0 release](https://github.com/MetaMask/metamask-design-system/releases/tag/v61.0.0).

**Rebased onto `main`** — pure-black removal and elevated-token migration landed in #45479, so this PR only carries the remaining v61 delta.

**Packages upgraded:**
- `@metamask/design-system-react`: `^0.36.0` → `^0.37.0`

**Already on `main` (no changes in this PR):**
- `@metamask/design-tokens`: `^9.0.0`
- `@metamask/design-system-tailwind-preset`: `^0.11.0`
- `@metamask/design-system-shared`: `^0.33.0`
- PureBlackProvider / `usePureBlack` / `MM_PURE_BLACK_PREVIEW` removal (#45479)

**Breaking changes addressed:**

### Checkbox unselected background (design-system-react 0.37.0)
Upstream changed unselected checkboxes to use a transparent background instead of `background.default`.

**Migration:** Regenerated Jest snapshots across 5 test suites (metametrics, create-password, bridge alert banner/modal).

### Other breaking changes (no code changes needed)
- `PureBlackProvider` / `usePureBlack` — already removed on `main` (#45479)
- `showCloseButton` on `ToastOptions` — extension does not use the imperative toast API
- `BannerBase` alignment changes — inherited by design-system components; no local overrides affected

**Legacy component deprecations:**
- Added `@deprecated` JSDoc to `AvatarGroup` in `ui/components/multichain/avatar-group/avatar-group.tsx`

## **Changelog**

CHANGELOG entry: upgrades design system libraries which update the Checkbox colors

## **Related issues**

Fixes: N/A

## **Manual testing steps**

Feature: Design system upgrade to v61.0.0

  Scenario: Core app functionality is unaffected
    Given I am on the main app screen
    When I navigate through the primary user flows
    Then the UI renders correctly with no visual regressions

  Scenario: Checkbox styling is correct
    Given I view screens with unchecked checkboxes (onboarding metametrics, create-password, bridge alerts)
    When I inspect unselected checkbox controls
    Then they render with transparent backgrounds and visible borders


## **Screenshots/Recordings**

### **Before**

Checkbox using `bg-default`

https://github.com/user-attachments/assets/dd208de2-47ff-4cc5-9683-01d349a29259

### **After**

Checkbox using `bg-muted`. We will likely need to update the TextField's as well

https://github.com/user-attachments/assets/94bb371d-3c68-41bd-9777-b92970b40bd4

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33d535a8-4894-4b99-984b-02012a145444?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33d535a8-4894-4b99-984b-02012a145444&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

