### PR TITLE
fix: patch eth-json-rpc-middleware to accept numeric chainId

### DIFF
--- a/.yarn/patches/@metamask-eth-json-rpc-middleware-npm-24.0.0-5eb4bbc3a3.patch
+++ b/.yarn/patches/@metamask-eth-json-rpc-middleware-npm-24.0.0-5eb4bbc3a3.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/utils/validation.cjs b/dist/utils/validation.cjs
+index 9e150df1d23cc5996e9fcacadbc4e927ca8c2006..0879d9948a9463ef1f49610548538665263b616b 100644
+--- a/dist/utils/validation.cjs
++++ b/dist/utils/validation.cjs
+@@ -202,7 +202,7 @@ exports.TransactionParamsStruct = (0, superstruct_1.object)({
+         s: (0, superstruct_1.optional)((0, superstruct_1.string)()),
+         yParity: (0, superstruct_1.optional)((0, superstruct_1.string)()),
+     }))),
+-    chainId: (0, superstruct_1.optional)((0, superstruct_1.string)()),
++    chainId: (0, superstruct_1.optional)(QuantityStruct),
+     data: (0, superstruct_1.optional)((0, superstruct_1.string)()),
+     from: (0, superstruct_1.string)(),
+     gas: (0, superstruct_1.optional)(QuantityStruct),
+diff --git a/dist/utils/validation.mjs b/dist/utils/validation.mjs
+index 5929e1fe251a593a3fb3b17addd6e294bc790b37..4bff55631e1e0c282e4fee303074f0d82fab5033 100644
+--- a/dist/utils/validation.mjs
++++ b/dist/utils/validation.mjs
+@@ -193,7 +193,7 @@ export const TransactionParamsStruct = object({
+         s: optional(string()),
+         yParity: optional(string()),
+     }))),
+-    chainId: optional(string()),
++    chainId: optional(QuantityStruct),
+     data: optional(string()),
+     from: string(),
+     gas: optional(QuantityStruct),

--- a/package.json
+++ b/package.json
@@ -402,7 +402,7 @@
     "@metamask/ens-resolver-snap": "^1.2.0",
     "@metamask/eth-hd-keyring": "^15.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
-    "@metamask/eth-json-rpc-middleware": "^24.0.0",
+    "@metamask/eth-json-rpc-middleware": "patch:@metamask/eth-json-rpc-middleware@npm%3A24.0.0#~/.yarn/patches/@metamask-eth-json-rpc-middleware-npm-24.0.0-5eb4bbc3a3.patch",
     "@metamask/eth-ledger-bridge-keyring": "^13.1.0",
     "@metamask/eth-money-keyring": "3.0.0",
     "@metamask/eth-qr-keyring": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,6 +6626,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-json-rpc-middleware@npm:24.0.0":
+  version: 24.0.0
+  resolution: "@metamask/eth-json-rpc-middleware@npm:24.0.0"
+  dependencies:
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/json-rpc-engine": "npm:^10.5.0"
+    "@metamask/message-manager": "npm:^14.1.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    klona: "npm:^2.0.6"
+    safe-stable-stringify: "npm:^2.4.3"
+  checksum: 10/d78b93518b2914bdf049cbc7a3c8a6a353c1c79727b106c7eb108813528dc0f8a26ed7feef5b9e27a94239e58286af0d0fe4e4d15323ba4db13e1b64d97e5d48
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-json-rpc-middleware@npm:^23.1.3":
   version: 23.1.3
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.3"
@@ -6645,9 +6663,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^24.0.0":
+"@metamask/eth-json-rpc-middleware@patch:@metamask/eth-json-rpc-middleware@npm%3A24.0.0#~/.yarn/patches/@metamask-eth-json-rpc-middleware-npm-24.0.0-5eb4bbc3a3.patch":
   version: 24.0.0
-  resolution: "@metamask/eth-json-rpc-middleware@npm:24.0.0"
+  resolution: "@metamask/eth-json-rpc-middleware@patch:@metamask/eth-json-rpc-middleware@npm%3A24.0.0#~/.yarn/patches/@metamask-eth-json-rpc-middleware-npm-24.0.0-5eb4bbc3a3.patch::version=24.0.0&hash=4227fe"
   dependencies:
     "@metamask/eth-block-tracker": "npm:^15.0.1"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
@@ -6659,7 +6677,7 @@ __metadata:
     "@metamask/utils": "npm:^11.11.0"
     klona: "npm:^2.0.6"
     safe-stable-stringify: "npm:^2.4.3"
-  checksum: 10/d78b93518b2914bdf049cbc7a3c8a6a353c1c79727b106c7eb108813528dc0f8a26ed7feef5b9e27a94239e58286af0d0fe4e4d15323ba4db13e1b64d97e5d48
+  checksum: 10/851e9c765a731879a70e7377914542ca11c17f121b0ebc78cc5bbff986a9bb470ce3581fbb34fec4fcbba162c32fd69cbd4734ebbe87c12335be7ed73f25416c
   languageName: node
   linkType: hard
 
