### PR TITLE
test: share swap/bridge error UI as a page-object component

### DIFF
--- a/test/e2e/page-objects/components/swap-and-bridge-error-ui.ts
+++ b/test/e2e/page-objects/components/swap-and-bridge-error-ui.ts
@@ -8,43 +8,57 @@ const notPresentGuards = {
 };
 
 /**
- * Shared Swap/Bridge quote-error UI locators. Send and confirmation can both
- * surface these banners when a same-chain native send is mis-routed.
+ * Shared Swap/Bridge quote-error UI. Send and confirmation can both surface
+ * these banners when a same-chain native send is mis-routed.
  */
-const swapAndBridgeBannerAlerts: RawLocator =
-  '[data-testid="bridge-banner-alerts"]';
+export class SwapAndBridgeErrorUi {
+  private readonly driver: Driver;
 
-const swapAndBridgeCtaButton: RawLocator = '[data-testid="bridge-cta-button"]';
+  private readonly swapAndBridgeBannerAlerts: RawLocator =
+    '[data-testid="bridge-banner-alerts"]';
 
-const swapAndBridgeFetchingQuotesLabel: RawLocator = {
-  tag: 'p',
-  text: 'Fetching quotes...',
-};
+  private readonly swapAndBridgeCtaButton: RawLocator =
+    '[data-testid="bridge-cta-button"]';
 
-const swapAndBridgeNoQuotes: RawLocator = '[data-testid="bridge-no-quotes"]';
+  private readonly swapAndBridgeFetchingQuotesLabel: RawLocator = {
+    tag: 'p',
+    text: 'Fetching quotes...',
+  };
 
-const swapsBannerTitle: RawLocator = '[data-testid="swaps-banner-title"]';
+  private readonly swapAndBridgeNoQuotes: RawLocator =
+    '[data-testid="bridge-no-quotes"]';
 
-/**
- * Asserts that Swap/Bridge quote-error UI is not shown.
- *
- * @param driver - WebDriver wrapper.
- */
-export async function assertSwapAndBridgeErrorUiIsAbsent(
-  driver: Driver,
-): Promise<void> {
-  await driver.assertElementNotPresent(
-    swapAndBridgeBannerAlerts,
-    notPresentGuards,
-  );
-  await driver.assertElementNotPresent(swapsBannerTitle, notPresentGuards);
-  await driver.assertElementNotPresent(swapAndBridgeNoQuotes, notPresentGuards);
-  await driver.assertElementNotPresent(
-    swapAndBridgeFetchingQuotesLabel,
-    notPresentGuards,
-  );
-  await driver.assertElementNotPresent(
-    swapAndBridgeCtaButton,
-    notPresentGuards,
-  );
+  private readonly swapsBannerTitle: RawLocator =
+    '[data-testid="swaps-banner-title"]';
+
+  constructor(driver: Driver) {
+    this.driver = driver;
+  }
+
+  /**
+   * Asserts that Swap/Bridge quote-error UI is not shown.
+   */
+  async checkErrorUiIsAbsent(): Promise<void> {
+    console.log('Checking swap/bridge error UI is absent');
+    await this.driver.assertElementNotPresent(
+      this.swapAndBridgeBannerAlerts,
+      notPresentGuards,
+    );
+    await this.driver.assertElementNotPresent(
+      this.swapsBannerTitle,
+      notPresentGuards,
+    );
+    await this.driver.assertElementNotPresent(
+      this.swapAndBridgeNoQuotes,
+      notPresentGuards,
+    );
+    await this.driver.assertElementNotPresent(
+      this.swapAndBridgeFetchingQuotesLabel,
+      notPresentGuards,
+    );
+    await this.driver.assertElementNotPresent(
+      this.swapAndBridgeCtaButton,
+      notPresentGuards,
+    );
+  }
 }

--- a/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
@@ -3,7 +3,6 @@ import { By, Key } from 'selenium-webdriver';
 import { tEn } from '../../../../lib/i18n-helpers';
 import { Driver } from '../../../webdriver/driver';
 import { RawLocator } from '../../common';
-import { assertSwapAndBridgeErrorUiIsAbsent } from '../../components/swap-and-bridge-error-ui';
 import Confirmation from './confirmation';
 
 /**
@@ -413,17 +412,6 @@ class TransactionConfirmation extends Confirmation {
       `Check Site suggested time ${time} on transaction confirmation page.`,
     );
     await this.driver.waitForSelector(this.siteSuggestedGasFee(time));
-  }
-
-  /**
-   * Asserts that Swap/Bridge quote-error UI is not shown on confirmation.
-   * Same-chain native sends must remain a normal send, not a swap/bridge flow.
-   */
-  async checkSwapAndBridgeErrorUiIsAbsent(): Promise<void> {
-    console.log(
-      'Checking swap/bridge error UI is absent on transaction confirmation',
-    );
-    await assertSwapAndBridgeErrorUiIsAbsent(this.driver);
   }
 
   async checkWalletInitiatedHeadingTitle() {

--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -1,5 +1,4 @@
 import { Driver } from '../../../webdriver/driver';
-import { assertSwapAndBridgeErrorUiIsAbsent } from '../../components/swap-and-bridge-error-ui';
 
 /**
  * Multichain send flow: asset, recipient, amount, and continue.
@@ -285,15 +284,6 @@ class SendPage {
   async checkSolanaNetworkIsPresent(): Promise<void> {
     console.log('Checking if Solana network is present');
     await this.driver.findElement(this.solanaNetwork);
-  }
-
-  /**
-   * Asserts that Swap/Bridge quote-error UI is not shown on the send form.
-   * Same-chain native sends must not surface cross-chain quote banners.
-   */
-  async checkSwapAndBridgeErrorUiIsAbsent(): Promise<void> {
-    console.log('Checking swap/bridge error UI is absent on send page');
-    await assertSwapAndBridgeErrorUiIsAbsent(this.driver);
   }
 
   /**

--- a/test/e2e/tests/send/send-custom-network-native.spec.ts
+++ b/test/e2e/tests/send/send-custom-network-native.spec.ts
@@ -14,6 +14,7 @@ import { Driver } from '../../webdriver/driver';
 import { withFixtures } from '../../helpers';
 import { prepareCustomNetwork } from '../../helpers/custom-network-harness';
 import { login } from '../../page-objects/flows/login.flow';
+import { SwapAndBridgeErrorUi } from '../../page-objects/components/swap-and-bridge-error-ui';
 import ActivityTab from '../../page-objects/pages/home/activity-tab';
 import HomePage from '../../page-objects/pages/home/homepage';
 import SendPage from '../../page-objects/pages/send/send-page';
@@ -75,6 +76,7 @@ describe('Send native on custom network', function () {
         const homePage = new HomePage(driver);
         const sendPage = new SendPage(driver);
         const transactionConfirmation = new TransactionConfirmation(driver);
+        const swapAndBridgeErrorUi = new SwapAndBridgeErrorUi(driver);
         const activityTab = new ActivityTab(driver);
 
         await homePage.startSendFlow();
@@ -82,12 +84,12 @@ describe('Send native on custom network', function () {
         await sendPage.selectToken(network.chainIdHex, network.nativeSymbol);
         await sendPage.fillRecipient({ recipientAddress: DEFAULT_RECIPIENT });
         await sendPage.fillAmount(SEND_AMOUNT);
-        await sendPage.checkSwapAndBridgeErrorUiIsAbsent();
+        await swapAndBridgeErrorUi.checkErrorUiIsAbsent();
         await sendPage.pressContinueButton();
 
         await transactionConfirmation.checkPageIsLoaded();
         await transactionConfirmation.checkWalletInitiatedHeadingTitle();
-        await transactionConfirmation.checkSwapAndBridgeErrorUiIsAbsent();
+        await swapAndBridgeErrorUi.checkErrorUiIsAbsent();
         await transactionConfirmation.clickFooterConfirmButtonAndWaitToDisappear();
 
         await homePage.goToActivityList();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Addresses review comments on #45694.

1. `waitAtLeastGuard` is applied to every `assertElementNotPresent` check for Swap/Bridge error UI.
2. The duplicated `checkSwapAndBridgeErrorUiIsAbsent` methods on `SendPage` and `TransactionConfirmation` are replaced with a shared `SwapAndBridgeErrorUi` page-object component, matching the `TxToastNotification` pattern.

The `check-template-and-add-labels` failure on #45694 was caused by a missing `team-*` label. `team-be-trade` was added there to match other custom-network send E2E PRs from the same author.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [WPN-1799](https://consensyssoftware.atlassian.net/browse/WPN-1799)

## **Manual testing steps**

1. Load the extension with XDC Network added as a custom RPC and a native XDC balance.
2. Open Send, select native XDC, enter a recipient and amount, then continue.
3. Confirm the transaction. Verify there is no Swap/Bridge error banner, no-quotes message, or quote-fetching UI.
4. Confirm the heading is a normal send (Sending), then check Activity for a confirmed Sent of the native amount.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test the code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-512a5f1c-958e-42be-9ede-becd199cbc18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-512a5f1c-958e-42be-9ede-becd199cbc18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[WPN-1799]: https://consensyssoftware.atlassian.net/browse/WPN-1799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