### PR TITLE
fix: persist split-state backup during recovery

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -998,9 +998,11 @@ export async function loadStateFromPersistence(backup) {
       if (backup) {
         // Recovery also needs every backed-up controller.
         for (const key of backedUpStateKeys) {
+          const value = versionedData.data[key];
           // Avoid queuing the same key twice.
-          if (!changedKeys.has(key)) {
-            persistenceManager.update(key, versionedData.data[key]);
+          // Missing backup values would delete existing state.
+          if (!changedKeys.has(key) && value !== undefined) {
+            persistenceManager.update(key, value);
           }
         }
       }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -985,15 +985,12 @@ export async function loadStateFromPersistence(backup) {
       await persistenceManager.persist();
     }
   } else if (persistenceManager.storageKind === 'split') {
-    if (writeAllKeysToState) {
-      for (const [key, value] of Object.entries(versionedData.data)) {
-        persistenceManager.update(key, value);
-      }
-    } else {
-      // write changes only
-      for (const key of changedKeys) {
-        persistenceManager.update(key, versionedData.data[key]);
-      }
+    const keysToPersist =
+      writeAllKeysToState || backup
+        ? new Set([...Object.keys(versionedData.data), ...changedKeys])
+        : changedKeys;
+    for (const key of keysToPersist) {
+      persistenceManager.update(key, versionedData.data[key]);
     }
     // write to disk
     await persistenceManager.persist();

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -985,10 +985,12 @@ export async function loadStateFromPersistence(backup) {
       await persistenceManager.persist();
     }
   } else if (persistenceManager.storageKind === 'split') {
-    const keysToPersist =
-      writeAllKeysToState || backup
-        ? new Set([...Object.keys(versionedData.data), ...changedKeys])
-        : changedKeys;
+    const keysToPersist = writeAllKeysToState
+      ? Object.keys(versionedData.data)
+      : new Set([
+          ...changedKeys,
+          ...(backup ? backedUpStateKeys : []),
+        ]);
     for (const key of keysToPersist) {
       persistenceManager.update(key, versionedData.data[key]);
     }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -986,15 +986,19 @@ export async function loadStateFromPersistence(backup) {
     }
   } else if (persistenceManager.storageKind === 'split') {
     if (writeAllKeysToState) {
+      // New state needs every controller persisted.
       for (const key of Object.keys(versionedData.data)) {
         persistenceManager.update(key, versionedData.data[key]);
       }
     } else {
+      // Existing state starts with explicitly changed controllers.
       for (const key of changedKeys) {
         persistenceManager.update(key, versionedData.data[key]);
       }
       if (backup) {
+        // Recovery also needs every backed-up controller.
         for (const key of backedUpStateKeys) {
+          // Avoid queuing the same key twice.
           if (!changedKeys.has(key)) {
             persistenceManager.update(key, versionedData.data[key]);
           }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -985,14 +985,21 @@ export async function loadStateFromPersistence(backup) {
       await persistenceManager.persist();
     }
   } else if (persistenceManager.storageKind === 'split') {
-    const keysToPersist = writeAllKeysToState
-      ? Object.keys(versionedData.data)
-      : new Set([
-          ...changedKeys,
-          ...(backup ? backedUpStateKeys : []),
-        ]);
-    for (const key of keysToPersist) {
-      persistenceManager.update(key, versionedData.data[key]);
+    if (writeAllKeysToState) {
+      for (const key of Object.keys(versionedData.data)) {
+        persistenceManager.update(key, versionedData.data[key]);
+      }
+    } else {
+      for (const key of changedKeys) {
+        persistenceManager.update(key, versionedData.data[key]);
+      }
+      if (backup) {
+        for (const key of backedUpStateKeys) {
+          if (!changedKeys.has(key)) {
+            persistenceManager.update(key, versionedData.data[key]);
+          }
+        }
+      }
     }
     // write to disk
     await persistenceManager.persist();

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -8,12 +8,14 @@ import {
   completeCreateNewWalletOnboardingFlow,
   completeVaultRecoveryOnboardingFlow,
 } from '../../page-objects/flows/onboarding.flow';
+import { reloadAndUnlock } from '../../page-objects/flows/login.flow';
 import {
   getBackupVault,
   getFirstAddress,
   onboardThenTriggerCorruptionFlow,
 } from '../../page-objects/flows/vault-corruption.flow';
 import VaultRecoveryPage from '../../page-objects/pages/vault-recovery-page';
+import { pausePersistence } from '../state-persistence/helpers';
 import { getConfig, mockFeatureFlagsWithoutNonEvmAccounts } from './helpers';
 
 describe('Vault Corruption', function () {
@@ -112,6 +114,10 @@ describe('Vault Corruption', function () {
           breakPrimaryDatabaseOnlyScript,
         );
 
+        // Disable debounced writes so this test verifies that recovery itself
+        // persists the restored vault before initialization completes.
+        await pausePersistence(driver);
+
         // start recovery
         const vaultRecoveryPage = new VaultRecoveryPage(driver);
         await vaultRecoveryPage.clickRecoveryButton({ confirm: true });
@@ -130,6 +136,18 @@ describe('Vault Corruption', function () {
           restoredFirstAddress,
           initialFirstAddress,
           'Addresses should match',
+        );
+
+        // Verify recovery survives a restart without relying on a later
+        // debounced controller state write.
+        await reloadAndUnlock(driver);
+        const persistedFirstAddress = await getFirstAddress(driver, undefined, {
+          waitForSync: false,
+        });
+        assert.equal(
+          persistedFirstAddress,
+          initialFirstAddress,
+          'Address should persist after extension restart',
         );
       },
     );

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -8,14 +8,13 @@ import {
   completeCreateNewWalletOnboardingFlow,
   completeVaultRecoveryOnboardingFlow,
 } from '../../page-objects/flows/onboarding.flow';
-import { reloadAndUnlock } from '../../page-objects/flows/login.flow';
 import {
   getBackupVault,
   getFirstAddress,
   onboardThenTriggerCorruptionFlow,
 } from '../../page-objects/flows/vault-corruption.flow';
 import VaultRecoveryPage from '../../page-objects/pages/vault-recovery-page';
-import { pausePersistence } from '../state-persistence/helpers';
+import { pausePersistence, readStorage } from '../state-persistence/helpers';
 import { getConfig, mockFeatureFlagsWithoutNonEvmAccounts } from './helpers';
 
 describe('Vault Corruption', function () {
@@ -75,12 +74,12 @@ describe('Vault Corruption', function () {
   }
 
   /**
-   * Script to break both the primary and backup databases.
+   * Script to break the primary database and delete one backup key.
    *
    * @param backupKeyToDelete - The key to delete from the backup database.
    */
-  const breakAllDatabasesScript = (
-    backupKeyToDelete: 'meta' | 'KeyringController',
+  const breakPrimaryDatabaseAndDeleteBackupKeyScript = (
+    backupKeyToDelete: 'AnalyticsController' | 'KeyringController' | 'meta',
   ) => {
     return createCorruptionScript(`
       // indexedDB is not scuttled in test builds, so we can use it to access the
@@ -102,7 +101,7 @@ describe('Vault Corruption', function () {
       };`);
   };
 
-  it('recovers metamask vault when primary database is broken but backup is intact', async function () {
+  it('preserves primary controller state omitted from the recovery backup', async function () {
     await withFixtures(
       {
         ...getConfig(this.test?.title),
@@ -111,12 +110,21 @@ describe('Vault Corruption', function () {
       async ({ driver }: { driver: Driver }) => {
         const initialFirstAddress = await onboardThenTriggerCorruptionFlow(
           driver,
-          breakPrimaryDatabaseOnlyScript,
+          breakPrimaryDatabaseAndDeleteBackupKeyScript('AnalyticsController'),
         );
+        const backupVault = await getBackupVault(driver);
+        assert.ok(backupVault, 'Expected backup vault to exist');
 
         // Disable debounced writes so this test verifies that recovery itself
         // persists the restored vault before initialization completes.
         await pausePersistence(driver);
+        const storageBeforeRecovery = await readStorage(driver);
+        assert.ok(
+          'AnalyticsController' in storageBeforeRecovery,
+          'AnalyticsController should exist in primary storage before recovery',
+        );
+        const analyticsStateBeforeRecovery =
+          storageBeforeRecovery.AnalyticsController;
 
         // start recovery
         const vaultRecoveryPage = new VaultRecoveryPage(driver);
@@ -137,17 +145,24 @@ describe('Vault Corruption', function () {
           initialFirstAddress,
           'Addresses should match',
         );
-
-        // Verify recovery survives a restart without relying on a later
-        // debounced controller state write.
-        await reloadAndUnlock(driver);
-        const persistedFirstAddress = await getFirstAddress(driver, undefined, {
-          waitForSync: false,
-        });
+        const storageAfterRecovery = await readStorage(driver);
+        assert.ok(
+          'AnalyticsController' in storageAfterRecovery,
+          'AnalyticsController should remain in primary storage after recovery',
+        );
+        assert.deepStrictEqual(
+          storageAfterRecovery.AnalyticsController,
+          analyticsStateBeforeRecovery,
+          'AnalyticsController should remain unchanged after recovery',
+        );
         assert.equal(
-          persistedFirstAddress,
-          initialFirstAddress,
-          'Address should persist after extension restart',
+          (
+            storageAfterRecovery.KeyringController as
+              | { vault?: unknown }
+              | undefined
+          )?.vault,
+          backupVault,
+          'Recovered vault should be persisted to primary storage',
         );
       },
     );
@@ -233,7 +248,7 @@ describe('Vault Corruption', function () {
       async ({ driver }: { driver: Driver }) => {
         const initialFirstAddress = await onboardThenTriggerCorruptionFlow(
           driver,
-          breakAllDatabasesScript('KeyringController'),
+          breakPrimaryDatabaseAndDeleteBackupKeyScript('KeyringController'),
         );
 
         // start reset
@@ -321,7 +336,7 @@ describe('Vault Corruption', function () {
       async ({ driver }: { driver: Driver }) => {
         const initialFirstAddress = await onboardThenTriggerCorruptionFlow(
           driver,
-          breakAllDatabasesScript('meta'),
+          breakPrimaryDatabaseAndDeleteBackupKeyScript('meta'),
         );
 
         // start recovery


### PR DESCRIPTION
## **Description**

When vault recovery loads a current-version backup with split-state storage, migrations can report no changed controller keys. The recovery path then persists metadata without writing the recovered vault to primary storage. Recovery appears successful in memory, but the recovery screen can return after the extension restarts.

This PR writes every recovered backup key in the existing awaited split-state persistence operation. It unions those keys with migration-reported changes so migration deletions keep their current semantics.

The vault-corruption E2E now disables later debounced controller writes before recovery, then restarts the extension and verifies that the original account can still be unlocked.

## **Changelog**

CHANGELOG entry: Fixed an issue that could make vault recovery repeat after MetaMask restarted

## **Related issues**

Related to #42740

## **Manual testing steps**

1. Load this branch's Chrome test build, create a wallet, and record the first account address.
2. Lock MetaMask and wait a few seconds for the vault backup to finish.
3. Open the extension service worker's DevTools and run `chrome.storage.local.set({ KeyringController: null }, () => chrome.runtime.reload())`.
4. Reopen MetaMask, choose the recovery option, confirm it, and sign in with the existing password.
5. Complete the recovery flow and verify that the original account address is present.
6. Reload MetaMask from `chrome://extensions`, reopen it, and sign in again.
7. Verify that the recovery screen does not return and that the original account address is still present.

<!--
## **Screenshots/Recordings**

Not applicable; this change has no visual impact.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches vault recovery and split-state persistence on startup; incorrect key handling could corrupt or drop controller state, but guards avoid double-writes and undefined backup deletions.
> 
> **Overview**
> Fixes vault recovery under **split-state** storage when migrations report no changed controller keys: recovery could succeed in memory but skip writing the restored vault (and other backup keys) to primary storage, so the recovery flow could reappear after restart.
> 
> During the existing split-state load path, when recovery runs from a **backup** (`backup` is true), the code now also queues **`backedUpStateKeys`** from the loaded state for persistence—skipping keys already in `changedKeys` and skipping undefined backup values so primary-only controllers are not wiped.
> 
> E2E updates rename the corruption helper to reflect **primary break + one backup key deleted**, and add **`preserves primary controller state omitted from the recovery backup`**, which pauses debounced persistence and asserts **`AnalyticsController`** stays unchanged, the recovered vault is written to primary storage, and the account address still matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3822b692d07c42ef01a3d6db5ef80ebfce5089ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->