### PR TITLE
fix: cancel requires 2 clicks

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -555,11 +555,6 @@
       "count": 1
     }
   },
-  "ui/hooks/hardware-wallets/useHwSignTracker.ts": {
-    "react-hooks/refs": {
-      "count": 3
-    }
-  },
   "ui/hooks/hardware-wallets/useHwSwapConfirmationMonitoring.ts": {
     "react-hooks/refs": {
       "count": 2

--- a/ui/hooks/hardware-wallets/hw-sign-tracker/batch-tracking-strategy.test.ts
+++ b/ui/hooks/hardware-wallets/hw-sign-tracker/batch-tracking-strategy.test.ts
@@ -219,12 +219,12 @@ describe('BatchTrackingStrategy', () => {
   describe('checkRetryGeneration', () => {
     it('marks seen batches as stale when generation bumps', () => {
       const retryGenRef = createRetryGenRef(0);
-      const lastSeenRef = { current: 0 };
 
       strategy.processStatusUpdated(createTxMeta({ batchId: 'batch-old' }));
 
       retryGenRef.current = 1;
-      strategy.checkRetryGeneration(retryGenRef, lastSeenRef);
+      // The call returns the new last-seen generation for the caller to persist.
+      expect(strategy.checkRetryGeneration(retryGenRef, 0)).toBe(1);
 
       // Old batch should now be stale — finished event blocked
       const result = strategy.processFinished(
@@ -238,12 +238,11 @@ describe('BatchTrackingStrategy', () => {
 
     it('allows new batch events after generation reset', () => {
       const retryGenRef = createRetryGenRef(0);
-      const lastSeenRef = { current: 0 };
 
       strategy.processStatusUpdated(createTxMeta({ batchId: 'batch-old' }));
 
       retryGenRef.current = 1;
-      strategy.checkRetryGeneration(retryGenRef, lastSeenRef);
+      expect(strategy.checkRetryGeneration(retryGenRef, 0)).toBe(1);
 
       const result = strategy.processStatusUpdated(
         createTxMeta({
@@ -258,12 +257,11 @@ describe('BatchTrackingStrategy', () => {
 
     it('allows rejection from new batch before signed event establishes batch (null state)', () => {
       const retryGenRef = createRetryGenRef(0);
-      const lastSeenRef = { current: 0 };
 
       strategy.processStatusUpdated(createTxMeta({ batchId: 'batch-old' }));
 
       retryGenRef.current = 1;
-      strategy.checkRetryGeneration(retryGenRef, lastSeenRef);
+      expect(strategy.checkRetryGeneration(retryGenRef, 0)).toBe(1);
 
       const result = strategy.processRejected(
         createTxMeta({ batchId: 'batch-new' }),
@@ -275,12 +273,11 @@ describe('BatchTrackingStrategy', () => {
 
     it('blocks stale signed events after retry', () => {
       const retryGenRef = createRetryGenRef(0);
-      const lastSeenRef = { current: 0 };
 
       strategy.processStatusUpdated(createTxMeta({ batchId: 'batch-old' }));
 
       retryGenRef.current = 1;
-      strategy.checkRetryGeneration(retryGenRef, lastSeenRef);
+      expect(strategy.checkRetryGeneration(retryGenRef, 0)).toBe(1);
 
       const result = strategy.processStatusUpdated(
         createTxMeta({
@@ -289,6 +286,19 @@ describe('BatchTrackingStrategy', () => {
         }),
       );
       expect(result.action).toBeNull();
+    });
+
+    it('returns null when the generation has not bumped', () => {
+      const retryGenRef = createRetryGenRef(1);
+
+      // Already seen generation 1 → no bump, nothing to persist.
+      expect(strategy.checkRetryGeneration(retryGenRef, 1)).toBeNull();
+    });
+
+    it('returns null when retry tracking is disabled', () => {
+      strategy.processStatusUpdated(createTxMeta({ batchId: 'batch-1' }));
+
+      expect(strategy.checkRetryGeneration(undefined, 0)).toBeNull();
     });
   });
 

--- a/ui/hooks/hardware-wallets/hw-sign-tracker/batch-tracking-strategy.ts
+++ b/ui/hooks/hardware-wallets/hw-sign-tracker/batch-tracking-strategy.ts
@@ -34,35 +34,43 @@ export class BatchTrackingStrategy implements TrackingStrategy {
 
   #trackedTxIds = new Set<string>();
 
+  /**
+   * Tx IDs that have finished signing (signed / rejected / failed / finished).
+   * Cancel uses this to skip waiting for abort events that will never come.
+   */
+  #settledTxIds = new Set<string>();
+
   // ---------------------------------------------------------------
   // TrackingStrategy implementation
   // ---------------------------------------------------------------
 
   /**
    * Detects a retry-generation bump and marks all seen batches as stale. When
-   * `retryGenerationRef` advances past `lastSeenGenerationRef`, every seen
-   * batch ID is moved to the stale set, seen batches are cleared, and the
-   * active batch is unlocked (`#currentBatchId = null`) so the next signed
-   * event re-establishes the batch from the new retry generation.
+   * `retryGenerationRef` advances past `lastSeenGeneration`, every seen batch
+   * ID is moved to the stale set, seen batches are cleared, and the active
+   * batch is unlocked (`#currentBatchId = null`) so the next signed event
+   * re-establishes the batch from the new retry generation.
    *
    * @param retryGenerationRef - External ref bumped on retry; `undefined`
    * disables retry tracking.
-   * @param lastSeenGenerationRef - Mutable ref tracking the last retry
-   * generation this strategy observed; updated in place when a bump is detected.
+   * @param lastSeenGeneration - The last-seen generation value to compare against.
+   * @returns The new last-seen generation when a bump was applied, otherwise
+   * `null`; the caller owns persisting the returned value.
    */
   checkRetryGeneration(
     retryGenerationRef: React.RefObject<number | undefined> | undefined,
-    lastSeenGenerationRef: React.MutableRefObject<number>,
-  ): void {
-    const bumped = applyRetryGenerationBump(
+    lastSeenGeneration: number,
+  ): number | null {
+    const newLastSeenGeneration = applyRetryGenerationBump(
       retryGenerationRef,
-      lastSeenGenerationRef,
+      lastSeenGeneration,
       this.#seenBatchIds,
       this.#staleBatchIds,
     );
-    if (bumped) {
+    if (newLastSeenGeneration !== null) {
       this.#currentBatchId = null;
     }
+    return newLastSeenGeneration;
   }
 
   /**
@@ -85,6 +93,16 @@ export class BatchTrackingStrategy implements TrackingStrategy {
 
     this.#seenBatchIds.add(batchId);
     this.#trackedTxIds.add(transactionMeta.id);
+
+    // Mark settled even if #handleSigned/#handleFailed ignore this batch.
+    // The tx is still done; cancel must not wait for abort confirmations.
+    if (
+      status === TransactionStatus.signed ||
+      status === TransactionStatus.failed ||
+      status === TransactionStatus.rejected
+    ) {
+      this.#settledTxIds.add(transactionMeta.id);
+    }
 
     if (status === TransactionStatus.signed) {
       return this.#handleSigned(
@@ -116,6 +134,8 @@ export class BatchTrackingStrategy implements TrackingStrategy {
     const wasTracked = this.#trackedTxIds.has(transactionMeta.id);
     this.#seenBatchIds.add(batchId);
     this.#trackedTxIds.add(transactionMeta.id);
+    // Settled even if we drop the action — signing already finished.
+    this.#settledTxIds.add(transactionMeta.id);
 
     if (
       shouldIgnoreBatchEvent(
@@ -148,6 +168,8 @@ export class BatchTrackingStrategy implements TrackingStrategy {
     const wasTracked = this.#trackedTxIds.has(transactionMeta.id);
     this.#seenBatchIds.add(batchId);
     this.#trackedTxIds.add(transactionMeta.id);
+    // Finished is always terminal, even if we drop a stale-batch action.
+    this.#settledTxIds.add(transactionMeta.id);
 
     if (
       shouldIgnoreBatchEvent(
@@ -181,6 +203,21 @@ export class BatchTrackingStrategy implements TrackingStrategy {
   }
 
   /**
+   * True when every tracked tx has finished signing.
+   * Cancel uses this to skip waiting for abort confirmations.
+   *
+   * @returns True when all tracked transaction IDs have settled.
+   */
+  hasSettledSigning(): boolean {
+    for (const txId of this.#trackedTxIds) {
+      if (!this.#settledTxIds.has(txId)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * Clears all batch, stale, seen, and tracked-tx state. Called on cancel,
    * subscription teardown, and when the tracker is disabled.
    */
@@ -189,6 +226,7 @@ export class BatchTrackingStrategy implements TrackingStrategy {
     this.#staleBatchIds = new Set();
     this.#seenBatchIds = new Set();
     this.#trackedTxIds = new Set();
+    this.#settledTxIds = new Set();
   }
 
   // ---------------------------------------------------------------

--- a/ui/hooks/hardware-wallets/hw-sign-tracker/sequential-tracking-strategy.test.ts
+++ b/ui/hooks/hardware-wallets/hw-sign-tracker/sequential-tracking-strategy.test.ts
@@ -41,10 +41,10 @@ describe('SequentialTrackingStrategy', () => {
       // First, track a tx
       strategy.processStatusUpdated(createTxMeta({ id: 'tx-old' }));
 
-      // Simulate retry generation bump
+      // Simulate retry generation bump; the call returns the new last-seen
+      // generation for the caller to persist.
       const retryGenRef = createRetryGenRef(1);
-      const lastSeenRef = { current: 0 };
-      strategy.checkRetryGeneration(retryGenRef, lastSeenRef);
+      expect(strategy.checkRetryGeneration(retryGenRef, 0)).toBe(1);
 
       const result = strategy.processStatusUpdated(
         createTxMeta({ id: 'tx-old', type: TransactionType.bridge }),
@@ -81,8 +81,7 @@ describe('SequentialTrackingStrategy', () => {
       strategy.processStatusUpdated(createTxMeta({ id: 'tx-old' }));
 
       const retryGenRef = createRetryGenRef(1);
-      const lastSeenRef = { current: 0 };
-      strategy.checkRetryGeneration(retryGenRef, lastSeenRef);
+      expect(strategy.checkRetryGeneration(retryGenRef, 0)).toBe(1);
 
       const result = strategy.processStatusUpdated(
         createTxMeta({ id: 'tx-old', status: TransactionStatus.failed }),
@@ -164,12 +163,11 @@ describe('SequentialTrackingStrategy', () => {
   describe('checkRetryGeneration', () => {
     it('clears tracked tx ids on retry generation change', () => {
       const retryGenRef = createRetryGenRef(0);
-      const lastSeenRef = { current: 0 };
 
       strategy.processStatusUpdated(createTxMeta({ id: 'tx-old' }));
 
       retryGenRef.current = 1;
-      strategy.checkRetryGeneration(retryGenRef, lastSeenRef);
+      expect(strategy.checkRetryGeneration(retryGenRef, 0)).toBe(1);
 
       // Stale tx should be blocked
       const result = strategy.processRejected(createTxMeta({ id: 'tx-old' }));
@@ -178,12 +176,11 @@ describe('SequentialTrackingStrategy', () => {
 
     it('processes events from new tx after retry', () => {
       const retryGenRef = createRetryGenRef(0);
-      const lastSeenRef = { current: 0 };
 
       strategy.processStatusUpdated(createTxMeta({ id: 'tx-old' }));
 
       retryGenRef.current = 1;
-      strategy.checkRetryGeneration(retryGenRef, lastSeenRef);
+      expect(strategy.checkRetryGeneration(retryGenRef, 0)).toBe(1);
 
       const result = strategy.processStatusUpdated(
         createTxMeta({
@@ -194,6 +191,19 @@ describe('SequentialTrackingStrategy', () => {
       expect(result.action).toEqual({
         type: HardwareWalletSignatureEvent.TransactionSubmitted,
       });
+    });
+
+    it('returns null when the generation has not bumped', () => {
+      const retryGenRef = createRetryGenRef(1);
+
+      // Already seen generation 1 → no bump, nothing to persist.
+      expect(strategy.checkRetryGeneration(retryGenRef, 1)).toBeNull();
+    });
+
+    it('returns null when retry tracking is disabled', () => {
+      strategy.processStatusUpdated(createTxMeta({ id: 'tx-1' }));
+
+      expect(strategy.checkRetryGeneration(undefined, 0)).toBeNull();
     });
   });
 

--- a/ui/hooks/hardware-wallets/hw-sign-tracker/sequential-tracking-strategy.ts
+++ b/ui/hooks/hardware-wallets/hw-sign-tracker/sequential-tracking-strategy.ts
@@ -31,24 +31,31 @@ export class SequentialTrackingStrategy implements TrackingStrategy {
   #staleTxIds = new Set<string>();
 
   /**
+   * Tx IDs that have finished signing (signed / rejected / failed / finished).
+   * Cancel uses this to skip waiting for abort events that will never come.
+   */
+  #settledTxIds = new Set<string>();
+
+  /**
    * Detects a retry-generation bump and marks all currently tracked transaction
    * IDs as stale. When the retry generation referenced by `retryGenerationRef`
-   * advances beyond the last-seen value in `lastSeenGenerationRef`, every tracked
-   * ID is moved to {@link #staleTxIds} and {@link #trackedTxIds} is reset so only
-   * transactions from the new generation are processed going forward.
+   * advances beyond `lastSeenGeneration`, every tracked ID is moved to
+   * {@link #staleTxIds} and {@link #trackedTxIds} is reset so only transactions
+   * from the new generation are processed going forward.
    *
    * @param retryGenerationRef - Ref holding the current retry generation
    * (or `undefined` if retry tracking is disabled).
-   * @param lastSeenGenerationRef - Mutable ref tracking the last retry generation
-   * this strategy observed; updated in place when a bump is detected.
+   * @param lastSeenGeneration - The last-seen generation value to compare against.
+   * @returns The new last-seen generation when a bump was applied, otherwise
+   * `null`; the caller owns persisting the returned value.
    */
   checkRetryGeneration(
     retryGenerationRef: React.RefObject<number | undefined> | undefined,
-    lastSeenGenerationRef: React.MutableRefObject<number>,
-  ): void {
-    applyRetryGenerationBump(
+    lastSeenGeneration: number,
+  ): number | null {
+    return applyRetryGenerationBump(
       retryGenerationRef,
-      lastSeenGenerationRef,
+      lastSeenGeneration,
       this.#trackedTxIds,
       this.#staleTxIds,
     );
@@ -74,6 +81,15 @@ export class SequentialTrackingStrategy implements TrackingStrategy {
     }
 
     this.#trackedTxIds.add(transactionMeta.id);
+
+    // Mark settled even if the branches below emit no action.
+    if (
+      status === TransactionStatus.signed ||
+      status === TransactionStatus.failed ||
+      status === TransactionStatus.rejected
+    ) {
+      this.#settledTxIds.add(transactionMeta.id);
+    }
 
     if (status === TransactionStatus.signed) {
       if (!type) {
@@ -104,6 +120,9 @@ export class SequentialTrackingStrategy implements TrackingStrategy {
       return NO_ACTION;
     }
 
+    // Signing is done; cancel can skip the abort wait.
+    this.#settledTxIds.add(transactionMeta.id);
+
     return {
       action: { type: HardwareWalletSignatureEvent.TransactionRejected },
     };
@@ -123,6 +142,9 @@ export class SequentialTrackingStrategy implements TrackingStrategy {
     if (!this.#trackedTxIds.has(transactionMeta.id)) {
       return NO_ACTION;
     }
+
+    // Finished is always terminal, even if it maps to no action.
+    this.#settledTxIds.add(transactionMeta.id);
 
     if (
       status === TransactionStatus.rejected ||
@@ -145,11 +167,27 @@ export class SequentialTrackingStrategy implements TrackingStrategy {
   }
 
   /**
+   * True when every tracked tx has finished signing.
+   * Cancel uses this to skip waiting for abort confirmations.
+   *
+   * @returns True when all tracked transaction IDs have settled.
+   */
+  hasSettledSigning(): boolean {
+    for (const txId of this.#trackedTxIds) {
+      if (!this.#settledTxIds.has(txId)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * Clears all tracking and stale state. Called on cancel, subscription
    * teardown, and when the tracker is disabled.
    */
   reset(): void {
     this.#trackedTxIds = new Set();
     this.#staleTxIds = new Set();
+    this.#settledTxIds = new Set();
   }
 }

--- a/ui/hooks/hardware-wallets/hw-sign-tracker/types.ts
+++ b/ui/hooks/hardware-wallets/hw-sign-tracker/types.ts
@@ -46,12 +46,14 @@ export type TrackingStrategy = {
    * When the generation bumps, previously seen batches/txs are marked stale.
    *
    * @param retryGenerationRef - External ref that gets bumped on retry.
-   * @param lastSeenGenerationRef - Internal ref tracking the last-seen generation.
+   * @param lastSeenGeneration - The last-seen generation value to compare against.
+   * @returns The new last-seen generation when a retry-generation bump was
+   * applied, otherwise `null`; the caller owns persisting the returned value.
    */
   checkRetryGeneration(
     retryGenerationRef: React.RefObject<number | undefined> | undefined,
-    lastSeenGenerationRef: React.MutableRefObject<number>,
-  ): void;
+    lastSeenGeneration: number,
+  ): number | null;
 
   /**
    * Process a transactionStatusUpdated event.
@@ -76,6 +78,12 @@ export type TrackingStrategy = {
 
   /** Get all currently tracked transaction IDs (for abort). */
   getTrackedTxIds(): Set<string>;
+
+  /**
+   * True when every tracked tx has finished signing.
+   * Cancel uses this to skip waiting for abort confirmations.
+   */
+  hasSettledSigning(): boolean;
 
   /** Reset all tracking state (called on cancel, subscription teardown, enable toggle). */
   reset(): void;

--- a/ui/hooks/hardware-wallets/hw-sign-tracker/utils.ts
+++ b/ui/hooks/hardware-wallets/hw-sign-tracker/utils.ts
@@ -90,32 +90,34 @@ export function checkPendingAbort(
 /**
  * Detects a retry-generation bump and, when it advanced, moves every entry
  * from `seenSet` into `staleSet` and clears `seenSet`. Shared by both tracking
- * strategies so the bump handling stays consistent.
+ * strategies so the bump handling stays consistent. Pure with respect to the
+ * last-seen generation: the caller owns persisting the returned value.
  *
  * @param retryGenerationRef - External ref bumped on retry (undefined disables).
- * @param lastSeenGenerationRef - Mutable ref tracking the last-seen generation; updated in place.
+ * @param lastSeenGeneration - The last-seen generation value to compare against.
  * @param seenSet - The currently-seen IDs/batch IDs (mutated: cleared on bump).
  * @param staleSet - The stale IDs/batch IDs (mutated: receives seen entries on bump).
- * @returns True if a bump was detected and applied.
+ * @returns The new last-seen generation when a bump was detected and applied,
+ * otherwise `null`.
  */
 export function applyRetryGenerationBump(
   retryGenerationRef: React.RefObject<number | undefined> | undefined,
-  lastSeenGenerationRef: React.MutableRefObject<number>,
+  lastSeenGeneration: number,
   seenSet: Set<string>,
   staleSet: Set<string>,
-): boolean {
+): number | null {
   if (
     !retryGenerationRef ||
-    retryGenerationRef.current === lastSeenGenerationRef.current
+    retryGenerationRef.current === lastSeenGeneration
   ) {
-    return false;
+    return null;
   }
-  lastSeenGenerationRef.current = retryGenerationRef.current ?? 0;
+  const newLastSeenGeneration = retryGenerationRef.current ?? 0;
   for (const id of seenSet) {
     staleSet.add(id);
   }
   seenSet.clear();
-  return true;
+  return newLastSeenGeneration;
 }
 
 /**

--- a/ui/hooks/hardware-wallets/useHwSignTracker.test.ts
+++ b/ui/hooks/hardware-wallets/useHwSignTracker.test.ts
@@ -467,11 +467,14 @@ describe.each<string, boolean>([
 
     rerender({ dispatch: dispatch2 });
 
+    expect(mockSubscribe).toHaveBeenCalledTimes(3);
+
     const cb = callbacks.get(STATUS_UPDATED);
     await act(async () => {
       cb?.([{ transactionMeta: createTxMeta() }]);
     });
 
+    expect(dispatch1).not.toHaveBeenCalled();
     expect(dispatch2).toHaveBeenCalledWith({
       type: HardwareWalletSignatureEvent.FirstSignatureSubmitted,
     });
@@ -513,6 +516,106 @@ describe.each<string, boolean>([
         'abortTransactionSigning',
         ['tx-1'],
       );
+    });
+
+    it('resolves cancel without waiting for the abort-settle timeout when signing has settled', async () => {
+      // Regression: after a device rejection the tx is already terminal, but
+      // the TransactionController leaks the tx's abort callback (the delete
+      // after the awaited signing promise is skipped on rejection), so
+      // abortTransactionSigning resolves without emitting any confirmation
+      // events. Cancel must not block on the 5s settle timeout in that case.
+      const { result, fire } = await setupTracker({ useBatchTracking });
+      // Track the tx with a non-terminal status, then let the device reject
+      // it: the strategy observes the terminal event and derives that
+      // signing has settled.
+      await fire(STATUS_UPDATED, {
+        id: 'tx-1',
+        batchId: 'batch-1',
+        status: 'unapproved',
+      });
+      await fire(REJECTED, { id: 'tx-1', batchId: 'batch-1' });
+      mockSubmitRequestToBackground.mockClear();
+
+      let resolved = false;
+      const cancelPromise = result.current.cancelCurrentBatch().then(() => {
+        resolved = true;
+      });
+
+      await act(async () => {
+        // Flush microtasks only; do NOT advance past the 5s settle timeout.
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      expect(resolved).toBe(true);
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'abortTransactionSigning',
+        ['tx-1'],
+      );
+      await cancelPromise;
+    });
+
+    it('still waits for abort events to settle when signing has not settled', async () => {
+      const { result, fire } = await setupTracker({ useBatchTracking });
+      // Tracked, but no signing-terminal event observed for the tx yet.
+      await fire(STATUS_UPDATED, {
+        id: 'tx-1',
+        batchId: 'batch-1',
+        status: 'unapproved',
+      });
+      mockSubmitRequestToBackground.mockClear();
+
+      let resolved = false;
+      const cancelPromise = result.current.cancelCurrentBatch().then(() => {
+        resolved = true;
+      });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      // Without a terminal event the cancel waits for abort confirmation
+      // events (or the timeout), so it must still be pending here.
+      expect(resolved).toBe(false);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(6_000);
+      });
+      await cancelPromise;
+      expect(resolved).toBe(true);
+    });
+
+    it('resolves the settle wait early when a terminal event arrives mid-wait', async () => {
+      const { result, fire } = await setupTracker({ useBatchTracking });
+      await fire(STATUS_UPDATED, {
+        id: 'tx-1',
+        batchId: 'batch-1',
+        status: 'unapproved',
+      });
+      mockSubmitRequestToBackground.mockClear();
+
+      let resolved = false;
+      const cancelPromise = result.current.cancelCurrentBatch().then(() => {
+        resolved = true;
+      });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      // Cancel is parked waiting for the tracked tx's abort confirmation.
+      expect(resolved).toBe(false);
+
+      // The terminal rejection consumes the pending abort and resolves the
+      // settle wait without the 5s timeout elapsing.
+      await fire(REJECTED, { id: 'tx-1', batchId: 'batch-1' });
+
+      await act(async () => {
+        // Flush microtasks only; the settle timer must not be needed.
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      expect(resolved).toBe(true);
+      await cancelPromise;
     });
 
     it('calls abortTransactionSigning for tracked tx ids', async () => {

--- a/ui/hooks/hardware-wallets/useHwSignTracker.ts
+++ b/ui/hooks/hardware-wallets/useHwSignTracker.ts
@@ -148,7 +148,9 @@ export function useHwSignTracker(
   retryGenerationRef?: React.RefObject<number | undefined>,
 ) {
   const dispatchRef = useRef(dispatchSignatureEvent);
-  dispatchRef.current = dispatchSignatureEvent;
+  useEffect(() => {
+    dispatchRef.current = dispatchSignatureEvent;
+  }, [dispatchSignatureEvent]);
 
   const enabled = options?.enabled ?? true;
   const {
@@ -208,11 +210,20 @@ export function useHwSignTracker(
     [useBatchTracking],
   );
 
-  const lastSeenGenerationRef = useRef(retryGenerationRef?.current ?? 0);
+  const lastSeenGenerationRef = useRef(0);
   const pendingAbortTxIdsRef = useRef<Set<string>>(new Set());
   const abortSettleResolveRef = useRef<((value: void) => void) | null>(null);
   /** Bumped when the subscription effect re-runs so stale cancel cleanup cannot wipe a new flow. */
   const subscriptionGenerationRef = useRef(0);
+
+  // Seeded in an effect (not during render) per react-hooks/refs. Declared
+  // before the subscription effect so the seed lands before any event can be
+  // processed; the ref object identity is stable, so it runs once on mount.
+  // Do not re-sync on every render: that would hide retry bumps from
+  // `checkRetryGeneration`.
+  useEffect(() => {
+    lastSeenGenerationRef.current = retryGenerationRef?.current ?? 0;
+  }, [retryGenerationRef]);
 
   const clearSubscriptionTracking = useCallback(() => {
     strategy.reset();
@@ -236,6 +247,8 @@ export function useHwSignTracker(
     };
 
     const txIds = [...strategy.getTrackedTxIds()];
+    // Capture before reset(), which would make hasSettledSigning() true for an empty set.
+    const hasSettledSigning = strategy.hasSettledSigning();
     strategy.reset();
 
     if (txIds.length === 0) {
@@ -264,7 +277,12 @@ export function useHwSignTracker(
       }),
     );
 
-    if (pendingAbortTxIdsRef.current.size === 0) {
+    if (
+      pendingAbortTxIdsRef.current.size === 0 ||
+      // Already terminal: abortTransactionSigning resolves with no follow-up
+      // event, so waiting here would stall Cancel for the full 5s timeout.
+      hasSettledSigning
+    ) {
       finishCancelCleanup();
       return;
     }
@@ -339,10 +357,13 @@ export function useHwSignTracker(
         const transactionMeta =
           'transactionMeta' in firstArg ? firstArg.transactionMeta : firstArg;
 
-        strategy.checkRetryGeneration(
+        const newLastSeenGeneration = strategy.checkRetryGeneration(
           retryGenerationRef,
-          lastSeenGenerationRef,
+          lastSeenGenerationRef.current,
         );
+        if (newLastSeenGeneration !== null) {
+          lastSeenGenerationRef.current = newLastSeenGeneration;
+        }
 
         const { status, type } = transactionMeta;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Cancelling a hardware wallet signing flow required two clicks: the first click appeared to do nothing while the cancel logic waited out a 5s abort-settle timeout, and only a second click completed the cancellation.

**Root cause:** Once a transaction reaches a terminal state on the device (e.g. the user rejects it on the Ledger/Trezor), `abortTransactionSigning` resolves without emitting any abort-confirmation events (the TransactionController leaks the tx's abort callback on rejection). `cancelCurrentBatch` was still waiting for those events, so it blocked for the full settle timeout even though signing had already finished.

**Solution:**
- `BatchTrackingStrategy` and `SequentialTrackingStrategy` now record which tracked transactions have settled (signed / rejected / failed / finished) and expose `hasSettledSigning()`.
- `cancelCurrentBatch` skips the abort-settle wait entirely when signing has already settled, and resolves the wait early if a terminal event arrives while it is already waiting — no more 5s stall, single-click cancel.
- Made `checkRetryGeneration` / `applyRetryGenerationBump` pure with respect to the last-seen retry generation: they now return the new generation (or `null`) for the caller to persist, instead of mutating a ref in place. Also moved `dispatchRef` / `lastSeenGenerationRef` updates into effects per react-hooks ref rules.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that required hardware wallet users to click Cancel twice to dismiss a signature request after it was already rejected or completed on the device.


## **Related issues**

Fixes: [MUL-2173](https://consensys.atlassian.net/browse/MUL-2173)
Fixes: https://github.com/MetaMask/metamask-extension/issues/45071

## **Manual testing steps**

1. Connect a Ledger or Trezor hardware wallet and open the extension.
2. Initiate a transaction signature (or a batch signature) from the wallet.
3. Reject the transaction on the device.
4. Click "Cancel" in the extension immediately after the rejection.
5. Verify the cancellation completes on the first click with no delay (previously the first click appeared ignored and the flow only closed after a second click).
6. Repeat step 2 but cancel while the device is still waiting for input, and verify the cancel still completes normally after the abort confirmation.



## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/a3419871-5585-4b2d-b02d-050231849046



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUL-2173]: https://consensyssoftware.atlassian.net/browse/MUL-2173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing and cleanup in the hardware-wallet sign tracker cancel/abort path; regressions could leave signing UI stuck or abort too early, though behavior for in-flight signing is explicitly preserved and covered by new tests.
> 
> **Overview**
> Fixes hardware wallet **Cancel** stalling for the full ~5s abort-settle timeout (and feeling like a second click was needed) when signing already finished on the device—e.g. after a Ledger/Trezor rejection—because `abortTransactionSigning` can resolve without abort-confirmation events.
> 
> Batch and sequential tracking strategies now record **settled** tx IDs on terminal statuses and expose **`hasSettledSigning()`**; **`cancelCurrentBatch`** skips the settle wait when every tracked tx is already settled, while still waiting (or timing out) when signing is genuinely in flight. Terminal events during that wait can still clear pending aborts as before.
> 
> **Retry-generation** handling is refactored so **`checkRetryGeneration`** / **`applyRetryGenerationBump`** return the new generation (or `null`) for the hook to persist instead of mutating a ref inside the strategy. **`useHwSignTracker`** moves **`dispatchRef`** and initial **`lastSeenGenerationRef`** seeding into effects to satisfy **`react-hooks/refs`**, and drops the related eslint suppressions. Tests cover settled vs unsettled cancel paths and dispatch identity on rerender.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4096c12ab4a8afe02e6735e0b144b346c476284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->