### PR TITLE
feat: add the Money keyring, MoneyAccountController, and availability service

### DIFF
--- a/app/scripts/constants/sentry-state.ts
+++ b/app/scripts/constants/sentry-state.ts
@@ -191,6 +191,9 @@ export const SENTRY_BACKGROUND_STATE: SentryBackgroundControllerMasks = {
   LoggingController: {
     logs: false,
   },
+  MoneyAccountController: {
+    moneyAccounts: false,
+  },
   NotificationServicesController: {
     subscriptionAccountsSeen: false,
     isMetamaskNotificationsFeatureSeen: false,

--- a/app/scripts/lib/money/money-account-availability.test.ts
+++ b/app/scripts/lib/money/money-account-availability.test.ts
@@ -1,10 +1,7 @@
 import type { Hex } from '@metamask/utils';
 import { CHAIN_IDS } from '../../../../shared/constants/chain-ids';
 import { FEATURED_RPCS } from '../../../../shared/constants/network';
-import {
-  MONEY_ACCOUNT_GEO_BLOCKED_COUNTRIES_FLAG_NAME,
-  MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME,
-} from '../../../../shared/lib/money/feature-flags';
+import { MONEY_ACCOUNT_GEO_BLOCKED_COUNTRIES_FLAG_NAME } from '../../../../shared/lib/money/feature-flags';
 import { MONEY_ACCOUNT_VAULT_CONFIG_FLAG_NAME } from '../../../../shared/lib/money/vault-config';
 import { deriveMoneyAccountAddress } from './get-money-account-address';
 import {
@@ -16,8 +13,6 @@ jest.mock('./get-money-account-address');
 
 const MONEY_ADDRESS = '0xd5fe9b0579443e7025cf3309ba420977710e7183' as Hex;
 
-const ENABLED_FLAG = { enabled: true, minimumVersion: '0.0.1' };
-const DISABLED_FLAG = { enabled: false, minimumVersion: '0.0.1' };
 const VAULT_CONFIG = {
   chainId: CHAIN_IDS.MONAD,
   boringVault: '0xb4563bcD3B7764CCBf497f515585f70B6C3EA5Ae',
@@ -33,14 +28,12 @@ const MONAD_NETWORK_CONFIGURATION = FEATURED_RPCS.find(
 const deriveMoneyAccountAddressMock = jest.mocked(deriveMoneyAccountAddress);
 
 function createMockMessenger({
-  moneyFlag = ENABLED_FLAG as unknown,
   vaultConfig = VAULT_CONFIG as unknown,
   networkConfigured = true,
   geoFlag,
   location = 'US',
   getGeolocation,
 }: {
-  moneyFlag?: unknown;
   vaultConfig?: unknown;
   networkConfigured?: boolean;
   geoFlag?: unknown;
@@ -52,7 +45,6 @@ function createMockMessenger({
     if (action === 'RemoteFeatureFlagController:getState') {
       return {
         remoteFeatureFlags: {
-          [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: moneyFlag,
           [MONEY_ACCOUNT_VAULT_CONFIG_FLAG_NAME]: vaultConfig,
           ...(geoFlag === undefined
             ? {}
@@ -107,9 +99,7 @@ function createMockMessenger({
   };
 }
 
-function createService(
-  options: Parameters<typeof createMockMessenger>[0] = {},
-) {
+function createService(options?: Parameters<typeof createMockMessenger>[0]) {
   const mock = createMockMessenger(options);
   const service = new MoneyAccountAvailabilityService({
     messenger: mock.messenger,
@@ -123,7 +113,7 @@ describe('MoneyAccountAvailabilityService', () => {
     deriveMoneyAccountAddressMock.mockResolvedValue(MONEY_ADDRESS);
   });
 
-  it('answers available with the derived address when the flag is on', async () => {
+  it('answers available with the derived address', async () => {
     const { service } = createService();
 
     expect(await service.getAvailability()).toStrictEqual({
@@ -153,63 +143,6 @@ describe('MoneyAccountAvailabilityService', () => {
     await service.getAvailability();
 
     expect(addNetwork).not.toHaveBeenCalled();
-  });
-
-  it('answers unavailable when the flag is off, without touching the seed, geolocation, or networks', async () => {
-    const { service, addNetwork, call } = createService({
-      moneyFlag: DISABLED_FLAG,
-    });
-
-    expect(await service.getAvailability()).toStrictEqual({
-      isAvailable: false,
-    });
-    expect(deriveMoneyAccountAddressMock).not.toHaveBeenCalled();
-    expect(addNetwork).not.toHaveBeenCalled();
-    expect(call).not.toHaveBeenCalledWith('NetworkController:getState');
-    expect(call).not.toHaveBeenCalledWith(
-      'GeolocationController:getGeolocation',
-    );
-  });
-
-  it('answers unavailable when the flag is absent or malformed', async () => {
-    for (const moneyFlag of [null, 'yes', { enabled: true }]) {
-      const { service } = createService({ moneyFlag });
-
-      expect(await service.getAvailability()).toStrictEqual({
-        isAvailable: false,
-      });
-    }
-  });
-
-  it('re-reads the flag on every call so a remote-flag refresh takes effect', async () => {
-    let flag: unknown = DISABLED_FLAG;
-    const { service, call } = createService();
-    call.mockImplementation((action: string) => {
-      if (action === 'RemoteFeatureFlagController:getState') {
-        return {
-          remoteFeatureFlags: {
-            [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: flag,
-            [MONEY_ACCOUNT_VAULT_CONFIG_FLAG_NAME]: VAULT_CONFIG,
-          },
-        };
-      }
-      if (action === 'GeolocationController:getGeolocation') {
-        return 'US';
-      }
-      if (action === 'NetworkController:getState') {
-        return {
-          networkConfigurationsByChainId: {
-            [CHAIN_IDS.MONAD]: MONAD_NETWORK_CONFIGURATION,
-          },
-        };
-      }
-      throw new Error(`Unexpected action: ${action}`);
-    });
-
-    expect((await service.getAvailability()).isAvailable).toBe(false);
-
-    flag = ENABLED_FLAG;
-    expect((await service.getAvailability()).isAvailable).toBe(true);
   });
 
   it('answers unavailable when the vault chain is not a featured network', async () => {

--- a/app/scripts/lib/money/money-account-availability.ts
+++ b/app/scripts/lib/money/money-account-availability.ts
@@ -12,7 +12,6 @@ import { FEATURED_RPCS } from '../../../../shared/constants/network';
 import type { MoneyAccountAvailability } from '../../../../shared/lib/money/availability';
 import {
   getMoneyAccountGeoBlockedCountries,
-  isMoneyAccountEnabled,
   isMoneyAccountGeoEligible,
 } from '../../../../shared/lib/money/feature-flags';
 import { getMoneyAccountVaultConfig } from '../../../../shared/lib/money/vault-config';
@@ -43,18 +42,8 @@ export type MoneyAccountAvailabilityServiceGetAvailabilityAction = {
   handler: MoneyAccountAvailabilityService['getAvailability'];
 };
 
-/**
- * The action other clients use to call {@link MoneyAccountAvailabilityService.getAddress}
- * directly through the messenger, instead of via a controller wrapper method.
- */
-export type MoneyAccountAvailabilityServiceGetAddressAction = {
-  type: `${typeof serviceName}:getAddress`;
-  handler: MoneyAccountAvailabilityService['getAddress'];
-};
-
 type MoneyAccountAvailabilityActions =
-  | MoneyAccountAvailabilityServiceGetAvailabilityAction
-  | MoneyAccountAvailabilityServiceGetAddressAction;
+  MoneyAccountAvailabilityServiceGetAvailabilityAction;
 
 export type MoneyAccountAvailabilityMessenger = Messenger<
   typeof serviceName,
@@ -69,17 +58,21 @@ const UNAVAILABLE: MoneyAccountAvailability = { isAvailable: false };
 /**
  * Resolves whether the Money Account surface should be shown at all.
  *
- * We look at the state of the `moneyEnableMoneyAccount` flag, whether the
- * user's region is allowed (`moneyAccountGeoBlockedCountries`), and whether
- * a money address can be derived from an unlocked wallet. The configured
- * Money Account chain must also be ready for use.
+ * We look at whether the user's region is allowed
+ * (`moneyAccountGeoBlockedCountries`), and whether a money address can be
+ * derived from an unlocked wallet. The configured Money Account chain must
+ * also be ready for use.
  *
  * A money account being available doesn’t mean that the account has been
  * upgraded yet.
  *
- * The flag and geo check are never cached because they can change when
- * remote feature flags update or geolocation refreshes. Unknown or failed
- * geolocation is treated as blocked (fail closed).
+ * Callers are expected to gate on the `moneyEnableMoneyAccount` flag
+ * themselves before calling; this service does not check it, to avoid
+ * re-implementing a check every caller already has to make.
+ *
+ * The geo check is never cached because it can change when remote feature
+ * flags update or geolocation refreshes. Unknown or failed geolocation is
+ * treated as blocked (fail closed).
  *
  * The derived address is cached as a promise until the next unlock,
  * so concurrent callers share one in-flight derivation; failures are not
@@ -108,10 +101,7 @@ export class MoneyAccountAvailabilityService {
       this.#address = undefined;
     });
 
-    this.#messenger.registerMethodActionHandlers(this, [
-      'getAvailability',
-      'getAddress',
-    ]);
+    this.#messenger.registerMethodActionHandlers(this, ['getAvailability']);
   }
 
   /**
@@ -124,15 +114,12 @@ export class MoneyAccountAvailabilityService {
       const { remoteFeatureFlags } = this.#messenger.call(
         'RemoteFeatureFlagController:getState',
       );
-      if (!isMoneyAccountEnabled(remoteFeatureFlags)) {
-        return UNAVAILABLE;
-      }
 
       if (!(await this.#isGeoEligible(remoteFeatureFlags))) {
         return UNAVAILABLE;
       }
 
-      const address = await this.getAddress();
+      const address = await this.#getAddress();
       await this.#ensureChainConfigured(remoteFeatureFlags);
 
       return { isAvailable: true, address };
@@ -156,7 +143,7 @@ export class MoneyAccountAvailabilityService {
    *
    * @returns The money account address.
    */
-  async getAddress(): Promise<Hex> {
+  async #getAddress(): Promise<Hex> {
     if (!this.#address) {
       const address = deriveMoneyAccountAddress(this.#messenger);
 

--- a/app/scripts/lib/money/money-account-availability.ts
+++ b/app/scripts/lib/money/money-account-availability.ts
@@ -64,7 +64,10 @@ const UNAVAILABLE: MoneyAccountAvailability = { isAvailable: false };
  * also be ready for use.
  *
  * A money account being available doesn’t mean that the account has been
- * upgraded yet.
+ * upgraded yet, nor that the Money keyring exists in the vault yet. The
+ * address is derived straight from the seed, so it is the same whether or not
+ * `MoneyAccountController.init()` has run; creating the keyring is that
+ * controller's job, and it creates it on demand before any signing.
  *
  * Callers are expected to gate on the `moneyEnableMoneyAccount` flag
  * themselves before calling; this service does not check it, to avoid

--- a/app/scripts/lib/money/money-account-availability.ts
+++ b/app/scripts/lib/money/money-account-availability.ts
@@ -42,12 +42,10 @@ export type MoneyAccountAvailabilityServiceGetAvailabilityAction = {
   handler: MoneyAccountAvailabilityService['getAvailability'];
 };
 
-type MoneyAccountAvailabilityActions =
-  MoneyAccountAvailabilityServiceGetAvailabilityAction;
-
 export type MoneyAccountAvailabilityMessenger = Messenger<
   typeof serviceName,
-  MoneyAccountAvailabilityActions | MoneyAccountAvailabilityAllowedActions,
+  | MoneyAccountAvailabilityServiceGetAvailabilityAction
+  | MoneyAccountAvailabilityAllowedActions,
   MoneyAccountAvailabilityEvents
 >;
 

--- a/app/scripts/lib/money/money-keyring-builder.test.ts
+++ b/app/scripts/lib/money/money-keyring-builder.test.ts
@@ -1,0 +1,195 @@
+import { MoneyKeyring } from '@metamask/eth-money-keyring';
+import { MoneyKeyring as MoneyKeyringV2 } from '@metamask/eth-money-keyring/v2';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import { encodeMnemonic } from '@metamask/keyring-sdk';
+import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
+import {
+  moneyKeyringBuilder,
+  moneyKeyringV2Builder,
+  type MoneyKeyringBuilderMessenger,
+} from './money-keyring-builder';
+
+const TEST_MNEMONIC =
+  'spread raise short crane omit tent fringe mandate neglect detail suspect cradle';
+
+/**
+ * The money account address for `TEST_MNEMONIC`. The same vector
+ * `get-money-account-address.test.ts` asserts, so a registered keyring and D3's
+ * bare deriver are held to producing the same account.
+ */
+const EXPECTED_MONEY_ADDRESS = '0xd5fe9b0579443e7025cf3309ba420977710e7183';
+
+const ENTROPY_SOURCE = 'primary-hd-keyring-id';
+
+/**
+ * Encode a mnemonic the way `HdKeyring` holds it internally: a byte view over
+ * the 16-bit indices of its words in the English wordlist.
+ *
+ * @param mnemonic - The mnemonic phrase.
+ * @returns The wordlist indices as a byte array.
+ */
+function toMnemonicIndicesBytes(mnemonic: string): Uint8Array {
+  const indices = mnemonic.split(' ').map((word) => wordlist.indexOf(word));
+
+  return new Uint8Array(new Uint16Array(indices).buffer);
+}
+
+type KeyringFilter = (
+  keyring: { type: string },
+  metadata: { id: string },
+) => boolean;
+
+type WithKeyringUnsafeCall = [
+  'KeyringController:withKeyringUnsafe',
+  { filter: KeyringFilter },
+  (args: { keyring: unknown }) => Promise<unknown>,
+];
+
+/**
+ * Build a messenger whose `withKeyringUnsafe` hands the callback a stub HD
+ * keyring, and record the calls so the selector can be inspected.
+ *
+ * @param options - Options.
+ * @param options.mnemonic - The mnemonic the stub keyring holds, or `null` for
+ * a keyring that has none.
+ * @returns The messenger and the recorded calls.
+ */
+function buildMessengerMock({
+  mnemonic = TEST_MNEMONIC,
+}: { mnemonic?: string | null } = {}) {
+  const calls: WithKeyringUnsafeCall[] = [];
+
+  const keyring = {
+    type: KeyringTypes.hd,
+    mnemonic: mnemonic === null ? null : toMnemonicIndicesBytes(mnemonic),
+  };
+
+  const messenger = {
+    call: (...args: unknown[]) => {
+      calls.push(args as WithKeyringUnsafeCall);
+      const [, , operation] = args as WithKeyringUnsafeCall;
+      return operation({ keyring });
+    },
+  } as unknown as MoneyKeyringBuilderMessenger;
+
+  return { messenger, calls };
+}
+
+describe('moneyKeyringBuilder', () => {
+  it('is keyed by the Money keyring type', () => {
+    const { messenger } = buildMessengerMock();
+
+    expect(moneyKeyringBuilder(messenger).type).toBe(KeyringTypes.money);
+    expect(moneyKeyringBuilder(messenger).type).toBe('Money Keyring');
+  });
+
+  it('builds a MoneyKeyring', () => {
+    const { messenger } = buildMessengerMock();
+
+    expect(moneyKeyringBuilder(messenger)()).toBeInstanceOf(MoneyKeyring);
+  });
+
+  it('derives the money account for the primary seed', async () => {
+    const { messenger } = buildMessengerMock();
+
+    const keyring = moneyKeyringBuilder(messenger)();
+    // The keyring holds only the entropy source; the mnemonic is resolved
+    // through the callback when it first has to derive.
+    await keyring.deserialize({ entropySource: ENTROPY_SOURCE });
+
+    await expect(keyring.addAccounts(1)).resolves.toStrictEqual([
+      EXPECTED_MONEY_ADDRESS,
+    ]);
+  });
+
+  it('reads the mnemonic without taking the controller lock', async () => {
+    const { messenger, calls } = buildMessengerMock();
+
+    const keyring = moneyKeyringBuilder(messenger)();
+    await keyring.deserialize({ entropySource: ENTROPY_SOURCE });
+    await keyring.addAccounts(1);
+
+    // `withKeyringUnsafe`, not `withKeyring`: the derivation above can run
+    // inside a locked `withKeyring`, so a locking read would deadlock.
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe('KeyringController:withKeyringUnsafe');
+  });
+
+  it('selects the HD keyring matching the entropy source, and no other', async () => {
+    const { messenger, calls } = buildMessengerMock();
+
+    const keyring = moneyKeyringBuilder(messenger)();
+    await keyring.deserialize({ entropySource: ENTROPY_SOURCE });
+    await keyring.addAccounts(1);
+
+    const { filter } = calls[0][1];
+
+    expect(filter({ type: KeyringTypes.hd }, { id: ENTROPY_SOURCE })).toBe(
+      true,
+    );
+    // A second HD keyring (another SRP) must not be picked.
+    expect(filter({ type: KeyringTypes.hd }, { id: 'other-srp' })).toBe(false);
+    // Nor a non-HD keyring that happens to share the id.
+    expect(filter({ type: KeyringTypes.simple }, { id: ENTROPY_SOURCE })).toBe(
+      false,
+    );
+  });
+
+  it('encodes the mnemonic the way MoneyKeyring expects it', async () => {
+    const { messenger, calls } = buildMessengerMock();
+
+    const keyring = moneyKeyringBuilder(messenger)();
+    await keyring.deserialize({ entropySource: ENTROPY_SOURCE });
+    await keyring.addAccounts(1);
+
+    const indices = toMnemonicIndicesBytes(TEST_MNEMONIC);
+
+    await expect(
+      calls[0][2]({ keyring: { mnemonic: indices } }),
+    ).resolves.toStrictEqual(encodeMnemonic(indices));
+  });
+
+  it('throws when the selected keyring has no mnemonic', async () => {
+    const { messenger } = buildMessengerMock({ mnemonic: null });
+
+    const keyring = moneyKeyringBuilder(messenger)();
+    await keyring.deserialize({ entropySource: ENTROPY_SOURCE });
+
+    await expect(keyring.addAccounts(1)).rejects.toThrow(
+      'Unable to get mnemonic to initialize MoneyKeyring',
+    );
+  });
+
+  it('does not read the mnemonic until the keyring needs it', () => {
+    const { messenger, calls } = buildMessengerMock();
+
+    moneyKeyringBuilder(messenger)();
+
+    expect(calls).toStrictEqual([]);
+  });
+});
+
+describe('moneyKeyringV2Builder', () => {
+  it('is keyed by the legacy Money keyring type, which is how the controller dispatches it', () => {
+    expect(moneyKeyringV2Builder().type).toBe(MoneyKeyring.type);
+  });
+
+  it('wraps the legacy keyring, which it takes directly rather than in an options object', async () => {
+    const legacyKeyring = moneyKeyringBuilder(buildMessengerMock().messenger)();
+    await legacyKeyring.deserialize({ entropySource: ENTROPY_SOURCE });
+    await legacyKeyring.addAccounts(1);
+
+    // The metadata argument the hardware V2 builders use for their entropy
+    // source is deliberately ignored: the Money keyring already knows its own.
+    const wrapper = moneyKeyringV2Builder()(legacyKeyring as never, {
+      id: 'ignored-metadata-id',
+      name: '',
+    }) as unknown as MoneyKeyringV2;
+
+    expect(wrapper).toBeInstanceOf(MoneyKeyringV2);
+    expect(wrapper.entropySource).toBe(ENTROPY_SOURCE);
+    expect(
+      (await wrapper.getAccounts()).map((account) => account.address),
+    ).toStrictEqual([EXPECTED_MONEY_ADDRESS]);
+  });
+});

--- a/app/scripts/lib/money/money-keyring-builder.test.ts
+++ b/app/scripts/lib/money/money-keyring-builder.test.ts
@@ -4,8 +4,8 @@ import { KeyringTypes } from '@metamask/keyring-controller';
 import { encodeMnemonic } from '@metamask/keyring-sdk';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import {
-  moneyKeyringBuilder,
-  moneyKeyringV2Builder,
+  buildMoneyKeyringBuilder,
+  buildMoneyKeyringV2Builder,
   type MoneyKeyringBuilderMessenger,
 } from './money-keyring-builder';
 
@@ -75,24 +75,24 @@ function buildMessengerMock({
   return { messenger, calls };
 }
 
-describe('moneyKeyringBuilder', () => {
+describe('buildMoneyKeyringBuilder', () => {
   it('is keyed by the Money keyring type', () => {
     const { messenger } = buildMessengerMock();
 
-    expect(moneyKeyringBuilder(messenger).type).toBe(KeyringTypes.money);
-    expect(moneyKeyringBuilder(messenger).type).toBe('Money Keyring');
+    expect(buildMoneyKeyringBuilder(messenger).type).toBe(KeyringTypes.money);
+    expect(buildMoneyKeyringBuilder(messenger).type).toBe('Money Keyring');
   });
 
   it('builds a MoneyKeyring', () => {
     const { messenger } = buildMessengerMock();
 
-    expect(moneyKeyringBuilder(messenger)()).toBeInstanceOf(MoneyKeyring);
+    expect(buildMoneyKeyringBuilder(messenger)()).toBeInstanceOf(MoneyKeyring);
   });
 
   it('derives the money account for the primary seed', async () => {
     const { messenger } = buildMessengerMock();
 
-    const keyring = moneyKeyringBuilder(messenger)();
+    const keyring = buildMoneyKeyringBuilder(messenger)();
     // The keyring holds only the entropy source; the mnemonic is resolved
     // through the callback when it first has to derive.
     await keyring.deserialize({ entropySource: ENTROPY_SOURCE });
@@ -105,7 +105,7 @@ describe('moneyKeyringBuilder', () => {
   it('reads the mnemonic without taking the controller lock', async () => {
     const { messenger, calls } = buildMessengerMock();
 
-    const keyring = moneyKeyringBuilder(messenger)();
+    const keyring = buildMoneyKeyringBuilder(messenger)();
     await keyring.deserialize({ entropySource: ENTROPY_SOURCE });
     await keyring.addAccounts(1);
 
@@ -118,7 +118,7 @@ describe('moneyKeyringBuilder', () => {
   it('selects the HD keyring matching the entropy source, and no other', async () => {
     const { messenger, calls } = buildMessengerMock();
 
-    const keyring = moneyKeyringBuilder(messenger)();
+    const keyring = buildMoneyKeyringBuilder(messenger)();
     await keyring.deserialize({ entropySource: ENTROPY_SOURCE });
     await keyring.addAccounts(1);
 
@@ -138,7 +138,7 @@ describe('moneyKeyringBuilder', () => {
   it('encodes the mnemonic the way MoneyKeyring expects it', async () => {
     const { messenger, calls } = buildMessengerMock();
 
-    const keyring = moneyKeyringBuilder(messenger)();
+    const keyring = buildMoneyKeyringBuilder(messenger)();
     await keyring.deserialize({ entropySource: ENTROPY_SOURCE });
     await keyring.addAccounts(1);
 
@@ -152,7 +152,7 @@ describe('moneyKeyringBuilder', () => {
   it('throws when the selected keyring has no mnemonic', async () => {
     const { messenger } = buildMessengerMock({ mnemonic: null });
 
-    const keyring = moneyKeyringBuilder(messenger)();
+    const keyring = buildMoneyKeyringBuilder(messenger)();
     await keyring.deserialize({ entropySource: ENTROPY_SOURCE });
 
     await expect(keyring.addAccounts(1)).rejects.toThrow(
@@ -163,25 +163,27 @@ describe('moneyKeyringBuilder', () => {
   it('does not read the mnemonic until the keyring needs it', () => {
     const { messenger, calls } = buildMessengerMock();
 
-    moneyKeyringBuilder(messenger)();
+    buildMoneyKeyringBuilder(messenger)();
 
     expect(calls).toStrictEqual([]);
   });
 });
 
-describe('moneyKeyringV2Builder', () => {
+describe('buildMoneyKeyringV2Builder', () => {
   it('is keyed by the legacy Money keyring type, which is how the controller dispatches it', () => {
-    expect(moneyKeyringV2Builder().type).toBe(MoneyKeyring.type);
+    expect(buildMoneyKeyringV2Builder().type).toBe(MoneyKeyring.type);
   });
 
   it('wraps the legacy keyring, which it takes directly rather than in an options object', async () => {
-    const legacyKeyring = moneyKeyringBuilder(buildMessengerMock().messenger)();
+    const legacyKeyring = buildMoneyKeyringBuilder(
+      buildMessengerMock().messenger,
+    )();
     await legacyKeyring.deserialize({ entropySource: ENTROPY_SOURCE });
     await legacyKeyring.addAccounts(1);
 
     // The metadata argument the hardware V2 builders use for their entropy
     // source is deliberately ignored: the Money keyring already knows its own.
-    const wrapper = moneyKeyringV2Builder()(legacyKeyring as never, {
+    const wrapper = buildMoneyKeyringV2Builder()(legacyKeyring as never, {
       id: 'ignored-metadata-id',
       name: '',
     }) as unknown as MoneyKeyringV2;

--- a/app/scripts/lib/money/money-keyring-builder.ts
+++ b/app/scripts/lib/money/money-keyring-builder.ts
@@ -1,0 +1,107 @@
+import type { HdKeyring } from '@metamask/eth-hd-keyring';
+import { MoneyKeyring } from '@metamask/eth-money-keyring';
+import { MoneyKeyring as MoneyKeyringV2 } from '@metamask/eth-money-keyring/v2';
+import {
+  KeyringTypes,
+  type KeyringControllerWithKeyringUnsafeAction,
+  type KeyringV2Builder,
+} from '@metamask/keyring-controller';
+import { encodeMnemonic } from '@metamask/keyring-sdk';
+import type { Messenger } from '@metamask/messenger';
+
+export type MoneyKeyringBuilderMessenger = Messenger<
+  string,
+  KeyringControllerWithKeyringUnsafeAction,
+  never
+>;
+
+/**
+ * Read the mnemonic of the HD keyring identified by an entropy source id.
+ *
+ * `MoneyKeyring` never stores a mnemonic itself: it holds only the entropy
+ * source id, and resolves the mnemonic through this callback whenever it needs
+ * to derive or sign. The callback is therefore invoked lazily, and — because
+ * `createMoneyAccount` derives the account from inside a locked
+ * `KeyringController:withKeyring` — potentially while the controller's mutex is
+ * held. `withKeyringUnsafe` is what makes that safe: it takes no lock, so this
+ * cannot deadlock against the operation that triggered it. The read is
+ * legitimately "unsafe"-eligible, being a read of a field that an `HdKeyring`
+ * sets during `deserialize` and never mutates.
+ *
+ * @param messenger - The messenger used to reach the `KeyringController`.
+ * @param entropySource - The id of the keyring whose mnemonic to read.
+ * @returns The mnemonic as UTF-8 byte values, which is what `MoneyKeyring`
+ * expects.
+ */
+async function getMnemonic(
+  messenger: MoneyKeyringBuilderMessenger,
+  entropySource: string,
+): Promise<number[]> {
+  return (await messenger.call(
+    'KeyringController:withKeyringUnsafe',
+    {
+      filter: (keyring, metadata) =>
+        keyring.type === KeyringTypes.hd && metadata.id === entropySource,
+    },
+    async ({ keyring }) => {
+      // `mnemonic` holds wordlist indices as a byte view, not the phrase
+      // itself; `encodeMnemonic` turns it into the UTF-8 bytes of the phrase.
+      const { mnemonic } = keyring as HdKeyring;
+
+      if (!mnemonic) {
+        throw new Error('Unable to get mnemonic to initialize MoneyKeyring');
+      }
+
+      return encodeMnemonic(mnemonic);
+      // The action type erases `withKeyringUnsafe`'s `CallbackResult` generic
+      // to its `void` default, so the callback's return type is lost here.
+    },
+  )) as unknown as number[];
+}
+
+/**
+ * Build the V1 keyring builder for the Money keyring.
+ *
+ * The builder is registered unconditionally, and not behind the Money feature
+ * flag. A builder is what lets `KeyringController` recognise the
+ * `"Money Keyring"` type while deserializing the vault, so a user who has a
+ * Money keyring must always have the builder available — including when the
+ * flag has since been turned off. Registering it creates nothing on its own:
+ * the keyring only enters the vault when `MoneyAccountController` asks for it.
+ *
+ * @param messenger - The messenger used to resolve the mnemonic.
+ * @returns The Money keyring builder.
+ */
+export function moneyKeyringBuilder(messenger: MoneyKeyringBuilderMessenger) {
+  const builder = () =>
+    new MoneyKeyring({
+      getMnemonic: async (entropySource: string) =>
+        getMnemonic(messenger, entropySource),
+    });
+
+  builder.type = MoneyKeyring.type;
+
+  return builder;
+}
+
+/**
+ * Build the V2 keyring builder for the Money keyring.
+ *
+ * Unlike the hardware V2 wrappers, `MoneyKeyringV2` takes the legacy keyring
+ * directly rather than a `{ legacyKeyring, entropySource }` options object —
+ * it reads the entropy source from the wrapped keyring, which already knows it.
+ *
+ * @returns The Money keyring V2 builder.
+ */
+export function moneyKeyringV2Builder(): KeyringV2Builder {
+  const builder = Object.assign(
+    (keyring: unknown) => new MoneyKeyringV2(keyring as MoneyKeyring),
+    { type: MoneyKeyring.type },
+  );
+
+  // `KeyringV2Builder` declares its parameter and return types in terms of
+  // `@metamask/keyring-controller`'s `Keyring` / `KeyringV2`, which the wrapper
+  // satisfies structurally; this single boundary cast keeps callers free of
+  // repeated assertions, as it does for the hardware builders.
+  return builder as unknown as KeyringV2Builder;
+}

--- a/app/scripts/lib/money/money-keyring-builder.ts
+++ b/app/scripts/lib/money/money-keyring-builder.ts
@@ -10,9 +10,8 @@ import { encodeMnemonic } from '@metamask/keyring-sdk';
 import type { Messenger } from '@metamask/messenger';
 
 export type MoneyKeyringBuilderMessenger = Messenger<
-  string,
-  KeyringControllerWithKeyringUnsafeAction,
-  never
+  'MoneyKeyringBuilder',
+  KeyringControllerWithKeyringUnsafeAction
 >;
 
 /**

--- a/app/scripts/lib/money/money-keyring-builder.ts
+++ b/app/scripts/lib/money/money-keyring-builder.ts
@@ -72,7 +72,9 @@ async function getMnemonic(
  * @param messenger - The messenger used to resolve the mnemonic.
  * @returns The Money keyring builder.
  */
-export function moneyKeyringBuilder(messenger: MoneyKeyringBuilderMessenger) {
+export function buildMoneyKeyringBuilder(
+  messenger: MoneyKeyringBuilderMessenger,
+) {
   const builder = () =>
     new MoneyKeyring({
       getMnemonic: async (entropySource: string) =>
@@ -93,7 +95,7 @@ export function moneyKeyringBuilder(messenger: MoneyKeyringBuilderMessenger) {
  *
  * @returns The Money keyring V2 builder.
  */
-export function moneyKeyringV2Builder(): KeyringV2Builder {
+export function buildMoneyKeyringV2Builder(): KeyringV2Builder {
   const builder = Object.assign(
     (keyring: unknown) => new MoneyKeyringV2(keyring as MoneyKeyring),
     { type: MoneyKeyring.type },

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -113,6 +113,7 @@ import { AnalyticsController } from '@metamask/analytics-controller';
 import { SentinelApiService } from '@metamask/sentinel-api-service';
 import { MoneyAccountApiDataService } from '@metamask/money-account-api-data-service';
 import { MoneyAccountBalanceService } from '@metamask/money-account-balance-service';
+import { MoneyAccountController } from '@metamask/money-account-controller';
 import { MoneyAccountAvailabilityService } from '../lib/money/money-account-availability';
 import { OnboardingController } from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
@@ -181,6 +182,7 @@ export type MessengerClient =
   | MoneyAccountApiDataService
   | MoneyAccountAvailabilityService
   | MoneyAccountBalanceService
+  | MoneyAccountController
   | MultichainAssetsController
   | MultichainAssetsRatesController
   | MultichainBalancesController

--- a/app/scripts/messenger-client-init/messengers/accounts/index.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/index.ts
@@ -14,6 +14,9 @@ export type { MultichainAccountServiceInitMessenger } from './multichain-account
 export type { SnapAccountServiceMessenger } from './snap-account-service-messenger';
 export { getSnapAccountServiceMessenger } from './snap-account-service-messenger';
 
+export type { MoneyKeyringBuilderMessenger } from './money-keyring-builder-messenger';
+export { getMoneyKeyringBuilderMessenger } from './money-keyring-builder-messenger';
+
 export type { SnapKeyringBuilderMessenger } from './snap-keyring-builder-messenger';
 export { getSnapKeyringBuilderMessenger } from './snap-keyring-builder-messenger';
 

--- a/app/scripts/messenger-client-init/messengers/accounts/money-keyring-builder-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/money-keyring-builder-messenger.ts
@@ -1,0 +1,33 @@
+import { Messenger } from '@metamask/messenger';
+import {
+  RootMessenger,
+  RootMessengerActions,
+  RootMessengerEvents,
+} from '../../../lib/messenger';
+import type { MoneyKeyringBuilderMessenger } from '../../../lib/money/money-keyring-builder';
+
+export type { MoneyKeyringBuilderMessenger };
+
+/**
+ * Gets the messenger for the Money keyring builder, scoped to the single
+ * action the keyring needs: reading the mnemonic of its entropy source
+ * through `KeyringController:withKeyringUnsafe`.
+ *
+ * @param messenger - The root messenger instance, used to create a child messenger for the Money keyring and to delegate the necessary action to it.
+ * @returns The Money keyring builder messenger instance.
+ */
+export function getMoneyKeyringBuilderMessenger(
+  messenger: RootMessenger<RootMessengerActions, RootMessengerEvents>,
+): MoneyKeyringBuilderMessenger {
+  const moneyKeyringMessenger: MoneyKeyringBuilderMessenger = new Messenger({
+    namespace: 'MoneyKeyringBuilder',
+    parent: messenger,
+  });
+
+  messenger.delegate({
+    messenger: moneyKeyringMessenger,
+    actions: ['KeyringController:withKeyringUnsafe'],
+  });
+
+  return moneyKeyringMessenger;
+}

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -195,6 +195,10 @@ import { getSentinelApiServiceMessenger } from './sentinel-api-service-messenger
 import { getMoneyAccountApiDataServiceMessenger } from './money-account-api-data-service-messenger';
 import { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-service-messenger';
 import { getMoneyAccountAvailabilityServiceMessenger } from './money-account-availability-service-messenger';
+import {
+  getMoneyAccountControllerInitMessenger,
+  getMoneyAccountControllerMessenger,
+} from './money-account-controller-messenger';
 
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
 export type { AccountTrackerControllerInitMessenger } from './account-tracker-controller-messenger';
@@ -266,6 +270,10 @@ export { getSentinelApiServiceMessenger } from './sentinel-api-service-messenger
 export { getMoneyAccountApiDataServiceMessenger } from './money-account-api-data-service-messenger';
 export { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-service-messenger';
 export { getMoneyAccountAvailabilityServiceMessenger } from './money-account-availability-service-messenger';
+export {
+  getMoneyAccountControllerInitMessenger,
+  getMoneyAccountControllerMessenger,
+} from './money-account-controller-messenger';
 export type { ComplianceControllerMessenger } from './compliance-controller-messenger';
 export { getComplianceControllerMessenger } from './compliance-controller-messenger';
 export type { ComplianceServiceMessenger } from './compliance-service-messenger';
@@ -480,6 +488,10 @@ export const MESSENGER_FACTORIES = {
   MoneyAccountBalanceService: {
     getMessenger: getMoneyAccountBalanceServiceMessenger,
     getInitMessenger: noop,
+  },
+  MoneyAccountController: {
+    getMessenger: getMoneyAccountControllerMessenger,
+    getInitMessenger: getMoneyAccountControllerInitMessenger,
   },
   MultichainAssetsController: {
     getMessenger: getMultichainAssetsControllerMessenger,

--- a/app/scripts/messenger-client-init/messengers/money-account-controller-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-controller-messenger.test.ts
@@ -1,0 +1,64 @@
+import { Messenger } from '@metamask/messenger';
+import { getRootMessenger } from '../../lib/messenger';
+import {
+  getMoneyAccountControllerInitMessenger,
+  getMoneyAccountControllerMessenger,
+} from './money-account-controller-messenger';
+
+describe('getMoneyAccountControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = getRootMessenger<never, never>();
+
+    expect(getMoneyAccountControllerMessenger(messenger)).toBeInstanceOf(
+      Messenger,
+    );
+  });
+
+  it('delegates the KeyringController actions the controller needs', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getMoneyAccountControllerMessenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: [
+          'KeyringController:getState',
+          'KeyringController:addNewKeyring',
+          'KeyringController:withKeyring',
+        ],
+        events: [],
+      }),
+    );
+  });
+});
+
+describe('getMoneyAccountControllerInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = getRootMessenger<never, never>();
+
+    expect(getMoneyAccountControllerInitMessenger(messenger)).toBeInstanceOf(
+      Messenger,
+    );
+  });
+
+  it('delegates the flag and unlock state the creation gate reads', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getMoneyAccountControllerInitMessenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: [
+          'KeyringController:getState',
+          'RemoteFeatureFlagController:getState',
+        ],
+        events: [
+          'KeyringController:unlock',
+          'RemoteFeatureFlagController:stateChange',
+        ],
+      }),
+    );
+  });
+});

--- a/app/scripts/messenger-client-init/messengers/money-account-controller-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-controller-messenger.test.ts
@@ -42,7 +42,7 @@ describe('getMoneyAccountControllerInitMessenger', () => {
     );
   });
 
-  it('delegates the flag and unlock state the creation gate reads', () => {
+  it('delegates the flag and keyring state the creation gate reads', () => {
     const messenger = getRootMessenger<never, never>();
     const delegateSpy = jest.spyOn(messenger, 'delegate');
 
@@ -55,7 +55,7 @@ describe('getMoneyAccountControllerInitMessenger', () => {
           'RemoteFeatureFlagController:getState',
         ],
         events: [
-          'KeyringController:unlock',
+          'KeyringController:stateChange',
           'RemoteFeatureFlagController:stateChange',
         ],
       }),

--- a/app/scripts/messenger-client-init/messengers/money-account-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-controller-messenger.ts
@@ -1,0 +1,105 @@
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import type { MoneyAccountControllerMessenger } from '@metamask/money-account-controller';
+import type {
+  KeyringControllerGetStateAction,
+  KeyringControllerUnlockEvent,
+} from '@metamask/keyring-controller';
+import type {
+  RemoteFeatureFlagControllerGetStateAction,
+  RemoteFeatureFlagControllerStateChangeEvent,
+} from '@metamask/remote-feature-flag-controller';
+import type { RootMessenger } from '../../lib/messenger';
+
+/**
+ * Create a messenger for the MoneyAccountController, scoped to the actions and
+ * events it is allowed to use.
+ *
+ * All three delegated actions are `KeyringController` ones: the controller reads
+ * the keyring list to find the primary entropy source, creates the Money
+ * keyring through `addNewKeyring`, and derives the account through
+ * `withKeyring`.
+ *
+ * @param messenger - The root messenger.
+ * @returns The MoneyAccountController messenger.
+ */
+export function getMoneyAccountControllerMessenger(
+  messenger: RootMessenger<
+    MessengerActions<MoneyAccountControllerMessenger>,
+    MessengerEvents<MoneyAccountControllerMessenger>
+  >,
+): MoneyAccountControllerMessenger {
+  const controllerMessenger: MoneyAccountControllerMessenger = new Messenger({
+    namespace: 'MoneyAccountController',
+    parent: messenger,
+  });
+
+  messenger.delegate({
+    messenger: controllerMessenger,
+    actions: [
+      'KeyringController:getState',
+      'KeyringController:addNewKeyring',
+      'KeyringController:withKeyring',
+    ],
+    events: [],
+  });
+
+  return controllerMessenger;
+}
+
+type AllowedInitializationActions =
+  | KeyringControllerGetStateAction
+  | RemoteFeatureFlagControllerGetStateAction;
+
+type AllowedInitializationEvents =
+  | KeyringControllerUnlockEvent
+  | RemoteFeatureFlagControllerStateChangeEvent;
+
+export type MoneyAccountControllerInitMessenger = ReturnType<
+  typeof getMoneyAccountControllerInitMessenger
+>;
+
+/**
+ * Create a messenger for the actions and events needed while initializing the
+ * MoneyAccountController.
+ *
+ * Money account creation is gated on the feature flag and on the wallet being
+ * unlocked, and neither is knowable at construction time — hence the flag
+ * state change and the unlock event.
+ *
+ * @param messenger - The root messenger.
+ * @returns The MoneyAccountController init messenger.
+ */
+export function getMoneyAccountControllerInitMessenger(
+  messenger: RootMessenger<
+    AllowedInitializationActions,
+    AllowedInitializationEvents
+  >,
+) {
+  const initMessenger = new Messenger<
+    'MoneyAccountControllerInit',
+    AllowedInitializationActions,
+    AllowedInitializationEvents,
+    typeof messenger
+  >({
+    namespace: 'MoneyAccountControllerInit',
+    parent: messenger,
+  });
+
+  messenger.delegate({
+    messenger: initMessenger,
+    actions: [
+      'KeyringController:getState',
+      'RemoteFeatureFlagController:getState',
+    ],
+    events: [
+      'KeyringController:unlock',
+      'RemoteFeatureFlagController:stateChange',
+    ],
+  });
+
+  return initMessenger;
+}

--- a/app/scripts/messenger-client-init/messengers/money-account-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/money-account-controller-messenger.ts
@@ -6,7 +6,7 @@ import {
 import type { MoneyAccountControllerMessenger } from '@metamask/money-account-controller';
 import type {
   KeyringControllerGetStateAction,
-  KeyringControllerUnlockEvent,
+  KeyringControllerStateChangeEvent,
 } from '@metamask/keyring-controller';
 import type {
   RemoteFeatureFlagControllerGetStateAction,
@@ -55,7 +55,7 @@ type AllowedInitializationActions =
   | RemoteFeatureFlagControllerGetStateAction;
 
 type AllowedInitializationEvents =
-  | KeyringControllerUnlockEvent
+  | KeyringControllerStateChangeEvent
   | RemoteFeatureFlagControllerStateChangeEvent;
 
 export type MoneyAccountControllerInitMessenger = ReturnType<
@@ -67,8 +67,10 @@ export type MoneyAccountControllerInitMessenger = ReturnType<
  * MoneyAccountController.
  *
  * Money account creation is gated on the feature flag and on the wallet being
- * unlocked, and neither is knowable at construction time — hence the flag
- * state change and the unlock event.
+ * unlocked with its keyrings loaded, and none of that is knowable at
+ * construction time — hence both state change events. The keyring trigger is
+ * `stateChange` rather than `unlock` because a vault restore fires `unlock`
+ * before the restored keyrings land in state.
  *
  * @param messenger - The root messenger.
  * @returns The MoneyAccountController init messenger.
@@ -96,7 +98,7 @@ export function getMoneyAccountControllerInitMessenger(
       'RemoteFeatureFlagController:getState',
     ],
     events: [
-      'KeyringController:unlock',
+      'KeyringController:stateChange',
       'RemoteFeatureFlagController:stateChange',
     ],
   });

--- a/app/scripts/messenger-client-init/money-account-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/money-account-controller-init.test.ts
@@ -12,7 +12,7 @@ import {
 import type {
   KeyringControllerGetStateAction,
   KeyringControllerState,
-  KeyringControllerUnlockEvent,
+  KeyringControllerStateChangeEvent,
 } from '@metamask/keyring-controller';
 import type {
   RemoteFeatureFlagControllerGetStateAction,
@@ -51,27 +51,36 @@ type BaseMessenger = Messenger<
   | ActionConstraint
   | KeyringControllerGetStateAction
   | RemoteFeatureFlagControllerGetStateAction,
-  KeyringControllerUnlockEvent | RemoteFeatureFlagControllerStateChangeEvent
+  | KeyringControllerStateChangeEvent
+  | RemoteFeatureFlagControllerStateChangeEvent
 >;
 
 /**
- * Build a base messenger with the flag and lock state the init function reads.
- * The returned `config` is read live by the action handlers, so tests can flip
- * either value between triggers.
+ * Build a base messenger with the flag and keyring state the init function
+ * reads. The returned `config` is read live by the action handlers, so tests
+ * can flip any value between triggers.
  *
  * @param options - Options.
  * @param options.isEnabled - Whether the Money Account feature flag is on.
  * @param options.isUnlocked - Whether the wallet is unlocked.
+ * @param options.keyringIds - The metadata ids of the HD keyrings in the
+ * vault. Defaults to just the primary; pass `[]` to model the mid-restore
+ * window where the wallet is unlocked but the keyring list is still empty.
  * @returns The base messenger and its mutable config.
  */
 function buildBaseMessenger({
   isEnabled = true,
   isUnlocked = true,
-}: { isEnabled?: boolean; isUnlocked?: boolean } = {}): {
+  keyringIds = [PRIMARY_ENTROPY_SOURCE],
+}: {
+  isEnabled?: boolean;
+  isUnlocked?: boolean;
+  keyringIds?: string[];
+} = {}): {
   messenger: BaseMessenger;
-  config: { isEnabled: boolean; isUnlocked: boolean };
+  config: { isEnabled: boolean; isUnlocked: boolean; keyringIds: string[] };
 } {
-  const config = { isEnabled, isUnlocked };
+  const config = { isEnabled, isUnlocked, keyringIds };
   const messenger: BaseMessenger = new Messenger({
     namespace: MOCK_ANY_NAMESPACE,
   });
@@ -95,7 +104,15 @@ function buildBaseMessenger({
     () =>
       ({
         isUnlocked: config.isUnlocked,
-        keyrings: [],
+        // As in the real controller, the keyring list is empty while locked;
+        // the stale-account check and the mid-restore guard depend on it.
+        keyrings: config.isUnlocked
+          ? config.keyringIds.map((id) => ({
+              type: 'HD Key Tree',
+              accounts: [],
+              metadata: { id, name: '' },
+            }))
+          : [],
       }) as KeyringControllerState,
   );
 
@@ -137,12 +154,17 @@ function publishFlagChange(messenger: BaseMessenger) {
 }
 
 /**
- * Publish an unlock.
+ * Publish a keyring state change, as fired on unlock and when the keyring
+ * list is (re)populated.
  *
  * @param messenger - The base messenger.
  */
-function publishUnlock(messenger: BaseMessenger) {
-  messenger.publish('KeyringController:unlock');
+function publishKeyringStateChange(messenger: BaseMessenger) {
+  messenger.publish(
+    'KeyringController:stateChange',
+    {} as KeyringControllerState,
+    [],
+  );
 }
 
 describe('MoneyAccountControllerInit', () => {
@@ -249,14 +271,14 @@ describe('MoneyAccountControllerInit', () => {
     expect(init).toHaveBeenCalledTimes(1);
   });
 
-  it('creates the account on unlock', async () => {
+  it('creates the account when the keyring state change lands the unlock', async () => {
     const { messenger, config } = buildBaseMessenger({ isUnlocked: false });
     MoneyAccountControllerInit(getInitRequestMock(messenger));
     await Promise.resolve();
     expect(init).not.toHaveBeenCalled();
 
     config.isUnlocked = true;
-    publishUnlock(messenger);
+    publishKeyringStateChange(messenger);
     await Promise.resolve();
 
     expect(init).toHaveBeenCalledTimes(1);
@@ -278,7 +300,7 @@ describe('MoneyAccountControllerInit', () => {
     MoneyAccountControllerInit(getInitRequestMock(messenger));
 
     publishFlagChange(messenger);
-    publishUnlock(messenger);
+    publishKeyringStateChange(messenger);
     await Promise.resolve();
 
     expect(init).not.toHaveBeenCalled();
@@ -292,25 +314,74 @@ describe('MoneyAccountControllerInit', () => {
 
     publishFlagChange(messenger);
     await Promise.resolve();
-    publishUnlock(messenger);
+    publishKeyringStateChange(messenger);
     await Promise.resolve();
 
     expect(init).toHaveBeenCalledTimes(1);
+    // An account whose entropy source still exists is not stale, so the
+    // repeated triggers must not have wiped it.
+    expect(clearState).not.toHaveBeenCalled();
   });
 
-  it('creates a fresh account after a vault restore, when the recorded one belongs to a previous seed', async () => {
+  it('replaces a stale account after a vault restore, when the recorded one belongs to a previous seed', async () => {
     const { messenger, config } = buildBaseMessenger({ isUnlocked: false });
     state.moneyAccounts = { old: moneyAccountFor('a-previous-seed') };
 
     MoneyAccountControllerInit(getInitRequestMock(messenger));
 
     config.isUnlocked = true;
-    publishUnlock(messenger);
+    publishKeyringStateChange(messenger);
     await Promise.resolve();
 
+    // The stale record must be removed — its entropy source no longer exists,
+    // so leaving it would expose an address this wallet does not control.
+    expect(clearState).toHaveBeenCalledTimes(1);
     // Counting entries would have found one and skipped, leaving the restored
     // wallet permanently without a money account.
     expect(init).toHaveBeenCalledTimes(1);
+    expect(Object.values(state.moneyAccounts)).toStrictEqual([
+      moneyAccountFor(PRIMARY_ENTROPY_SOURCE),
+    ]);
+  });
+
+  it('leaves stale accounts untouched while the wallet is locked', async () => {
+    const { messenger } = buildBaseMessenger({ isUnlocked: false });
+    state.moneyAccounts = { old: moneyAccountFor('a-previous-seed') };
+
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+    publishFlagChange(messenger);
+    await Promise.resolve();
+
+    // While locked the keyring list is empty, so every account would look
+    // stale; the check must not run until the vault is readable.
+    expect(clearState).not.toHaveBeenCalled();
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  it('does nothing during the mid-restore window, then completes when the keyrings land', async () => {
+    // A vault restore fires the unlock while the keyring list is still empty;
+    // the restored keyrings only reach state at the end of the operation.
+    const { messenger, config } = buildBaseMessenger({ keyringIds: [] });
+    state.moneyAccounts = { old: moneyAccountFor('a-previous-seed') };
+
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+    publishKeyringStateChange(messenger);
+    await Promise.resolve();
+
+    // With no HD keyring nothing can be judged stale and nothing can be
+    // created, so both must wait rather than wipe state or warn-and-skip.
+    expect(clearState).not.toHaveBeenCalled();
+    expect(init).not.toHaveBeenCalled();
+
+    config.keyringIds = [PRIMARY_ENTROPY_SOURCE];
+    publishKeyringStateChange(messenger);
+    await Promise.resolve();
+
+    expect(clearState).toHaveBeenCalledTimes(1);
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(Object.values(state.moneyAccounts)).toStrictEqual([
+      moneyAccountFor(PRIMARY_ENTROPY_SOURCE),
+    ]);
   });
 
   it('clears its state when the flag is turned off after an account was created', async () => {
@@ -341,7 +412,7 @@ describe('MoneyAccountControllerInit', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    publishUnlock(messenger);
+    publishKeyringStateChange(messenger);
     await Promise.resolve();
 
     expect(init).toHaveBeenCalledTimes(3);

--- a/app/scripts/messenger-client-init/money-account-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/money-account-controller-init.test.ts
@@ -1,0 +1,349 @@
+import {
+  ActionConstraint,
+  MOCK_ANY_NAMESPACE,
+  Messenger,
+  MockAnyNamespace,
+} from '@metamask/messenger';
+import {
+  MoneyAccountController,
+  type MoneyAccountControllerMessenger,
+  type MoneyAccountControllerState,
+} from '@metamask/money-account-controller';
+import type {
+  KeyringControllerGetStateAction,
+  KeyringControllerState,
+  KeyringControllerUnlockEvent,
+} from '@metamask/keyring-controller';
+import type {
+  RemoteFeatureFlagControllerGetStateAction,
+  RemoteFeatureFlagControllerState,
+  RemoteFeatureFlagControllerStateChangeEvent,
+} from '@metamask/remote-feature-flag-controller';
+import { MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME } from '../../../shared/lib/money/feature-flags';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getMoneyAccountControllerInitMessenger,
+  getMoneyAccountControllerMessenger,
+  type MoneyAccountControllerInitMessenger,
+} from './messengers/money-account-controller-messenger';
+import { MoneyAccountControllerInit } from './money-account-controller-init';
+import type { MessengerClientInitRequest } from './types';
+
+jest.mock('@metamask/money-account-controller');
+
+const PRIMARY_ENTROPY_SOURCE = 'primary-hd-keyring-id';
+
+/**
+ * Build a money account for an entropy source.
+ *
+ * @param entropySource - The entropy source the account belongs to.
+ * @returns The money account.
+ */
+const moneyAccountFor = (entropySource: string) =>
+  ({
+    id: `money-account-${entropySource}`,
+    address: '0xd5fe9b0579443e7025cf3309ba420977710e7183',
+    options: { entropy: { id: entropySource } },
+  }) as unknown as MoneyAccountControllerState['moneyAccounts'][string];
+
+type BaseMessenger = Messenger<
+  MockAnyNamespace,
+  | ActionConstraint
+  | KeyringControllerGetStateAction
+  | RemoteFeatureFlagControllerGetStateAction,
+  KeyringControllerUnlockEvent | RemoteFeatureFlagControllerStateChangeEvent
+>;
+
+/**
+ * Build a base messenger with the flag and lock state the init function reads.
+ * The returned `config` is read live by the action handlers, so tests can flip
+ * either value between triggers.
+ *
+ * @param options - Options.
+ * @param options.isEnabled - Whether the Money Account feature flag is on.
+ * @param options.isUnlocked - Whether the wallet is unlocked.
+ * @returns The base messenger and its mutable config.
+ */
+function buildBaseMessenger({
+  isEnabled = true,
+  isUnlocked = true,
+}: { isEnabled?: boolean; isUnlocked?: boolean } = {}): {
+  messenger: BaseMessenger;
+  config: { isEnabled: boolean; isUnlocked: boolean };
+} {
+  const config = { isEnabled, isUnlocked };
+  const messenger: BaseMessenger = new Messenger({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+
+  messenger.registerActionHandler(
+    'RemoteFeatureFlagController:getState',
+    () =>
+      ({
+        remoteFeatureFlags: {
+          [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: {
+            enabled: config.isEnabled,
+            minimumVersion: '0.0.1',
+          },
+        },
+        cacheTimestamp: Date.now(),
+      }) as unknown as RemoteFeatureFlagControllerState,
+  );
+
+  messenger.registerActionHandler(
+    'KeyringController:getState',
+    () =>
+      ({
+        isUnlocked: config.isUnlocked,
+        keyrings: [],
+      }) as KeyringControllerState,
+  );
+
+  return { messenger, config };
+}
+
+/**
+ * Build the init request for the given base messenger.
+ *
+ * @param baseMessenger - The base messenger.
+ * @returns The init request.
+ */
+function getInitRequestMock(
+  baseMessenger: BaseMessenger,
+): jest.Mocked<
+  MessengerClientInitRequest<
+    MoneyAccountControllerMessenger,
+    MoneyAccountControllerInitMessenger
+  >
+> {
+  return {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getMoneyAccountControllerMessenger(baseMessenger),
+    initMessenger: getMoneyAccountControllerInitMessenger(baseMessenger),
+  };
+}
+
+/**
+ * Publish a remote feature flag state change.
+ *
+ * @param messenger - The base messenger.
+ */
+function publishFlagChange(messenger: BaseMessenger) {
+  messenger.publish(
+    'RemoteFeatureFlagController:stateChange',
+    {} as RemoteFeatureFlagControllerState,
+    [],
+  );
+}
+
+/**
+ * Publish an unlock.
+ *
+ * @param messenger - The base messenger.
+ */
+function publishUnlock(messenger: BaseMessenger) {
+  messenger.publish('KeyringController:unlock');
+}
+
+describe('MoneyAccountControllerInit', () => {
+  let state: MoneyAccountControllerState;
+  let primaryEntropySource: string;
+  let init: jest.Mock;
+  let clearState: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    state = { moneyAccounts: {} };
+    primaryEntropySource = PRIMARY_ENTROPY_SOURCE;
+
+    // The real `init` creates the keyring and records the account, so the stub
+    // does the state half of that — the flow under test reads it back to decide
+    // whether there is anything left to do.
+    init = jest.fn(() => {
+      const account = moneyAccountFor(primaryEntropySource);
+      state.moneyAccounts[account.id] = account;
+      return Promise.resolve();
+    });
+    clearState = jest.fn(() => {
+      state.moneyAccounts = {};
+    });
+    // Matches the real controller: the account is looked up by the primary
+    // entropy source, not by "is there any account at all".
+    const getMoneyAccount = jest.fn(() =>
+      Object.values(state.moneyAccounts).find(
+        (account) => account.options.entropy.id === primaryEntropySource,
+      ),
+    );
+
+    jest.mocked(MoneyAccountController).mockImplementation(
+      () =>
+        ({
+          get state() {
+            return state;
+          },
+          init,
+          clearState,
+          getMoneyAccount,
+        }) as unknown as MoneyAccountController,
+    );
+  });
+
+  it('initializes the controller with its messenger and persisted state', () => {
+    const request = getInitRequestMock(buildBaseMessenger().messenger);
+    request.persistedState = { MoneyAccountController: { moneyAccounts: {} } };
+
+    const { messengerClient } = MoneyAccountControllerInit(request);
+
+    expect(messengerClient).toBe(
+      jest.mocked(MoneyAccountController).mock.results[0].value,
+    );
+    expect(jest.mocked(MoneyAccountController)).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: { moneyAccounts: {} },
+    });
+  });
+
+  it('persists its state, so the account survives a restart', () => {
+    const result = MoneyAccountControllerInit(
+      getInitRequestMock(buildBaseMessenger().messenger),
+    );
+
+    // Both undefined means "use the controller name", i.e. persisted and
+    // mirrored to the UI — unlike the money services, which opt out of both.
+    expect(result.persistedStateKey).toBeUndefined();
+    expect(result.memStateKey).toBeUndefined();
+  });
+
+  it('creates the account at construction when the flag is on and the wallet is unlocked', async () => {
+    const { messenger } = buildBaseMessenger();
+
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+    await Promise.resolve();
+
+    // No event is needed: a wallet that is already unlocked with the flag
+    // already on would otherwise never get an account, since neither trigger
+    // fires again.
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not create the account at construction while the wallet is locked', async () => {
+    const { messenger } = buildBaseMessenger({ isUnlocked: false });
+
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+    await Promise.resolve();
+
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  it('creates the account when the remote flags arrive', async () => {
+    const { messenger, config } = buildBaseMessenger({ isEnabled: false });
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+    await Promise.resolve();
+    expect(init).not.toHaveBeenCalled();
+
+    config.isEnabled = true;
+    publishFlagChange(messenger);
+    await Promise.resolve();
+
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates the account on unlock', async () => {
+    const { messenger, config } = buildBaseMessenger({ isUnlocked: false });
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+    await Promise.resolve();
+    expect(init).not.toHaveBeenCalled();
+
+    config.isUnlocked = true;
+    publishUnlock(messenger);
+    await Promise.resolve();
+
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not create the account while the wallet is locked', async () => {
+    const { messenger } = buildBaseMessenger({ isUnlocked: false });
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+
+    publishFlagChange(messenger);
+    await Promise.resolve();
+
+    // The controller cannot reach the seed while locked, and throws if asked.
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  it('does not create the account when the feature flag is off', async () => {
+    const { messenger } = buildBaseMessenger({ isEnabled: false });
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+
+    publishFlagChange(messenger);
+    publishUnlock(messenger);
+    await Promise.resolve();
+
+    expect(init).not.toHaveBeenCalled();
+    expect(clearState).not.toHaveBeenCalled();
+  });
+
+  it('does not create a second account once one exists', async () => {
+    const { messenger } = buildBaseMessenger();
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+    await Promise.resolve();
+
+    publishFlagChange(messenger);
+    await Promise.resolve();
+    publishUnlock(messenger);
+    await Promise.resolve();
+
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a fresh account after a vault restore, when the recorded one belongs to a previous seed', async () => {
+    const { messenger, config } = buildBaseMessenger({ isUnlocked: false });
+    state.moneyAccounts = { old: moneyAccountFor('a-previous-seed') };
+
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+
+    config.isUnlocked = true;
+    publishUnlock(messenger);
+    await Promise.resolve();
+
+    // Counting entries would have found one and skipped, leaving the restored
+    // wallet permanently without a money account.
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears its state when the flag is turned off after an account was created', async () => {
+    const { messenger, config } = buildBaseMessenger();
+
+    MoneyAccountControllerInit(getInitRequestMock(messenger));
+    await Promise.resolve();
+    expect(init).toHaveBeenCalledTimes(1);
+
+    config.isEnabled = false;
+    publishFlagChange(messenger);
+    await Promise.resolve();
+
+    expect(clearState).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a creation failure, leaving the next trigger to retry', async () => {
+    const { messenger } = buildBaseMessenger();
+    init.mockRejectedValue(new Error('vault is busy'));
+
+    expect(() =>
+      MoneyAccountControllerInit(getInitRequestMock(messenger)),
+    ).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(() => publishFlagChange(messenger)).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    publishUnlock(messenger);
+    await Promise.resolve();
+
+    expect(init).toHaveBeenCalledTimes(3);
+  });
+});

--- a/app/scripts/messenger-client-init/money-account-controller-init.ts
+++ b/app/scripts/messenger-client-init/money-account-controller-init.ts
@@ -1,0 +1,119 @@
+import {
+  MoneyAccountController,
+  type MoneyAccountControllerMessenger,
+} from '@metamask/money-account-controller';
+import { createProjectLogger } from '@metamask/utils';
+import { isMoneyAccountEnabled } from '../../../shared/lib/money/feature-flags';
+import type { MoneyAccountControllerInitMessenger } from './messengers/money-account-controller-messenger';
+import type { MessengerClientInitFunction } from './types';
+
+const log = createProjectLogger('money-account-controller');
+
+/**
+ * Initialize the MoneyAccountController.
+ *
+ * ## When the account is created
+ *
+ * `init()` creates the Money keyring in the vault if it is missing, so it is
+ * only called when the feature flag is on and the wallet is unlocked — the
+ * controller throws while locked, because it cannot reach the seed. Both
+ * conditions can change after this function returns, so both triggers are
+ * subscribed to and each re-checks the other. `init()` is idempotent (it
+ * returns the existing account, guarded by the controller's own mutex), so
+ * being driven from several places is safe.
+ *
+ * A sync also runs once at construction. Today this is a no-op — the wallet is
+ * always locked while controllers are constructed, because `isUnlocked` is
+ * volatile state and every unlock path fires `KeyringController:unlock` after
+ * the subscription above exists — but the eager sync makes creation correct by
+ * construction rather than dependent on that event ordering.
+ *
+ * Creating the account is deliberately **not** gated on the money account being
+ * usable. A user with no EIP-7702 delegation on the money chain still gets the
+ * keyring — they simply see nothing, which `MoneyAccountAvailabilityService`
+ * decides independently. Gating creation on the delegation instead would mean
+ * the same seed produced a money account on mobile and none here.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.initMessenger - The messenger to use for initialization.
+ * @param request.persistedState - The persisted state to restore.
+ * @returns The initialized controller.
+ */
+export const MoneyAccountControllerInit: MessengerClientInitFunction<
+  MoneyAccountController,
+  MoneyAccountControllerMessenger,
+  MoneyAccountControllerInitMessenger
+> = ({ controllerMessenger, initMessenger, persistedState }) => {
+  const controller = new MoneyAccountController({
+    messenger: controllerMessenger,
+    state: persistedState.MoneyAccountController,
+  });
+
+  const isFeatureEnabled = () => {
+    const { remoteFeatureFlags } = initMessenger.call(
+      'RemoteFeatureFlagController:getState',
+    );
+
+    return isMoneyAccountEnabled(remoteFeatureFlags);
+  };
+
+  /**
+   * Whether the **current** primary seed already has a money account.
+   *
+   * Asked of the controller rather than by counting entries, because the two
+   * differ after a vault restore: the restored SRP gets a new keyring metadata
+   * id, so the account recorded against the old one is not this wallet's money
+   * account and must not be mistaken for it. Counting entries would leave such
+   * a user permanently without one.
+   */
+  const hasMoneyAccountForPrimarySeed = () =>
+    controller.getMoneyAccount() !== undefined;
+
+  const hasAnyMoneyAccount = () =>
+    Object.keys(controller.state.moneyAccounts).length > 0;
+
+  const syncMoneyAccount = async () => {
+    try {
+      const isEnabled = isFeatureEnabled();
+
+      if (!isEnabled) {
+        if (hasAnyMoneyAccount()) {
+          // Only the controller's own state is cleared. The keyring stays in
+          // the vault: removing it would be a destructive response to a flag
+          // that can flip back, and re-creating it derives the same address.
+          controller.clearState();
+        }
+        return;
+      }
+
+      if (hasMoneyAccountForPrimarySeed()) {
+        return;
+      }
+
+      const { isUnlocked } = initMessenger.call('KeyringController:getState');
+      if (!isUnlocked) {
+        return;
+      }
+
+      await controller.init();
+    } catch (error) {
+      // A failure here must not take the background down with it. The next
+      // unlock or remote-flag refresh retries, and until one succeeds the
+      // Money surface stays hidden rather than half-rendered.
+      log('Failed to sync the money account', error);
+    }
+  };
+
+  // Fire and forget: `syncMoneyAccount` handles its own failures, so the
+  // `catch` is only here to keep the subscription callbacks synchronous.
+  const onTrigger = () => {
+    syncMoneyAccount().catch(() => undefined);
+  };
+
+  initMessenger.subscribe('RemoteFeatureFlagController:stateChange', onTrigger);
+  initMessenger.subscribe('KeyringController:unlock', onTrigger);
+  onTrigger();
+
+  return { messengerClient: controller };
+};

--- a/app/scripts/messenger-client-init/money-account-controller-init.ts
+++ b/app/scripts/messenger-client-init/money-account-controller-init.ts
@@ -1,3 +1,4 @@
+import { KeyringTypes } from '@metamask/keyring-controller';
 import {
   MoneyAccountController,
   type MoneyAccountControllerMessenger,
@@ -22,10 +23,18 @@ const log = createProjectLogger('money-account-controller');
  * returns the existing account, guarded by the controller's own mutex), so
  * being driven from several places is safe.
  *
+ * The keyring-side trigger is `KeyringController:stateChange`, not `:unlock`,
+ * because the unlock event can fire before the keyring list is usable: during
+ * a vault restore, `:unlock` is published mid-rebuild while `state.keyrings`
+ * is still empty, and the restored HD keyring only lands in state when the
+ * operation completes — which fires `stateChange`, since both `isUnlocked`
+ * and `keyrings` live in that state. A sync that ran only on `:unlock` would
+ * find no primary keyring after a restore and never run again.
+ *
  * A sync also runs once at construction. Today this is a no-op — the wallet is
  * always locked while controllers are constructed, because `isUnlocked` is
- * volatile state and every unlock path fires `KeyringController:unlock` after
- * the subscription above exists — but the eager sync makes creation correct by
+ * volatile state and every unlock path fires the state change after the
+ * subscription above exists — but the eager sync makes creation correct by
  * construction rather than dependent on that event ordering.
  *
  * Creating the account is deliberately **not** gated on the money account being
@@ -73,6 +82,29 @@ export const MoneyAccountControllerInit: MessengerClientInitFunction<
   const hasAnyMoneyAccount = () =>
     Object.keys(controller.state.moneyAccounts).length > 0;
 
+  /**
+   * Whether any recorded money account points at an entropy source that no
+   * longer exists in the vault.
+   *
+   * This happens after a vault restore over an existing wallet: the restore
+   * replaces every keyring, so accounts recorded against the old keyring ids
+   * become orphans that nothing will ever match again — but they stay in
+   * persisted, UI-visible state unless removed here.
+   *
+   * @param keyrings - The current keyring list, from an unlocked wallet with
+   * at least one HD keyring — while locked or mid-rebuild the list is empty
+   * and every account would wrongly look stale.
+   */
+  const hasStaleMoneyAccounts = (keyrings: { metadata: { id: string } }[]) => {
+    const entropySourceIds = new Set(
+      keyrings.map(({ metadata }) => metadata.id),
+    );
+
+    return Object.values(controller.state.moneyAccounts).some(
+      (account) => !entropySourceIds.has(account.options.entropy.id),
+    );
+  };
+
   const syncMoneyAccount = async () => {
     try {
       const isEnabled = isFeatureEnabled();
@@ -87,20 +119,37 @@ export const MoneyAccountControllerInit: MessengerClientInitFunction<
         return;
       }
 
-      if (hasMoneyAccountForPrimarySeed()) {
+      const { isUnlocked, keyrings } = initMessenger.call(
+        'KeyringController:getState',
+      );
+      if (!isUnlocked) {
         return;
       }
 
-      const { isUnlocked } = initMessenger.call('KeyringController:getState');
-      if (!isUnlocked) {
+      // An unlocked wallet with no HD keyring is a vault mid-rebuild (the
+      // unlock during a restore fires before the keyring list is
+      // repopulated). Nothing can be created or judged stale yet; the
+      // `stateChange` that lands the keyrings re-runs this sync.
+      if (!keyrings.some((keyring) => keyring.type === KeyringTypes.hd)) {
+        return;
+      }
+
+      if (hasStaleMoneyAccounts(keyrings)) {
+        // A restore invalidates every previous entropy source at once, so a
+        // stale entry means they are all stale: clearing the whole state loses
+        // nothing that `init()` below cannot re-derive for the current seed.
+        controller.clearState();
+      }
+
+      if (hasMoneyAccountForPrimarySeed()) {
         return;
       }
 
       await controller.init();
     } catch (error) {
       // A failure here must not take the background down with it. The next
-      // unlock or remote-flag refresh retries, and until one succeeds the
-      // Money surface stays hidden rather than half-rendered.
+      // keyring state change or remote-flag refresh retries, and until one
+      // succeeds the Money surface stays hidden rather than half-rendered.
       log('Failed to sync the money account', error);
     }
   };
@@ -112,7 +161,7 @@ export const MoneyAccountControllerInit: MessengerClientInitFunction<
   };
 
   initMessenger.subscribe('RemoteFeatureFlagController:stateChange', onTrigger);
-  initMessenger.subscribe('KeyringController:unlock', onTrigger);
+  initMessenger.subscribe('KeyringController:stateChange', onTrigger);
   onTrigger();
 
   return { messengerClient: controller };

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -388,6 +388,7 @@ import { SentinelApiServiceInit } from './messenger-client-init/sentinel-api-ser
 import { MoneyAccountApiDataServiceInit } from './messenger-client-init/money-account-api-data-service-init';
 import { MoneyAccountAvailabilityServiceInit } from './messenger-client-init/money-account-availability-service-init';
 import { MoneyAccountBalanceServiceInit } from './messenger-client-init/money-account-balance-service-init';
+import { MoneyAccountControllerInit } from './messenger-client-init/money-account-controller-init';
 import { initializeWallet } from './wallet-init/initialization';
 import { ExtensionConnectivityAdapter } from './controllers/connectivity';
 import { getTransactionControllerApi } from './wallet-init/instance-options/transaction-controller';
@@ -671,6 +672,7 @@ export default class MetamaskController extends EventEmitter {
       MoneyAccountApiDataService: MoneyAccountApiDataServiceInit,
       MoneyAccountAvailabilityService: MoneyAccountAvailabilityServiceInit,
       MoneyAccountBalanceService: MoneyAccountBalanceServiceInit,
+      MoneyAccountController: MoneyAccountControllerInit,
       ...(getIsAssetsUnifiedStateIncludedInBuild()
         ? { AssetsController: AssetsControllerInit }
         : {}),

--- a/app/scripts/wallet-init/keyrings.test.ts
+++ b/app/scripts/wallet-init/keyrings.test.ts
@@ -9,8 +9,10 @@ import { LedgerKeyring } from '@metamask/eth-ledger-bridge-keyring';
 import { LedgerKeyring as LedgerKeyringV2 } from '@metamask/eth-ledger-bridge-keyring/v2';
 import LatticeKeyring from 'eth-lattice-keyring';
 import { SnapKeyring as SnapKeyringV2 } from '@metamask/eth-snap-keyring/v2';
+import { MoneyKeyring } from '@metamask/eth-money-keyring';
 import { LatticeKeyringV2 } from '../lib/offscreen-bridge/lattice-keyring-v2';
-import { getKeyringV2Builders } from './keyrings';
+import { getRootMessenger } from '../lib/messenger';
+import { getKeyringBuilders, getKeyringV2Builders } from './keyrings';
 
 // The V2 wrappers have their own tests; here we only verify that
 // `getKeyringV2Builders` wires each one up correctly, so stub them out.
@@ -40,6 +42,7 @@ describe('getKeyringV2Builders', () => {
       QrKeyring.type,
       TrezorKeyring.type,
       OneKeyKeyring.type,
+      MoneyKeyring.type,
       SnapKeyringV2.type,
     ]);
   });
@@ -69,5 +72,17 @@ describe('getKeyringV2Builders', () => {
     expect(QrKeyringV2).toHaveBeenCalledWith(expectedArgs);
     expect(TrezorKeyringV2).toHaveBeenCalledWith(expectedArgs);
     expect(OneKeyKeyringV2).toHaveBeenCalledWith(expectedArgs);
+  });
+});
+
+describe('getKeyringBuilders', () => {
+  it('registers the Money keyring, so the vault can always be deserialized', () => {
+    const messenger = getRootMessenger<never, never>();
+
+    const builders = getKeyringBuilders(messenger as never);
+
+    expect(builders.map((builder) => builder.type)).toContain(
+      MoneyKeyring.type,
+    );
   });
 });

--- a/app/scripts/wallet-init/keyrings.ts
+++ b/app/scripts/wallet-init/keyrings.ts
@@ -17,6 +17,10 @@ import {
 } from '@metamask/eth-ledger-bridge-keyring';
 import { LedgerKeyring as LedgerKeyringV2 } from '@metamask/eth-ledger-bridge-keyring/v2';
 import { isManifestV3 } from '../../../shared/lib/mv3.utils';
+import {
+  moneyKeyringBuilder,
+  moneyKeyringV2Builder,
+} from '../lib/money/money-keyring-builder';
 import { qrKeyringBuilderFactory } from '../lib/qr-keyring-builder-factory';
 import { TrezorOffscreenBridge } from '../lib/offscreen-bridge/trezor-offscreen-bridge';
 import { TrezorMv2Bridge } from '../lib/offscreen-bridge/trezor-mv2-bridge';
@@ -101,6 +105,7 @@ export function getKeyringV2Builders(): KeyringV2Builder[] {
     buildHardwareV2Builder(QrKeyringV2, QrKeyring.type),
     buildHardwareV2Builder(TrezorKeyringV2, TrezorKeyring.type),
     buildHardwareV2Builder(OneKeyKeyringV2, OneKeyKeyring.type),
+    moneyKeyringV2Builder(),
     // The v2 Snap keyring is registered via `SnapKeyringV1Adapter`, which owns the
     // inner `SnapKeyring` (v2) instance and exposes a proper v1-compatible face for
     // KeyringController vault management. The same inner instance is retrieved via
@@ -179,6 +184,11 @@ export function getKeyringBuilders(
       keyringBuilderFactory(LatticeKeyringOffscreen as unknown as KeyringClass),
     );
   }
+
+  // Registered unconditionally, not behind the Money feature flag, so the
+  // `KeyringController` can always recognise the Money keyring type while
+  // deserializing the vault. See `moneyKeyringBuilder`.
+  keyrings.push(moneyKeyringBuilder(messenger));
 
   // @ts-expect-error: `addAccounts` is missing in `SnapKeyring` type.
   keyrings.push(snapKeyringBuilder(getSnapKeyringBuilderMessenger(messenger)));

--- a/app/scripts/wallet-init/keyrings.ts
+++ b/app/scripts/wallet-init/keyrings.ts
@@ -34,6 +34,7 @@ import {
   RootMessengerActions,
   RootMessengerEvents,
 } from '../lib/messenger';
+import { getMoneyKeyringBuilderMessenger } from '../messenger-client-init/messengers/accounts/money-keyring-builder-messenger';
 import { getSnapKeyringBuilderMessenger } from '../messenger-client-init/messengers/accounts/snap-keyring-builder-messenger';
 import {
   getSnapKeyringV2BuilderMessenger,
@@ -188,7 +189,9 @@ export function getKeyringBuilders(
   // Registered unconditionally, not behind the Money feature flag, so the
   // `KeyringController` can always recognise the Money keyring type while
   // deserializing the vault. See `buildMoneyKeyringBuilder`.
-  keyrings.push(buildMoneyKeyringBuilder(messenger));
+  keyrings.push(
+    buildMoneyKeyringBuilder(getMoneyKeyringBuilderMessenger(messenger)),
+  );
 
   // @ts-expect-error: `addAccounts` is missing in `SnapKeyring` type.
   keyrings.push(snapKeyringBuilder(getSnapKeyringBuilderMessenger(messenger)));

--- a/app/scripts/wallet-init/keyrings.ts
+++ b/app/scripts/wallet-init/keyrings.ts
@@ -18,8 +18,8 @@ import {
 import { LedgerKeyring as LedgerKeyringV2 } from '@metamask/eth-ledger-bridge-keyring/v2';
 import { isManifestV3 } from '../../../shared/lib/mv3.utils';
 import {
-  moneyKeyringBuilder,
-  moneyKeyringV2Builder,
+  buildMoneyKeyringBuilder,
+  buildMoneyKeyringV2Builder,
 } from '../lib/money/money-keyring-builder';
 import { qrKeyringBuilderFactory } from '../lib/qr-keyring-builder-factory';
 import { TrezorOffscreenBridge } from '../lib/offscreen-bridge/trezor-offscreen-bridge';
@@ -105,7 +105,7 @@ export function getKeyringV2Builders(): KeyringV2Builder[] {
     buildHardwareV2Builder(QrKeyringV2, QrKeyring.type),
     buildHardwareV2Builder(TrezorKeyringV2, TrezorKeyring.type),
     buildHardwareV2Builder(OneKeyKeyringV2, OneKeyKeyring.type),
-    moneyKeyringV2Builder(),
+    buildMoneyKeyringV2Builder(),
     // The v2 Snap keyring is registered via `SnapKeyringV1Adapter`, which owns the
     // inner `SnapKeyring` (v2) instance and exposes a proper v1-compatible face for
     // KeyringController vault management. The same inner instance is retrieved via
@@ -187,8 +187,8 @@ export function getKeyringBuilders(
 
   // Registered unconditionally, not behind the Money feature flag, so the
   // `KeyringController` can always recognise the Money keyring type while
-  // deserializing the vault. See `moneyKeyringBuilder`.
-  keyrings.push(moneyKeyringBuilder(messenger));
+  // deserializing the vault. See `buildMoneyKeyringBuilder`.
+  keyrings.push(buildMoneyKeyringBuilder(messenger));
 
   // @ts-expect-error: `addAccounts` is missing in `SnapKeyring` type.
   keyrings.push(snapKeyringBuilder(getSnapKeyringBuilderMessenger(messenger)));

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -1303,6 +1303,29 @@
         "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography' reexports from '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1390,6 +1413,16 @@
     "@metamask/eth-money-keyring": {
       "packages": {
         "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
         "@metamask/keyring-api": true,
         "@metamask/superstruct": true,
         "async-mutex": true
@@ -1711,6 +1744,18 @@
         "@metamask/keyring-sdk>uuid": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": true
+      }
+    },
     "@metamask/keyring-snap-client": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -1839,8 +1884,24 @@
         "cockatiel": true
       }
     },
+    "@metamask/money-account-controller": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/accounts-controller": true,
+        "@metamask/base-controller": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
     "@metamask/money-account-utils": {
       "packages": {
+        "@ethersproject/abi": true,
+        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },
@@ -3002,6 +3063,14 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@metamask/eth-sig-util>ethereum-cryptography>@noble/curves": {
       "globals": {
         "TextEncoder": true
@@ -3066,6 +3135,12 @@
       }
     },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -3265,6 +3340,12 @@
         "TextEncoder": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
       "globals": {
         "TextDecoder": true,
@@ -3276,6 +3357,13 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
@@ -4731,6 +4819,16 @@
       },
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/eth-sig-util>ethereum-cryptography": {
@@ -6890,6 +6988,11 @@
       }
     },
     "@metamask/keyring-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": {
       "globals": {
         "crypto": true
       }

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -1900,8 +1900,6 @@
     },
     "@metamask/money-account-utils": {
       "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -1303,6 +1303,29 @@
         "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography' reexports from '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1390,6 +1413,16 @@
     "@metamask/eth-money-keyring": {
       "packages": {
         "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
         "@metamask/keyring-api": true,
         "@metamask/superstruct": true,
         "async-mutex": true
@@ -1711,6 +1744,18 @@
         "@metamask/keyring-sdk>uuid": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": true
+      }
+    },
     "@metamask/keyring-snap-client": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -1839,8 +1884,24 @@
         "cockatiel": true
       }
     },
+    "@metamask/money-account-controller": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/accounts-controller": true,
+        "@metamask/base-controller": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
     "@metamask/money-account-utils": {
       "packages": {
+        "@ethersproject/abi": true,
+        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },
@@ -3002,6 +3063,14 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@metamask/eth-sig-util>ethereum-cryptography>@noble/curves": {
       "globals": {
         "TextEncoder": true
@@ -3066,6 +3135,12 @@
       }
     },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -3265,6 +3340,12 @@
         "TextEncoder": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
       "globals": {
         "TextDecoder": true,
@@ -3276,6 +3357,13 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
@@ -4731,6 +4819,16 @@
       },
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/eth-sig-util>ethereum-cryptography": {
@@ -6890,6 +6988,11 @@
       }
     },
     "@metamask/keyring-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": {
       "globals": {
         "crypto": true
       }

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -1900,8 +1900,6 @@
     },
     "@metamask/money-account-utils": {
       "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -1303,6 +1303,29 @@
         "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography' reexports from '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1390,6 +1413,16 @@
     "@metamask/eth-money-keyring": {
       "packages": {
         "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
         "@metamask/keyring-api": true,
         "@metamask/superstruct": true,
         "async-mutex": true
@@ -1711,6 +1744,18 @@
         "@metamask/keyring-sdk>uuid": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": true
+      }
+    },
     "@metamask/keyring-snap-client": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -1839,8 +1884,24 @@
         "cockatiel": true
       }
     },
+    "@metamask/money-account-controller": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/accounts-controller": true,
+        "@metamask/base-controller": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
     "@metamask/money-account-utils": {
       "packages": {
+        "@ethersproject/abi": true,
+        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },
@@ -3002,6 +3063,14 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@metamask/eth-sig-util>ethereum-cryptography>@noble/curves": {
       "globals": {
         "TextEncoder": true
@@ -3066,6 +3135,12 @@
       }
     },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -3265,6 +3340,12 @@
         "TextEncoder": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
       "globals": {
         "TextDecoder": true,
@@ -3276,6 +3357,13 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
@@ -4731,6 +4819,16 @@
       },
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/eth-sig-util>ethereum-cryptography": {
@@ -6890,6 +6988,11 @@
       }
     },
     "@metamask/keyring-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": {
       "globals": {
         "crypto": true
       }

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -1900,8 +1900,6 @@
     },
     "@metamask/money-account-utils": {
       "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -1303,6 +1303,29 @@
         "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography' reexports from '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1390,6 +1413,16 @@
     "@metamask/eth-money-keyring": {
       "packages": {
         "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
         "@metamask/keyring-api": true,
         "@metamask/superstruct": true,
         "async-mutex": true
@@ -1711,6 +1744,18 @@
         "@metamask/keyring-sdk>uuid": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": true
+      }
+    },
     "@metamask/keyring-snap-client": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -1839,8 +1884,24 @@
         "cockatiel": true
       }
     },
+    "@metamask/money-account-controller": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/accounts-controller": true,
+        "@metamask/base-controller": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
     "@metamask/money-account-utils": {
       "packages": {
+        "@ethersproject/abi": true,
+        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },
@@ -3002,6 +3063,14 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@metamask/eth-sig-util>ethereum-cryptography>@noble/curves": {
       "globals": {
         "TextEncoder": true
@@ -3066,6 +3135,12 @@
       }
     },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -3265,6 +3340,12 @@
         "TextEncoder": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
       "globals": {
         "TextDecoder": true,
@@ -3276,6 +3357,13 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
@@ -4731,6 +4819,16 @@
       },
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/eth-sig-util>ethereum-cryptography": {
@@ -6890,6 +6988,11 @@
       }
     },
     "@metamask/keyring-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": {
       "globals": {
         "crypto": true
       }

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -1900,8 +1900,6 @@
     },
     "@metamask/money-account-utils": {
       "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -1389,6 +1389,29 @@
         "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography' reexports from '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1476,6 +1499,16 @@
     "@metamask/eth-money-keyring": {
       "packages": {
         "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
         "@metamask/keyring-api": true,
         "@metamask/superstruct": true,
         "async-mutex": true
@@ -1797,6 +1830,18 @@
         "@metamask/keyring-sdk>uuid": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": true
+      }
+    },
     "@metamask/keyring-snap-client": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -1925,8 +1970,24 @@
         "cockatiel": true
       }
     },
+    "@metamask/money-account-controller": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/accounts-controller": true,
+        "@metamask/base-controller": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
     "@metamask/money-account-utils": {
       "packages": {
+        "@ethersproject/abi": true,
+        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },
@@ -3098,6 +3159,14 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@metamask/eth-sig-util>ethereum-cryptography>@noble/curves": {
       "globals": {
         "TextEncoder": true
@@ -3162,6 +3231,12 @@
       }
     },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -3361,6 +3436,12 @@
         "TextEncoder": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
       "globals": {
         "TextDecoder": true,
@@ -3372,6 +3453,13 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
@@ -4862,6 +4950,16 @@
       },
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/eth-sig-util>ethereum-cryptography": {
@@ -7039,6 +7137,11 @@
       }
     },
     "@metamask/keyring-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": {
       "globals": {
         "crypto": true
       }

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -1986,8 +1986,6 @@
     },
     "@metamask/money-account-utils": {
       "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -1389,6 +1389,29 @@
         "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography' reexports from '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1476,6 +1499,16 @@
     "@metamask/eth-money-keyring": {
       "packages": {
         "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
         "@metamask/keyring-api": true,
         "@metamask/superstruct": true,
         "async-mutex": true
@@ -1797,6 +1830,18 @@
         "@metamask/keyring-sdk>uuid": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": true
+      }
+    },
     "@metamask/keyring-snap-client": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -1925,8 +1970,24 @@
         "cockatiel": true
       }
     },
+    "@metamask/money-account-controller": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/accounts-controller": true,
+        "@metamask/base-controller": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
     "@metamask/money-account-utils": {
       "packages": {
+        "@ethersproject/abi": true,
+        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },
@@ -3098,6 +3159,14 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@metamask/eth-sig-util>ethereum-cryptography>@noble/curves": {
       "globals": {
         "TextEncoder": true
@@ -3162,6 +3231,12 @@
       }
     },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -3361,6 +3436,12 @@
         "TextEncoder": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
       "globals": {
         "TextDecoder": true,
@@ -3372,6 +3453,13 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
@@ -4862,6 +4950,16 @@
       },
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/eth-sig-util>ethereum-cryptography": {
@@ -7039,6 +7137,11 @@
       }
     },
     "@metamask/keyring-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": {
       "globals": {
         "crypto": true
       }

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -1986,8 +1986,6 @@
     },
     "@metamask/money-account-utils": {
       "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -1389,6 +1389,29 @@
         "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography' reexports from '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1476,6 +1499,16 @@
     "@metamask/eth-money-keyring": {
       "packages": {
         "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
         "@metamask/keyring-api": true,
         "@metamask/superstruct": true,
         "async-mutex": true
@@ -1797,6 +1830,18 @@
         "@metamask/keyring-sdk>uuid": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": true
+      }
+    },
     "@metamask/keyring-snap-client": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -1925,8 +1970,24 @@
         "cockatiel": true
       }
     },
+    "@metamask/money-account-controller": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/accounts-controller": true,
+        "@metamask/base-controller": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
     "@metamask/money-account-utils": {
       "packages": {
+        "@ethersproject/abi": true,
+        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },
@@ -3098,6 +3159,14 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@metamask/eth-sig-util>ethereum-cryptography>@noble/curves": {
       "globals": {
         "TextEncoder": true
@@ -3162,6 +3231,12 @@
       }
     },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -3361,6 +3436,12 @@
         "TextEncoder": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
       "globals": {
         "TextDecoder": true,
@@ -3372,6 +3453,13 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
@@ -4862,6 +4950,16 @@
       },
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/eth-sig-util>ethereum-cryptography": {
@@ -7039,6 +7137,11 @@
       }
     },
     "@metamask/keyring-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": {
       "globals": {
         "crypto": true
       }

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -1986,8 +1986,6 @@
     },
     "@metamask/money-account-utils": {
       "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -1389,6 +1389,29 @@
         "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "TextEncoder": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography' reexports from '@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": true,
+        "buffer": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -1476,6 +1499,16 @@
     "@metamask/eth-money-keyring": {
       "packages": {
         "@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring": true,
         "@metamask/keyring-api": true,
         "@metamask/superstruct": true,
         "async-mutex": true
@@ -1797,6 +1830,18 @@
         "@metamask/keyring-sdk>uuid": true
       }
     },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography": true,
+        "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": true
+      }
+    },
     "@metamask/keyring-snap-client": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -1925,8 +1970,24 @@
         "cockatiel": true
       }
     },
+    "@metamask/money-account-controller": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/accounts-controller": true,
+        "@metamask/base-controller": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "async-mutex": true
+      }
+    },
     "@metamask/money-account-utils": {
       "packages": {
+        "@ethersproject/abi": true,
+        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },
@@ -3098,6 +3159,14 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
     "@metamask/eth-sig-util>ethereum-cryptography>@noble/curves": {
       "globals": {
         "TextEncoder": true
@@ -3162,6 +3231,12 @@
       }
     },
     "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -3361,6 +3436,12 @@
         "TextEncoder": true
       }
     },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32>@scure/base": {
       "globals": {
         "TextDecoder": true,
@@ -3372,6 +3453,13 @@
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
         "@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/curves": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true,
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@scure/bip32>@scure/base": true
       }
     },
     "@metamask/eth-money-keyring>@metamask/keyring-sdk>ethereum-cryptography>@scure/bip32": {
@@ -4862,6 +4950,16 @@
       },
       "packages": {
         "@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true,
+        "module": true
+      },
+      "packages": {
+        "@metamask/money-account-controller>@metamask/eth-money-keyring>@metamask/eth-hd-keyring>ethereum-cryptography>@noble/hashes": true
       }
     },
     "@metamask/eth-sig-util>ethereum-cryptography": {
@@ -7039,6 +7137,11 @@
       }
     },
     "@metamask/keyring-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/eth-money-keyring>@metamask/keyring-sdk>uuid": {
       "globals": {
         "crypto": true
       }

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -1986,8 +1986,6 @@
     },
     "@metamask/money-account-utils": {
       "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/contracts": true,
         "@metamask/transaction-controller": true
       }
     },

--- a/package.json
+++ b/package.json
@@ -436,7 +436,7 @@
     "@metamask/mobile-wallet-protocol-dapp-client": "^0.3.0",
     "@metamask/money-account-api-data-service": "^0.4.0",
     "@metamask/money-account-balance-service": "2.4.0",
-    "@metamask/money-account-controller": "0.3.3",
+    "@metamask/money-account-controller": "^0.3.3",
     "@metamask/money-account-utils": "^1.1.0",
     "@metamask/multichain-account-service": "^13.0.1",
     "@metamask/multichain-api-client": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -436,6 +436,7 @@
     "@metamask/mobile-wallet-protocol-dapp-client": "^0.3.0",
     "@metamask/money-account-api-data-service": "^0.4.0",
     "@metamask/money-account-balance-service": "2.4.0",
+    "@metamask/money-account-controller": "0.3.3",
     "@metamask/money-account-utils": "^1.1.0",
     "@metamask/multichain-account-service": "^13.0.1",
     "@metamask/multichain-api-client": "^0.10.1",

--- a/shared/lib/money/money-account-flow.test.ts
+++ b/shared/lib/money/money-account-flow.test.ts
@@ -1,0 +1,57 @@
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { getMoneyAccountFlow, MoneyAccountFlow } from './money-account-flow';
+
+describe('getMoneyAccountFlow', () => {
+  it('returns Deposit for a top-level deposit transaction', () => {
+    expect(
+      getMoneyAccountFlow({
+        type: TransactionType.moneyAccountDeposit,
+      } as TransactionMeta),
+    ).toBe(MoneyAccountFlow.Deposit);
+  });
+
+  it('returns Withdraw for a top-level withdrawal transaction', () => {
+    expect(
+      getMoneyAccountFlow({
+        type: TransactionType.moneyAccountWithdraw,
+      } as TransactionMeta),
+    ).toBe(MoneyAccountFlow.Withdraw);
+  });
+
+  it('returns Deposit when the deposit type is on a nested transaction', () => {
+    expect(
+      getMoneyAccountFlow({
+        nestedTransactions: [
+          { type: TransactionType.tokenMethodApprove },
+          { type: TransactionType.moneyAccountDeposit },
+        ],
+      } as TransactionMeta),
+    ).toBe(MoneyAccountFlow.Deposit);
+  });
+
+  it('returns Withdraw when the withdraw type is on a nested transaction', () => {
+    expect(
+      getMoneyAccountFlow({
+        nestedTransactions: [
+          { type: TransactionType.moneyAccountWithdraw },
+          { type: TransactionType.tokenMethodTransfer },
+        ],
+      } as TransactionMeta),
+    ).toBe(MoneyAccountFlow.Withdraw);
+  });
+
+  it('returns undefined for a transaction with neither type', () => {
+    expect(
+      getMoneyAccountFlow({
+        type: TransactionType.simpleSend,
+      } as TransactionMeta),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the transaction is undefined', () => {
+    expect(getMoneyAccountFlow(undefined)).toBeUndefined();
+  });
+});

--- a/shared/lib/money/money-account-flow.ts
+++ b/shared/lib/money/money-account-flow.ts
@@ -1,0 +1,41 @@
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { hasTransactionType } from '../transactions.utils';
+
+/**
+ * Which Money Account flow a transaction belongs to. A single discriminated
+ * result rather than two independent booleans, so a transaction that somehow
+ * matched neither (or, in principle, both) transaction types is representable
+ * as `undefined` instead of silently falling through whichever `if` happened
+ * to run first.
+ */
+export enum MoneyAccountFlow {
+  Deposit = 'deposit',
+  Withdraw = 'withdraw',
+}
+
+/**
+ * Resolves which Money Account flow a transaction belongs to, checking both
+ * the transaction's own type and its nested transactions (batches created via
+ * `addTransactionBatch` carry the money account type on a nested
+ * transaction, not the parent).
+ *
+ * @param transaction - The transaction to check.
+ * @returns The matching flow, or `undefined` if the transaction is not a
+ * Money Account deposit or withdrawal.
+ */
+export function getMoneyAccountFlow(
+  transaction: TransactionMeta | undefined,
+): MoneyAccountFlow | undefined {
+  if (hasTransactionType(transaction, [TransactionType.moneyAccountDeposit])) {
+    return MoneyAccountFlow.Deposit;
+  }
+
+  if (hasTransactionType(transaction, [TransactionType.moneyAccountWithdraw])) {
+    return MoneyAccountFlow.Withdraw;
+  }
+
+  return undefined;
+}

--- a/shared/lib/money/withdraw-amount-commit.ts
+++ b/shared/lib/money/withdraw-amount-commit.ts
@@ -1,0 +1,11 @@
+import type { Hex } from '@metamask/utils';
+
+/**
+ * Result of committing a Money Account withdrawal amount. Crosses the
+ * background→UI bridge, so it carries the recipient the commit actually
+ * encoded: the UI's Confirm gate compares it against the recipient currently
+ * displayed, which can change between commits.
+ */
+export type WithdrawAmountCommitResult =
+  | { didCommit: true; recipient: Hex }
+  | { didCommit: false };

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -413,6 +413,9 @@
       "metaMetricsDataDeletionId": null,
       "metaMetricsDataDeletionTimestamp": 0
     },
+    "MoneyAccountController": {
+      "moneyAccounts": {}
+    },
     "MultichainAssetsController": {
       "accountsAssets": {
         "688e01b8-3134-4ef4-80e6-8772bab38ef7": [

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -182,6 +182,9 @@
       "metaMetricsDataDeletionId": null,
       "metaMetricsDataDeletionTimestamp": 0
     },
+    "MoneyAccountController": {
+      "moneyAccounts": {}
+    },
     "MultichainAssetsController": {
       "accountsAssets": {},
       "allIgnoredAssets": {},

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -179,6 +179,9 @@
     "metaMetricsDataDeletionId": null,
     "metaMetricsDataDeletionTimestamp": 0
   },
+  "MoneyAccountController": {
+    "moneyAccounts": "object"
+  },
   "MultichainAssetsController": {
     "accountsAssets": "object",
     "allIgnoredAssets": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -247,6 +247,7 @@
     "migrationVersion": "number",
     "minimumBalanceForRentExemptionInLamports": "string",
     "mode": "string",
+    "moneyAccounts": "object",
     "multichainNetworkConfigurationsByChainId": "object",
     "musdConversionDismissedCtaKeys": "object",
     "musdConversionEducationSeen": "boolean",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -116,6 +116,7 @@
       "metaMetricsDataDeletionId": null,
       "metaMetricsDataDeletionTimestamp": 0
     },
+    "MoneyAccountController": { "moneyAccounts": "object" },
     "MultichainAssetsController": {
       "accountsAssets": "object",
       "allIgnoredAssets": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -135,6 +135,7 @@
       "metaMetricsDataDeletionId": null,
       "metaMetricsDataDeletionTimestamp": 0
     },
+    "MoneyAccountController": { "moneyAccounts": "object" },
     "MultichainAssetsController": {
       "accountsAssets": "object",
       "allIgnoredAssets": "object",

--- a/test/e2e/tests/money/money-account-vault-restore.spec.ts
+++ b/test/e2e/tests/money/money-account-vault-restore.spec.ts
@@ -1,0 +1,170 @@
+import { strict as assert } from 'assert';
+import { Suite } from 'mocha';
+import type { Mockttp } from 'mockttp';
+import { getCleanAppState, withFixtures } from '../../helpers';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { getProductionRemoteFlagApiResponse } from '../../feature-flags';
+import { completeImportSRPOnboardingFlow } from '../../page-objects/flows/onboarding.flow';
+import HomePage from '../../page-objects/pages/home/homepage';
+import HeaderNavbar from '../../page-objects/pages/header-navbar';
+import AccountListPage from '../../page-objects/pages/account-list-page';
+import { Driver } from '../../webdriver/driver';
+import { MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME } from '../../../../shared/lib/money/feature-flags';
+
+/**
+ * The money account address derived from `E2E_SRP` at the fixed money
+ * derivation path (`m/44'/4392018'/0'/0`). Mobile derives the same address
+ * from the same SRP, so asserting this exact value pins cross-client
+ * derivation, not just self-consistency.
+ */
+const MONEY_ACCOUNT_ADDRESS = '0xd5fe9b0579443e7025cf3309ba420977710e7183';
+
+const HD_KEYRING_TYPE = 'HD Key Tree';
+const MONEY_KEYRING_TYPE = 'Money Keyring';
+
+const MONEY_ACCOUNT_FLAG_VALUE = { enabled: true, minimumVersion: '0.0.0' };
+
+/**
+ * Serves the production remote flags plus the money-account flag from the
+ * mock server. Seeding `RemoteFeatureFlagController` state alone is not
+ * enough: the background controller refetches /v1/flags on load and would
+ * overwrite the seeded flag with the mocked production defaults, which do
+ * not include it — leaving the money account never created.
+ *
+ * @param server - The Mockttp server instance to register the mock on.
+ */
+async function mockMoneyAccountFlag(server: Mockttp): Promise<void> {
+  await server
+    .forGet('https://client-config.api.cx.metamask.io/v1/flags')
+    .withQuery({ client: 'extension', distribution: 'main' })
+    .thenCallback(() => ({
+      ok: true,
+      statusCode: 200,
+      json: [
+        ...getProductionRemoteFlagApiResponse(),
+        { [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: MONEY_ACCOUNT_FLAG_VALUE },
+      ],
+    }));
+}
+
+type MoneyAccountRecord = {
+  address: string;
+  options: { entropy?: { id?: string } };
+};
+
+type KeyringRecord = {
+  type: string;
+  accounts: string[];
+  metadata: { id: string };
+};
+
+describe('Money account', function (this: Suite) {
+  it('is created on vault restore into a fresh profile and stays out of the account list', async function () {
+    await withFixtures(
+      {
+        // `MoneyAccountControllerInit`'s enablement check reads
+        // `RemoteFeatureFlagController` state directly (background code does
+        // not honour manifest overrides), so the flag must be seeded there
+        // rather than via `manifestFlags`. The mock below keeps the flag set
+        // after the controller's own /v1/flags refetch replaces this state.
+        fixtures: new FixtureBuilderV2({ onboarding: true })
+          .withRemoteFeatureFlagController({
+            remoteFeatureFlags: {
+              [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: MONEY_ACCOUNT_FLAG_VALUE,
+            },
+          })
+          .build(),
+        testSpecificMock: mockMoneyAccountFlag,
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        // A fresh profile plus an SRP import is the vault-restore path: the
+        // restored HD keyring gets a new metadata id, so a money account can
+        // only appear if `MoneyAccountController.init()` genuinely creates one
+        // for this keyring rather than finding a pre-existing record.
+        await completeImportSRPOnboardingFlow({ driver });
+
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+
+        // Account creation runs asynchronously off the unlock event, so poll
+        // rather than read once.
+        let uiState: {
+          metamask: {
+            moneyAccounts: Record<string, MoneyAccountRecord>;
+            keyrings: KeyringRecord[];
+            internalAccounts: {
+              accounts: Record<string, { address: string }>;
+            };
+          };
+        };
+        await driver.wait(async () => {
+          uiState = await getCleanAppState(driver);
+          return Object.keys(uiState?.metamask?.moneyAccounts ?? {}).length > 0;
+        }, 10000);
+
+        const { moneyAccounts, keyrings, internalAccounts } =
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          uiState!.metamask;
+
+        const moneyAccountList = Object.values(moneyAccounts);
+        assert.equal(
+          moneyAccountList.length,
+          1,
+          `Expected exactly one money account, got ${moneyAccountList.length}`,
+        );
+        const [moneyAccount] = moneyAccountList;
+
+        assert.equal(
+          moneyAccount.address.toLowerCase(),
+          MONEY_ACCOUNT_ADDRESS,
+          'The money account address must match the cross-client derivation vector for E2E_SRP',
+        );
+
+        // The account must be recorded against the entropy source of the HD
+        // keyring created by *this* restore — the same single-snapshot check
+        // `selectPrimaryMoneyAccount` performs. If these ids diverge, the UI
+        // cannot see a money account that exists in the vault.
+        const hdKeyring = keyrings.find(
+          (keyring) => keyring.type === HD_KEYRING_TYPE,
+        );
+        assert(hdKeyring, 'Expected an HD keyring after the SRP import');
+        assert.equal(
+          moneyAccount.options.entropy?.id,
+          hdKeyring.metadata.id,
+          'The money account entropy source must be the restored HD keyring',
+        );
+
+        // The keyring must genuinely be in the vault — without it the account
+        // could not sign, and the deposit flow would fail only at signing time.
+        const moneyKeyring = keyrings.find(
+          (keyring) => keyring.type === MONEY_KEYRING_TYPE,
+        );
+        assert(moneyKeyring, 'Expected a Money keyring in the vault');
+        assert.deepEqual(
+          moneyKeyring.accounts.map((address) => address.toLowerCase()),
+          [MONEY_ACCOUNT_ADDRESS],
+          'The Money keyring must hold exactly the derived money account',
+        );
+
+        // The money account is internal plumbing: `accounts-controller`
+        // excludes money keyrings from its sync paths, so the address must not
+        // surface as an internal (listable, selectable) account.
+        const internalAddresses = Object.values(internalAccounts.accounts).map(
+          (account) => account.address.toLowerCase(),
+        );
+        assert(
+          !internalAddresses.includes(MONEY_ACCOUNT_ADDRESS),
+          'The money account must not appear among internal accounts',
+        );
+
+        // And the account list UI shows only the restored account.
+        await new HeaderNavbar(driver).openAccountMenu();
+        const accountListPage = new AccountListPage(driver);
+        await accountListPage.checkPageIsLoaded();
+        await accountListPage.checkAccountDisplayedInAccountList('Account 1');
+        await accountListPage.checkNumberOfAvailableAccounts(1);
+      },
+    );
+  });
+});

--- a/test/e2e/tests/money/money-account-vault-restore.spec.ts
+++ b/test/e2e/tests/money/money-account-vault-restore.spec.ts
@@ -1,14 +1,23 @@
 import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
 import type { Mockttp } from 'mockttp';
+import { Browser } from 'selenium-webdriver';
 import { getCleanAppState, withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { getProductionRemoteFlagApiResponse } from '../../feature-flags';
 import { completeImportSRPOnboardingFlow } from '../../page-objects/flows/onboarding.flow';
+import {
+  lockAndWaitForLoginPage,
+  login,
+} from '../../page-objects/flows/login.flow';
 import HomePage from '../../page-objects/pages/home/homepage';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
-import AccountListPage from '../../page-objects/pages/account-list-page';
+import AccountListPage from '../../page-objects/pages/accounts/list-page';
+import LoginPage from '../../page-objects/pages/login-page';
+import ResetPasswordPage from '../../page-objects/pages/reset-password-page';
+import SetupPasskeyPage from '../../page-objects/pages/onboarding/setup-passkey-page';
 import { Driver } from '../../webdriver/driver';
+import { TEST_SEED_PHRASE } from '../../constants';
 import { MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME } from '../../../../shared/lib/money/feature-flags';
 
 /**
@@ -18,6 +27,14 @@ import { MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME } from '../../../../shared/lib/mon
  * derivation, not just self-consistency.
  */
 const MONEY_ACCOUNT_ADDRESS = '0xd5fe9b0579443e7025cf3309ba420977710e7183';
+
+/**
+ * The money account address derived from `TEST_SEED_PHRASE` at the money
+ * derivation path, used as the "different SRP" in the restore-over-existing
+ * test so the replacement is observable as a changed address.
+ */
+const RESTORED_MONEY_ACCOUNT_ADDRESS =
+  '0x192588eb047d4a2421ac43fa920bd9fc206b9b82';
 
 const HD_KEYRING_TYPE = 'HD Key Tree';
 const MONEY_KEYRING_TYPE = 'Money Keyring';
@@ -58,6 +75,38 @@ type KeyringRecord = {
   metadata: { id: string };
 };
 
+type MoneyUiState = {
+  metamask: {
+    moneyAccounts: Record<string, MoneyAccountRecord>;
+    keyrings: KeyringRecord[];
+    internalAccounts: {
+      accounts: Record<string, { address: string }>;
+    };
+  };
+};
+
+/**
+ * Poll the background state until the money accounts satisfy `predicate`.
+ * Account creation runs asynchronously off the unlock event, so a single read
+ * would race it.
+ *
+ * @param driver - The webdriver instance.
+ * @param predicate - Condition on the current list of money accounts.
+ * @returns The background state from the read that satisfied the predicate.
+ */
+async function waitForMoneyAccounts(
+  driver: Driver,
+  predicate: (moneyAccounts: MoneyAccountRecord[]) => boolean,
+): Promise<MoneyUiState['metamask']> {
+  let uiState: MoneyUiState | undefined;
+  await driver.wait(async () => {
+    uiState = await getCleanAppState(driver);
+    return predicate(Object.values(uiState?.metamask?.moneyAccounts ?? {}));
+  }, 10000);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return uiState!.metamask;
+}
+
 describe('Money account', function (this: Suite) {
   it('is created on vault restore into a fresh profile and stays out of the account list', async function () {
     await withFixtures(
@@ -87,25 +136,8 @@ describe('Money account', function (this: Suite) {
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
 
-        // Account creation runs asynchronously off the unlock event, so poll
-        // rather than read once.
-        let uiState: {
-          metamask: {
-            moneyAccounts: Record<string, MoneyAccountRecord>;
-            keyrings: KeyringRecord[];
-            internalAccounts: {
-              accounts: Record<string, { address: string }>;
-            };
-          };
-        };
-        await driver.wait(async () => {
-          uiState = await getCleanAppState(driver);
-          return Object.keys(uiState?.metamask?.moneyAccounts ?? {}).length > 0;
-        }, 10000);
-
         const { moneyAccounts, keyrings, internalAccounts } =
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          uiState!.metamask;
+          await waitForMoneyAccounts(driver, (accounts) => accounts.length > 0);
 
         const moneyAccountList = Object.values(moneyAccounts);
         assert.equal(
@@ -164,6 +196,102 @@ describe('Money account', function (this: Suite) {
         await accountListPage.checkPageIsLoaded();
         await accountListPage.checkAccountDisplayedInAccountList('Account 1');
         await accountListPage.checkNumberOfAvailableAccounts(1);
+      },
+    );
+  });
+
+  it('replaces stale money accounts when restoring a different SRP over an existing wallet', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2()
+          .withRemoteFeatureFlagController({
+            remoteFeatureFlags: {
+              [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: MONEY_ACCOUNT_FLAG_VALUE,
+            },
+          })
+          .build(),
+        testSpecificMock: mockMoneyAccountFlag,
+        // Locking the wallet mid-test can cut off in-flight requests; these
+        // are the same benign errors the forgot-password suite ignores.
+        ignoredConsoleErrors: [
+          'The snap "npm:@metamask/message-signing-snap" has been terminated during execution',
+          'npm:@metamask/message-signing-snap was stopped and the request was cancelled. This is likely because the Snap crashed.',
+          'Legacy syncing failed for wallet',
+        ],
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+
+        // The fixture wallet holds `E2E_SRP`, so unlocking creates its money
+        // account — the record that must become stale after the restore.
+        const { moneyAccounts: originalMoneyAccounts } =
+          await waitForMoneyAccounts(driver, (accounts) => accounts.length > 0);
+        const [originalMoneyAccount] = Object.values(originalMoneyAccounts);
+        assert.equal(
+          originalMoneyAccount.address.toLowerCase(),
+          MONEY_ACCOUNT_ADDRESS,
+        );
+
+        // Restore a different SRP over the wallet via the forgot-password
+        // flow. This replaces every keyring, orphaning the recorded money
+        // account's entropy source.
+        await lockAndWaitForLoginPage(driver);
+        await new LoginPage(driver).gotoResetPasswordPage();
+
+        const resetPasswordPage = new ResetPasswordPage(driver);
+        await resetPasswordPage.checkPageIsLoaded();
+        await resetPasswordPage.resetPassword(
+          TEST_SEED_PHRASE,
+          'this is the best password ever',
+        );
+        await resetPasswordPage.waitForPasswordInputToNotBeVisible();
+
+        // Chrome offers passkey setup after the restore; Firefox does not
+        // support the flow and skips straight to home.
+        if (process.env.SELENIUM_BROWSER !== Browser.FIREFOX) {
+          const setupPasskeyPage = new SetupPasskeyPage(driver);
+          await setupPasskeyPage.checkPageIsLoaded();
+          await setupPasskeyPage.skipPasskeySetup();
+        }
+        await new HomePage(driver).headerNavbar.checkPageIsLoaded();
+
+        // The stale account must be replaced — not merely joined — by one for
+        // the restored seed, so wait for the map to contain exactly the new
+        // address and nothing else.
+        const { moneyAccounts, keyrings } = await waitForMoneyAccounts(
+          driver,
+          (accounts) =>
+            accounts.length === 1 &&
+            accounts[0].address.toLowerCase() ===
+              RESTORED_MONEY_ACCOUNT_ADDRESS,
+        );
+
+        // The surviving record must belong to the HD keyring created by this
+        // restore, not to the pre-restore wallet.
+        const [moneyAccount] = Object.values(moneyAccounts);
+        const hdKeyring = keyrings.find(
+          (keyring) => keyring.type === HD_KEYRING_TYPE,
+        );
+        assert(hdKeyring, 'Expected an HD keyring after the restore');
+        assert.equal(
+          moneyAccount.options.entropy?.id,
+          hdKeyring.metadata.id,
+          'The money account entropy source must be the restored HD keyring',
+        );
+
+        // The vault keyring must hold only the new derivation: the old money
+        // address belongs to a seed this wallet no longer controls.
+        const moneyKeyrings = keyrings.filter(
+          (keyring) => keyring.type === MONEY_KEYRING_TYPE,
+        );
+        assert.deepEqual(
+          moneyKeyrings.flatMap((keyring) =>
+            keyring.accounts.map((address) => address.toLowerCase()),
+          ),
+          [RESTORED_MONEY_ACCOUNT_ADDRESS],
+          'The Money keyring must hold exactly the restored money account',
+        );
       },
     );
   });

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -733,6 +733,7 @@
     "migrationVersion": "number",
     "minimumBalanceForRentExemptionInLamports": "string",
     "mode": "string",
+    "moneyAccounts": {},
     "multichainNetworkConfigurationsByChainId": {
       "bip122:000000000019d6689c085ae165831e93": {
         "chainId": "string",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7544,7 +7544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-controller@npm:0.3.3":
+"@metamask/money-account-controller@npm:^0.3.3":
   version: 0.3.3
   resolution: "@metamask/money-account-controller@npm:0.3.3"
   dependencies:
@@ -33304,7 +33304,7 @@ __metadata:
     "@metamask/mobile-wallet-protocol-dapp-client": "npm:^0.3.0"
     "@metamask/money-account-api-data-service": "npm:^0.4.0"
     "@metamask/money-account-balance-service": "npm:2.4.0"
-    "@metamask/money-account-controller": "npm:0.3.3"
+    "@metamask/money-account-controller": "npm:^0.3.3"
     "@metamask/money-account-utils": "npm:^1.1.0"
     "@metamask/multichain-account-service": "npm:^13.0.1"
     "@metamask/multichain-api-client": "npm:^0.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6737,6 +6737,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-money-keyring@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@metamask/eth-money-keyring@npm:2.0.4"
+  dependencies:
+    "@metamask/eth-hd-keyring": "npm:^14.1.1"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-utils": "npm:^3.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    async-mutex: "npm:^0.5.0"
+  checksum: 10/2e3941355be1750c433cf8106235df1b0785becc47c0c87dfabbe7ed43006fa5d303bca70a1d5a308c0d0b281b75468440ab5c8883d70e12fa3923a5ccba3dd1
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-qr-keyring@npm:^3.0.0":
   version: 3.0.0
   resolution: "@metamask/eth-qr-keyring@npm:3.0.0"
@@ -7528,6 +7541,21 @@ __metadata:
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
   checksum: 10/064ebd057c871b3ee861d901efdca9eaea7e52aa5681c8d539913cfbb2e474651f85ece5c7afcc873f4c681e02152eba8e29e1eba1a7356e4cc99c2b47781bac
+  languageName: node
+  linkType: hard
+
+"@metamask/money-account-controller@npm:0.3.3":
+  version: 0.3.3
+  resolution: "@metamask/money-account-controller@npm:0.3.3"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^39.0.1"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/eth-money-keyring": "npm:^2.0.4"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-controller": "npm:^27.0.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    async-mutex: "npm:^0.5.0"
+  checksum: 10/f7128bd41e37a9a7fc17de110b1256aaade4af5ab0d45cb561044946136e0b57b76fbbe2059d38dad7599db776dc304c2f6db0587323afceb18bac2658004b63
   languageName: node
   linkType: hard
 
@@ -33276,6 +33304,7 @@ __metadata:
     "@metamask/mobile-wallet-protocol-dapp-client": "npm:^0.3.0"
     "@metamask/money-account-api-data-service": "npm:^0.4.0"
     "@metamask/money-account-balance-service": "npm:2.4.0"
+    "@metamask/money-account-controller": "npm:0.3.3"
     "@metamask/money-account-utils": "npm:^1.1.0"
     "@metamask/multichain-account-service": "npm:^13.0.1"
     "@metamask/multichain-api-client": "npm:^0.10.1"


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Adds the @metamask/money-account-controller dependency and LavaMoat policies, registers the Money keyring builder and MoneyAccountController, updates the availability service, and covers vault-restore account creation with an e2e spec. 

## **Changelog**


<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add money account keyring 

## **Related issues**

Fixes: musd-1265

## **Manual testing steps**
1. Enable the feature flag (it's currently enabled in `main dev`
2. Import a new SRP
3. in full screen mode open the developer console
4. run 
```
const s = await window.stateHooks.getCleanAppState();
s.metamask.keyrings.map((k) => k.type) // confirm that the result contains money keyring
s.metamask.keyrings.find((k) => k.type === 'Money Keyring') // confirm that the values are good
```

## **Screenshots/Recordings**
N/A
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch vault keyring creation, unsafe mnemonic reads, and persisted money-account state with restore/flag edge cases—errors could affect wallet unlock or show wrong addresses.
> 
> **Overview**
> This PR **integrates `@metamask/money-account-controller`** into the extension background: persisted `moneyAccounts` state, messenger wiring, and **`MoneyAccountControllerInit`** that creates the Money keyring/account when **`moneyEnableMoneyAccount`** is on and the wallet is unlocked (including an eager sync at init). It listens for remote-flag and **`KeyringController:stateChange`** (not unlock alone) so vault restore mid-rebuild is handled, **clears stale persisted accounts** when entropy sources no longer exist, and **clears controller state** when the flag turns off without removing the vault keyring.
> 
> **Money keyring builders** (V1 + V2) are registered **unconditionally** so existing vaults can deserialize; derivation resolves the HD mnemonic lazily via **`KeyringController:withKeyringUnsafe`** to avoid deadlocks during locked `withKeyring` flows.
> 
> **`MoneyAccountAvailabilityService`** no longer checks the enable flag or exposes **`getAddress`** publicly—callers gate on the flag; availability still covers geo, address derivation, and chain setup.
> 
> Also adds shared **`getMoneyAccountFlow`** / withdraw commit types, **LavaMoat** entries for the new packages, fixture/snapshot updates, and **e2e** coverage for money account creation on SRP import and replacement after restore over a different seed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fee16b16bbcf1b85f3b3a1c6bca03aa3a7d2aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->