### PR TITLE
feat(perps): restore the whole perps route stack on reopen

### DIFF
--- a/app/scripts/controllers/app-state-controller.test.ts
+++ b/app/scripts/controllers/app-state-controller.test.ts
@@ -236,17 +236,21 @@ describe('AppStateController', () => {
   });
 
   describe('setLastVisitedRoute', () => {
-    it('stores the route namespace, path, and current timestamp', async () => {
+    it('stores the route namespace, stack, and current timestamp', async () => {
       await withController(({ controller }) => {
         const before = Date.now();
-        controller.setLastVisitedRoute('perps', '/perps/market/BTC');
+        controller.setLastVisitedRoute('perps', [
+          '/perps/market-list',
+          '/perps/market/BTC',
+        ]);
         const after = Date.now();
 
         expect(controller.state.lastVisitedRoute).not.toBeNull();
         expect(controller.state.lastVisitedRoute?.name).toBe('perps');
-        expect(controller.state.lastVisitedRoute?.path).toBe(
+        expect(controller.state.lastVisitedRoute?.paths).toStrictEqual([
+          '/perps/market-list',
           '/perps/market/BTC',
-        );
+        ]);
         const { timestamp } = controller.state.lastVisitedRoute ?? {
           timestamp: 0,
         };
@@ -257,7 +261,7 @@ describe('AppStateController', () => {
 
     it('clears the stored route when passed null', async () => {
       await withController(({ controller }) => {
-        controller.setLastVisitedRoute('perps', '/perps/trade/ETH');
+        controller.setLastVisitedRoute('perps', ['/perps/trade/ETH']);
         expect(controller.state.lastVisitedRoute).not.toBeNull();
 
         controller.setLastVisitedRoute('perps', null);
@@ -265,14 +269,24 @@ describe('AppStateController', () => {
       });
     });
 
+    it('clears the stored route when passed an empty stack', async () => {
+      await withController(({ controller }) => {
+        controller.setLastVisitedRoute('perps', ['/perps/trade/ETH']);
+        expect(controller.state.lastVisitedRoute).not.toBeNull();
+
+        controller.setLastVisitedRoute('perps', []);
+        expect(controller.state.lastVisitedRoute).toBeNull();
+      });
+    });
+
     it('does not clear a route stored for another namespace', async () => {
       await withController(({ controller }) => {
-        controller.setLastVisitedRoute('bridge', '/bridge');
+        controller.setLastVisitedRoute('bridge', ['/bridge']);
 
         controller.setLastVisitedRoute('perps', null);
 
         expect(controller.state.lastVisitedRoute).toStrictEqual(
-          expect.objectContaining({ name: 'bridge', path: '/bridge' }),
+          expect.objectContaining({ name: 'bridge', paths: ['/bridge'] }),
         );
       });
     });

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -157,11 +157,16 @@ export type AppStateControllerState = {
    */
   pendingRedirectRoute: PendingRedirectRoute | null;
   /**
-   * The last visited feature route together with the timestamp it was recorded.
-   * Used by feature flows that resume a recent in-extension route after a brief
-   * close/reopen, then clear the entry once inspected.
+   * The route stack a feature was showing, oldest first, and when it was
+   * recorded. Used by feature flows that resume a recent in-extension route
+   * after a brief close/reopen, then clear the entry once inspected. A stack
+   * rather than one path, so the resumed screen's back control still works.
    */
-  lastVisitedRoute: { name: string; path: string; timestamp: number } | null;
+  lastVisitedRoute: {
+    name: string;
+    paths: string[];
+    timestamp: number;
+  } | null;
   pendingShieldCohort: string | null;
   pendingShieldCohortTxType: string | null;
   defaultSubscriptionPaymentOptions?: DefaultSubscriptionPaymentOptions;
@@ -1680,12 +1685,13 @@ export class AppStateController extends BaseController<
    * route after a brief close/reopen.
    *
    * @param name - The feature route namespace.
-   * @param path - The route path to persist, or `null` to clear.
+   * @param paths - The route stack to persist, oldest first, or `null`/empty to
+   * clear.
    */
-  setLastVisitedRoute(name: string, path: string | null): void {
+  setLastVisitedRoute(name: string, paths: string[] | null): void {
     this.update((state) => {
-      if (path) {
-        state.lastVisitedRoute = { name, path, timestamp: Date.now() };
+      if (paths?.length) {
+        state.lastVisitedRoute = { name, paths, timestamp: Date.now() };
       } else if (state.lastVisitedRoute?.name === name) {
         state.lastVisitedRoute = null;
       }

--- a/test/e2e/tests/perps/perps-reopen-resume.spec.ts
+++ b/test/e2e/tests/perps/perps-reopen-resume.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Perps close/reopen resume E2E test.
+ *
+ * A reopened popup is a brand new document, so the resume is driven entirely by
+ * `AppStateController.lastVisitedRoute` in the background. Closing the popup
+ * document and opening `popup-init.html` reproduces that; a same-tab navigation
+ * would not, since it keeps the document's history.
+ *
+ * PREREQUISITE: PERPS_ENABLED=true in the extension build (.metamaskrc) so the
+ * background PerpsController is included.
+ */
+import { Suite } from 'mocha';
+import { withFixtures } from '../../helpers';
+import { Driver } from '../../webdriver/driver';
+import { login } from '../../page-objects/flows/login.flow';
+import { PerpsTab } from '../../page-objects/pages/home/perps-tab';
+import { PerpsMarketDetailPage } from '../../page-objects/pages/perps/perps-market-detail-page';
+import { PerpsMarketListPage } from '../../page-objects/pages/perps/perps-market-list-page';
+import { PerpsOrderEntryPage } from '../../page-objects/pages/perps/perps-order-entry-page';
+import { getPerpsConfigEligible } from './perps-fixture-config';
+import { WS_USER_WITH_FUNDED_ACCOUNT } from './mocks/websocketPositionMocks';
+
+describe('Perps reopen resume', function (this: Suite) {
+  it('restores the order screen and the screens beneath it after a close/reopen', async function () {
+    await withFixtures(
+      {
+        ...getPerpsConfigEligible(this.test?.fullTitle()),
+        perpsWebSocketSpecificMocks: WS_USER_WITH_FUNDED_ACCOUNT,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver, { validateBalance: false });
+        const walletWindow = await driver.driver.getWindowHandle();
+
+        // Build a real stack in a popup document: market list -> market -> order.
+        await driver.openNewPage(`${driver.extensionUrl}/popup.html`);
+        const perpsTab = new PerpsTab(driver);
+        await perpsTab.navigateToPerpsHome();
+        await perpsTab.checkPageIsLoaded();
+
+        const marketListPage = new PerpsMarketListPage(driver);
+        await marketListPage.navigateToMarketList();
+
+        const marketDetailPage = new PerpsMarketDetailPage(driver);
+        await marketDetailPage.navigateToMarket('AVAX');
+        await marketDetailPage.waitForTradeCtaButtons();
+        await marketDetailPage.clickLong();
+
+        const orderEntryPage = new PerpsOrderEntryPage(driver);
+        await orderEntryPage.checkPageIsLoaded();
+
+        await driver.driver.close();
+        await driver.switchToWindow(walletWindow);
+        await driver.openNewPage(`${driver.extensionUrl}/popup-init.html`);
+
+        await orderEntryPage.checkPageIsLoaded();
+        await driver.assertElementNotPresent({ testId: 'error-page-title' });
+
+        // Back walks the restored stack instead of dropping straight to home.
+        await orderEntryPage.clickBack();
+        await marketDetailPage.checkPageIsLoaded();
+
+        await driver.clickElement({
+          testId: 'perps-market-detail-back-button',
+        });
+        await marketListPage.checkPageIsLoaded();
+
+        await marketListPage.clickBack();
+        await perpsTab.checkPageIsLoaded();
+      },
+    );
+  });
+
+  it('restores the stack again after a second close/reopen', async function () {
+    await withFixtures(
+      {
+        ...getPerpsConfigEligible(this.test?.fullTitle()),
+        perpsWebSocketSpecificMocks: WS_USER_WITH_FUNDED_ACCOUNT,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver, { validateBalance: false });
+        const walletWindow = await driver.driver.getWindowHandle();
+
+        await driver.openNewPage(`${driver.extensionUrl}/popup.html`);
+        const perpsTab = new PerpsTab(driver);
+        await perpsTab.navigateToPerpsHome();
+        await perpsTab.checkPageIsLoaded();
+
+        const marketListPage = new PerpsMarketListPage(driver);
+        await marketListPage.navigateToMarketList();
+
+        const marketDetailPage = new PerpsMarketDetailPage(driver);
+        await marketDetailPage.navigateToMarket('AVAX');
+        await marketDetailPage.waitForTradeCtaButtons();
+        await marketDetailPage.clickLong();
+
+        const orderEntryPage = new PerpsOrderEntryPage(driver);
+        await orderEntryPage.checkPageIsLoaded();
+
+        const reopen = async () => {
+          await driver.driver.close();
+          await driver.switchToWindow(walletWindow);
+          await driver.openNewPage(`${driver.extensionUrl}/popup-init.html`);
+          await orderEntryPage.checkPageIsLoaded();
+        };
+
+        await reopen();
+
+        // Navigating within the restored stack must keep tracking it, so a
+        // second close/reopen restores just as much as the first.
+        await orderEntryPage.clickBack();
+        await marketDetailPage.checkPageIsLoaded();
+        await marketDetailPage.waitForTradeCtaButtons();
+        await marketDetailPage.clickLong();
+        await orderEntryPage.checkPageIsLoaded();
+
+        await reopen();
+
+        await orderEntryPage.clickBack();
+        await marketDetailPage.checkPageIsLoaded();
+      },
+    );
+  });
+});

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -214,6 +214,10 @@ export const MONEY_HOME_ROUTE = '/money-home';
 // do not hijack the user's home view after a long break.
 export const PERPS_REOPEN_TTL_MS = 5 * 60 * 1000;
 
+// Entries the close/reopen resume records and replays. Bounded so a long
+// browsing session cannot replay dozens of navigations on reopen.
+export const PERPS_RESUME_MAX_STACK_DEPTH = 5;
+
 export const SHIELD_PLAN_ROUTE = '/shield-plan';
 export const REWARDS_ROUTE = '/rewards';
 export const ACTIVITY_ROUTE = '/activity';

--- a/ui/helpers/perps/route-history.test.ts
+++ b/ui/helpers/perps/route-history.test.ts
@@ -1,0 +1,196 @@
+import {
+  buildRouteStack,
+  getRouterHistoryIndex,
+  hasInAppHistoryEntry,
+  readResumedStack,
+  resolveStackBase,
+} from './route-history';
+
+describe('getRouterHistoryIndex', () => {
+  const originalState = window.history.state;
+
+  afterEach(() => {
+    window.history.replaceState(originalState, '');
+  });
+
+  it('reads the router index', () => {
+    window.history.replaceState({ idx: 4 }, '');
+
+    expect(getRouterHistoryIndex()).toBe(4);
+  });
+
+  it('is undefined when history state carries no index', () => {
+    window.history.replaceState({ some: 'value' }, '');
+
+    expect(getRouterHistoryIndex()).toBeUndefined();
+  });
+});
+
+describe('hasInAppHistoryEntry', () => {
+  const originalState = window.history.state;
+
+  afterEach(() => {
+    window.history.replaceState(originalState, '');
+  });
+
+  it('is false on the first router entry even though the popup init redirect left one behind', () => {
+    window.history.replaceState({ idx: 0 }, '');
+    Object.defineProperty(window.history, 'length', {
+      value: 2,
+      configurable: true,
+    });
+
+    expect(hasInAppHistoryEntry()).toBe(false);
+  });
+
+  it('is true once the app has pushed an entry', () => {
+    window.history.replaceState({ idx: 1 }, '');
+
+    expect(hasInAppHistoryEntry()).toBe(true);
+  });
+
+  it('falls back to history length when the router index is absent', () => {
+    window.history.replaceState(null, '');
+    Object.defineProperty(window.history, 'length', {
+      value: 1,
+      configurable: true,
+    });
+
+    expect(hasInAppHistoryEntry()).toBe(false);
+  });
+});
+
+describe('buildRouteStack', () => {
+  const maxDepth = 5;
+
+  it('records the first path at the base', () => {
+    expect(
+      buildRouteStack({
+        previous: [],
+        path: '/perps/market-list',
+        depth: 0,
+        maxDepth,
+      }),
+    ).toStrictEqual(['/perps/market-list']);
+  });
+
+  it('extends the stack on a push', () => {
+    expect(
+      buildRouteStack({
+        previous: ['/perps/market-list'],
+        path: '/perps/market/BTC',
+        depth: 1,
+        maxDepth,
+      }),
+    ).toStrictEqual(['/perps/market-list', '/perps/market/BTC']);
+  });
+
+  it('truncates the entries above a pop', () => {
+    expect(
+      buildRouteStack({
+        previous: [
+          '/perps/market-list',
+          '/perps/market/BTC',
+          '/perps/trade/BTC',
+        ],
+        path: '/perps/market/BTC',
+        depth: 1,
+        maxDepth,
+      }),
+    ).toStrictEqual(['/perps/market-list', '/perps/market/BTC']);
+  });
+
+  it('overwrites in place on a replace', () => {
+    expect(
+      buildRouteStack({
+        previous: ['/perps/market-list', '/perps/market/BTC'],
+        path: '/perps/market/ETH',
+        depth: 1,
+        maxDepth,
+      }),
+    ).toStrictEqual(['/perps/market-list', '/perps/market/ETH']);
+  });
+
+  it('keeps the newest entries when the stack exceeds maxDepth', () => {
+    expect(
+      buildRouteStack({
+        previous: ['/perps/a', '/perps/b', '/perps/c'],
+        path: '/perps/d',
+        depth: 3,
+        maxDepth: 2,
+      }),
+    ).toStrictEqual(['/perps/c', '/perps/d']);
+  });
+
+  it('drops holes left by a depth beyond the recorded stack', () => {
+    expect(
+      buildRouteStack({
+        previous: ['/perps/market-list'],
+        path: '/perps/trade/BTC',
+        depth: 3,
+        maxDepth,
+      }),
+    ).toStrictEqual(['/perps/market-list', '/perps/trade/BTC']);
+  });
+});
+
+describe('readResumedStack', () => {
+  it('reads the replayed stack from route state', () => {
+    expect(
+      readResumedStack({ perpsResumedStack: ['/perps/market/BTC'] }),
+    ).toStrictEqual(['/perps/market/BTC']);
+  });
+
+  it('ignores state without a string stack', () => {
+    expect(readResumedStack(null)).toBeUndefined();
+    expect(readResumedStack({})).toBeUndefined();
+    expect(readResumedStack({ perpsResumedStack: [1, 2] })).toBeUndefined();
+  });
+});
+
+describe('resolveStackBase', () => {
+  const resumedStack = [
+    '/perps/market-list',
+    '/perps/market/BTC',
+    '/perps/trade/BTC',
+  ];
+
+  it('adopts the replayed stack when mounted on its top entry', () => {
+    expect(
+      resolveStackBase({
+        resumedStack,
+        path: '/perps/trade/BTC',
+        historyIndex: 3,
+      }),
+    ).toStrictEqual({ base: 1, stack: resumedStack });
+  });
+
+  it('adopts only the entries up to where it mounted', () => {
+    expect(
+      resolveStackBase({
+        resumedStack,
+        path: '/perps/market/BTC',
+        historyIndex: 2,
+      }),
+    ).toStrictEqual({
+      base: 1,
+      stack: ['/perps/market-list', '/perps/market/BTC'],
+    });
+  });
+
+  it('starts fresh when the entry is not part of a replayed stack', () => {
+    expect(
+      resolveStackBase({ path: '/perps/market/BTC', historyIndex: 2 }),
+    ).toStrictEqual({ base: 2, stack: [] });
+  });
+
+  it('starts fresh when the current path is absent from the replayed stack', () => {
+    expect(
+      resolveStackBase({
+        resumedStack,
+        path: '/perps/withdraw',
+        historyIndex: 4,
+      }),
+    ).toStrictEqual({ base: 4, stack: [] });
+  });
+});

--- a/ui/helpers/perps/route-history.ts
+++ b/ui/helpers/perps/route-history.ts
@@ -1,0 +1,114 @@
+/**
+ * The popup's `popup-init.html` leaves a session-history entry behind when it
+ * meta-refreshes to `popup.html`, so `window.history.length` is never 1 there.
+ * Using it to ask "can I go back in-app?" hides the up-navigation fallbacks and
+ * lets `navigate(-1)` walk the document out of the SPA.
+ */
+
+/**
+ * @returns The router's index for the current entry, counting only entries the
+ * app pushed, or `undefined` outside a router navigation.
+ */
+export function getRouterHistoryIndex(): number | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+  const { idx } = (window.history.state ?? {}) as { idx?: number };
+  return typeof idx === 'number' ? idx : undefined;
+}
+
+/**
+ * @returns true when `navigate(-1)` stays inside the app.
+ */
+export function hasInAppHistoryEntry(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const idx = getRouterHistoryIndex();
+  return idx === undefined ? window.history.length > 1 : idx > 0;
+}
+
+/** Route state the resume attaches so a layout can adopt the stack it replayed. */
+export type PerpsResumeRouteState = {
+  perpsResumedStack?: string[];
+};
+
+/**
+ * @param state - `useLocation().state`.
+ * @returns The stack a resume replayed into history, if this entry came from one.
+ */
+export function readResumedStack(state: unknown): string[] | undefined {
+  const stack = (state as PerpsResumeRouteState | null)?.perpsResumedStack;
+  return Array.isArray(stack) && stack.every((entry) => typeof entry === 'string')
+    ? stack
+    : undefined;
+}
+
+/**
+ * Where to start tracking a route stack from.
+ *
+ * A resume replays its entries before the layout's first effect runs, so the
+ * layout can mount already partway up the stack. Without adopting the replayed
+ * entries it would treat the current one as the base, and every later
+ * navigation would collapse to depth 0 — losing everything below and shrinking
+ * what the next reopen can restore.
+ *
+ * @param options0
+ * @param options0.resumedStack - Stack carried on the entry's route state.
+ * @param options0.path - Current path, including any search query.
+ * @param options0.historyIndex - Router index for the current entry.
+ * @returns The base index to measure depth against, and the entries already below.
+ */
+export function resolveStackBase({
+  resumedStack,
+  path,
+  historyIndex,
+}: {
+  resumedStack?: string[];
+  path: string;
+  historyIndex?: number;
+}): { base: number | undefined; stack: string[] } {
+  if (resumedStack && historyIndex !== undefined) {
+    const position = resumedStack.lastIndexOf(path);
+    if (position !== -1) {
+      return {
+        base: historyIndex - position,
+        stack: resumedStack.slice(0, position + 1),
+      };
+    }
+  }
+  return { base: historyIndex, stack: [] };
+}
+
+/**
+ * Record `path` at `depth` in a feature's route stack.
+ *
+ * Position is the caller's distance from the entry it started tracking at, so a
+ * deeper `depth` extends the stack, a shallower one truncates it (the entries
+ * above were popped), and an equal one overwrites in place (a replace). Keeps
+ * the newest `maxDepth` entries.
+ *
+ * @param options0
+ * @param options0.previous - Stack recorded for the previous navigation.
+ * @param options0.path - Path to record, including any search query.
+ * @param options0.depth - Position of `path` in the stack.
+ * @param options0.maxDepth - Entries to retain.
+ * @returns The updated stack, oldest entry first.
+ */
+export function buildRouteStack({
+  previous,
+  path,
+  depth,
+  maxDepth,
+}: {
+  previous: string[];
+  path: string;
+  depth: number;
+  maxDepth: number;
+}): string[] {
+  const stack = previous.slice(0, depth);
+  stack[depth] = path;
+  // A pop below the tracked base leaves holes; drop them rather than persisting
+  // undefined entries.
+  return stack.filter(Boolean).slice(-maxDepth);
+}

--- a/ui/helpers/perps/route-history.ts
+++ b/ui/helpers/perps/route-history.ts
@@ -39,7 +39,8 @@ export type PerpsResumeRouteState = {
  */
 export function readResumedStack(state: unknown): string[] | undefined {
   const stack = (state as PerpsResumeRouteState | null)?.perpsResumedStack;
-  return Array.isArray(stack) && stack.every((entry) => typeof entry === 'string')
+  return Array.isArray(stack) &&
+    stack.every((entry) => typeof entry === 'string')
     ? stack
     : undefined;
 }

--- a/ui/pages/home/home.tsx
+++ b/ui/pages/home/home.tsx
@@ -192,7 +192,7 @@ export default function Home() {
     lastVisitedPerpsRoute,
     pendingRedirectRoute,
     envType,
-    setRedirectAfterDefaultPage: setRedirectAfterDefaultPageAction,
+    navigate,
     clearLastVisitedPerpsRoute,
   });
 

--- a/ui/pages/home/useHomeRedirects.strict-mode.test.ts
+++ b/ui/pages/home/useHomeRedirects.strict-mode.test.ts
@@ -1,0 +1,30 @@
+// Must be the first import: mocks @testing-library/react to wrap renders in
+// React.StrictMode, so effects run setup -> cleanup -> setup like a dev build.
+import '../../../test/jest/strict-mode';
+
+import { renderHook } from '@testing-library/react';
+import { useLastVisitedPerpsRoute } from './useHomeRedirects';
+
+describe('useLastVisitedPerpsRoute under StrictMode', () => {
+  it('resumes once across the double-mount cycle', () => {
+    const navigate = jest.fn();
+    const clearLastVisitedPerpsRoute = jest.fn();
+
+    renderHook(() =>
+      useLastVisitedPerpsRoute({
+        lastVisitedPerpsRoute: {
+          paths: ['/perps/market/BTC', '/perps/trade/BTC'],
+          timestamp: Date.now(),
+        },
+        navigate,
+        clearLastVisitedPerpsRoute,
+      }),
+    );
+
+    const stack = ['/perps/market/BTC', '/perps/trade/BTC'];
+    expect(navigate.mock.calls).toStrictEqual(
+      stack.map((path) => [path, { state: { perpsResumedStack: stack } }]),
+    );
+    expect(clearLastVisitedPerpsRoute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/pages/home/useHomeRedirects.test.ts
+++ b/ui/pages/home/useHomeRedirects.test.ts
@@ -250,23 +250,23 @@ describe('useLastVisitedPerpsRoute', () => {
   const TTL_MS = 5 * 60_000;
 
   it('does nothing when lastVisitedPerpsRoute is null', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
       useLastVisitedPerpsRoute({
         lastVisitedPerpsRoute: null,
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     expect(clearLastVisitedPerpsRoute).not.toHaveBeenCalled();
   });
 
   it('redirects to the persisted perps path when within the TTL', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
@@ -275,19 +275,17 @@ describe('useLastVisitedPerpsRoute', () => {
           path: '/perps/market/BTC',
           timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
         },
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(setRedirectAfterDefaultPage).toHaveBeenCalledWith({
-      path: '/perps/market/BTC',
-    });
+    expect(navigate).toHaveBeenCalledWith('/perps/market/BTC');
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
   it('does not redirect but still clears when TTL has expired', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
@@ -296,17 +294,17 @@ describe('useLastVisitedPerpsRoute', () => {
           path: '/perps/market/BTC',
           timestamp: Date.now() - (TTL_MS + 1_000),
         },
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
   it('ignores persisted path that does not start with /perps', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
@@ -315,17 +313,17 @@ describe('useLastVisitedPerpsRoute', () => {
           path: '/settings',
           timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
         },
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
   it('rejects a path with the /perps prefix that is not actually a /perps subroute', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
@@ -334,17 +332,17 @@ describe('useLastVisitedPerpsRoute', () => {
           path: '/perpsNew/market/BTC',
           timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
         },
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
   it('defers to pendingRedirectRoute when both are set but still clears the persisted perps entry', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
@@ -354,13 +352,13 @@ describe('useLastVisitedPerpsRoute', () => {
           path: '/perps/market/BTC',
           timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
         },
-        setRedirectAfterDefaultPage,
+        navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
     // The pending redirect wins — perps resume must not fire.
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     // Even when pendingRedirectRoute wins, the perps entry must be cleared
     // so a later home mount cannot replay it after the higher-priority
     // redirect has already fired.
@@ -374,7 +372,7 @@ describe('useLastVisitedPerpsRoute', () => {
       __resetPerpsInAppLeaveMarkerForTests: resetPerpsInAppLeaveMarkerForTests,
     } = await import(markerModulePath);
 
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     try {
@@ -386,12 +384,12 @@ describe('useLastVisitedPerpsRoute', () => {
             path: '/perps/market/BTC',
             timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
           },
-          setRedirectAfterDefaultPage,
+          navigate,
           clearLastVisitedPerpsRoute,
         }),
       );
 
-      expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
       expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
     } finally {
       resetPerpsInAppLeaveMarkerForTests();
@@ -399,14 +397,14 @@ describe('useLastVisitedPerpsRoute', () => {
   });
 
   it('fires when lastVisitedPerpsRoute transitions from null to a value', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     const { rerender } = renderHook(
       ({ route }: { route: { path: string; timestamp: number } | null }) =>
         useLastVisitedPerpsRoute({
           lastVisitedPerpsRoute: route,
-          setRedirectAfterDefaultPage,
+          navigate,
           clearLastVisitedPerpsRoute,
         }),
       {
@@ -416,7 +414,7 @@ describe('useLastVisitedPerpsRoute', () => {
       },
     );
 
-    expect(setRedirectAfterDefaultPage).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
     expect(clearLastVisitedPerpsRoute).not.toHaveBeenCalled();
 
     act(() => {
@@ -428,14 +426,42 @@ describe('useLastVisitedPerpsRoute', () => {
       });
     });
 
-    expect(setRedirectAfterDefaultPage).toHaveBeenCalledWith({
-      path: '/perps/market/BTC',
-    });
+    expect(navigate).toHaveBeenCalledWith('/perps/market/BTC');
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
+  it('redirects once when the selector hands back a new object identity every render', () => {
+    // A repeated resume spins Home into "Maximum update depth exceeded".
+    const navigate = jest.fn();
+    const clearLastVisitedPerpsRoute = jest.fn();
+    const timestamp = Date.now() - FRESH_ENOUGH_OFFSET_MS;
+
+    const { rerender } = renderHook(
+      ({ lastVisited }: { lastVisited: LastVisitedPerpsRoute }) =>
+        useLastVisitedPerpsRoute({
+          lastVisitedPerpsRoute: lastVisited,
+          navigate,
+          clearLastVisitedPerpsRoute,
+        }),
+      {
+        initialProps: {
+          lastVisited: { path: '/perps/trade/BTC', timestamp },
+        },
+      },
+    );
+
+    for (let i = 0; i < 5; i++) {
+      act(() => {
+        rerender({ lastVisited: { path: '/perps/trade/BTC', timestamp } });
+      });
+    }
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(clearLastVisitedPerpsRoute).toHaveBeenCalledTimes(1);
+  });
+
   it('does not redirect again after perps route is cleared on remount', () => {
-    const setRedirectAfterDefaultPage = jest.fn();
+    const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
     const route = {
       path: '/perps/market/BTC',
@@ -450,20 +476,20 @@ describe('useLastVisitedPerpsRoute', () => {
       }) =>
         useLastVisitedPerpsRoute({
           lastVisitedPerpsRoute: lastVisited,
-          setRedirectAfterDefaultPage,
+          navigate,
           clearLastVisitedPerpsRoute,
         }),
       { initialProps: { lastVisited: route as LastVisitedPerpsRoute | null } },
     );
 
-    expect(setRedirectAfterDefaultPage).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledTimes(1);
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalledTimes(1);
 
     act(() => {
       rerender({ lastVisited: null });
     });
 
-    expect(setRedirectAfterDefaultPage).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledTimes(1);
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/pages/home/useHomeRedirects.test.ts
+++ b/ui/pages/home/useHomeRedirects.test.ts
@@ -248,6 +248,10 @@ describe('usePendingRedirectRoute', () => {
 describe('useLastVisitedPerpsRoute', () => {
   const FRESH_ENOUGH_OFFSET_MS = 60_000;
   const TTL_MS = 5 * 60_000;
+  const fresh = (paths: string[]) => ({
+    paths,
+    timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
+  });
 
   it('does nothing when lastVisitedPerpsRoute is null', () => {
     const navigate = jest.fn();
@@ -265,22 +269,31 @@ describe('useLastVisitedPerpsRoute', () => {
     expect(clearLastVisitedPerpsRoute).not.toHaveBeenCalled();
   });
 
-  it('redirects to the persisted perps path when within the TTL', () => {
+  it('replays the persisted stack oldest first so back walks it', () => {
     const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
       useLastVisitedPerpsRoute({
-        lastVisitedPerpsRoute: {
-          path: '/perps/market/BTC',
-          timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
-        },
+        lastVisitedPerpsRoute: fresh([
+          '/perps/market-list',
+          '/perps/market/BTC',
+          '/perps/trade/BTC?direction=long',
+        ]),
         navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    expect(navigate).toHaveBeenCalledWith('/perps/market/BTC');
+    const stack = [
+      '/perps/market-list',
+      '/perps/market/BTC',
+      '/perps/trade/BTC?direction=long',
+    ];
+    // Every replayed entry carries the stack so PerpsLayout can adopt it.
+    expect(navigate.mock.calls).toStrictEqual(
+      stack.map((path) => [path, { state: { perpsResumedStack: stack } }]),
+    );
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
@@ -291,7 +304,7 @@ describe('useLastVisitedPerpsRoute', () => {
     renderHook(() =>
       useLastVisitedPerpsRoute({
         lastVisitedPerpsRoute: {
-          path: '/perps/market/BTC',
+          paths: ['/perps/market/BTC'],
           timestamp: Date.now() - (TTL_MS + 1_000),
         },
         navigate,
@@ -303,16 +316,13 @@ describe('useLastVisitedPerpsRoute', () => {
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
-  it('ignores persisted path that does not start with /perps', () => {
+  it('ignores a stack containing a non-perps path', () => {
     const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
       useLastVisitedPerpsRoute({
-        lastVisitedPerpsRoute: {
-          path: '/settings',
-          timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
-        },
+        lastVisitedPerpsRoute: fresh(['/settings', '/perps/market/BTC']),
         navigate,
         clearLastVisitedPerpsRoute,
       }),
@@ -322,16 +332,13 @@ describe('useLastVisitedPerpsRoute', () => {
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
-  it('rejects a path with the /perps prefix that is not actually a /perps subroute', () => {
+  it('rejects a path with the /perps prefix that is not a /perps subroute', () => {
     const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
 
     renderHook(() =>
       useLastVisitedPerpsRoute({
-        lastVisitedPerpsRoute: {
-          path: '/perpsNew/market/BTC',
-          timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
-        },
+        lastVisitedPerpsRoute: fresh(['/perpsNew/market/BTC']),
         navigate,
         clearLastVisitedPerpsRoute,
       }),
@@ -348,20 +355,13 @@ describe('useLastVisitedPerpsRoute', () => {
     renderHook(() =>
       useLastVisitedPerpsRoute({
         pendingRedirectRoute: { path: '/shield-plan' },
-        lastVisitedPerpsRoute: {
-          path: '/perps/market/BTC',
-          timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
-        },
+        lastVisitedPerpsRoute: fresh(['/perps/market/BTC']),
         navigate,
         clearLastVisitedPerpsRoute,
       }),
     );
 
-    // The pending redirect wins — perps resume must not fire.
     expect(navigate).not.toHaveBeenCalled();
-    // Even when pendingRedirectRoute wins, the perps entry must be cleared
-    // so a later home mount cannot replay it after the higher-priority
-    // redirect has already fired.
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
@@ -380,10 +380,7 @@ describe('useLastVisitedPerpsRoute', () => {
 
       renderHook(() =>
         useLastVisitedPerpsRoute({
-          lastVisitedPerpsRoute: {
-            path: '/perps/market/BTC',
-            timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
-          },
+          lastVisitedPerpsRoute: fresh(['/perps/market/BTC']),
           navigate,
           clearLastVisitedPerpsRoute,
         }),
@@ -401,36 +398,28 @@ describe('useLastVisitedPerpsRoute', () => {
     const clearLastVisitedPerpsRoute = jest.fn();
 
     const { rerender } = renderHook(
-      ({ route }: { route: { path: string; timestamp: number } | null }) =>
+      ({ route }: { route: LastVisitedPerpsRoute | null }) =>
         useLastVisitedPerpsRoute({
           lastVisitedPerpsRoute: route,
           navigate,
           clearLastVisitedPerpsRoute,
         }),
-      {
-        initialProps: {
-          route: null as { path: string; timestamp: number } | null,
-        },
-      },
+      { initialProps: { route: null as LastVisitedPerpsRoute | null } },
     );
 
     expect(navigate).not.toHaveBeenCalled();
-    expect(clearLastVisitedPerpsRoute).not.toHaveBeenCalled();
 
     act(() => {
-      rerender({
-        route: {
-          path: '/perps/market/BTC',
-          timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
-        },
-      });
+      rerender({ route: fresh(['/perps/market/BTC']) });
     });
 
-    expect(navigate).toHaveBeenCalledWith('/perps/market/BTC');
+    expect(navigate).toHaveBeenCalledWith('/perps/market/BTC', {
+      state: { perpsResumedStack: ['/perps/market/BTC'] },
+    });
     expect(clearLastVisitedPerpsRoute).toHaveBeenCalled();
   });
 
-  it('redirects once when the selector hands back a new object identity every render', () => {
+  it('replays once when the selector hands back a new object identity every render', () => {
     // A repeated resume spins Home into "Maximum update depth exceeded".
     const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
@@ -445,14 +434,14 @@ describe('useLastVisitedPerpsRoute', () => {
         }),
       {
         initialProps: {
-          lastVisited: { path: '/perps/trade/BTC', timestamp },
+          lastVisited: { paths: ['/perps/trade/BTC'], timestamp },
         },
       },
     );
 
     for (let i = 0; i < 5; i++) {
       act(() => {
-        rerender({ lastVisited: { path: '/perps/trade/BTC', timestamp } });
+        rerender({ lastVisited: { paths: ['/perps/trade/BTC'], timestamp } });
       });
     }
 
@@ -463,17 +452,10 @@ describe('useLastVisitedPerpsRoute', () => {
   it('does not redirect again after perps route is cleared on remount', () => {
     const navigate = jest.fn();
     const clearLastVisitedPerpsRoute = jest.fn();
-    const route = {
-      path: '/perps/market/BTC',
-      timestamp: Date.now() - FRESH_ENOUGH_OFFSET_MS,
-    };
+    const route = fresh(['/perps/market/BTC']);
 
     const { rerender } = renderHook(
-      ({
-        lastVisited,
-      }: {
-        lastVisited: { path: string; timestamp: number } | null;
-      }) =>
+      ({ lastVisited }: { lastVisited: LastVisitedPerpsRoute | null }) =>
         useLastVisitedPerpsRoute({
           lastVisitedPerpsRoute: lastVisited,
           navigate,

--- a/ui/pages/home/useHomeRedirects.ts
+++ b/ui/pages/home/useHomeRedirects.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { NavigateFunction } from 'react-router-dom';
 import { wasPerpsUnmountedInAppRecently } from '../../helpers/perps/in-app-leave-marker';
 import {
@@ -97,34 +97,49 @@ export function usePendingRedirectRoute({
 
 /**
  * When `lastVisitedPerpsRoute` is set, resumes the persisted perps path when all
- * guards pass. Always clears the persisted entry so StrictMode remounts cannot
+ * guards pass. Always clears the persisted entry so a later home mount cannot
  * replay it.
+ *
+ * Navigates directly rather than via `redirectAfterDefaultPage`: the
+ * `pageChanged` reducer cancels that flag while the path is the default route,
+ * which is where this hook runs.
  * @param options0
  * @param options0.lastVisitedPerpsRoute
  * @param options0.pendingRedirectRoute
  * @param options0.envType
- * @param options0.setRedirectAfterDefaultPage
+ * @param options0.navigate
  * @param options0.clearLastVisitedPerpsRoute
  */
 export function useLastVisitedPerpsRoute({
   lastVisitedPerpsRoute,
   pendingRedirectRoute,
   envType,
-  setRedirectAfterDefaultPage,
+  navigate,
   clearLastVisitedPerpsRoute,
 }: {
   lastVisitedPerpsRoute?: LastVisitedPerpsRoute | null;
   pendingRedirectRoute?: PendingRedirectRoute | null;
   envType?: string;
-  setRedirectAfterDefaultPage?: (redirect: { path: string }) => void;
+  navigate?: NavigateFunction;
   clearLastVisitedPerpsRoute?: () => void;
 }) {
+  // One resume per path, so the dispatching effect below cannot repeat even if a
+  // caller passes a new object identity every render.
+  const resumedPathRef = useRef<string | null>(null);
+  const path = lastVisitedPerpsRoute?.path ?? null;
+  const timestamp = lastVisitedPerpsRoute?.timestamp;
+  const hasPendingRedirect = Boolean(pendingRedirectRoute);
+  const pendingEnvironmentType = pendingRedirectRoute?.environmentType;
+
   useEffect(() => {
-    if (!lastVisitedPerpsRoute) {
+    if (path === null || timestamp === undefined) {
       return;
     }
+    if (resumedPathRef.current === path) {
+      return;
+    }
+    resumedPathRef.current = path;
 
-    const { path, timestamp } = lastVisitedPerpsRoute;
     clearLastVisitedPerpsRoute?.();
 
     const isFresh = Date.now() - timestamp < PERPS_REOPEN_TTL_MS;
@@ -132,19 +147,20 @@ export function useLastVisitedPerpsRoute({
     const isPerpsPath =
       pathname === PERPS_ROUTE || pathname.startsWith(`${PERPS_ROUTE}/`);
     const pendingApplies =
-      Boolean(pendingRedirectRoute) &&
-      (!pendingRedirectRoute?.environmentType ||
-        pendingRedirectRoute?.environmentType === envType);
+      hasPendingRedirect &&
+      (!pendingEnvironmentType || pendingEnvironmentType === envType);
     const justLeftPerpsInApp = wasPerpsUnmountedInAppRecently(1500);
 
     if (!pendingApplies && !justLeftPerpsInApp && isFresh && isPerpsPath) {
-      setRedirectAfterDefaultPage?.({ path });
+      navigate?.(path);
     }
   }, [
-    lastVisitedPerpsRoute,
-    pendingRedirectRoute,
+    path,
+    timestamp,
+    hasPendingRedirect,
+    pendingEnvironmentType,
     envType,
-    setRedirectAfterDefaultPage,
+    navigate,
     clearLastVisitedPerpsRoute,
   ]);
 }

--- a/ui/pages/home/useHomeRedirects.ts
+++ b/ui/pages/home/useHomeRedirects.ts
@@ -18,7 +18,8 @@ export type RedirectAfterDefaultPage = {
 };
 
 export type LastVisitedPerpsRoute = {
-  path: string;
+  /** The Perps route stack, oldest entry first. */
+  paths: string[];
   timestamp: number;
 };
 
@@ -96,9 +97,12 @@ export function usePendingRedirectRoute({
 }
 
 /**
- * When `lastVisitedPerpsRoute` is set, resumes the persisted perps path when all
- * guards pass. Always clears the persisted entry so a later home mount cannot
- * replay it.
+ * When `lastVisitedPerpsRoute` is set, resumes the persisted perps stack when
+ * all guards pass. Always clears the persisted entry so a later home mount
+ * cannot replay it.
+ *
+ * Pushes every entry, not just the last, so back walks the screens the user came
+ * through — no per-screen "my parent is X" rule for each new Perps route.
  *
  * Navigates directly rather than via `redirectAfterDefaultPage`: the
  * `pageChanged` reducer cancels that flag while the path is the default route,
@@ -123,39 +127,45 @@ export function useLastVisitedPerpsRoute({
   navigate?: NavigateFunction;
   clearLastVisitedPerpsRoute?: () => void;
 }) {
-  // One resume per path, so the dispatching effect below cannot repeat even if a
-  // caller passes a new object identity every render.
-  const resumedPathRef = useRef<string | null>(null);
-  const path = lastVisitedPerpsRoute?.path ?? null;
+  // One resume per stack, so the dispatching effect below cannot repeat even if
+  // a caller passes a new object identity every render.
+  const resumedStackRef = useRef<string | null>(null);
+  const stackKey = lastVisitedPerpsRoute?.paths?.join('\n') ?? null;
   const timestamp = lastVisitedPerpsRoute?.timestamp;
   const hasPendingRedirect = Boolean(pendingRedirectRoute);
   const pendingEnvironmentType = pendingRedirectRoute?.environmentType;
 
   useEffect(() => {
-    if (path === null || timestamp === undefined) {
+    if (!stackKey || timestamp === undefined) {
       return;
     }
-    if (resumedPathRef.current === path) {
+    if (resumedStackRef.current === stackKey) {
       return;
     }
-    resumedPathRef.current = path;
+    resumedStackRef.current = stackKey;
 
     clearLastVisitedPerpsRoute?.();
 
+    const paths = stackKey.split('\n');
     const isFresh = Date.now() - timestamp < PERPS_REOPEN_TTL_MS;
-    const pathname = typeof path === 'string' ? path.split(/[?#]/u)[0] : '';
-    const isPerpsPath =
-      pathname === PERPS_ROUTE || pathname.startsWith(`${PERPS_ROUTE}/`);
+    const isPerpsStack = paths.every((path) => {
+      const pathname = path.split(/[?#]/u)[0];
+      return pathname === PERPS_ROUTE || pathname.startsWith(`${PERPS_ROUTE}/`);
+    });
     const pendingApplies =
       hasPendingRedirect &&
       (!pendingEnvironmentType || pendingEnvironmentType === envType);
     const justLeftPerpsInApp = wasPerpsUnmountedInAppRecently(1500);
 
-    if (!pendingApplies && !justLeftPerpsInApp && isFresh && isPerpsPath) {
-      navigate?.(path);
+    if (!pendingApplies && !justLeftPerpsInApp && isFresh && isPerpsStack) {
+      // Carried on every replayed entry so PerpsLayout can adopt this stack
+      // whichever entry its first effect observes.
+      paths.forEach((path) =>
+        navigate?.(path, { state: { perpsResumedStack: paths } }),
+      );
     }
   }, [
-    path,
+    stackKey,
     timestamp,
     hasPendingRedirect,
     pendingEnvironmentType,

--- a/ui/pages/perps/perps-layout.test.tsx
+++ b/ui/pages/perps/perps-layout.test.tsx
@@ -127,7 +127,7 @@ describe('PerpsLayout', () => {
     );
   });
 
-  it('persists the active perps path on mount and clears it on unmount', () => {
+  it('persists the active perps route stack on mount and clears it on unmount', () => {
     const { unmount } = renderWithProvider(
       <PerpsLayout />,
       store,
@@ -136,7 +136,7 @@ describe('PerpsLayout', () => {
 
     expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
       'setLastVisitedRoute',
-      ['perps', '/perps/market/BTC'],
+      ['perps', ['/perps/market/BTC']],
     );
 
     unmount();
@@ -156,7 +156,7 @@ describe('PerpsLayout', () => {
 
     expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
       'setLastVisitedRoute',
-      ['perps', '/perps/market/BTC?source=toast'],
+      ['perps', ['/perps/market/BTC?source=toast']],
     );
   });
 

--- a/ui/pages/perps/perps-layout.tsx
+++ b/ui/pages/perps/perps-layout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect } from 'react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { Outlet, useLocation } from 'react-router-dom';
 import { PROVIDER_CONFIG } from '@metamask/perps-controller';
@@ -15,6 +15,13 @@ import {
 } from '../../../shared/lib/selectors/accounts';
 import { getIsPerpsTerminalBackendEnabled } from '../../selectors/perps';
 import { markPerpsUnmountInApp } from '../../helpers/perps/in-app-leave-marker';
+import {
+  buildRouteStack,
+  getRouterHistoryIndex,
+  readResumedStack,
+  resolveStackBase,
+} from '../../helpers/perps/route-history';
+import { PERPS_RESUME_MAX_STACK_DEPTH } from '../../helpers/constants/routes';
 import { PerpsAttributionProvider } from '../../providers/perps/PerpsAttributionContext';
 import { useDispatch } from '../../store/hooks';
 
@@ -58,7 +65,7 @@ export default function PerpsLayout() {
   usePerpsLifecycleBreadcrumbs();
 
   const dispatch = useDispatch();
-  const { pathname, search } = useLocation();
+  const { pathname, search, state: locationState } = useLocation();
 
   const selectedAddress = useSelector(
     (state: AccountsState) =>
@@ -111,17 +118,46 @@ export default function PerpsLayout() {
     );
   }, [cacheSnapshot, selectedAddress, useTerminalApi]);
 
-  // Persist the active Perps path on every in-Perps navigation so that a
-  // brief close/reopen within PERPS_REOPEN_TTL_MS returns the user to this
-  // exact screen. We do NOT clear on pathname change — only on true React
-  // unmount via the effect below — to avoid a null-vs-next-path race when
-  // the user navigates rapidly between Perps screens.
+  // Persist the Perps route stack on every in-Perps navigation so that a brief
+  // close/reopen within PERPS_REOPEN_TTL_MS restores this screen and the ones
+  // beneath it. We do NOT clear on pathname change — only on true React unmount
+  // via the effect below — to avoid a null-vs-next-path race when the user
+  // navigates rapidly between Perps screens.
+  //
+  // A path's stack position is its distance from the entry this layout mounted
+  // on, so pushes extend, pops truncate, and replaces overwrite in place.
+  const baseHistoryIndexRef = useRef<number | undefined>(undefined);
+  const routeStackRef = useRef<string[]>([]);
   useEffect(() => {
     const fullPath = search ? `${pathname}${search}` : pathname;
-    Promise.resolve(dispatch(setLastVisitedPerpsRoute(fullPath))).catch(() => {
+    const historyIndex = getRouterHistoryIndex();
+    if (baseHistoryIndexRef.current === undefined) {
+      const { base, stack } = resolveStackBase({
+        resumedStack: readResumedStack(locationState),
+        path: fullPath,
+        historyIndex,
+      });
+      baseHistoryIndexRef.current = base;
+      routeStackRef.current = stack;
+    }
+
+    const depth =
+      historyIndex === undefined || baseHistoryIndexRef.current === undefined
+        ? 0
+        : Math.max(historyIndex - baseHistoryIndexRef.current, 0);
+    routeStackRef.current = buildRouteStack({
+      previous: routeStackRef.current,
+      path: fullPath,
+      depth,
+      maxDepth: PERPS_RESUME_MAX_STACK_DEPTH,
+    });
+
+    Promise.resolve(
+      dispatch(setLastVisitedPerpsRoute(routeStackRef.current)),
+    ).catch(() => {
       // fire-and-forget — persistence failure should not break Perps
     });
-  }, [dispatch, pathname, search]);
+  }, [dispatch, pathname, search, locationState]);
 
   // Clear only when the user intentionally leaves Perps in-app. A popup
   // close kills the page before React processes this cleanup, so the

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -54,6 +54,7 @@ import {
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import { getPreferences } from '../../../shared/lib/selectors/preferences';
 import { useI18nContext } from '../../hooks/useI18nContext';
+import { hasInAppHistoryEntry } from '../../helpers/perps/route-history';
 import { useTheme } from '../../hooks/useTheme';
 import {
   DEFAULT_ROUTE,
@@ -825,7 +826,7 @@ const PerpsMarketDetailPage = () => {
   }, []);
 
   const handleBackClick = useCallback(() => {
-    if (typeof window !== 'undefined' && window.history.length > 1) {
+    if (hasInAppHistoryEntry()) {
       navigate(PREVIOUS_ROUTE);
       return;
     }

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -28,6 +28,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
+import { PREVIOUS_ROUTE } from '../../helpers/constants/routes';
 import {
   mockPositions,
   mockAccountState,
@@ -1311,6 +1312,20 @@ describe('PerpsOrderEntryPage', () => {
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         replace: true,
       });
+    });
+
+    it('pops history when an in-app entry exists below the order screen', () => {
+      const originalState = window.history.state;
+      window.history.replaceState({ idx: 2 }, '');
+
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      fireEvent.click(screen.getByTestId('perps-order-entry-back-button'));
+
+      expect(mockUseNavigate).toHaveBeenCalledWith(PREVIOUS_ROUTE);
+
+      window.history.replaceState(originalState, '');
     });
 
     it('navigates back in history for encoded symbol markets', () => {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -55,6 +55,7 @@ import {
 } from '../../selectors/perps/feature-flags';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import { useI18nContext } from '../../hooks/useI18nContext';
+import { hasInAppHistoryEntry } from '../../helpers/perps/route-history';
 import {
   DEFAULT_ROUTE,
   PERPS_MARKET_DETAIL_ROUTE,
@@ -1166,7 +1167,7 @@ const PerpsOrderEntryPage = () => {
   // market-detail -> order-entry -> market-detail loop, since the
   // market-detail back button uses navigate(-1).
   const navigateBack = useCallback(() => {
-    if (typeof window !== 'undefined' && window.history.length > 1) {
+    if (hasInAppHistoryEntry()) {
       navigate(PREVIOUS_ROUTE);
       return;
     }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -4054,18 +4054,20 @@ export function getPendingRedirectRoute(state) {
 /**
  * Get the last visited Perps route and the timestamp it was recorded.
  *
+ * Keyed on the primitive fields, not on `lastVisitedRoute`: state pushes replace
+ * nested objects, and a fresh reference per push re-runs the dispatching effect
+ * in `useLastVisitedPerpsRoute` on every render.
+ *
  * @param {MetaMaskReduxState} state - The Redux state
  * @returns {{ path: string, timestamp: number } | null} The last visited Perps route, or null if none.
  */
-export function getLastVisitedPerpsRoute(state) {
-  const lastVisitedRoute = state.metamask?.lastVisitedRoute;
-  return lastVisitedRoute?.name === 'perps'
-    ? {
-        path: lastVisitedRoute.path,
-        timestamp: lastVisitedRoute.timestamp,
-      }
-    : null;
-}
+export const getLastVisitedPerpsRoute = createSelector(
+  (state) => state.metamask?.lastVisitedRoute?.name,
+  (state) => state.metamask?.lastVisitedRoute?.path,
+  (state) => state.metamask?.lastVisitedRoute?.timestamp,
+  (name, path, timestamp) =>
+    name === 'perps' && path !== undefined ? { path, timestamp } : null,
+);
 
 /**
  * Retrieves the deferred deep link from the MetaMask state.

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -4052,21 +4052,24 @@ export function getPendingRedirectRoute(state) {
 }
 
 /**
- * Get the last visited Perps route and the timestamp it was recorded.
+ * Get the Perps route stack the extension was showing, oldest entry first, and
+ * the timestamp it was recorded.
  *
  * Keyed on the primitive fields, not on `lastVisitedRoute`: state pushes replace
  * nested objects, and a fresh reference per push re-runs the dispatching effect
  * in `useLastVisitedPerpsRoute` on every render.
  *
  * @param {MetaMaskReduxState} state - The Redux state
- * @returns {{ path: string, timestamp: number } | null} The last visited Perps route, or null if none.
+ * @returns {{ paths: string[], timestamp: number } | null} The last visited Perps route stack, or null if none.
  */
 export const getLastVisitedPerpsRoute = createSelector(
   (state) => state.metamask?.lastVisitedRoute?.name,
-  (state) => state.metamask?.lastVisitedRoute?.path,
+  (state) => state.metamask?.lastVisitedRoute?.paths?.join('\n'),
   (state) => state.metamask?.lastVisitedRoute?.timestamp,
-  (name, path, timestamp) =>
-    name === 'perps' && path !== undefined ? { path, timestamp } : null,
+  (name, joinedPaths, timestamp) =>
+    name === 'perps' && joinedPaths
+      ? { paths: joinedPaths.split('\n'), timestamp }
+      : null,
 );
 
 /**

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -5033,6 +5033,22 @@ describe('getLastVisitedPerpsRoute', () => {
 
     expect(selectors.getLastVisitedPerpsRoute(state)).toBeNull();
   });
+
+  it('returns a stable reference when a state push replaces the route object', () => {
+    const buildState = () => ({
+      metamask: {
+        lastVisitedRoute: {
+          name: 'perps',
+          path: '/perps/trade/BTC',
+          timestamp: 1700000000000,
+        },
+      },
+    });
+
+    expect(selectors.getLastVisitedPerpsRoute(buildState())).toBe(
+      selectors.getLastVisitedPerpsRoute(buildState()),
+    );
+  });
 });
 
 describe('snap selectors', () => {

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -5005,13 +5005,21 @@ describe('getLastQrScanCompletedSuccessfully', () => {
 });
 
 describe('getLastVisitedPerpsRoute', () => {
-  it('returns the perps lastVisitedRoute value when set', () => {
-    const entry = { path: '/perps/market/BTC', timestamp: 1700000000000 };
+  it('returns the perps route stack when set', () => {
     const state = {
-      metamask: { lastVisitedRoute: { name: 'perps', ...entry } },
+      metamask: {
+        lastVisitedRoute: {
+          name: 'perps',
+          paths: ['/perps/market/BTC', '/perps/trade/BTC'],
+          timestamp: 1700000000000,
+        },
+      },
     };
 
-    expect(selectors.getLastVisitedPerpsRoute(state)).toStrictEqual(entry);
+    expect(selectors.getLastVisitedPerpsRoute(state)).toStrictEqual({
+      paths: ['/perps/market/BTC', '/perps/trade/BTC'],
+      timestamp: 1700000000000,
+    });
   });
 
   it('returns null when lastVisitedRoute is for another feature', () => {
@@ -5019,7 +5027,7 @@ describe('getLastVisitedPerpsRoute', () => {
       metamask: {
         lastVisitedRoute: {
           name: 'bridge',
-          path: '/bridge',
+          paths: ['/bridge'],
           timestamp: 1700000000000,
         },
       },
@@ -5034,12 +5042,22 @@ describe('getLastVisitedPerpsRoute', () => {
     expect(selectors.getLastVisitedPerpsRoute(state)).toBeNull();
   });
 
+  it('returns null when the stored stack is empty', () => {
+    const state = {
+      metamask: {
+        lastVisitedRoute: { name: 'perps', paths: [], timestamp: 1 },
+      },
+    };
+
+    expect(selectors.getLastVisitedPerpsRoute(state)).toBeNull();
+  });
+
   it('returns a stable reference when a state push replaces the route object', () => {
     const buildState = () => ({
       metamask: {
         lastVisitedRoute: {
           name: 'perps',
-          path: '/perps/trade/BTC',
+          paths: ['/perps/trade/BTC'],
           timestamp: 1700000000000,
         },
       },

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3988,7 +3988,7 @@ export async function setDefaultHomeActiveTabName(
 }
 
 export function setLastVisitedPerpsRoute(
-  path: string | null,
+  paths: string[] | null,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async (_dispatch: MetaMaskReduxDispatch) => {
     // Fire-and-forget: this write is a pure navigation hint for the next
@@ -3998,7 +3998,7 @@ export function setLastVisitedPerpsRoute(
     // (persist:false) and every Perps route change would otherwise pull
     // the entire background state.
     try {
-      await submitRequestToBackground('setLastVisitedRoute', ['perps', path]);
+      await submitRequestToBackground('setLastVisitedRoute', ['perps', paths]);
     } catch (error) {
       log.error('[setLastVisitedPerpsRoute] error', error);
     }


### PR DESCRIPTION
## **Description**

  Follow-up to [#45734](https://github.com/MetaMask/metamask-extension/pull/45734), stacked on `TAT-3834-crash-fix`.

  With the crash fixed, the resume still only persisted the single screen you were on, so tapping back from a restored screen dropped you to the wallet home instead of the market you came from. Adding a "my parent is X" rule per screen would mean repeating that for every new Perps route, so this persists the stack instead.

  - `AppStateController.lastVisitedRoute` now carries `paths` (oldest first) rather than a single `path`. The field is memory-only (`persist: false`), so there's no migration.
  - `PerpsLayout` derives each path's position from its distance from the entry it started tracking at: pushes extend the stack, pops truncate it, replaces overwrite in place - no push/pop bookkeeping of its own.
  - The resume pushes every entry, so back walks the screens the user actually came through and then out to the wallet home.
  - The resume replays its entries *before* the layout's first effect runs, so the layout can mount partway up the stack. It therefore adopts the replayed stack from the entry's route state. Treating the current entry as the base collapsed
  every later navigation to depth 0, which meant the first reopen worked and the second didn't - caught in manual testing, now covered by an e2e that does two close/reopen cycles.
  - Also replaces the `window.history.length > 1` checks in both Perps pages. `popup-init.html` leaves a session-history entry behind when it meta-refreshes to `popup.html`, so that count is never 1 in the popup: the up-navigation fallbacks in both pages were unreachable, and `navigate(-1)` on a first screen walked the document out of the SPA and back through the init redirect. The router's own history index counts only entries the app pushed, which is what those checks actually wanted.

  ## **Changelog**

  CHANGELOG entry: Reopening the extension on a Perps screen now restores the screens you navigated through, so the back arrow returns you where you came from.

  ## **Related issues**

  Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3834

  ## **Manual testing steps**

  1. Open the extension, go to a Perps market, tap Long to open the order screen.
  2. Close the extension, reopen within 5 minutes → the order screen renders.
  3. Tap back → the market detail screen for that market.
  4. Tap Long again → order screen.
  5. Close and reopen again → order screen renders.
  6. Tap back → market detail again. *(Before this PR, step 6 sent you to the wallet home — the second cycle only restored one screen.)*
  7. Separately: enter via a market list page (back arrow + search, inside perps), tap a market, tap Long, then close/reopen. Back should walk order → market → market list.

  ## **Screenshots/Recordings**

  ### **Before**

https://www.loom.com/share/8453efb5814742f8af5a5a764d3484e1

  ### **After**

https://www.loom.com/share/63632e92690d409e9005cbbefd8498ed

  ## **Pre-merge author checklist**

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I’ve included tests if applicable
  - [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.