### PR TITLE
fix: cp-13.45.1 update `eth-json-rpc-middleware` to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,7 +402,7 @@
     "@metamask/ens-resolver-snap": "^1.2.0",
     "@metamask/eth-hd-keyring": "^15.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
-    "@metamask/eth-json-rpc-middleware": "^24.0.0",
+    "@metamask/eth-json-rpc-middleware": "npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434",
     "@metamask/eth-ledger-bridge-keyring": "^13.1.0",
     "@metamask/eth-money-keyring": "3.0.0",
     "@metamask/eth-qr-keyring": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -402,7 +402,7 @@
     "@metamask/ens-resolver-snap": "^1.2.0",
     "@metamask/eth-hd-keyring": "^15.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
-    "@metamask/eth-json-rpc-middleware": "npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434",
+    "@metamask/eth-json-rpc-middleware": "^24.0.1",
     "@metamask/eth-ledger-bridge-keyring": "^13.1.0",
     "@metamask/eth-money-keyring": "3.0.0",
     "@metamask/eth-qr-keyring": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,24 +6626,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434":
-  version: 24.0.0-preview-9a81434
-  resolution: "@metamask-previews/eth-json-rpc-middleware@npm:24.0.0-preview-9a81434"
-  dependencies:
-    "@metamask/eth-block-tracker": "npm:^15.0.1"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/json-rpc-engine": "npm:^10.5.0"
-    "@metamask/message-manager": "npm:^14.1.2"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
-    klona: "npm:^2.0.6"
-    safe-stable-stringify: "npm:^2.4.3"
-  checksum: 10/80a6bfcb26db8bc9e29d8ff5a3246cd4d11a08204d2530c841328a36bf4cfa03688769016c8a622adcc2daa72dd39b9dfcc889ad0cb5d2bf4f57f83107685adc
-  languageName: node
-  linkType: hard
-
 "@metamask/eth-json-rpc-middleware@npm:^23.1.3":
   version: 23.1.3
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.3"
@@ -6660,6 +6642,24 @@ __metadata:
     pify: "npm:^5.0.0"
     safe-stable-stringify: "npm:^2.4.3"
   checksum: 10/aee4866afa78cb21aed9daa1211ee9a3515cb9549d9b325d5904b8769fb54790296224b58ec3555eb34a7125d2fd5180d6cba915bb1ca8dc3f04bf75e502c6b0
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-json-rpc-middleware@npm:^24.0.1":
+  version: 24.0.1
+  resolution: "@metamask/eth-json-rpc-middleware@npm:24.0.1"
+  dependencies:
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/json-rpc-engine": "npm:^10.5.0"
+    "@metamask/message-manager": "npm:^14.1.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    klona: "npm:^2.0.6"
+    safe-stable-stringify: "npm:^2.4.3"
+  checksum: 10/54ebe641625c1dec7c8d2e9b46551ca9b0006b2b0f0cbdb6aa79644334222711b15cc660250710c4d5bfd0767e5a5e27a35f62dc93e63d90e35e1cf83727be28
   languageName: node
   linkType: hard
 
@@ -33237,7 +33237,7 @@ __metadata:
     "@metamask/eslint-plugin-design-tokens": "npm:^1.1.1"
     "@metamask/eth-hd-keyring": "npm:^15.0.0"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
-    "@metamask/eth-json-rpc-middleware": "npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434"
+    "@metamask/eth-json-rpc-middleware": "npm:^24.0.1"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
     "@metamask/eth-ledger-bridge-keyring": "npm:^13.1.0"
     "@metamask/eth-money-keyring": "npm:3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,6 +6626,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-json-rpc-middleware@npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434":
+  version: 24.0.0-preview-9a81434
+  resolution: "@metamask-previews/eth-json-rpc-middleware@npm:24.0.0-preview-9a81434"
+  dependencies:
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/json-rpc-engine": "npm:^10.5.0"
+    "@metamask/message-manager": "npm:^14.1.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    klona: "npm:^2.0.6"
+    safe-stable-stringify: "npm:^2.4.3"
+  checksum: 10/80a6bfcb26db8bc9e29d8ff5a3246cd4d11a08204d2530c841328a36bf4cfa03688769016c8a622adcc2daa72dd39b9dfcc889ad0cb5d2bf4f57f83107685adc
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-json-rpc-middleware@npm:^23.1.3":
   version: 23.1.3
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.3"
@@ -6642,24 +6660,6 @@ __metadata:
     pify: "npm:^5.0.0"
     safe-stable-stringify: "npm:^2.4.3"
   checksum: 10/aee4866afa78cb21aed9daa1211ee9a3515cb9549d9b325d5904b8769fb54790296224b58ec3555eb34a7125d2fd5180d6cba915bb1ca8dc3f04bf75e502c6b0
