### PR TITLE
fix(assets): Refresh List

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -14,6 +14,7 @@ import {
   NETWORKS_ROUTE,
   TOKEN_MANAGEMENT_ROUTE,
 } from '../../../../../helpers/constants/routes';
+import { getIsAssetsUnifyStateEnabled } from '../../../../../selectors/assets-unify-state/feature-flags';
 import AssetListControlBar from './asset-list-control-bar';
 
 type TooltipProps = {
@@ -43,6 +44,13 @@ jest.mock('react-router-dom', () => {
     useNavigate: () => mockUseNavigate,
   };
 });
+
+jest.mock('../../../../../selectors/assets-unify-state/feature-flags', () => ({
+  ...jest.requireActual(
+    '../../../../../selectors/assets-unify-state/feature-flags',
+  ),
+  getIsAssetsUnifyStateEnabled: jest.fn(() => false),
+}));
 
 const backgroundConnectionMock = new Proxy(
   {},
@@ -76,6 +84,7 @@ const createMockState = () => {
         ...state.metamask.multichainNetworkConfigurationsByChainId,
       },
       selectedNetworkClientId: 'selectedNetworkClientId',
+      completedOnboarding: true,
       networkConfigurationsByChainId: {
         '0x1': {
           chainId: '0x1',
@@ -122,9 +131,16 @@ const addSolanaAccountToSelectedGroup = (
   ].groups[DEFAULT_ACCOUNT_GROUP_ID].accounts.push(SOLANA_ACCOUNT_ID);
 };
 
+const selectSolanaAccount = (state: ReturnType<typeof createMockState>) => {
+  addSolanaAccountToSelectedGroup(state);
+  state.metamask.internalAccounts.selectedAccount = SOLANA_ACCOUNT_ID;
+  state.metamask.completedOnboarding = true;
+};
+
 describe('NFTs options', () => {
   afterEach(() => {
     jest.clearAllMocks();
+    jest.mocked(getIsAssetsUnifyStateEnabled).mockReturnValue(false);
   });
 
   it('should render a link "Refresh list" when some NFTs are present on mainnet and NFT auto-detection preference is set to true, which, when clicked calls methods DetectNFTs and checkAndUpdateNftsOwnershipStatus', async () => {
@@ -487,6 +503,111 @@ describe('NFTs options', () => {
     fireEvent.click(await findByTestId('home-network-filter-manage-networks'));
 
     expect(mockUseNavigate).toHaveBeenCalledWith(NETWORKS_ROUTE);
+  });
+
+  it('shows Refresh list for non-EVM accounts on the tokens tab', async () => {
+    const state = createMockState();
+    selectSolanaAccount(state);
+    const store = configureMockStore([thunk])(state);
+
+    const { findByTestId } = renderWithProvider(
+      <AssetListControlBar showTokensLinks />,
+      store,
+    );
+
+    fireEvent.click(await findByTestId('asset-list-control-bar-action-button'));
+
+    const refreshListButton = await findByTestId('refreshList__button');
+    expect(refreshListButton).toHaveTextContent(messages.refreshList.message);
+    expect(await findByTestId('manageTokens__button')).toBeInTheDocument();
+  });
+
+  it('refreshes via AssetsController when assets unify state is enabled', async () => {
+    setBackgroundConnection(backgroundConnectionMock as never);
+    jest.mocked(getIsAssetsUnifyStateEnabled).mockReturnValue(true);
+    const refreshAssetsSpy = jest.spyOn(
+      actions,
+      'refreshAssetsForSelectedAccount',
+    );
+    const updateBalancesSpy = jest.spyOn(actions, 'updateBalancesFoAccounts');
+    const detectTokensSpy = jest.spyOn(actions, 'detectTokens');
+
+    const state = createMockState();
+    state.metamask.enabledNetworkMap = {
+      eip155: {
+        '0x1': true,
+      },
+    };
+    const store = configureMockStore([thunk])(state);
+
+    const { findByTestId } = renderWithProvider(
+      <AssetListControlBar showTokensLinks />,
+      store,
+    );
+
+    fireEvent.click(await findByTestId('asset-list-control-bar-action-button'));
+    fireEvent.click(await findByTestId('refreshList__button'));
+
+    expect(refreshAssetsSpy).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3' })],
+      {
+        chainIds: ['eip155:1'],
+        assetTypes: ['token', 'price', 'metadata'],
+      },
+    );
+    expect(updateBalancesSpy).not.toHaveBeenCalled();
+    expect(detectTokensSpy).not.toHaveBeenCalled();
+  });
+
+  it('refreshes via the legacy token controllers when assets unify state is disabled', async () => {
+    setBackgroundConnection(backgroundConnectionMock as never);
+    const refreshAssetsSpy = jest.spyOn(
+      actions,
+      'refreshAssetsForSelectedAccount',
+    );
+    const updateBalancesSpy = jest.spyOn(actions, 'updateBalancesFoAccounts');
+    const detectTokensSpy = jest.spyOn(actions, 'detectTokens');
+
+    const state = createMockState();
+    state.metamask.enabledNetworkMap = {
+      eip155: {
+        '0x1': true,
+      },
+    };
+    const store = configureMockStore([thunk])(state);
+
+    const { findByTestId } = renderWithProvider(
+      <AssetListControlBar showTokensLinks />,
+      store,
+    );
+
+    fireEvent.click(await findByTestId('asset-list-control-bar-action-button'));
+    fireEvent.click(await findByTestId('refreshList__button'));
+
+    expect(updateBalancesSpy).toHaveBeenCalledWith(['0x1'], false);
+    expect(detectTokensSpy).toHaveBeenCalledWith(['0x1']);
+    expect(refreshAssetsSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps the original NFT overflow menu for non-EVM accounts', async () => {
+    const state = createMockState();
+    selectSolanaAccount(state);
+    const store = configureMockStore([thunk])(state);
+
+    const { findByTestId, queryByTestId } = renderWithProvider(
+      <AssetListControlBar />,
+      store,
+    );
+
+    fireEvent.click(await findByTestId('importTokens-button'));
+
+    expect(queryByTestId('refreshList__button')).not.toBeInTheDocument();
+    expect(queryByTestId('import-nfts')).not.toBeInTheDocument();
+    expect(mockUseNavigate).toHaveBeenCalledWith(TOKEN_MANAGEMENT_ROUTE, {
+      state: {
+        globalMenuTransition: 'forward',
+      },
+    });
   });
 
   it('shows a refresh-only menu when onRefresh is provided and import token button is hidden', async () => {

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -344,18 +344,24 @@ const AssetListControlBar = ({
   };
 
   const handleRefresh = () => {
-    if (isAssetsUnifyStateEnabled && selectedInternalAccount) {
+    if (isAssetsUnifyStateEnabled) {
+      if (selectedInternalAccount) {
+        dispatch(
+          refreshAssetsForSelectedAccount([selectedInternalAccount], {
+            chainIds: selectedCaipChainIds,
+            assetTypes: ['token', 'price', 'metadata'],
+          }),
+        );
+      }
+    } else {
       dispatch(
-        refreshAssetsForSelectedAccount([selectedInternalAccount], {
-          chainIds: allEnabledNetworksForAllNamespaces,
-          assetTypes: ['token', 'price', 'metadata'],
-        }),
+        updateBalancesFoAccounts(
+          Object.keys(enabledNetworksByNamespace),
+          false,
+        ),
       );
+      dispatch(detectTokens(Object.keys(enabledNetworksByNamespace)));
     }
-    dispatch(
-      updateBalancesFoAccounts(Object.keys(enabledNetworksByNamespace), false),
-    );
-    dispatch(detectTokens(Object.keys(enabledNetworksByNamespace)));
     closePopover();
   };
 
@@ -461,7 +467,8 @@ const AssetListControlBar = ({
           )}
 
           {showImportTokenButton &&
-            (isEvm ? (
+            (isEvm || showTokensLinks ? (
+              // Tokens (EVM and non-EVM) and EVM NFT: overflow menu with Refresh list
               <ImportControl
                 ref={importButtonRef}
                 showTokensLinks={showTokensLinks}
@@ -472,6 +479,7 @@ const AssetListControlBar = ({
                 }
               />
             ) : (
+              // Non-EVM NFT: no Refresh list
               <Tooltip
                 title={t('manageTokens')}
                 position="bottom"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Fix "Refresh List" to call AssetsController with the correct input
- Have "Refresh List" for non-EVM too


Before PR
<img width="1725" height="1081" alt="image" src="https://github.com/user-attachments/assets/7c893a5a-dc71-4b52-82fa-34419aca6648" />


With PR
<img width="1725" height="1081" alt="image" src="https://github.com/user-attachments/assets/bfb25b3b-161e-4e78-9c6f-660b0b3028f2" />

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which backend paths run on refresh and which chain IDs are passed to AssetsController; mistakes could leave balances stale or skip detection for some users depending on the unify flag.
> 
> **Overview**
> Fixes **Refresh list** in the asset list control bar so it no longer runs legacy balance/token detection when assets unify state is on, and exposes the tokens overflow menu (including Refresh list) for **non-EVM** accounts on the tokens tab.
> 
> **Refresh behavior:** With unify enabled, refresh only dispatches `refreshAssetsForSelectedAccount` for the selected account using **enabled networks as CAIP chain IDs** (`selectedCaipChainIds`) and asset types `token`, `price`, `metadata`. With unify disabled, it uses the legacy path (`updateBalancesFoAccounts` + `detectTokens`) only—no AssetsController call.
> 
> **UI:** The overflow menu with Refresh list is shown when the account is EVM **or** `showTokensLinks` is set (tokens view). Non-EVM **NFT** view still uses the single “manage tokens” button without Refresh list in that menu.
> 
> Tests cover Solana tokens refresh visibility, unify vs legacy dispatch paths, and unchanged non-EVM NFT behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75d80d3e07d3fb2d23628b0cec01deeb403142b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->