### PR TITLE
fix: remove QuoteMetadata references in useHardwareWalletSignatures

### DIFF
--- a/ui/pages/hardware-wallets/swap/hooks/useHardwareWalletSignatures.test.tsx
+++ b/ui/pages/hardware-wallets/swap/hooks/useHardwareWalletSignatures.test.tsx
@@ -850,17 +850,19 @@ describe('useHardwareWalletSignatures', () => {
     it('navigates back to the bridge page when cancelling a non-sendBundle flow', async () => {
       mockUseHwSwapQuoteData.mockReturnValue({
         activeQuote: {
-          quote: { requestId: 'quote-1' },
-          sentAmount: { amount: '1' },
+          quote: {
+            requestId: 'quote-1',
+            src: { normalizedAmount: '1' },
+            dest: { normalizedAmount: '2' },
+          },
           trade: { from: FROM_ADDRESS, to: TO_ADDRESS },
         },
         lockedQuote: {
           quote: {
             requestId: 'quote-1',
-            srcTokenAmount: '1',
-            destTokenAmount: '2',
+            src: { normalizedAmount: '1' },
+            dest: { normalizedAmount: '2' },
           },
-          sentAmount: { amount: '1' },
           trade: { from: FROM_ADDRESS, to: TO_ADDRESS },
         },
         fromToken: { symbol: 'ETH' },

--- a/ui/pages/hardware-wallets/swap/hooks/useHardwareWalletSignatures.ts
+++ b/ui/pages/hardware-wallets/swap/hooks/useHardwareWalletSignatures.ts
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import type { QuoteMetadata, QuoteResponse } from '@metamask/bridge-controller';
+import type { QuoteResponse } from '@metamask/bridge-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { useAppSelector } from '../../../../store/store';
 
@@ -133,11 +133,11 @@ export function useHardwareWalletSignatures(): UseHardwareWalletSignaturesReturn
       : undefined,
   );
 
-  const { lockedQuote, fromToken, toToken } = useHwSwapQuoteData();
+  const { lockedQuote, fromToken } = useHwSwapQuoteData();
   const needsTwoConfirmations = isSendBundleFlow
     ? Boolean(sendBundleState?.needsTwoConfirmations)
     : Boolean(lockedQuote?.approval);
-  const fromAmount = lockedQuote?.sentAmount?.amount;
+  const fromAmount = lockedQuote?.quote.src?.normalizedAmount;
   const activeSigningRequestId =
     lockedQuote?.quote.requestId ?? sendBundleTxMeta?.id ?? '';
   const expectedSignTrackerTxIds = useMemo(() => {
@@ -232,7 +232,7 @@ export function useHardwareWalletSignatures(): UseHardwareWalletSignaturesReturn
    * submission started).
    */
   const submitBridgeTransaction = useCallback(
-    async (quoteResponse: QuoteResponse & QuoteMetadata) => {
+    async (quoteResponse: QuoteResponse) => {
       const submissionGeneration = retryGenerationRef.current;
 
       try {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Swap/bridge QuoteMetadata is deprecated. Read src/dest amounts from the nested fields on QuoteResponse instead.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: remove QuoteMetadata references in useHardwareWalletSignatures

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. No user-facing changes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small typing and field-path update with no auth or submission logic changes; tests were aligned to the new quote shape.
> 
> **Overview**
> Migrates hardware-wallet bridge signing off deprecated **QuoteMetadata** fields so amounts and submission types match the current **`QuoteResponse`** shape.
> 
> **`useHardwareWalletSignatures`** now derives the displayed from-amount from `lockedQuote.quote.src.normalizedAmount` instead of `lockedQuote.sentAmount.amount`, drops the unused `toToken` destructure, and types bridge submit as `QuoteResponse` only (no `QuoteMetadata` intersection). The bridge-cancel unit test mocks were updated to use nested `quote.src` / `quote.dest` `normalizedAmount` values instead of `sentAmount` and flat token amount fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 784e79856bb4fa6dd62cf4f7fce351111ce43a88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->