### PR TITLE
fix: `PRF` not supported error for biometrics setup cp-14.36.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6637,7 +6637,7 @@
     "description": "Shown when biometrics unlock fails because no passkey is enrolled. $1 is the OS-specific auth-method noun (Biometrics / Touch ID / Windows Hello)."
   },
   "passkeyErrorNotSupported": {
-    "message": "Passkey not supported",
+    "message": "MetaMask can't use passkeys saved here. Try again and save it to a password manager.",
     "description": "Shown when passkey setup fails because the authenticator does not return the required PRF extension result."
   },
   "passkeyErrorRegistrationFailed": {

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6637,7 +6637,7 @@
     "description": "Shown when biometrics unlock fails because no passkey is enrolled. $1 is the OS-specific auth-method noun (Biometrics / Touch ID / Windows Hello)."
   },
   "passkeyErrorNotSupported": {
-    "message": "Passkey not supported",
+    "message": "MetaMask can't use passkeys saved here. Try again and save it to a password manager.",
     "description": "Shown when passkey setup fails because the authenticator does not return the required PRF extension result."
   },
   "passkeyErrorRegistrationFailed": {

--- a/ui/components/app/setup-passkey-content.tsx
+++ b/ui/components/app/setup-passkey-content.tsx
@@ -7,6 +7,8 @@ import React, {
 } from 'react';
 import log from 'loglevel';
 import {
+  BannerAlert,
+  BannerAlertSeverity,
   Box,
   Text,
   BoxFlexDirection,
@@ -19,7 +21,6 @@ import {
   TextVariant,
   FontWeight,
   TextColor,
-  TextAlign,
 } from '@metamask/design-system-react';
 import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../hooks/useI18nContext';
@@ -394,14 +395,11 @@ export default function SetupPasskeyContent({
           </Text>
 
           {enrollmentError ? (
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.ErrorDefault}
-              textAlign={TextAlign.Center}
+            <BannerAlert
+              severity={BannerAlertSeverity.Danger}
+              description={enrollmentError}
               data-testid="passkey-enrollment-error"
-            >
-              {enrollmentError}
-            </Text>
+            />
           ) : null}
 
           <Box

--- a/ui/pages/settings/security-and-password-tab/passkey-register-sub-page.tsx
+++ b/ui/pages/settings/security-and-password-tab/passkey-register-sub-page.tsx
@@ -3,6 +3,8 @@ import log from 'loglevel';
 import { useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
+  BannerAlert,
+  BannerAlertSeverity,
   Box,
   Text,
   BoxAlignItems,
@@ -13,7 +15,6 @@ import {
   Button,
   TextVariant,
   TextColor,
-  TextAlign,
 } from '@metamask/design-system-react';
 import {
   FormTextField,
@@ -429,14 +430,11 @@ export default function PasskeyRegisterSubPage() {
           ) : (
             <>
               {enrollmentError && (
-                <Text
-                  variant={TextVariant.BodySm}
-                  color={TextColor.ErrorDefault}
-                  textAlign={TextAlign.Center}
+                <BannerAlert
+                  severity={BannerAlertSeverity.Danger}
+                  description={enrollmentError}
                   data-testid="passkey-enrollment-error"
-                >
-                  {enrollmentError}
-                </Text>
+                />
               )}
 
               <Button


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR updated the error message and informative message to the biometrics setup, so that user won't be confused if ran into the `PRF not supported` error.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added informative error and messages for the passkey PRF not supported error.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/45783

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy and error UI only; no changes to passkey registration, PRF validation, or vault logic.
> 
> **Overview**
> When passkey setup fails because the authenticator doesn’t return the required **PRF** extension, users now see a clearer message instead of generic “Passkey not supported”: **MetaMask can’t use passkeys saved here**, with guidance to try again and save the passkey to a password manager (`passkeyErrorNotSupported` in **en** and **en_GB**).
> 
> Passkey enrollment errors on **onboarding setup** and **Settings → passkey register** are shown in a **danger `BannerAlert`** instead of centered red body text, so the PRF (and other enrollment) failures are more visible and consistent with the design system.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce333299afa46bf8e4805b7f5c0a1c66a61bddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->