### PR TITLE
chore(ui): migrate multichain ButtonLinks to MMDS

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.tsx
@@ -14,6 +14,8 @@ import {
   Text as DsText,
   TextColor as DsTextColor,
   TextVariant as DsTextVariant,
+  TextButton,
+  TextButtonSize,
 } from '@metamask/design-system-react';
 import {
   Display,
@@ -32,7 +34,6 @@ import {
   ModalBody,
   Modal,
   Box,
-  ButtonLink,
   Text,
 } from '../../../component-library';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -195,9 +196,9 @@ export const AssetPickerModalNetwork = ({
           onClose={isMultiselectEnabled ? undefined : onClose}
           endAccessory={
             isMultiselectEnabled && selectedChainIds ? (
-              <ButtonLink
-                variant={TextVariant.bodyMdMedium}
-                disabled={Object.values(checkedChainIds).every((v) => !v)}
+              <TextButton
+                size={TextButtonSize.BodyMd}
+                isDisabled={Object.values(checkedChainIds).every((v) => !v)}
                 onClick={() => {
                   onMultiselectSubmit?.(
                     Object.keys(checkedChainIds).filter(
@@ -208,7 +209,7 @@ export const AssetPickerModalNetwork = ({
                 }}
               >
                 {t('apply')}
-              </ButtonLink>
+              </TextButton>
             ) : undefined
           }
         >
@@ -228,18 +229,15 @@ export const AssetPickerModalNetwork = ({
                 handleToggleAllNetworks();
               }}
             />
-            <ButtonLink
-              variant={TextVariant.bodyMdMedium}
+            <TextButton
+              size={TextButtonSize.BodyMd}
               onClick={() => {
                 handleToggleAllNetworks();
               }}
-              style={{
-                alignSelf: AlignItems.flexStart,
-                paddingInline: 16,
-              }}
+              className="self-start px-4"
             >
               {t('selectAll')}
-            </ButtonLink>
+            </TextButton>
           </Box>
         )}
         <ModalBody

--- a/ui/components/multichain/import-account/__snapshots__/json.test.tsx.snap
+++ b/ui/components/multichain/import-account/__snapshots__/json.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Json should match snapshot 1`] = `
   >
     Used by a variety of different clients
     <a
-      class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+      class="items-center justify-center font-medium overflow-hidden relative duration-100 ease-linear active:ease-[cubic-bezier(0.3,0.8,0.3,1)] h-auto rounded-none bg-transparent px-0 transform-none transition-none active:scale-100 text-primary-default hover:text-primary-default-hover hover:underline hover:decoration-primary-default-hover hover:decoration-2 hover:underline-offset-4 active:text-primary-default-pressed active:decoration-primary-default-pressed inline"
       href="https://support.metamask.io/start/how-to-import-an-account/?utm_source=extension#how-can-i-import-my-private-key-using-a-json-file"
       rel="noopener noreferrer"
       target="_blank"

--- a/ui/components/multichain/import-account/import-account.js
+++ b/ui/components/multichain/import-account/import-account.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
+import { TextButton } from '@metamask/design-system-react';
 import { getErrorMessage } from '../../../../shared/lib/error';
 import {
   MetaMetricsEventAccountImportType,
@@ -8,14 +9,13 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { Box, ButtonLink, Label, Text } from '../../component-library';
+import { Box, Label, Text } from '../../component-library';
 import Dropdown from '../../ui/dropdown';
 import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   BlockSize,
   FontWeight,
   JustifyContent,
-  Size,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
@@ -167,29 +167,35 @@ export const ImportAccount = ({ onActionComplete }) => {
           </Text>
           <Text variant={TextVariant.bodySm}>
             {t('importAccountWithSocialMsgLearnMore', [
-              <ButtonLink
-                size={Size.inherit}
-                href={ZENDESK_URLS.IMPORTED_ACCOUNTS_PRIVATE_KEY}
-                target="_blank"
-                rel="noopener noreferrer"
+              <TextButton
+                size="body-sm"
+                asChild
+                className="inline"
                 key="importAccountWithSocialMsgLearnMore"
               >
-                {t('learnMoreUpperCase')}
-              </ButtonLink>,
+                <a
+                  href={ZENDESK_URLS.IMPORTED_ACCOUNTS_PRIVATE_KEY}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t('learnMoreUpperCase')}
+                </a>
+              </TextButton>,
             ])}
           </Text>
         </>
       ) : (
         <Text variant={TextVariant.bodySm} marginTop={2}>
           {t('importAccountMsg')}{' '}
-          <ButtonLink
-            size={Size.inherit}
-            href={ZENDESK_URLS.IMPORTED_ACCOUNTS_PRIVATE_KEY}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {t('here')}
-          </ButtonLink>
+          <TextButton size="body-sm" asChild className="inline">
+            <a
+              href={ZENDESK_URLS.IMPORTED_ACCOUNTS_PRIVATE_KEY}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('here')}
+            </a>
+          </TextButton>
         </Text>
       )}
       <Box paddingTop={4} paddingBottom={8}>

--- a/ui/components/multichain/import-account/json.js
+++ b/ui/components/multichain/import-account/json.js
@@ -1,14 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import FileInput from 'react-simple-file-input';
+import { TextButton } from '@metamask/design-system-react';
+import { TextFieldSize, TextFieldType, Text } from '../../component-library';
 import {
-  ButtonLink,
-  TextFieldSize,
-  TextFieldType,
-  Text,
-} from '../../component-library';
-import {
-  Size,
   TextAlign,
   TextVariant,
 } from '../../../helpers/constants/design-system';
@@ -48,14 +43,15 @@ export default function JsonImportSubview({
     <>
       <Text variant={TextVariant.bodyMd} textAlign={TextAlign.Center}>
         {t('usedByClients')}
-        <ButtonLink
-          size={Size.inherit}
-          href={ZENDESK_URLS.IMPORTED_ACCOUNT_JSON}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {t('fileImportFail')}
-        </ButtonLink>
+        <TextButton size="body-md" asChild className="inline">
+          <a
+            href={ZENDESK_URLS.IMPORTED_ACCOUNT_JSON}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t('fileImportFail')}
+          </a>
+        </TextButton>
       </Text>
 
       <FileInput

--- a/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
+++ b/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
@@ -8,13 +8,12 @@ import {
   IconName,
   IconSize,
   IconColor,
+  TextButton,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   Box,
   Text,
-  ButtonLinkSize,
-  ButtonLink,
   Popover,
   PopoverPosition,
 } from '../../../component-library';
@@ -107,9 +106,8 @@ const PopularNetworkList = ({
                 {t('popularNetworkAddToolTip')}{' '}
               </Text>
               <Box key="learn-more-link">
-                <ButtonLink
-                  size={ButtonLinkSize.Auto}
-                  externalLink
+                <TextButton
+                  size="body-md"
                   onClick={() => {
                     global.platform.openTab({
                       url: ZENDESK_URLS.UNKNOWN_NETWORK,
@@ -117,7 +115,7 @@ const PopularNetworkList = ({
                   }}
                 >
                   {t('learnMoreUpperCase')}
-                </ButtonLink>
+                </TextButton>
               </Box>
             </Popover>
           </Box>

--- a/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
+++ b/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
@@ -9,6 +9,7 @@ import {
   IconSize,
   IconColor,
   TextButton,
+  TextButtonSize,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
@@ -107,7 +108,7 @@ const PopularNetworkList = ({
               </Text>
               <Box key="learn-more-link">
                 <TextButton
-                  size="body-md"
+                  size={TextButtonSize.BodyMd}
                   onClick={() => {
                     global.platform.openTab({
                       url: ZENDESK_URLS.UNKNOWN_NETWORK,

--- a/ui/components/multichain/networks-form/networks-form.tsx
+++ b/ui/components/multichain/networks-form/networks-form.tsx
@@ -6,6 +6,8 @@ import {
   ButtonSize,
   ButtonVariant,
   IconName,
+  TextButton,
+  TextButtonSize,
 } from '@metamask/design-system-react';
 import {
   type UpdateNetworkFields,
@@ -49,7 +51,6 @@ import {
 } from '../../../store/actions';
 import {
   Box,
-  ButtonLink,
   FormTextField,
   FormTextFieldSize,
   HelpText,
@@ -524,19 +525,15 @@ export const NetworksForm = ({
                     data-testid="network-form-name-suggestion"
                   >
                     {t('suggestedTokenName')}
-                    <ButtonLink
-                      as="button"
-                      variant={TextVariant.bodySm}
-                      color={TextColor.primaryDefault}
+                    <TextButton
+                      size={TextButtonSize.BodySm}
                       onClick={() => {
                         setName(suggestedName);
                       }}
-                      paddingLeft={1}
-                      paddingRight={1}
-                      style={{ verticalAlign: 'baseline' }}
+                      className="px-1 align-baseline"
                     >
                       {suggestedName}
-                    </ButtonLink>
+                    </TextButton>
                   </Text>
                 )}
               </>
@@ -695,10 +692,8 @@ export const NetworksForm = ({
               data-testid="network-form-chain-id-error"
             >
               {t('updateOrEditNetworkInformations')}{' '}
-              <ButtonLink
-                as="button"
-                variant={TextVariant.bodySm}
-                color={TextColor.primaryDefault}
+              <TextButton
+                size={TextButtonSize.BodySm}
                 onClick={() => {
                   const chainIdHex = toHex(chainId);
                   if (chainIdHex) {
@@ -712,7 +707,7 @@ export const NetworksForm = ({
                 }}
               >
                 {t('editNetworkLink')}
-              </ButtonLink>
+              </TextButton>
             </HelpText>
           </Box>
         ) : null}
@@ -731,19 +726,15 @@ export const NetworksForm = ({
                 data-testid="network-form-ticker-suggestion"
               >
                 {t('suggestedCurrencySymbol')}
-                <ButtonLink
-                  as="button"
-                  variant={TextVariant.bodySm}
-                  color={TextColor.primaryDefault}
+                <TextButton
+                  size={TextButtonSize.BodySm}
                   onClick={() => {
                     setTicker(suggestedTicker);
                   }}
-                  paddingLeft={1}
-                  paddingRight={1}
-                  style={{ verticalAlign: 'baseline' }}
+                  className="px-1 align-baseline"
                 >
                   {suggestedTicker}
-                </ButtonLink>
+                </TextButton>
               </Text>
             ) : null
           }


### PR DESCRIPTION
## **Description**

### Context
The legacy component-library `ButtonLink` is deprecated. These multichain surfaces still used it for inline links and link-style actions.

### Solution
Replaced the five audited files' `ButtonLink` usages with MMDS `TextButton` components, preserving external navigation, click handlers, disabled states, sizing, and inline spacing. Updated the affected JSON import snapshot.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run extension
2. Open **Settings → Networks**, add or edit a network, and verify the suggested network name, existing-network edit link, suggested currency symbol, and RPC URL controls remain aligned and clickable.
3. Open a multichain asset picker with multi-select enabled and verify **Apply** and **Select all** retain their disabled and click behavior.
4. Open **Import account** and verify the help links in both private-key and social-login flows open the expected support pages.
5. Open JSON account import and verify the help link opens the expected support page.

<!--
## **Screenshots/Recordings**

### **Before**

Not captured.

### **After**

Not captured.
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)