### PR TITLE
chore(ui): migrate DeFi protocol cell AvatarGroup to MMDS

### DIFF
--- a/ui/components/app/assets/defi-list/cells/defi-protocol-cell.tsx
+++ b/ui/components/app/assets/defi-list/cells/defi-protocol-cell.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import {
+  AvatarGroup,
+  AvatarGroupSize,
+  AvatarGroupVariant,
+} from '@metamask/design-system-react';
 import GenericAssetCellLayout from '../../asset-list/cells/generic-asset-cell-layout';
 import { getPreferences } from '../../../../../../shared/lib/selectors/preferences';
 import { SensitiveText } from '../../../../component-library';
-import { AvatarType } from '../../../../multichain/avatar-group/avatar-group.types';
 import { AssetCellBadge } from '../../asset-list/cells/asset-cell-badge';
 import { AssetCellTitle } from '../../asset-list/cells/asset-title';
 import {
@@ -12,7 +16,6 @@ import {
 } from '../../../../../../shared/constants/metametrics';
 import { useAnalytics } from '../../../../../hooks/useAnalytics';
 import { DeFiProtocolPosition } from '../../types';
-import { AvatarGroup } from '../../../../multichain/avatar-group/avatar-group';
 import { DeFiSymbolGroup } from './defi-grouped-symbol-cell';
 
 type DeFiProtocolCellProps = {
@@ -76,9 +79,14 @@ export default function DefiProtocolCell({
       }
       footerRightDisplay={
         <AvatarGroup
-          avatarType={AvatarType.TOKEN}
-          limit={4}
-          members={position.iconGroup}
+          variant={AvatarGroupVariant.Token}
+          size={AvatarGroupSize.Xs}
+          max={4}
+          data-testid="avatar-group"
+          avatarPropsArr={position.iconGroup.map((icon) => ({
+            src: icon.avatarValue,
+            name: icon.symbol,
+          }))}
         />
       }
     />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Migrates one remaining consumer of the deprecated extension `ui/components/multichain/avatar-group` wrapper to `AvatarGroup` from `@metamask/design-system-react`.

The DeFi protocol list cell (legacy V1 list, used when the DeFi controller V2 flag is off) still passed the extension-only `avatarType` / `members` / `limit` API. That maps to the MMDS API documented in [metamask-design-system#1460](https://github.com/MetaMask/metamask-design-system/pull/1460):

- `avatarType={AvatarType.TOKEN}` → `variant={AvatarGroupVariant.Token}`
- `members` (`avatarValue` / `symbol`) → `avatarPropsArr` (`src` / `name`)
- `limit` → `max`
- explicit `size={AvatarGroupSize.Xs}` so we keep the extension default (MMDS defaults to `Md`)

`data-testid="avatar-group"` is preserved so existing DeFi tab E2E selectors keep working. This matches the already-migrated V2 cell in `defi-protocol-cell-v2.tsx`.

## **Changelog**

CHANGELOG entry: Updated the DeFi protocol list token avatars to use the design-system AvatarGroup component

## **Related issues**

Fixes: N/A

Related: [MetaMask/metamask-design-system#1460](https://github.com/MetaMask/metamask-design-system/pull/1460), [MetaMask/metamask-extension#45733](https://github.com/MetaMask/metamask-extension/pull/45733)

## **Manual testing steps**

1. Run the extension with the DeFi controller V2 flag **disabled** so the legacy DeFi list is shown.
2. Go to the homepage DeFi tab on a network/account that has at least one DeFi protocol position with underlying token icons.
3. Confirm the protocol row still shows the stacked token avatars on the right of the cell.
4. If a protocol has more than four underlying tokens, confirm the overflow `+N` badge still appears.
5. Enable "Hide zero-balance" / privacy mode if available and confirm the cell still renders without errors.
6. Click a protocol row and confirm DeFi details still open.

## **Screenshots/Recordings**

Renders of the DeFi protocol list cell AvatarGroup with the same token data, before and after swapping the legacy wrapper for MMDS. The Aave V3 row is the typical 2-token stack; Uniswap V3 shows overflow (`limit`/`max` 4).

### **Before**

Legacy `ui/components/multichain/avatar-group`: reverse stack order and overflow as separate `+N` text.

<img width="720" height="346" alt="image" src="https://github.com/user-attachments/assets/0e15c247-c90d-47f7-9b32-b985739af9ef" />


### **After**

MMDS `AvatarGroup`: original token order, overlapping avatars with borders, and overflow as an `AvatarBase` `+N` badge.

<img width="720" height="346" alt="image" src="https://github.com/user-attachments/assets/6592d301-9a59-4d63-bd19-da20a8d6e824" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab153936-c79e-4dc6-8536-869ff972f0c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab153936-c79e-4dc6-8536-869ff972f0c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