-  languageName: node
-  linkType: hard
-
-"@metamask/eth-json-rpc-middleware@npm:^24.0.0":
-  version: 24.0.0
-  resolution: "@metamask/eth-json-rpc-middleware@npm:24.0.0"
-  dependencies:
-    "@metamask/eth-block-tracker": "npm:^15.0.1"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/json-rpc-engine": "npm:^10.5.0"
-    "@metamask/message-manager": "npm:^14.1.2"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.11.0"
-    klona: "npm:^2.0.6"
-    safe-stable-stringify: "npm:^2.4.3"
-  checksum: 10/d78b93518b2914bdf049cbc7a3c8a6a353c1c79727b106c7eb108813528dc0f8a26ed7feef5b9e27a94239e58286af0d0fe4e4d15323ba4db13e1b64d97e5d48
   languageName: node
   linkType: hard
 
@@ -33237,7 +33237,7 @@ __metadata:
     "@metamask/eslint-plugin-design-tokens": "npm:^1.1.1"
     "@metamask/eth-hd-keyring": "npm:^15.0.0"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^24.0.0"
+    "@metamask/eth-json-rpc-middleware": "npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
     "@metamask/eth-ledger-bridge-keyring": "npm:^13.1.0"
     "@metamask/eth-money-keyring": "npm:3.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`@metamask/eth-json-rpc-middleware@24.0.0` added strict Superstruct validation of `eth_sendTransaction` / `eth_signTransaction` params. Most numeric fields accept both hex strings and numbers, but `chainId` (and the `authorizationList` `chainId` / `nonce` / `yParity` fields) were validated as string-only. As a result, requests that send a numeric `chainId` are rejected with `-32602 Invalid params` (`chainId - Expected a string, but received: <number>`), and no confirmation opens.

This updates `@metamask/eth-json-rpc-middleware` to a build that aligns those fields with the other quantity fields so they accept both hex strings and numbers, restoring the previous behavior.

> [!NOTE]
> This PR currently points `@metamask/eth-json-rpc-middleware` at a preview build (`npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434`) so the fix can be tested end-to-end. **This will be replaced with the released version before merge.**

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed transactions from dapps that send a numeric `chainId` being rejected with an "Invalid params" error instead of opening a confirmation.

## **Related issues**

Fixes: #45763

## **Manual testing steps**

1. Build and run this branch (`yarn start`), and load the unpacked build into the browser.
2. Open a dapp (e.g. the [test dapp](https://metamask.github.io/test-dapp/)) and connect the wallet.
3. Trigger an `eth_sendTransaction` whose `chainId` param is a JSON number rather than a hex string, e.g. from the browser console:
   ```js
   await ethereum.request({
     method: 'eth_sendTransaction',
     params: [{ from: ethereum.selectedAddress, to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb', value: '0x0', chainId: 4663 }],
   });
   ```
4. Confirm the transaction confirmation opens (instead of failing with `-32602 Invalid params - chainId - Expected a string, but received: 4663`).
5. Confirm a normal transaction (no `chainId`, or a hex-string `chainId`) still works as before.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="2041" height="1291" alt="before" src="https://github.com/user-attachments/assets/0080a7c8-9610-450f-b962-ee02efec915f" />


### **After - with @metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434**

<img width="1926" height="1179" alt="after" src="https://github.com/user-attachments/assets/26130729-a730-4849-baaf-3e6050fc24a9" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes JSON-RPC param validation on the dapp transaction path (middleware used by the wallet engine); behavior fix rather than new extension logic, but it affects whether transactions reach confirmation.
> 
> **Overview**
> Bumps **`@metamask/eth-json-rpc-middleware`** from `^24.0.0` to **`^24.0.1`** (lockfile only—no extension source changes). The wallet RPC stack still wires this package through **`createMetamaskMiddleware`** / **`createWalletMiddleware`**.
> 
> **24.0.0** tightened Superstruct validation on **`eth_sendTransaction`** and **`eth_signTransaction`**, but treated **`chainId`** (and related **`authorizationList`** quantity fields) as strings only. Dapps that pass a **numeric** `chainId` hit **`-32602 Invalid params`** and never reach the confirmation UI. **24.0.1** restores parity with other quantity fields so those values can be hex strings or numbers again.
> 
> The lockfile also picks up a transitive **`@metamask/superstruct`** bump (`^3.1.0` → **`^3.4.1`**) on that middleware package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36c1cf52f8256696289852cfa6ad0e31d17501d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->