@@ -33237,7 +33255,7 @@ __metadata:
     "@metamask/eslint-plugin-design-tokens": "npm:^1.1.1"
     "@metamask/eth-hd-keyring": "npm:^15.0.0"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^24.0.0"
+    "@metamask/eth-json-rpc-middleware": "patch:@metamask/eth-json-rpc-middleware@npm%3A24.0.0#~/.yarn/patches/@metamask-eth-json-rpc-middleware-npm-24.0.0-5eb4bbc3a3.patch"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
     "@metamask/eth-ledger-bridge-keyring": "npm:^13.1.0"
     "@metamask/eth-money-keyring": "npm:3.0.0"


### PR DESCRIPTION
## **Description**

13.45.0 bumped `@metamask/eth-json-rpc-middleware` from `23.1.3` to `24.0.0` (#45273). That major added strict validation of `eth_sendTransaction` / `eth_signTransaction` params, and typed `chainId` as string-only while every sibling quantity field accepts `union([string(), number()])`. Dapps that send `chainId` as a JSON number — Uniswap's swap and approval paths always do — now get `-32602` and no confirmation window ever opens. Details in #45763.

The real fix is upstream in MetaMask/core#9965, which changes `chainId: optional(string())` to `optional(QuantityStruct)`. **This PR is a stopgap**: it applies that same one-line change as a yarn patch of `24.0.0`, so users on 13.45.0+ are unblocked without waiting for `24.0.1` to be released and bumped here.

It is meant to be reverted. Once `@metamask/eth-json-rpc-middleware@24.0.1` ships, drop the patch and bump the dependency — that's the change that should close #45763, not this one.

The hardening from MetaMask/core#9482 is untouched: the 200KB size cap, unknown top-level key rejection, and ill-typed field rejection all still apply. The patch widens exactly one field, and that field's value is discarded downstream anyway — `chainId` is absent from `normalizeTransactionParams`' allow-list in `@metamask/transaction-controller`, and the chain is derived from `networkClientId`.

### Scope notes

- The patch touches only `dist/utils/validation.cjs` and `dist/utils/validation.mjs` — one line each. The bundled `.d.cts` / `.d.mts` still declare `chainId?: string`, which is now narrower than runtime accepts. Left alone deliberately to keep the patch small: nothing in this repo imports `TransactionParamsStruct` or `validateTransactionParams`, so `yarn lint:tsc` is unaffected, and the upstream release corrects the types properly.
- `yarn patch-commit` also wanted to add a `resolutions` entry mapping `@metamask/eth-json-rpc-middleware@npm:^23.1.3` onto the patched 24.0.0. I removed it — that range belongs to `@metamask/network-controller@35.0.0`, and 23.1.3 predates `validateTransactionParams` entirely, so it is not affected by this bug and should not be silently force-upgraded.

### Verification

Run against the installed, patched package:

```
PASS  want=OK      got=OK      chainId as number (the bug)
PASS  want=OK      got=OK      chainId as hex string
PASS  want=REJECT  got=REJECT  unknown top-level key (hardening)  [Invalid params]
PASS  want=REJECT  got=REJECT  oversized data (size cap)          [Request too large]
```

Also clean: `yarn install --immutable` (tree stays clean), `yarn dedupe --check`, `yarn lint:lockfile`, `yarn --check-resolutions`.

Not verified locally: LavaMoat policies, since `yarn lavamoat:auto` is three full production builds. I expect no drift — the policy grants this package `TextEncoder` plus five packages, and `QuantityStruct` is an existing local const already used by seven sibling fields, so the patch introduces no new global or import. Adding to `.yarn/patches/` busts the build hash, so `validate-lavamoat-policies` will run and confirm. Note `@metamaskbot update-policies` is gated off for fork PRs, so if there is drift I'll need the `lavamoat-policy-diff-*` artifact from the failed run.

## **Changelog**

CHANGELOG entry: Fixed a bug that caused transactions from some dapps, including Uniswap swaps, to fail with an "Invalid params" error

## **Related issues**

Related to: #45763 (deliberately not closed by this PR — the dependency bump should close it)

Upstream: MetaMask/core#9965 (fix), MetaMask/core#9964 (issue)
Regressed by: #45273

## **Manual testing steps**

1. Add a network whose dapp sends a numeric `chainId` — e.g. Robinhood Chain, chainId `4663`, RPC `https://rpc.mainnet.chain.robinhood.com` — and fund the account.
2. Open https://app.uniswap.org/swap?chain=robinhood&inputCurrency=NATIVE&outputCurrency=0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168&value=0.001&field=input
3. Connect the wallet, press **Review**, then **Swap**.
4. On `main`: no confirmation opens; the console shows `Invalid params / chainId - Expected a string, but received: 4663`.
5. On this branch: the confirmation opens normally and the swap proceeds.

Any dapp sending a numeric `chainId` reproduces this on any network; the chain above is just a convenient one.

## **Screenshots/Recordings**

### **Before**

<!-- UPLOAD: "Swap failed" modal + console error -->

### **After**

<!-- UPLOAD: MetaMask confirmation opening normally -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
