### PR TITLE
fix: use AssetsController state to fetch Tron resources

### DIFF
--- a/ui/pages/asset/hooks/useTronResources.test.ts
+++ b/ui/pages/asset/hooks/useTronResources.test.ts
@@ -93,23 +93,10 @@ describe('useTronResources', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAccountBalances.mockReset();
-    queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false },
-      },
-      logger: {
-        log: () => undefined,
-        warn: () => undefined,
-        // Silence expected error output from rejected snap queries.
-        error: () => undefined,
-      },
-    });
   });
 
   afterEach(() => {
     cleanup();
-    queryClient.clear();
   });
 
   describe('when account and chainId are provided', () => {

--- a/ui/pages/asset/hooks/useTronResources.test.ts
+++ b/ui/pages/asset/hooks/useTronResources.test.ts
@@ -1,6 +1,5 @@
 import React from 'react';
-import { renderHook, cleanup, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, cleanup } from '@testing-library/react';
 import { CaipAssetId } from '@metamask/keyring-api';
 import { Asset } from '@metamask/assets-controllers';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -11,22 +10,11 @@ import * as multichainSelectors from '../../../selectors/multichain';
 import * as assetsUnifyStateSelectors from '../../../selectors/assets-unify-state';
 import { useTronResources } from './useTronResources';
 
-const mockGetAccountBalances = jest.fn();
-
-jest.mock('@metamask/keyring-snap-client', () => ({
-  KeyringClient: jest.fn().mockImplementation(() => ({
-    getAccountBalances: mockGetAccountBalances,
-  })),
-}));
-
-jest.mock('../../../hooks/accounts/useMultichainWalletSnapSender', () => ({
-  MultichainWalletSnapSender: jest.fn(),
-}));
-
 // Mock the selectors
 jest.mock('../../../selectors/assets', () => ({
   ...jest.requireActual('../../../selectors/assets'),
   getAssetsBySelectedAccountGroupWithTronSpecialAssets: jest.fn(),
+  getAssetsBalance: jest.fn(),
 }));
 
 jest.mock('../../../selectors/multichain', () => ({
@@ -44,20 +32,10 @@ jest.mock('react-redux', () => ({
     selector({} as State),
 }));
 
-let queryClient: QueryClient;
-
-const createWrapper = () => {
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-};
-
 const renderTronResourcesHook = (
   account: InternalAccount | undefined,
   chainId: string,
-) =>
-  renderHook(() => useTronResources(account, chainId), {
-    wrapper: createWrapper(),
-  });
+) => renderHook(() => useTronResources(account, chainId));
 
 describe('useTronResources', () => {
   const mockAccount: InternalAccount = {
@@ -70,18 +48,6 @@ describe('useTronResources', () => {
       keyring: { type: 'HD Key Tree' },
     },
     methods: [],
-  } as unknown as InternalAccount;
-
-  const mockSnapAccount: InternalAccount = {
-    ...mockAccount,
-    metadata: {
-      ...mockAccount.metadata,
-      snap: {
-        id: 'npm:@metamask/tron-wallet-snap',
-        enabled: true,
-        name: 'Tron',
-      },
-    },
   } as unknown as InternalAccount;
 
   const chainId = MultichainNetworks.TRON;
@@ -102,6 +68,10 @@ describe('useTronResources', () => {
   const mockSelector = (
     assets: Record<string, Asset[]>,
     balances: Record<string, Record<string, { amount: string; unit: string }>>,
+    assetsControllerBalances: Record<
+      string,
+      Record<string, { amount: string }>
+    > = {},
     isAssetsUnifyStateEnabled = false,
   ) => {
     (
@@ -110,6 +80,10 @@ describe('useTronResources', () => {
 
     (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue(
       balances,
+    );
+
+    (assetsSelectors.getAssetsBalance as jest.Mock).mockReturnValue(
+      assetsControllerBalances,
     );
 
     (
@@ -123,6 +97,12 @@ describe('useTronResources', () => {
     queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
+      },
+      logger: {
+        log: () => undefined,
+        warn: () => undefined,
+        // Silence expected error output from rejected snap queries.
+        error: () => undefined,
       },
     });
   });
@@ -572,29 +552,22 @@ describe('useTronResources', () => {
     const maxBandwidthAssetId =
       `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_BANDWIDTH}` as CaipAssetId;
 
-    it('falls back to fetching balances directly from the snap', async () => {
-      // Redux state is empty because the new AssetsController strips assets
-      // without metadata. The hook should still surface values fetched from
-      // the snap directly.
-      mockSelector({}, {}, true);
+    it('reads resource balances from the AssetsController state', () => {
+      mockSelector(
+        {},
+        {},
+        {
+          [mockAccount.id]: {
+            [energyAssetId]: { amount: '500' },
+            [maxEnergyAssetId]: { amount: '1000' },
+            [bandwidthAssetId]: { amount: '300' },
+            [maxBandwidthAssetId]: { amount: '600' },
+          },
+        },
+        true,
+      );
 
-      mockGetAccountBalances.mockResolvedValue({
-        [energyAssetId]: { amount: '500', unit: 'energy' },
-        [maxEnergyAssetId]: { amount: '1000', unit: 'energy' },
-        [bandwidthAssetId]: { amount: '300', unit: 'bandwidth' },
-        [maxBandwidthAssetId]: { amount: '600', unit: 'bandwidth' },
-      });
-
-      const { result } = renderTronResourcesHook(mockSnapAccount, chainId);
-
-      await waitFor(() => expect(result.current.energy.current).toBe(500));
-
-      expect(mockGetAccountBalances).toHaveBeenCalledWith(mockSnapAccount.id, [
-        energyAssetId,
-        maxEnergyAssetId,
-        bandwidthAssetId,
-        maxBandwidthAssetId,
-      ]);
+      const { result } = renderTronResourcesHook(mockAccount, chainId);
 
       expect(result.current.energy).toEqual({
         type: 'energy',
@@ -611,63 +584,15 @@ describe('useTronResources', () => {
       });
     });
 
-    it('does not call the snap when the account has no snap metadata', () => {
-      mockSelector({}, {}, true);
+    it('returns zero values when resource balances are absent', () => {
+      mockSelector({}, {}, {}, true);
 
-      renderTronResourcesHook(mockAccount, chainId);
+      const { result } = renderTronResourcesHook(mockAccount, chainId);
 
-      expect(mockGetAccountBalances).not.toHaveBeenCalled();
-    });
-
-    it('returns zero values when the snap call fails', async () => {
-      mockSelector({}, {}, true);
-
-      mockGetAccountBalances.mockRejectedValue(new Error('snap blew up'));
-
-      const { result } = renderTronResourcesHook(mockSnapAccount, chainId);
-
-      await waitFor(() => expect(mockGetAccountBalances).toHaveBeenCalled());
-
-      expect(result.current.energy).toEqual({
-        type: 'energy',
-        current: 0,
-        max: 0,
-        percentage: 0,
-      });
-
-      expect(result.current.bandwidth).toEqual({
-        type: 'bandwidth',
-        current: 0,
-        max: 0,
-        percentage: 0,
-      });
-    });
-
-    it('does not call the snap when the feature flag is disabled', () => {
-      mockSelector({}, {}, false);
-
-      renderTronResourcesHook(mockSnapAccount, chainId);
-
-      expect(mockGetAccountBalances).not.toHaveBeenCalled();
-    });
-
-    it('does not call the snap when the chainId is not a Tron chain', () => {
-      mockSelector({}, {}, true);
-
-      renderTronResourcesHook(
-        mockSnapAccount,
-        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-      );
-
-      expect(mockGetAccountBalances).not.toHaveBeenCalled();
-    });
-
-    it('does not call the snap when the chainId is empty', () => {
-      mockSelector({}, {}, true);
-
-      renderTronResourcesHook(mockSnapAccount, '');
-
-      expect(mockGetAccountBalances).not.toHaveBeenCalled();
+      expect(result.current.energy.current).toBe(0);
+      expect(result.current.energy.max).toBe(0);
+      expect(result.current.bandwidth.current).toBe(0);
+      expect(result.current.bandwidth.max).toBe(0);
     });
   });
 });

--- a/ui/pages/asset/hooks/useTronResources.ts
+++ b/ui/pages/asset/hooks/useTronResources.ts
@@ -1,17 +1,15 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useQuery } from '@tanstack/react-query';
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { Balance, CaipAssetId, CaipAssetType } from '@metamask/keyring-api';
-import { KeyringClient } from '@metamask/keyring-snap-client';
-import { SnapId } from '@metamask/snaps-sdk';
+import { Balance, CaipAssetId } from '@metamask/keyring-api';
 import { isTronSpecialAsset } from '../../../../shared/lib/asset-utils';
-import { getAssetsBySelectedAccountGroupWithTronSpecialAssets } from '../../../selectors/assets';
+import {
+  getAssetsBalance,
+  getAssetsBySelectedAccountGroupWithTronSpecialAssets,
+} from '../../../selectors/assets';
 import { getMultichainBalances } from '../../../selectors/multichain';
 import { getIsAssetsUnifyStateEnabled } from '../../../selectors/assets-unify-state';
 import { TRON_SPECIAL_ASSET_CAIP_TYPES } from '../../../../shared/constants/multichain/assets';
-import { TRON_CHAINS } from '../../../../shared/constants/multichain/networks';
-import { MultichainWalletSnapSender } from '../../../hooks/accounts/useMultichainWalletSnapSender';
 
 const TronResourceType = {
   ENERGY: 'energy',
@@ -27,19 +25,6 @@ export type TronResource = {
   max: number;
   percentage: number;
 };
-
-const TRON_RESOURCE_CAIP_TYPES = [
-  TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY,
-  TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_ENERGY,
-  TRON_SPECIAL_ASSET_CAIP_TYPES.BANDWIDTH,
-  TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_BANDWIDTH,
-];
-
-const TRON_RESOURCE_BALANCES_QUERY_KEY_ROOT = [
-  'metamask-extension',
-  'tronResourceBalances',
-  'v1',
-] as const;
 
 /**
  * Internal hook that reads Tron resource balances from state.
@@ -81,56 +66,22 @@ const useMultichainStateTronBalances = (
 };
 
 /**
- * Internal hook that fetches Tron resource balances directly from the Tron
- * wallet snap. Used when the unified AssetsController is enabled, because the
- * new SnapDataSource does not call `onAssetsLookup` and therefore the resource
- * assets (energy, bandwidth and their daily maximums) are stripped from state.
+ * Internal hook that reads Tron resource balances from the unified
+ * AssetsController state.
  * @param account
- * @param chainId
- * @param enabled
  */
-const useSnapTronBalances = (
+const useAssetsControllerTronBalances = (
   account: InternalAccount | undefined,
-  chainId: string,
-  enabled: boolean,
-): Record<CaipAssetId, Balance> | undefined => {
-  const snapId = account?.metadata?.snap?.id;
-  const accountId = account?.id;
-  const isTronChain = TRON_CHAINS.includes(
-    chainId as (typeof TRON_CHAINS)[number],
-  );
+): Record<CaipAssetId, Balance> => {
+  const assetsBalance = useSelector(getAssetsBalance);
 
-  const queryKey = useMemo(
-    () =>
-      [
-        ...TRON_RESOURCE_BALANCES_QUERY_KEY_ROOT,
-        snapId,
-        accountId,
-        chainId,
-      ] as const,
-    [snapId, accountId, chainId],
-  );
+  return useMemo(() => {
+    if (!account) {
+      return {} as Record<CaipAssetId, Balance>;
+    }
 
-  const { data } = useQuery({
-    queryKey,
-    queryFn: async (): Promise<Record<string, Balance>> => {
-      // `enabled` guarantees snapId, accountId, and chainId are defined here.
-      const assetIds = TRON_RESOURCE_CAIP_TYPES.map(
-        (caipType) => `${chainId}/${caipType}` as CaipAssetType,
-      );
-      const client = new KeyringClient(
-        new MultichainWalletSnapSender(snapId as SnapId),
-      );
-      return (await client.getAccountBalances(
-        accountId as string,
-        assetIds,
-      )) as Record<string, Balance>;
-    },
-    enabled: enabled && Boolean(accountId && chainId && isTronChain && snapId),
-    retry: false,
-  });
-
-  return data as Record<CaipAssetId, Balance> | undefined;
+    return (assetsBalance[account.id] ?? {}) as Record<CaipAssetId, Balance>;
+  }, [account, assetsBalance]);
 };
 
 /**
@@ -149,20 +100,11 @@ export const useTronResources = (
 } => {
   const isAssetsUnifyStateEnabled = useSelector(getIsAssetsUnifyStateEnabled);
 
-  // Both hooks are always called (no conditional hook calls). The inactive
-  // path is a no-op: useQuery with enabled:false returns undefined immediately,
-  // and useMultichainStateTronBalances returns a stable empty map when data is absent.
-  // When the feature flag is removed, delete useMultichainStateTronBalances and its call,
-  // and drop the isAssetsUnifyStateEnabled ternary below.
   const multichainStateBalances = useMultichainStateTronBalances(
     account,
     chainId,
   );
-  const snapBalances = useSnapTronBalances(
-    account,
-    chainId,
-    isAssetsUnifyStateEnabled,
-  );
+  const assetsControllerBalances = useAssetsControllerTronBalances(account);
 
   return useMemo(() => {
     const defaultResources = {
@@ -185,7 +127,7 @@ export const useTronResources = (
     }
 
     const balances = isAssetsUnifyStateEnabled
-      ? snapBalances
+      ? assetsControllerBalances
       : multichainStateBalances;
 
     const getBalanceForCaipType = (caipType: string): number => {
@@ -227,6 +169,6 @@ export const useTronResources = (
     chainId,
     isAssetsUnifyStateEnabled,
     multichainStateBalances,
-    snapBalances,
+    assetsControllerBalances,
   ]);
 };


### PR DESCRIPTION
## **Description**

The Tron resources hook was still fetching energy and bandwidth balances directly from the Tron wallet Snap when the unified assets state was enabled. This updates that path to read the balances already maintained by `AssetsController`, while preserving the legacy multichain state path behind the feature flag.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run the extension with the unified AssetsController state enabled.
2. Open a Tron account and navigate to the asset page.
3. Verify that the Energy and Bandwidth resource values and percentages are displayed from the account's asset balances.

## **Screenshots/Recordings**

### **Before**

<img width="767" height="336" alt="Screenshot 2026-08-27 at 10 15 09" src="https://github.com/user-attachments/assets/34c514e5-9598-4d29-a665-b420e0e554bd" />

### **After**

<img width="401" height="350" alt="Screenshot 2026-08-27 at 10 06 57" src="https://github.com/user-attachments/assets/509441ac-7cc2-43f1-8b8f-5760edd46e36" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.