### PR TITLE
fix(ramps): align quote limit handling with mobile

### DIFF
--- a/ui/pages/ramps/build-quote/build-quote.test.tsx
+++ b/ui/pages/ramps/build-quote/build-quote.test.tsx
@@ -243,6 +243,27 @@ describe('RampsBuildQuoteScreen', () => {
     expect(screen.getByTestId('ramps-build-quote-continue')).toBeDisabled();
   });
 
+  it('does not fetch a quote for a stale debounced amount', () => {
+    jest.useFakeTimers();
+
+    renderWithProvider(
+      <RampsBuildQuoteScreen />,
+      createStore(),
+      '/ramps/build-quote',
+    );
+
+    fireEvent.change(screen.getByTestId('ramps-build-quote-amount-input'), {
+      target: { value: '25' },
+    });
+    fireEvent.change(screen.getByTestId('ramps-build-quote-amount-input'), {
+      target: { value: '100' },
+    });
+
+    expect(useRampsQuotes).not.toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 25 }),
+    );
+  });
+
   it('opens the provider widget via background watch and returns home on continue', async () => {
     mockGetBuyWidgetData.mockResolvedValue({
       url: 'https://provider.example/checkout',

--- a/ui/pages/ramps/build-quote/hooks/useRampsBuildQuote.ts
+++ b/ui/pages/ramps/build-quote/hooks/useRampsBuildQuote.ts
@@ -18,6 +18,8 @@ import {
 import { getCurrencySymbol } from '../../../../helpers/utils/common.util';
 import { showBuyTabOpenedToast } from '../../../../helpers/utils/show-buy-tab-opened-toast';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useFormatters } from '../../../../hooks/useFormatters';
+import { useDebouncedValue } from '../../../../hooks/useDebouncedValue';
 import { useRampsController } from '../../../../hooks/ramps/useRampsController';
 import { useRampsQuotes } from '../../../../hooks/ramps/useRampsQuotes';
 import { getRampCallbackBaseUrl } from '../../../../hooks/ramps/utils/getRampCallbackBaseUrl';
@@ -32,6 +34,7 @@ import {
   resolveDisplayedQuoteError,
   resolvePaymentMethodLabel,
 } from '../utils/build-quote';
+import { getProviderLimitMessage } from '../../utils/getProviderLimitMessage';
 import { useBuildQuoteAmount } from './useBuildQuoteAmount';
 
 type BuildQuoteLocationState = {
@@ -64,6 +67,7 @@ export type RampsBuildQuoteViewModel =
 
 export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
   const t = useI18nContext();
+  const { formatCurrency } = useFormatters();
   const navigate = useNavigate();
   const location = useLocation();
   const selectedAccount = useSelector(getSelectedInternalAccount);
@@ -106,6 +110,20 @@ export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
   const walletAddress = (chainAccount ?? selectedAccount)?.address ?? '';
   const hasAmount = amountAsNumber > 0;
   const hasSettledQuoteAmount = amountAsNumber === debouncedAmount;
+  const amountLimitError = getProviderLimitMessage({
+    provider: selectedProvider,
+    fiatCurrency: userRegion?.country?.currency,
+    paymentMethodId: selectedPaymentMethod?.id,
+    amount: amountAsNumber,
+    currency,
+    formatCurrency,
+    t,
+  });
+  const debouncedAmountLimitError = useDebouncedValue(amountLimitError);
+  const displayedAmountLimitError =
+    amountLimitError === debouncedAmountLimitError
+      ? amountLimitError
+      : null;
 
   const quoteFetchEnabled = Boolean(
     walletAddress &&
@@ -113,7 +131,8 @@ export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
     selectedProvider &&
     selectedToken?.assetId &&
     tokenStateIsSettled &&
-    debouncedAmount > 0,
+    debouncedAmount > 0 &&
+    !amountLimitError,
   );
 
   const quoteFetchParams = useMemo(
@@ -168,6 +187,23 @@ export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
     quotesResponse,
     selectedQuote,
   });
+  const providerQuoteError = quotesResponse?.error?.find(
+    (error) => error.provider === selectedProvider?.id && error.error,
+  )?.error;
+  const displayedError =
+    displayedAmountLimitError ??
+    (displayedQuoteError && providerQuoteError === displayedQuoteError
+      ? getProviderLimitMessage({
+          provider: selectedProvider,
+          fiatCurrency: userRegion?.country?.currency,
+          paymentMethodId: selectedPaymentMethod?.id,
+          amount: amountAsNumber,
+          currency,
+          formatCurrency,
+          t,
+          backendError: providerQuoteError,
+        }) ?? t('rampsQuoteUnavailable')
+      : displayedQuoteError);
 
   const paymentMethodLabel = useMemo(
     () =>
@@ -295,7 +331,7 @@ export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
       paymentMethodsStatus === 'loading' &&
       paymentMethods.length === 0 &&
       !selectedPaymentMethod,
-    displayedQuoteError: continueError ?? displayedQuoteError,
+    displayedQuoteError: continueError ?? displayedError,
     providerStatusLabel: providerLabel,
     isQuoteLoading: isQuoteLoading || isContinuing,
     canContinue,

--- a/ui/pages/ramps/build-quote/hooks/useRampsBuildQuote.ts
+++ b/ui/pages/ramps/build-quote/hooks/useRampsBuildQuote.ts
@@ -121,9 +121,7 @@ export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
   });
   const debouncedAmountLimitError = useDebouncedValue(amountLimitError);
   const displayedAmountLimitError =
-    amountLimitError === debouncedAmountLimitError
-      ? amountLimitError
-      : null;
+    amountLimitError === debouncedAmountLimitError ? amountLimitError : null;
 
   const quoteFetchEnabled = Boolean(
     walletAddress &&
@@ -193,7 +191,7 @@ export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
   const displayedError =
     displayedAmountLimitError ??
     (displayedQuoteError && providerQuoteError === displayedQuoteError
-      ? getProviderLimitMessage({
+      ? (getProviderLimitMessage({
           provider: selectedProvider,
           fiatCurrency: userRegion?.country?.currency,
           paymentMethodId: selectedPaymentMethod?.id,
@@ -202,7 +200,7 @@ export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
           formatCurrency,
           t,
           backendError: providerQuoteError,
-        }) ?? t('rampsQuoteUnavailable')
+        }) ?? t('rampsQuoteUnavailable'))
       : displayedQuoteError);
 
   const paymentMethodLabel = useMemo(
@@ -324,9 +322,7 @@ export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
     currencySymbol,
     amount,
     amountTextClassName: `text-[56px] font-normal leading-none ${
-      (continueError ?? displayedError)
-        ? 'text-error-default'
-        : 'text-default'
+      (continueError ?? displayedError) ? 'text-error-default' : 'text-default'
     }`,
     paymentMethodLabel,
     showPaymentMethodSpinner:

--- a/ui/pages/ramps/build-quote/hooks/useRampsBuildQuote.ts
+++ b/ui/pages/ramps/build-quote/hooks/useRampsBuildQuote.ts
@@ -130,6 +130,7 @@ export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
     selectedToken?.assetId &&
     tokenStateIsSettled &&
     debouncedAmount > 0 &&
+    hasSettledQuoteAmount &&
     !amountLimitError,
   );
 

--- a/ui/pages/ramps/build-quote/hooks/useRampsBuildQuote.ts
+++ b/ui/pages/ramps/build-quote/hooks/useRampsBuildQuote.ts
@@ -324,7 +324,9 @@ export function useRampsBuildQuote(): RampsBuildQuoteViewModel {
     currencySymbol,
     amount,
     amountTextClassName: `text-[56px] font-normal leading-none ${
-      displayedQuoteError ? 'text-error-default' : 'text-default'
+      (continueError ?? displayedError)
+        ? 'text-error-default'
+        : 'text-default'
     }`,
     paymentMethodLabel,
     showPaymentMethodSpinner:

--- a/ui/pages/ramps/payment-method/payment-method.test.tsx
+++ b/ui/pages/ramps/payment-method/payment-method.test.tsx
@@ -408,6 +408,42 @@ describe('RampsPaymentMethodScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith(PREVIOUS_ROUTE);
   });
 
+  it('does not reuse a provider error across payment methods', () => {
+    mockLocationState = { amount: 100 };
+    mockUseRampsQuotes.mockReturnValue({
+      data: {
+        success: [],
+        sorted: [],
+        error: [
+          {
+            provider: selectedProvider.id,
+            error: 'Minimum purchase is 24 USD',
+          },
+        ],
+        customActions: [],
+      },
+      loading: false,
+      status: 'success',
+      isSuccess: true,
+      error: null,
+      getQuotes: jest.fn(),
+      getBuyWidgetData: jest.fn(),
+    });
+
+    renderWithProvider(
+      <RampsPaymentMethodScreen />,
+      createStore(),
+      '/ramps/payment-method',
+    );
+
+    expect(
+      screen.getByTestId('ramps-payment-method-item-debit-credit-card'),
+    ).toHaveTextContent('Quote unavailable');
+    expect(
+      screen.getByTestId('ramps-payment-method-item-bank-transfer'),
+    ).toHaveTextContent('Quote unavailable');
+  });
+
   it('selects a payment method and navigates back', async () => {
     renderWithProvider(
       <RampsPaymentMethodScreen />,

--- a/ui/pages/ramps/payment-method/payment-method.tsx
+++ b/ui/pages/ramps/payment-method/payment-method.tsx
@@ -223,10 +223,6 @@ export function RampsPaymentMethodScreen() {
                   currency: fiatCurrency,
                   formatCurrency,
                   t,
-                  backendError: quotes?.error?.find(
-                    (error) =>
-                      error.provider === selectedProvider?.id && error.error,
-                  )?.error,
                 }) ?? t('rampsQuoteUnavailable'))
               : undefined;
 

--- a/ui/pages/ramps/payment-method/payment-method.tsx
+++ b/ui/pages/ramps/payment-method/payment-method.tsx
@@ -21,12 +21,14 @@ import { useRampsQuotes } from '../../../hooks/ramps/useRampsQuotes';
 import { getRampCallbackBaseUrl } from '../../../hooks/ramps/utils/getRampCallbackBaseUrl';
 import { normalizeAssetIdForApi } from '../../../hooks/ramps/utils/normalizeAssetIdForApi';
 import { useFiatFormatter } from '../../../hooks/useFiatFormatter';
+import { useFormatters } from '../../../hooks/useFormatters';
 import { ScrollContainer } from '../../../contexts/scroll-container';
 import RampsListSkeleton from '../components/ramps-list-skeleton';
 import {
   RampsSelectionCenteredMessage,
   RampsSelectionPage,
 } from '../components/ramps-selection-page';
+import { getProviderLimitMessage } from '../utils/getProviderLimitMessage';
 import RampsChangeProviderFooter from './components/ramps-change-provider-footer';
 import RampsPaymentMethodListItem from './components/ramps-payment-method-list-item';
 import {
@@ -64,6 +66,7 @@ export function RampsPaymentMethodScreen() {
   const fiatCurrency = userRegion?.country?.currency ?? 'USD';
   const regionCode = userRegion?.regionCode ?? '';
   const formatFiat = useFiatFormatter({ overrideCurrency: fiatCurrency });
+  const { formatCurrency } = useFormatters();
   useRampsScreenViewed('Payment Method');
   const [isSelecting, setIsSelecting] = useState(false);
   const isSelectingRef = useRef(false);
@@ -212,7 +215,19 @@ export function RampsPaymentMethodScreen() {
             const hasQuoteError =
               !quotesLoading && quotes !== null && matchedQuote === null;
             const quoteErrorMessage = hasQuoteError
-              ? t('rampsQuoteUnavailable')
+              ? (getProviderLimitMessage({
+                  provider: selectedProvider,
+                  fiatCurrency,
+                  paymentMethodId: paymentMethod.id,
+                  amount,
+                  currency: fiatCurrency,
+                  formatCurrency,
+                  t,
+                  backendError: quotes?.error?.find(
+                    (error) =>
+                      error.provider === selectedProvider?.id && error.error,
+                  )?.error,
+                }) ?? t('rampsQuoteUnavailable'))
               : undefined;
 
             return (

--- a/ui/pages/ramps/utils/getProviderLimitMessage.test.ts
+++ b/ui/pages/ramps/utils/getProviderLimitMessage.test.ts
@@ -68,4 +68,35 @@ describe('getProviderLimitMessage', () => {
   it('returns null when amount is not positive', () => {
     expect(getProviderLimitMessage({ ...baseArgs, amount: 0 })).toBeNull();
   });
+
+  it('returns a backend minimum limit error when structured limits are missing', () => {
+    expect(
+      getProviderLimitMessage({
+        ...baseArgs,
+        provider: { id: '/providers/x', name: 'X' } as unknown as Provider,
+        amount: 100,
+        backendError: 'Minimum purchase is 24 USD',
+      }),
+    ).toBe('Minimum purchase is 24 USD');
+  });
+
+  it('returns a backend maximum limit error when the amount is within stale structured limits', () => {
+    expect(
+      getProviderLimitMessage({
+        ...baseArgs,
+        amount: 100,
+        backendError: 'Maximum purchase is 90 USD',
+      }),
+    ).toBe('Maximum purchase is 90 USD');
+  });
+
+  it('ignores non-limit backend errors', () => {
+    expect(
+      getProviderLimitMessage({
+        ...baseArgs,
+        amount: 100,
+        backendError: 'Provider temporarily unavailable',
+      }),
+    ).toBeNull();
+  });
 });

--- a/ui/pages/ramps/utils/getProviderLimitMessage.ts
+++ b/ui/pages/ramps/utils/getProviderLimitMessage.ts
@@ -13,7 +13,14 @@ type GetProviderLimitMessageArgs = {
   currency: string;
   formatCurrency: FormatCurrency;
   t: TranslateFn;
+  backendError?: string | null;
 };
+
+function isProviderLimitError(message: string | null | undefined): boolean {
+  return Boolean(
+    message && /\b(minimum|maximum)\s+purchase\s+is\b/iu.test(message),
+  );
+}
 
 /**
  * Resolves the user-facing limit message for a provider that can't quote.
@@ -31,6 +38,7 @@ type GetProviderLimitMessageArgs = {
  * @param args.amount
  * @param args.currency
  * @param args.formatCurrency
+ * @param args.backendError
  * @param args.t
  * @returns The localized limit message, or null.
  */
@@ -42,28 +50,32 @@ export function getProviderLimitMessage({
   currency,
   formatCurrency,
   t,
+  backendError,
 }: GetProviderLimitMessageArgs): string | null {
-  if (amount <= 0) {
-    return null;
+  if (amount > 0) {
+    const buyLimit = getProviderBuyLimit(
+      provider,
+      fiatCurrency,
+      paymentMethodId,
+    );
+
+    if (buyLimit) {
+      if (Number.isFinite(buyLimit.minAmount) && amount < buyLimit.minAmount) {
+        return t('rampsMinPurchaseLimit', [
+          formatCurrency(buyLimit.minAmount, currency),
+        ]);
+      }
+
+      if (Number.isFinite(buyLimit.maxAmount) && amount > buyLimit.maxAmount) {
+        return t('rampsMaxPurchaseLimit', [
+          formatCurrency(buyLimit.maxAmount, currency),
+        ]);
+      }
+    }
   }
 
-  const buyLimit = getProviderBuyLimit(provider, fiatCurrency, paymentMethodId);
-
-  if (!buyLimit) {
-    return null;
+  if (isProviderLimitError(backendError)) {
+    return backendError ?? null;
   }
-
-  if (Number.isFinite(buyLimit.minAmount) && amount < buyLimit.minAmount) {
-    return t('rampsMinPurchaseLimit', [
-      formatCurrency(buyLimit.minAmount, currency),
-    ]);
-  }
-
-  if (Number.isFinite(buyLimit.maxAmount) && amount > buyLimit.maxAmount) {
-    return t('rampsMaxPurchaseLimit', [
-      formatCurrency(buyLimit.maxAmount, currency),
-    ]);
-  }
-
   return null;
 }


### PR DESCRIPTION
## **Description**

The extension ramps flow did not validate provider amount limits before requesting quotes and did not consistently surface actionable provider limit errors. This caused misleading quote-unavailable states for provider boundaries such as Mercuryo and Banxa/Revolut quote failures.

This change aligns the extension with the existing mobile behavior by validating known provider limits, skipping quote requests for invalid amounts, and falling back to provider-returned minimum/maximum messages when structured limits are unavailable or stale.

## **Changelog**

CHANGELOG entry: Fixed provider quote errors and amount-limit handling in the buy flow

## **Related issues**

Fixes: [TRAM-3931](https://consensyssoftware.atlassian.net/browse/TRAM-3931)


## **Manual testing steps**

1. Run the extension and open the Buy flow.
2. Select a region, token, provider, and payment method with published provider limits.
3. Enter an amount below the provider minimum and verify the localized minimum-purchase error appears, the amount is styled as invalid, Continue is disabled, and no quote request is made.
4. Enter an amount above the provider maximum and verify the corresponding maximum-purchase behavior.
5. Enter exactly the minimum and maximum boundaries and verify they are treated as valid and quotes are requested.
6. Use a provider/amount combination that returns a backend minimum or maximum error and verify the actionable provider message is shown.
7. Open the payment-method selector and verify provider-specific limit errors are shown there while non-limit failures remain generic Quote unavailable errors.

<!--
## **Screenshots/Recordings**

### **After**


https://github.com/user-attachments/assets/2f5b565c-4173-43ed-97c5-92dae8b91948


-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TRAM-3931]: https://consensyssoftware.atlassian.net/browse/TRAM-3931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quote-fetch gating and user-visible error paths in the ramps buy flow; incorrect limit logic could block valid purchases or show wrong errors.
> 
> **Overview**
> Aligns the extension **buy** flow with mobile by validating provider min/max limits **before** requesting quotes and showing clearer limit messaging instead of generic quote failures.
> 
> On **build quote**, `useRampsBuildQuote` uses `getProviderLimitMessage` (with debounced display) to block quote fetches when the amount is out of bounds, when debounce has not settled, or while a limit error is active—so rapid edits no longer trigger requests for stale amounts. Provider min/max strings from the quotes API are surfaced when they match limit-style errors and structured limits are missing or stale.
> 
> **`getProviderLimitMessage`** now accepts an optional `backendError` and only passes through messages that look like minimum/maximum purchase limits.
> 
> On **payment method** selection, missing per-method quotes prefer localized limit text from published provider limits, falling back to **Quote unavailable** when limits cannot be inferred (including provider-wide backend errors that must not be shown on every row).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9d9249cfbf03cd94e44fe62e1a8195f4f87e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->