### PR TITLE
fix(persistence): stop reporting "The browser is shutting down." as a storage failure

### DIFF
--- a/shared/constants/errors.test.ts
+++ b/shared/constants/errors.test.ts
@@ -69,6 +69,20 @@ describe('isBrowserShuttingDownError', () => {
     expect(isBrowserShuttingDownError({})).toBe(false);
     expect(isBrowserShuttingDownError({ message: 42 })).toBe(false);
   });
+
+  it('requires a name, so the ErrorLike narrowing is sound', () => {
+    // The predicate narrows to `ErrorLike`, which declares `name`. Callers may
+    // read it, so it has to be validated rather than assumed.
+    expect(
+      isBrowserShuttingDownError({ message: BROWSER_SHUTTING_DOWN_ERROR }),
+    ).toBe(false);
+    expect(
+      isBrowserShuttingDownError({
+        name: 'Error',
+        message: BROWSER_SHUTTING_DOWN_ERROR,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe('isStateCorruptionError', () => {

--- a/shared/constants/errors.test.ts
+++ b/shared/constants/errors.test.ts
@@ -1,0 +1,98 @@
+import {
+  BROWSER_SHUTTING_DOWN_ERROR,
+  CORRUPTION_BLOCK_CHECKSUM_MISMATCH,
+  MISSING_VAULT_ERROR,
+  isBrowserShuttingDownError,
+  isStateCorruptionError,
+} from './errors';
+
+describe('isBrowserShuttingDownError', () => {
+  it('identifies the browser shutdown rejection', () => {
+    expect(
+      isBrowserShuttingDownError(new Error(BROWSER_SHUTTING_DOWN_ERROR)),
+    ).toBe(true);
+  });
+
+  it('identifies it when raised as a DOMException', () => {
+    // Extension APIs can reject with one, so the predicate has to accept it.
+    expect(
+      isBrowserShuttingDownError(
+        new DOMException(BROWSER_SHUTTING_DOWN_ERROR, 'InvalidStateError'),
+      ),
+    ).toBe(true);
+  });
+
+  it('identifies it when the error has crossed a realm', () => {
+    // An extension has separate realms for the service worker, the offscreen
+    // document and each UI context. An error that crosses one keeps its shape
+    // but fails `instanceof Error`, so matching must not depend on the
+    // prototype - otherwise the error is reported after all.
+    const crossRealmError = Object.create(null);
+    crossRealmError.name = 'Error';
+    crossRealmError.message = BROWSER_SHUTTING_DOWN_ERROR;
+
+    expect(crossRealmError instanceof Error).toBe(false);
+    expect(isBrowserShuttingDownError(crossRealmError)).toBe(true);
+  });
+
+  it('rejects near-misses', () => {
+    // Matching is exact on purpose: this silences reporting, so a loose match
+    // could hide a real storage failure.
+    expect(
+      isBrowserShuttingDownError(new Error('The browser is shutting down')),
+    ).toBe(false);
+    expect(
+      isBrowserShuttingDownError(new Error('the browser is shutting down.')),
+    ).toBe(false);
+    expect(
+      isBrowserShuttingDownError(
+        new Error('Failed because: The browser is shutting down.'),
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects unrelated storage errors', () => {
+    expect(
+      isBrowserShuttingDownError(
+        new Error('Corruption: block checksum mismatch'),
+      ),
+    ).toBe(false);
+  });
+
+  it('tolerates values that carry no message', () => {
+    // A bare string is not treated as a match: only a thrown object with this
+    // exact `message` counts, so an unrelated value cannot silence reporting.
+    expect(isBrowserShuttingDownError(BROWSER_SHUTTING_DOWN_ERROR)).toBe(false);
+    expect(isBrowserShuttingDownError(undefined)).toBe(false);
+    expect(isBrowserShuttingDownError(null)).toBe(false);
+    expect(isBrowserShuttingDownError(42)).toBe(false);
+    expect(isBrowserShuttingDownError({})).toBe(false);
+    expect(isBrowserShuttingDownError({ message: 42 })).toBe(false);
+  });
+});
+
+describe('isStateCorruptionError', () => {
+  it('identifies the state corruption errors', () => {
+    expect(isStateCorruptionError(new Error(MISSING_VAULT_ERROR))).toBe(true);
+    expect(
+      isStateCorruptionError(new Error(CORRUPTION_BLOCK_CHECKSUM_MISMATCH)),
+    ).toBe(true);
+  });
+
+  it('identifies them on a serialized error sent over the port', () => {
+    // The critical-error port carries plain objects rather than Errors, so this
+    // must not depend on the prototype either.
+    expect(
+      isStateCorruptionError({ name: 'Error', message: MISSING_VAULT_ERROR }),
+    ).toBe(true);
+  });
+
+  it('rejects unrelated and message-less values', () => {
+    expect(isStateCorruptionError(new Error(BROWSER_SHUTTING_DOWN_ERROR))).toBe(
+      false,
+    );
+    expect(isStateCorruptionError(undefined)).toBe(false);
+    expect(isStateCorruptionError(null)).toBe(false);
+    expect(isStateCorruptionError({})).toBe(false);
+  });
+});

--- a/shared/constants/errors.ts
+++ b/shared/constants/errors.ts
@@ -12,9 +12,58 @@ export const MISSING_VAULT_ERROR =
 export const CORRUPTION_BLOCK_CHECKSUM_MISMATCH =
   'Corruption: block checksum mismatch';
 
-export function isStateCorruptionError(err: ErrorLike) {
+/**
+ * Chrome rejects with this from `PreRunValidation` once the browser has begun
+ * shutting down, for `chrome.storage.*`, `chrome.tabs.*`, `chrome.windows.*` and
+ * many other extension APIs. It is expected and not actionable: by the time it
+ * appears Chrome will shut down (or hang), the flags that cause it are never
+ * unset, and it only surfaces once every window, tab, popup and sidepanel has
+ * been destroyed.
+ */
+export const BROWSER_SHUTTING_DOWN_ERROR = 'The browser is shutting down.';
+
+/**
+ * Reads the `message` of a thrown value.
+ *
+ * Deliberately avoids `instanceof Error`, which is unreliable here: an
+ * extension has separate realms for the service worker, the offscreen document
+ * and each UI context, and an error that crosses one keeps its shape but loses
+ * its prototype identity. The message is what identifies these errors anyway.
+ *
+ * @param error - The thrown value to inspect.
+ * @returns The message, or `undefined` if the value does not carry one.
+ */
+function getThrownErrorMessage(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+  const { message } = error as { message?: unknown };
+  return typeof message === 'string' ? message : undefined;
+}
+
+/**
+ * Checks whether a thrown value is one of the errors that indicate the
+ * persisted state is unusable.
+ *
+ * @param error - The thrown value to check.
+ * @returns True if the error indicates state corruption.
+ */
+export function isStateCorruptionError(error: unknown): error is ErrorLike {
+  const message = getThrownErrorMessage(error);
   return (
-    err.message === MISSING_VAULT_ERROR ||
-    err.message === CORRUPTION_BLOCK_CHECKSUM_MISMATCH
+    message === MISSING_VAULT_ERROR ||
+    message === CORRUPTION_BLOCK_CHECKSUM_MISMATCH
   );
+}
+
+/**
+ * Checks whether a thrown value is the browser's shutdown rejection, which
+ * means a storage operation failed only because the browser is closing rather
+ * than because anything is wrong with the data.
+ *
+ * @param error - The thrown value to check.
+ * @returns True if the error is the browser shutdown rejection.
+ */
+export function isBrowserShuttingDownError(error: unknown): error is ErrorLike {
+  return getThrownErrorMessage(error) === BROWSER_SHUTTING_DOWN_ERROR;
 }

--- a/shared/constants/errors.ts
+++ b/shared/constants/errors.ts
@@ -23,22 +23,26 @@ export const CORRUPTION_BLOCK_CHECKSUM_MISMATCH =
 export const BROWSER_SHUTTING_DOWN_ERROR = 'The browser is shutting down.';
 
 /**
- * Reads the `message` of a thrown value.
+ * Checks whether a thrown value has the shape of an error.
  *
  * Deliberately avoids `instanceof Error`, which is unreliable here: an
  * extension has separate realms for the service worker, the offscreen document
  * and each UI context, and an error that crosses one keeps its shape but loses
- * its prototype identity. The message is what identifies these errors anyway.
+ * its prototype identity. Errors serialized over the critical-error port are
+ * plain objects for the same reason.
+ *
+ * Both `message` and `name` are checked so the narrowing is sound - callers can
+ * rely on every property `ErrorLike` declares.
  *
  * @param error - The thrown value to inspect.
- * @returns The message, or `undefined` if the value does not carry one.
+ * @returns True if the value carries a string `message` and `name`.
  */
-function getThrownErrorMessage(error: unknown): string | undefined {
+function isErrorLike(error: unknown): error is ErrorLike {
   if (typeof error !== 'object' || error === null) {
-    return undefined;
+    return false;
   }
-  const { message } = error as { message?: unknown };
-  return typeof message === 'string' ? message : undefined;
+  const { message, name } = error as { message?: unknown; name?: unknown };
+  return typeof message === 'string' && typeof name === 'string';
 }
 
 /**
@@ -49,10 +53,10 @@ function getThrownErrorMessage(error: unknown): string | undefined {
  * @returns True if the error indicates state corruption.
  */
 export function isStateCorruptionError(error: unknown): error is ErrorLike {
-  const message = getThrownErrorMessage(error);
   return (
-    message === MISSING_VAULT_ERROR ||
-    message === CORRUPTION_BLOCK_CHECKSUM_MISMATCH
+    isErrorLike(error) &&
+    (error.message === MISSING_VAULT_ERROR ||
+      error.message === CORRUPTION_BLOCK_CHECKSUM_MISMATCH)
   );
 }
 
@@ -65,5 +69,5 @@ export function isStateCorruptionError(error: unknown): error is ErrorLike {
  * @returns True if the error is the browser shutdown rejection.
  */
 export function isBrowserShuttingDownError(error: unknown): error is ErrorLike {
-  return getThrownErrorMessage(error) === BROWSER_SHUTTING_DOWN_ERROR;
+  return isErrorLike(error) && error.message === BROWSER_SHUTTING_DOWN_ERROR;
 }

--- a/shared/lib/sentry.test.ts
+++ b/shared/lib/sentry.test.ts
@@ -1,4 +1,9 @@
-import { captureException, captureMessage } from './sentry';
+import { checkOrSetAlreadyCaught } from '@sentry/core';
+import {
+  captureException,
+  captureMessage,
+  markErrorAsCaptured,
+} from './sentry';
 
 describe('Sentry', () => {
   beforeEach(() => {
@@ -81,6 +86,70 @@ describe('Sentry', () => {
       captureMessage('Test message', 'info');
 
       expect(captureMessageSpy).toHaveBeenCalledWith('Test message', 'info');
+    });
+  });
+
+  describe('markErrorAsCaptured', () => {
+    it('returns the same error', () => {
+      const testError = new Error('Test error');
+
+      expect(markErrorAsCaptured(testError)).toBe(testError);
+    });
+
+    it('keeps the mark off enumerable output', () => {
+      // Must stay invisible to `extraErrorDataIntegration` and to any
+      // serialization of the error, e.g. over the critical-error port.
+      const testError = markErrorAsCaptured(
+        Object.assign(new Error('Test error'), { detail: 'kept' }),
+      );
+
+      expect(Object.keys(testError)).toStrictEqual(['detail']);
+      expect(JSON.stringify(testError)).toStrictEqual('{"detail":"kept"}');
+    });
+
+    it('handles primitives without throwing', () => {
+      // Primitives cannot carry the mark, matching the SDK's own behaviour.
+      const primitives = ['not an error', null, undefined, 42];
+
+      for (const value of primitives) {
+        expect(markErrorAsCaptured(value)).toBe(value);
+      }
+    });
+
+    it('marks any value the SDK could also mark', () => {
+      // The SDK attempts `defineProperty` on whatever it is given, so gating on
+      // `typeof === 'object'` would leave a thrown function markable by the SDK
+      // but not by us, and it would then be reported twice.
+      const thrownFunction = markErrorAsCaptured(function boom() {
+        // Never called; only thrown.
+      });
+
+      expect(checkOrSetAlreadyCaught(thrownFunction)).toBe(true);
+    });
+
+    it('does not throw when the error is frozen', () => {
+      const frozenError = Object.freeze(new Error('Test error'));
+
+      expect(() => markErrorAsCaptured(frozenError)).not.toThrow();
+      // The mark could not be applied, so the error stays reportable. This
+      // fails open: it may be reported, never silently lost.
+      expect(checkOrSetAlreadyCaught(frozenError)).toBe(false);
+    });
+
+    // Pins our marker to the Sentry SDK internal it piggybacks on. If an SDK
+    // upgrade renames `__sentry_captured__` this fails, which is the signal to
+    // revisit `markErrorAsCaptured`. Without the pin, a rename would silently
+    // start reporting errors we intend to suppress.
+    it('marks errors with the property the SDK itself checks', () => {
+      const testError = markErrorAsCaptured(new Error('Test error'));
+
+      // `checkOrSetAlreadyCaught` is what `Client.captureException` and
+      // `Client.captureEvent` call to drop repeat captures of one object.
+      expect(checkOrSetAlreadyCaught(testError)).toBe(true);
+    });
+
+    it('leaves an unmarked error reportable', () => {
+      expect(checkOrSetAlreadyCaught(new Error('Test error'))).toBe(false);
     });
   });
 });

--- a/shared/lib/sentry.ts
+++ b/shared/lib/sentry.ts
@@ -9,6 +9,62 @@ export const sentryLogger = createModuleLogger(
 );
 
 /**
+ * The property the Sentry SDK sets on an exception the first time that exact
+ * object is captured, via its internal `checkOrSetAlreadyCaught` helper. Both
+ * `Client.captureException` and `Client.captureEvent` check it first and drop the
+ * event if it is set, and the global `onerror`/`onunhandledrejection` handlers
+ * report through `captureEvent` with `originalException`.
+ *
+ * Setting it ourselves therefore suppresses *every* later capture of that
+ * object, including ones we do not control such as the global
+ * unhandled-rejection handler.
+ *
+ * This is an SDK-internal name rather than a documented API. It fails open: if a
+ * future SDK version renames it we get reports back, never lost ones.
+ * `shared/lib/sentry.test.ts` pins the behaviour so an upgrade that changes it
+ * fails loudly.
+ */
+const SENTRY_CAPTURED_PROPERTY = '__sentry_captured__';
+
+/**
+ * Marks an error as already accounted for, so Sentry drops any attempt to
+ * capture it.
+ *
+ * Use this for errors that are deliberately not reported - an expected browser
+ * condition, say - that still need to propagate so callers can react. Without
+ * the mark, every layer the error passes through, plus the global
+ * unhandled-rejection handler, reports it.
+ *
+ * Only mark errors that were reported or deliberately suppressed. Marking an
+ * error that nobody has accounted for silences it permanently.
+ *
+ * @param error - The error to mark. Values that cannot carry the mark, such as
+ * primitives, are returned untouched.
+ * @returns The same error, for convenient use in `throw` and `return`.
+ */
+export function markErrorAsCaptured<ErrorType>(error: ErrorType): ErrorType {
+  try {
+    // Defined the same way the SDK does it (`addNonEnumerableProperty`) rather
+    // than importing that helper: this module intentionally reaches Sentry only
+    // through `globalThis.sentry`, so the SDK is not a hard dependency of every
+    // module that reports an error. `enumerable` defaults to false, which keeps
+    // the mark out of `extraErrorDataIntegration` payloads and out of
+    // `JSON.stringify` of the error.
+    Object.defineProperty(error, SENTRY_CAPTURED_PROPERTY, {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  } catch {
+    // A primitive, a frozen or sealed object, or a proxy that refuses
+    // `defineProperty`. Attempting it unconditionally and catching is what the
+    // SDK does, so a value it can mark - a thrown function, say - is one we can
+    // mark too. Worst case the error is reported, as it was before.
+  }
+  return error;
+}
+
+/**
  * Captures an exception event and sends it to Sentry.
  *
  * @param exception -The exception to capture.

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -3,9 +3,13 @@
 import 'navigator.locks';
 import log from 'loglevel';
 
+import { checkOrSetAlreadyCaught } from '@sentry/core';
 import { captureException, captureMessage } from '../sentry';
 import { getManifestFlags } from '../manifestFlags';
-import { MISSING_VAULT_ERROR } from '../../constants/errors';
+import {
+  BROWSER_SHUTTING_DOWN_ERROR,
+  MISSING_VAULT_ERROR,
+} from '../../constants/errors';
 import {
   PersistenceManager,
   PERSISTENCE_MANAGER_OPERATION_SAFENER_DEBOUNCE_MS,
@@ -39,6 +43,9 @@ jest.mock('loglevel', () => ({
   info: jest.fn(),
 }));
 jest.mock('../sentry', () => ({
+  // Keep the real `markErrorAsCaptured` so the marking assertions below
+  // exercise the actual behaviour rather than a stub of it.
+  ...jest.requireActual('../sentry'),
   captureException: jest.fn(),
   captureMessage: jest.fn(),
 }));
@@ -378,6 +385,108 @@ describe('PersistenceManager', () => {
       expect(mockedCaptureException).toHaveBeenCalledTimes(1);
     });
 
+    describe('when the browser is shutting down', () => {
+      it('does not report the failure, and marks it', async () => {
+        prepareForWriteRetry();
+        manager.setMetadata({ version: 10 });
+
+        const shutdownError = new Error(BROWSER_SHUTTING_DOWN_ERROR);
+        mockStoreSet
+          .mockRejectedValueOnce(shutdownError)
+          .mockRejectedValueOnce(shutdownError);
+
+        const setPromise = manager.set({ appState: { broken: true } });
+        await jest.advanceTimersByTimeAsync(WRITE_RETRY_DELAY_MS);
+        const [result, setError] = await setPromise;
+
+        expect(result).toBe(false);
+        expect(setError).toBe(shutdownError);
+        expect(mockedCaptureException).not.toHaveBeenCalled();
+        // `migrateToSplitState` re-throws this error, so without the mark
+        // `handleOnConnect` would report it.
+        expect(checkOrSetAlreadyCaught(shutdownError)).toBe(true);
+      });
+
+      it('does not report it when the backup write is the one that fails', async () => {
+        // The backup write has its own try/catch that sets `backupFailed` and
+        // rethrows into the same outer catch, so it reaches the guard with the
+        // primary write already succeeded. Without a guard this would report
+        // under the `set-backup-failed` tag.
+        await manager.open();
+        jest.useFakeTimers();
+        manager.setMetadata({ version: 10 });
+
+        const shutdownError = new Error(BROWSER_SHUTTING_DOWN_ERROR);
+        const backupSetSpy = jest
+          .spyOn(IndexedDBStore.prototype, 'set')
+          .mockRejectedValue(shutdownError);
+        mockStoreSet.mockResolvedValue(undefined);
+
+        const setPromise = manager.set({
+          KeyringController: { vault: 'encrypted-vault' },
+        } as unknown as MetaMaskStateType);
+        await jest.advanceTimersByTimeAsync(WRITE_RETRY_DELAY_MS);
+        const [result, setError] = await setPromise;
+
+        expect(backupSetSpy).toHaveBeenCalled();
+        expect(result).toBe(false);
+        expect(setError).toBe(shutdownError);
+        expect(mockedCaptureException).not.toHaveBeenCalled();
+        expect(checkOrSetAlreadyCaught(shutdownError)).toBe(true);
+
+        backupSetSpy.mockRestore();
+      });
+
+      it('does not flag a storage write error for the UI', async () => {
+        prepareForWriteRetry();
+        manager.setMetadata({ version: 10 });
+        const onSetFailed = jest.fn();
+        manager.setOnSetFailed(onSetFailed);
+
+        const shutdownError = new Error(BROWSER_SHUTTING_DOWN_ERROR);
+        mockStoreSet
+          .mockRejectedValueOnce(shutdownError)
+          .mockRejectedValueOnce(shutdownError);
+
+        const setPromise = manager.set({ appState: { broken: true } });
+        await jest.advanceTimersByTimeAsync(WRITE_RETRY_DELAY_MS);
+        await setPromise;
+
+        // This persists `storageWriteErrorType` into AppStateController, which
+        // would surface a false storage-error warning in the next session.
+        expect(onSetFailed).not.toHaveBeenCalled();
+      });
+
+      it('does not latch the duplicate-report flag, so a later real failure still reports', async () => {
+        prepareForWriteRetry();
+        manager.setMetadata({ version: 10 });
+
+        const shutdownError = new Error(BROWSER_SHUTTING_DOWN_ERROR);
+        const realError = new Error('store.set error');
+        mockStoreSet
+          .mockRejectedValueOnce(shutdownError)
+          .mockRejectedValueOnce(shutdownError)
+          .mockRejectedValueOnce(realError)
+          .mockRejectedValueOnce(realError);
+
+        const firstSetPromise = manager.set({ appState: { broken: true } });
+        await jest.advanceTimersByTimeAsync(WRITE_RETRY_DELAY_MS);
+        await firstSetPromise;
+
+        const secondSetPromise = manager.set({ appState: { broken: true } });
+        await jest.advanceTimersByTimeAsync(WRITE_RETRY_DELAY_MS);
+        await secondSetPromise;
+
+        // If the shutdown error had set `#dataPersistenceFailing`, this real
+        // failure would have been silently swallowed as a duplicate.
+        expect(mockedCaptureException).toHaveBeenCalledTimes(1);
+        expect(mockedCaptureException).toHaveBeenCalledWith(realError, {
+          tags: { 'persistence.error': 'set-failed' },
+          fingerprint: ['persistence-error', 'set-failed'],
+        });
+      });
+    });
+
     it('captures exception twice if store.set fails, then succeeds and then fails again', async () => {
       prepareForWriteRetry();
       manager.setMetadata({ version: 17 });
@@ -556,6 +665,83 @@ describe('PersistenceManager', () => {
       await expect(manager.get({ validateVault: true })).rejects.toThrow(
         MISSING_VAULT_ERROR,
       );
+    });
+
+    describe('when the browser is shutting down', () => {
+      /**
+       * A non-empty backup, so the tests prove vault recovery is deliberately
+       * skipped rather than merely unavailable.
+       */
+      function mockShutdownDuringRead(): Error {
+        const shutdownError = new Error(BROWSER_SHUTTING_DOWN_ERROR);
+        mockStoreGet.mockRejectedValueOnce(shutdownError);
+        jest.spyOn(manager, 'getBackup').mockResolvedValue({
+          KeyringController: { vault: 'vault' },
+        });
+        return shutdownError;
+      }
+
+      it('re-throws the original error rather than a vault error', async () => {
+        const shutdownError = mockShutdownDuringRead();
+
+        // Not MISSING_VAULT_ERROR: the vault is fine, the browser is closing.
+        // It still throws so callers abort instead of treating the store as
+        // empty and regenerating initial state over the top of it.
+        await expect(manager.get({ validateVault: true })).rejects.toThrow(
+          shutdownError,
+        );
+      });
+
+      it('does not report it to Sentry', async () => {
+        mockShutdownDuringRead();
+
+        await expect(manager.get({ validateVault: true })).rejects.toThrow(
+          BROWSER_SHUTTING_DOWN_ERROR,
+        );
+
+        expect(mockedCaptureException).not.toHaveBeenCalled();
+        expect(log.error).not.toHaveBeenCalled();
+      });
+
+      it('marks the error so no layer above reports it', async () => {
+        const shutdownError = mockShutdownDuringRead();
+
+        await expect(manager.get({ validateVault: true })).rejects.toThrow(
+          BROWSER_SHUTTING_DOWN_ERROR,
+        );
+
+        // What stops `handleOnConnect` and the SDK's global
+        // unhandled-rejection handler filing this same failure again.
+        expect(checkOrSetAlreadyCaught(shutdownError)).toBe(true);
+      });
+
+      it('does not emit vaultCorruptionDetected', async () => {
+        mockShutdownDuringRead();
+        const vaultCorruptionListener = jest.fn();
+        manager.on('vaultCorruptionDetected', vaultCorruptionListener);
+
+        await expect(manager.get({ validateVault: true })).rejects.toThrow(
+          BROWSER_SHUTTING_DOWN_ERROR,
+        );
+
+        // Would otherwise send a false-positive `VaultCorruptionDetected`
+        // event to Segment for a browser that is merely closing.
+        expect(vaultCorruptionListener).not.toHaveBeenCalled();
+      });
+
+      it('still reports genuine read failures', async () => {
+        const realError = new Error('Corruption: block checksum mismatch');
+        mockStoreGet.mockRejectedValueOnce(realError);
+
+        await expect(manager.get({ validateVault: false })).rejects.toThrow(
+          realError,
+        );
+
+        expect(mockedCaptureException).toHaveBeenCalledWith(realError, {
+          tags: { 'persistence.error': 'get-failed' },
+          fingerprint: ['persistence-error', 'get-failed'],
+        });
+      });
     });
   });
 
@@ -863,6 +1049,87 @@ describe('PersistenceManager', () => {
       expect(retryMap.get('meta')).toEqual({ version: 10 });
       expect(retryMap.get('FooController')).toEqual({ foo: 'bar' });
       /* eslint-enable jest/prefer-strict-equal */
+    });
+
+    describe('when the browser is shutting down', () => {
+      it('does not report the failure, and marks it', async () => {
+        prepareForWriteRetry();
+        manager.setMetadata({ version: 10 });
+        manager.update('FooController', { foo: 'bar' });
+
+        const shutdownError = new Error(BROWSER_SHUTTING_DOWN_ERROR);
+        mockStoreSetKeyValues
+          .mockRejectedValueOnce(shutdownError)
+          .mockRejectedValueOnce(shutdownError);
+
+        const persistPromise = manager.persist();
+        await jest.advanceTimersByTimeAsync(WRITE_RETRY_DELAY_MS);
+        const [result, persistError] = await persistPromise;
+
+        expect(result).toBe(false);
+        expect(persistError).toBe(shutdownError);
+        expect(mockedCaptureException).not.toHaveBeenCalled();
+        expect(checkOrSetAlreadyCaught(shutdownError)).toBe(true);
+      });
+
+      it('does not latch the duplicate-report flag, so a later real failure still reports', async () => {
+        prepareForWriteRetry();
+        manager.setMetadata({ version: 10 });
+        manager.update('FooController', { foo: 'bar' });
+
+        const shutdownError = new Error(BROWSER_SHUTTING_DOWN_ERROR);
+        const realError = new Error('store.setKeyValues error');
+        mockStoreSetKeyValues
+          .mockRejectedValueOnce(shutdownError)
+          .mockRejectedValueOnce(shutdownError)
+          .mockRejectedValueOnce(realError)
+          .mockRejectedValueOnce(realError);
+
+        const firstPersistPromise = manager.persist();
+        await jest.advanceTimersByTimeAsync(WRITE_RETRY_DELAY_MS);
+        await firstPersistPromise;
+
+        manager.update('FooController', { foo: 'baz' });
+        const secondPersistPromise = manager.persist();
+        await jest.advanceTimersByTimeAsync(WRITE_RETRY_DELAY_MS);
+        await secondPersistPromise;
+
+        expect(mockedCaptureException).toHaveBeenCalledTimes(1);
+        expect(mockedCaptureException).toHaveBeenCalledWith(realError, {
+          tags: { 'persistence.error': 'persist-failed' },
+          fingerprint: ['persistence-error', 'persist-failed'],
+        });
+      });
+
+      it('keeps pending pairs so the next write can retry them', async () => {
+        prepareForWriteRetry();
+        manager.setMetadata({ version: 10 });
+        manager.update('FooController', { foo: 'bar' });
+
+        const shutdownError = new Error(BROWSER_SHUTTING_DOWN_ERROR);
+        mockStoreSetKeyValues
+          .mockRejectedValueOnce(shutdownError)
+          .mockRejectedValueOnce(shutdownError)
+          .mockResolvedValueOnce(undefined);
+
+        const persistPromise = manager.persist();
+        await jest.advanceTimersByTimeAsync(WRITE_RETRY_DELAY_MS);
+        await persistPromise;
+
+        // The early return must not skip the pending-pairs restore that runs
+        // before it, or the update would be lost.
+        await manager.persist();
+
+        const retriedPairs = mockStoreSetKeyValues.mock.calls.at(
+          -1,
+        )?.[0] as Map<string, unknown>;
+        // Spread into a fresh object first: the value has been through
+        // `structuredClone`, so its prototype comes from another realm and a
+        // strict comparison against a literal would fail on that alone.
+        expect({
+          ...(retriedPairs.get('FooController') as object),
+        }).toStrictEqual({ foo: 'bar' });
+      });
     });
 
     it('captures exception only once if store.setKeyValues throws multiple times', async () => {

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -2,8 +2,15 @@ import EventEmitter from 'events';
 import log from 'loglevel';
 import { isEmpty } from 'lodash';
 import { RuntimeObject, hasProperty, isObject } from '@metamask/utils';
-import { captureException, captureMessage } from '../sentry';
-import { MISSING_VAULT_ERROR } from '../../constants/errors';
+import {
+  captureException,
+  captureMessage,
+  markErrorAsCaptured,
+} from '../sentry';
+import {
+  MISSING_VAULT_ERROR,
+  isBrowserShuttingDownError,
+} from '../../constants/errors';
 import { getManifestFlags } from '../manifestFlags';
 import { VaultCorruptionType } from '../../constants/state-corruption';
 import { StorageWriteErrorType } from '../../constants/app-state';
@@ -672,6 +679,18 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
 
           return [true, undefined];
         } catch (err) {
+          // See `get`: a write that fails only because the browser is closing is
+          // not a storage problem. Skipping the whole block matters, not just
+          // the capture - latching `#dataPersistenceFailing` here would suppress
+          // the report of a later real failure, and `#notifySetFailed` persists
+          // a storage-error flag in `AppStateController` that would surface a
+          // false warning in the next session.
+          if (isBrowserShuttingDownError(err)) {
+            log.info(
+              'MetaMask - storage write failed because the browser is shutting down',
+            );
+            return [false, markErrorAsCaptured(err)];
+          }
           if (!this.#dataPersistenceFailing) {
             this.#dataPersistenceFailing = true;
             // Use different tags to differentiate storage.local vs IndexedDB backup failures.
@@ -815,6 +834,18 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
 
           return [true, undefined];
         } catch (err) {
+          // See `get`: a write that fails only because the browser is closing is
+          // not a storage problem. Skipping the whole block matters, not just
+          // the capture - latching `#dataPersistenceFailing` here would suppress
+          // the report of a later real failure, and `#notifySetFailed` persists
+          // a storage-error flag in `AppStateController` that would surface a
+          // false warning in the next session.
+          if (isBrowserShuttingDownError(err)) {
+            log.info(
+              'MetaMask - storage write failed because the browser is shutting down',
+            );
+            return [false, markErrorAsCaptured(err)];
+          }
           if (!this.#dataPersistenceFailing) {
             this.#dataPersistenceFailing = true;
             // Use different tags to differentiate storage.local vs IndexedDB backup failures.
@@ -873,6 +904,24 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
             res,
           ])
           .catch((error: Error): [Error, undefined] => [error, undefined]);
+
+        // The browser shutting down mid-read is not a storage problem, so none
+        // of the failure handling below applies: reporting it, emitting
+        // `vaultCorruptionDetected`, and throwing `MISSING_VAULT_ERROR` would
+        // all be false positives. Mark it so no layer above - nor the SDK's
+        // global unhandled-rejection handler, which the uncaught
+        // `await isInitialized` call sites reach - reports it either, then
+        // re-throw so callers abort exactly as they would for a real failure.
+        //
+        // Re-throwing matters: returning `undefined` would let `background.js`
+        // treat this as an empty store, call `generateInitialState`, and
+        // overwrite persisted state on the next write.
+        if (isBrowserShuttingDownError(localStoreError)) {
+          log.info(
+            'MetaMask - storage.local.get rejected because the browser is shutting down',
+          );
+          throw markErrorAsCaptured(localStoreError);
+        }
 
         // Log and capture the error if one occurred, but don't throw yet
         if (localStoreError) {


### PR DESCRIPTION
## **Description**

Chrome rejects with `"The browser is shutting down."` from `PreRunValidation` once shutdown has begun — for `chrome.storage.*`, `chrome.tabs.*`, `chrome.windows.*` and many other extension APIs. This is expected and not actionable: by the time it appears Chrome will shut down or hang, the flags that cause it are never unset, and it only surfaces once every window, tab, popup and sidepanel has been destroyed.

`PersistenceManager` currently treats it as a storage failure, so a browser that is merely closing produces **three** false positives:

1. A Sentry report (`persistence.error: get-failed` / `set-failed` / `persist-failed`).
2. A `VaultCorruptionDetected` Segment event, plus a `PersistenceError: Data error: storage.local does not contain vault data` that is not true — the vault is fine.
3. A `storageWriteErrorType` flag persisted into `AppStateController`, which would surface a storage-error warning to the user in their **next** session.

### Approach

A predicate in `shared/constants/errors.ts` detects the message, and at each point that decides whether a storage failure is real we skip the report and **mark the error** instead.

Marking piggybacks on the property the Sentry SDK sets when it captures an object (`checkOrSetAlreadyCaught`). That matters because the SDK then also drops the captures we *don't* control — in particular the global unhandled-rejection handler, which the many uncaught `await isInitialized` call sites in `background.js` reach. The error still propagates, so callers abort exactly as they do for a real failure.

### Review notes

- **The write-path guard skips the whole block, not just the capture.** Skipping only `captureException` would still latch `#dataPersistenceFailing` — suppressing the report of a later *real* failure — and still call `#notifySetFailed`, which is what persists the storage-error flag.
- **Only shutdown errors are marked.** Marking write errors unconditionally is unsafe: it silences a failed split-state migration when `#dataPersistenceFailing` is already latched.
- **The read path re-throws rather than returning `undefined`.** Returning `undefined` would let `background.js` treat this as an empty store, call `generateInitialState`, and overwrite persisted state on the next write.
- **Matching is on `message`, not `instanceof Error`.** An extension has separate realms for the service worker, the offscreen document and each UI context; a value crossing one keeps its shape but loses prototype identity. `isStateCorruptionError` was given the same treatment, which it also needs — the critical-error port carries plain serialized objects rather than `Error` instances.
- **`markErrorAsCaptured` depends on an SDK-internal property name.** It fails open: if a future SDK renames it we get reports back, never lost ones. `shared/lib/sentry.test.ts` pins the behaviour against `checkOrSetAlreadyCaught` so an upgrade that changes it fails loudly.

### Expected impact, and what this does *not* cover

Measured over 14 days in production, this addresses roughly **9,900 of ~28,100** events carrying this message:

| Sentry issue | Events / 14d | Covered here? |
| --- | --- | --- |
| [METAMASK-YGZ8](https://metamask.sentry.io/explore/errors/?dataset=errors&environment=production&field=title&field=project&field=user.display&field=timestamp&name=All%20Errors&project=273505&query=issue%3AMETAMASK-YGZ8&queryDataset=error-events&sort=-timestamp&statsPeriod=44d&yAxis=count%28%29) (`get-failed`) | 4,703 | yes |
| [METAMASK-YH6J](https://metamask.sentry.io/explore/errors/?dataset=errors&environment=production&field=title&field=project&field=user.display&field=timestamp&name=All%20Errors&project=273505&query=issue%3AMETAMASK-YH6J&queryDataset=error-events&sort=-timestamp&statsPeriod=44d&yAxis=count%28%29) (`PersistenceError` wrapper) | ~4,470 | yes |
| [METAMASK-YGZ5](https://metamask.sentry.io/explore/errors/?dataset=errors&environment=production&field=title&field=project&field=user.display&field=timestamp&name=All%20Errors&project=273505&query=issue%3AMETAMASK-YGZ5&queryDataset=error-events&sort=-timestamp&statsPeriod=44d&yAxis=count%28%29) / [YGZH](https://metamask.sentry.io/explore/errors/?dataset=errors&environment=production&field=title&field=project&field=user.display&field=timestamp&name=All%20Errors&project=273505&query=issue%3AMETAMASK-YGZH&queryDataset=error-events&sort=-timestamp&statsPeriod=44d&yAxis=count%28%29) (`set-failed`, `persist-failed`) | 736 | yes |
| [METAMASK-XA56](https://metamask.sentry.io/explore/errors/?dataset=errors&environment=production&field=title&field=project&field=user.display&field=timestamp&name=All%20Errors&project=273505&query=issue%3AMETAMASK-XA56&queryDataset=error-events&sort=-timestamp&statsPeriod=44d&yAxis=count%28%29) | ~13,700 | **no** |
| [METAMASK-YNAS](https://metamask.sentry.io/explore/errors/?dataset=errors&environment=production&field=title&field=project&field=user.display&field=timestamp&name=All%20Errors&project=273505&query=issue%3AMETAMASK-YNAS&queryDataset=error-events&sort=-timestamp&statsPeriod=44d&yAxis=count%28%29) | ~4,470 | **no** |

The last two are unhandled rejections from unrelated `browser.*` calls that never pass through the storage layer — XA56 dates from June 2024 with 1.1M lifetime occurrences. Nothing in the storage layer can reach them. Sentry's `ignoreErrors` option would drop them in one line (there is already a use of it in `setupSentry.js`) in case we want to do it.

### One behavioural change

On the read path this previously threw `MISSING_VAULT_ERROR`, which `handleOnConnect` routes to the state-corruption screen; now the raw error routes to `DISPLAY_GENERAL_STARTUP_ERROR`. Moot in practice, since the error only fires once every window and popup is gone.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7579

Replaces: #45028
Supersedes the investigation in #44610

## **Manual testing steps**

There is no straightforward manual repro — the error is only emitted by Chrome once shutdown is already underway and every window has been destroyed, which is also why it cannot be reproduced with `chrome://indexeddb-internals` or the task manager. Verification is by unit test:

1. `yarn jest --no-coverage shared/constants/errors.test.ts shared/lib/sentry.test.ts shared/lib/stores/persistence-manager.test.ts` — 74 tests pass.
2. New coverage asserts, for a `storage.local.get` rejection with this message: no `captureException`, no `vaultCorruptionDetected` emit, the raw error re-thrown rather than `MISSING_VAULT_ERROR`, and the error marked. The `getBackup()` mock returns a **non-empty** backup so the test proves vault recovery is deliberately skipped rather than merely unavailable.
3. Equivalent coverage for `set()` and `persist()`, including the backup-write branch, and asserting that `#dataPersistenceFailing` is not latched (a following real failure still reports) and `setOnSetFailed` is not invoked.
4. A regression test builds a null-prototype error, asserts `instanceof Error` is `false`, and asserts the predicate still matches — it fails if `instanceof` is reintroduced.

## **Screenshots/Recordings**

No UI change.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup/persistence error handling and Sentry suppression on a narrow message match; misclassification could hide real failures, though exact matching and fail-open marking limit that risk.
> 
> **Overview**
> Chrome’s **"The browser is shutting down."** rejection during extension API calls was being treated like real storage corruption. This PR adds **`isBrowserShuttingDownError`** (exact message match via a new **`isErrorLike`** helper, not `instanceof Error`) and **`markErrorAsCaptured`**, which sets Sentry’s internal **`__sentry_captured__`** so later captures—including the global unhandled-rejection handler—are dropped while the error still propagates.
> 
> **`PersistenceManager`** now short-circuits on that error in **`get`**, **`set`**, and **`persist`**: no Sentry, no **`vaultCorruptionDetected`**, no **`#notifySetFailed`** / **`#dataPersistenceFailing`** latch on writes; reads re-throw the shutdown error instead of **`MISSING_VAULT_ERROR`**. **`isStateCorruptionError`** accepts **`unknown`** and uses the same shape-based matching for port-serialized errors. Unit tests cover predicates, Sentry marking, and persistence edge cases (backup failures, pending pairs on persist, later real failures still report).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1adc6b2efdc2e36ffeb578ad16cc5a041685dd29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->