### PR TITLE
fix(perps): stop the reopen resume from looping the wallet home page cp-13.46.0

### DIFF
--- a/ui/pages/home/home.tsx
+++ b/ui/pages/home/home.tsx
@@ -192,7 +192,7 @@ export default function Home() {
     lastVisitedPerpsRoute,
     pendingRedirectRoute,
     envType,
-    setRedirectAfterDefaultPage: setRedirectAfterDefaultPageAction,
+    navigate,
     clearLastVisitedPerpsRoute,
   });
 

--- a/ui/pages/home/useHomeRedirects.test.ts
+++ b/ui/pages/home/useHomeRedirects.test.ts
@@ -250,23 +250,23 @@ describe('useLastVisitedPerpsRoute', () => {
   const TTL_MS = 5 * 60_000;
 
   it('does nothing when lastVisitedPerpsRoute is null', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
       useLastVisitedPerpsRoute({
         lastVisitedPerpsRoute: null,
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     expect(clearLastVisitedPerpsRoute).not.toHaveBeenCalled();
   });
 
   it('redirects to the persisted perps path when within the TTL', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
@@ -275,19 +275,17 @@ describe('useLastVisitedPerpsRoute', () => {
           path: '/perps/market/BTC',
           timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
         },
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(setRedirectAfterDefaultPage).toHaveBeenCalledWith({
-      path: '/perps/market/BTC',
-    });
+    expect(navigate).toHaveBeenCalledWith('/perps/market/BTC');
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
   it('does not redirect but still clears when TTL has expired', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
@@ -296,17 +294,17 @@ describe('useLastVisitedPerpsRoute', () => {
           path: '/perps/market/BTC',
           timestamp: Date.now() - (TTL_MS + 1_000),
         },
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
   it('ignores persisted path that does not start with /perps', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
@@ -315,17 +313,17 @@ describe('useLastVisitedPerpsRoute', () => {
           path: '/settings',
           timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
         },
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
   it('rejects a path with the /perps prefix that is not actually a /perps subroute', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
@@ -334,17 +332,17 @@ describe('useLastVisitedPerpsRoute', () => {
           path: '/perpsNew/market/BTC',
           timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
         },
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
   it('defers to pendingRedirectRoute when both are set but still clears the persisted perps entry', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
@@ -354,13 +352,13 @@ describe('useLastVisitedPerpsRoute', () => {
           path: '/perps/market/BTC',
           timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
         },
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
     // The pending redirect wins — perps resume must not fire.
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     // Even when pendingRedirectRoute wins, the perps entry must be cleared
     // so a later home mount cannot replay it after the higher-priority
     // redirect has already fired.
@@ -374,7 +372,7 @@ describe('useLastVisitedPerpsRoute', () => {
       __resetPerpsInAppLeaveMarkerForTests: resetPerpsInAppLeaveMarkerForTests,
     } = await import(markerModulePath);
 
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     try {
@@ -386,12 +384,12 @@ describe('useLastVisitedPerpsRoute', () => {
             path: '/perps/market/BTC',
             timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
           },
-          setRedirectAfterDefaultPage,
+          navigate,
           clearLastVisitedPerpsRoute,
         }),
       );
 
-      expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
       expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
     } finally {
       resetPerpsInAppLeaveMarkerForTests();
@@ -399,14 +397,14 @@ describe('useLastVisitedPerpsRoute', () => {
   });
 
   it('fires when lastVisitedPerpsRoute transitions from null to a value', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     const { rerender } = renderHook(
       ({ route }: { route: { path: string; timestamp: number } | null }) =>
         useLastVisitedPerpsRoute({
           lastVisitedPerpsRoute: route,
-          setRedirectAfterDefaultPage,
+          navigate,
           clearLastVisitedPerpsRoute,
         }),
       {
@@ -416,7 +414,7 @@ describe('useLastVisitedPerpsRoute', () => {
       },
     );
 
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     expect(clearLastVisitedPerpsRoute).not.toHaveBeenCalled();
 
     act(() => {
@@ -428,14 +426,42 @@ describe('useLastVisitedPerpsRoute', () => {
       });
     });
 
-    expect(setRedirectAfterDefaultPage).toHaveBeenCalledWith({
-      path: '/perps/market/BTC',
-    });
+    expect(navigate).toHaveBeenCalledWith('/perps/market/BTC');
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
+  it('redirects once when the selector hands back a new object identity every render', () => {
+    // A repeated resume spins Home into "Maximum update depth exceeded".
+    const navigate = jest.fn();
+    const clearLastVisitedPerpsRoute = jest.fn();
+    const timestamp = Date.now() - FRESH_ENOUGH_OFFSET_MS;
+
+    const { rerender } = renderHook(
+      ({ lastVisited }: { lastVisited: LastVisitedPerpsRoute }) =>
+        useLastVisitedPerpsRoute({
+          lastVisitedPerpsRoute: lastVisited,
+          navigate,
+          clearLastVisitedPerpsRoute,
+        }),
+      {
+        initialProps: {
+          lastVisited: { path: '/perps/trade/BTC', timestamp },
+        },
+      },
+    );
+
+    for (let i = 0; i < 5; i++) {
+      act(() => {
+        rerender({ lastVisited: { path: '/perps/trade/BTC', timestamp } });
+      });
+    }
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(clearLastVisitedPerpsRoute).toHaveBeenCalledTimes(1);
+  });
+
   it('does not redirect again after perps route is cleared on remount', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
     const route = {
       path: '/perps/market/BTC',
@@ -450,20 +476,20 @@ describe('useLastVisitedPerpsRoute', () => {
       }) =>
         useLastVisitedPerpsRoute({
           lastVisitedPerpsRoute: lastVisited,
-          setRedirectAfterDefaultPage,
+          navigate,
           clearLastVisitedPerpsRoute,
         }),
       { initialProps: { lastVisited: route as LastVisitedPerpsRoute | null } },
     );
 
-    expect(setRedirectAfterDefaultPage).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledTimes(1);
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalledTimes(1);
 
     act(() => {
       rerender({ lastVisited: null });
     });
 
-    expect(setRedirectAfterDefaultPage).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledTimes(1);
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/pages/home/useHomeRedirects.ts
+++ b/ui/pages/home/useHomeRedirects.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { NavigateFunction } from 'react-router-dom';
 import { wasPerpsUnmountedInAppRecently } from '../../helpers/perps/in-app-leave-marker';
 import {
@@ -97,34 +97,49 @@ export function usePendingRedirectRoute({
 
 /**
  * When `lastVisitedPerpsRoute` is set, resumes the persisted perps path when all
- * guards pass. Always clears the persisted entry so StrictMode remounts cannot
+ * guards pass. Always clears the persisted entry so a later home mount cannot
  * replay it.
+ *
+ * Navigates directly rather than via `redirectAfterDefaultPage`: the
+ * `pageChanged` reducer cancels that flag while the path is the default route,
+ * which is where this hook runs.
  * @param options0
  * @param options0.lastVisitedPerpsRoute
  * @param options0.pendingRedirectRoute
  * @param options0.envType
- * @param options0.setRedirectAfterDefaultPage
+ * @param options0.navigate
  * @param options0.clearLastVisitedPerpsRoute
  */
 export function useLastVisitedPerpsRoute({
   lastVisitedPerpsRoute,
   pendingRedirectRoute,
   envType,
-  setRedirectAfterDefaultPage,
+  navigate,
   clearLastVisitedPerpsRoute,
 }: {
   lastVisitedPerpsRoute?: LastVisitedPerpsRoute | null;
   pendingRedirectRoute?: PendingRedirectRoute | null;
   envType?: string;
-  setRedirectAfterDefaultPage?: (redirect: { path: string }) => void;
+  navigate?: NavigateFunction;
   clearLastVisitedPerpsRoute?: () => void;
 }) {
+  // One resume per path, so the dispatching effect below cannot repeat even if a
+  // caller passes a new object identity every render.
+  const resumedPathRef = useRef<string | null>(null);
+  const path = lastVisitedPerpsRoute?.path ?? null;
+  const timestamp = lastVisitedPerpsRoute?.timestamp;
+  const hasPendingRedirect = Boolean(pendingRedirectRoute);
+  const pendingEnvironmentType = pendingRedirectRoute?.environmentType;
+
   useEffect(() => {
-    if (!lastVisitedPerpsRoute) {
+    if (path === null || timestamp === undefined) {
       return;
     }
+    if (resumedPathRef.current === path) {
+      return;
+    }
+    resumedPathRef.current = path;
 
-    const { path, timestamp } = lastVisitedPerpsRoute;
     clearLastVisitedPerpsRoute?.();
 
     const isFresh = Date.now() - timestamp < PERPS_REOPEN_TTL_MS;
@@ -132,19 +147,20 @@ export function useLastVisitedPerpsRoute({
     const isPerpsPath =
       pathname === PERPS_ROUTE || pathname.startsWith(`${PERPS_ROUTE}/`);
     const pendingApplies =
-      Boolean(pendingRedirectRoute) &&
-      (!pendingRedirectRoute?.environmentType ||
-        pendingRedirectRoute?.environmentType === envType);
+      hasPendingRedirect &&
+      (!pendingEnvironmentType || pendingEnvironmentType === envType);
     const justLeftPerpsInApp = wasPerpsUnmountedInAppRecently(1500);
 
     if (!pendingApplies && !justLeftPerpsInApp && isFresh && isPerpsPath) {
-      setRedirectAfterDefaultPage?.({ path });
+      navigate?.(path);
     }
   }, [
-    lastVisitedPerpsRoute,
-    pendingRedirectRoute,
+    path,
+    timestamp,
+    hasPendingRedirect,
+    pendingEnvironmentType,
     envType,
-    setRedirectAfterDefaultPage,
+    navigate,
     clearLastVisitedPerpsRoute,
   ]);
 }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -4054,18 +4054,20 @@ export function getPendingRedirectRoute(state) {
 /**
  * Get the last visited Perps route and the timestamp it was recorded.
  *
+ * Keyed on the primitive fields, not on `lastVisitedRoute`: state pushes replace
+ * nested objects, and a fresh reference per push re-runs the dispatching effect
+ * in `useLastVisitedPerpsRoute` on every render.
+ *
  * @param {MetaMaskReduxState} state - The Redux state
  * @returns {{ path: string, timestamp: number } | null} The last visited Perps route, or null if none.
  */
-export function getLastVisitedPerpsRoute(state) {
-  const lastVisitedRoute = state.metamask?.lastVisitedRoute;
-  return lastVisitedRoute?.name === 'perps'
-    ? {
-        path: lastVisitedRoute.path,
-        timestamp: lastVisitedRoute.timestamp,
-      }
-    : null;
-}
+export const getLastVisitedPerpsRoute = createSelector(
+  (state) => state.metamask?.lastVisitedRoute?.name,
+  (state) => state.metamask?.lastVisitedRoute?.path,
+  (state) => state.metamask?.lastVisitedRoute?.timestamp,
+  (name, path, timestamp) =>
+    name === 'perps' && path !== undefined ? { path, timestamp } : null,
+);
 
 /**
  * Retrieves the deferred deep link from the MetaMask state.

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -5033,6 +5033,22 @@ describe('getLastVisitedPerpsRoute', () => {
 
     expect(selectors.getLastVisitedPerpsRoute(state)).toBeNull();
   });
+
+  it('returns a stable reference when a state push replaces the route object', () => {
+    const buildState = () => ({
+      metamask: {
+        lastVisitedRoute: {
+          name: 'perps',
+          path: '/perps/trade/BTC',
+          timestamp: 1700000000000,
+        },
+      },
+    });
+
+    expect(selectors.getLastVisitedPerpsRoute(buildState())).toBe(
+      selectors.getLastVisitedPerpsRoute(buildState()),
+    );
+  });
 });
 
 describe('snap selectors', () => {


### PR DESCRIPTION
  ## **Description**

  Reopening the extension on a Perps screen crashed the UI.
  An error page flashed:
  > ("Your information can't be shown", React error # 185 — Maximum update depth exceeded)

  and then clicking the back arrow did nothing, leaving the user stuck on the page.

  The loop is in the wallet home page, not in Perps.  getLastVisitedPerpsRoute built a fresh object on every call, and useSelector compares by reference, so the resume effect that dispatches re-ran on every render.  The loop also pushed duplicate history entries for the same path, which is why back appeared frozen rather than merely going somewhere unexpected.

  Three changes:

  1. Memoize the selector on its primitive fields, so its result is referentially stable across background state pushes.
  2. Latch the resume to one shot per path, so the dispatching effect body cannot repeat even if a caller hands it a new object identity.
  3. Navigate directly instead of routing through `redirectAfterDefaultPage`. The `pageChanged` reducer cancels that flag whenever the current path is the default route.

  Scope note: after this PR, back from a resumed screen goes to the wallet home.  Restoring the full navigation stack so back returns you to the market you came from is a follow-up PR stacked on this one; this change is deliberately limited to stopping the crash.

  ## **Changelog**

  CHANGELOG entry: Fixed a crash when reopening the extension on a Perps screen, which briefly showed an error page and left the back arrow unresponsive.

  ## **Related issues**

  Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3834

  ## **Manual testing steps**

  1. Open the extension and navigate to a Perps market, then tap Long or Short to open the order screen.
  2. Close the extension.
  3. Reopen it within 5 minutes.
  4. The order screen renders without error.
  5. Tap the back arrow, it navigates (to the wallet home; see the stacked follow-up for restoring the full stack).
  6. Repeat on main to see the failure: step 3 flashes the error page, and step 5 does nothing.

  ## **Screenshots/Recordings**

  ### **Before**

https://github.com/user-attachments/assets/55bbaca8-d421-4d85-9648-7b6306265cb3

  ### **After**

https://www.loom.com/share/8453efb5814742f8af5a5a764d3484e1

  ## **Pre-merge author checklist**

  - [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
  - [x] I've completed the PR template to the best of my ability
  - [x] I’ve included tests if applicable
  - [x] I’ve documented my code using JSDoc format if applicable
  - [x] I’ve applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.