### PR TITLE
fix(ramps): use browser context for extension providers

### DIFF
--- a/app/scripts/messenger-client-init/ramps-service-init.test.ts
+++ b/app/scripts/messenger-client-init/ramps-service-init.test.ts
@@ -42,7 +42,7 @@ describe('RampsServiceInit', () => {
     expect(serviceMock).toHaveBeenCalledWith({
       messenger: expect.any(Object),
       environment: 'staging',
-      context: 'extension',
+      context: 'browser',
       fetch: expect.any(Function),
     });
   });

--- a/app/scripts/messenger-client-init/ramps-service-init.ts
+++ b/app/scripts/messenger-client-init/ramps-service-init.ts
@@ -19,7 +19,7 @@ export const RampsServiceInit: MessengerClientInitFunction<
   const messengerClient = new RampsService({
     messenger: controllerMessenger,
     environment: getRampsEnvironment(),
-    context: 'extension',
+    context: 'browser',
     fetch: globalThis.fetch.bind(globalThis),
   });
 

--- a/test/e2e/tests/btc/mocks/ramps.ts
+++ b/test/e2e/tests/btc/mocks/ramps.ts
@@ -10,7 +10,7 @@ export async function mockRampsDynamicFeatureFlag(
       `https://on-ramp-content.${subDomain}.cx.metamask.io/regions/networks`,
     )
     .withQuery({
-      context: 'extension',
+      context: 'browser',
     })
     .thenJson(200, {
       networks: [


### PR DESCRIPTION
## **Description**

The extension initialized `RampsService` with the `extension` context. The on-ramp API uses the request context to select provider-specific behavior, including PayPal's browser partner configuration. This caused the extension to use the wrong provider context for the extension buy flow.

This changes the ramps service and corresponding E2E mock request to use the `browser` context, aligning the extension with the API's browser partner behavior.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TRAM-3847

## **Manual testing steps**

1. Build the extension with `yarn build:test`.
2. Load `dist/chrome` as an unpacked extension in Chrome.
3. Open the Buy flow and select a supported asset, region, payment method, and provider.
4. Verify that the provider list loads and providers are not duplicated.
5. Select a provider and continue through the checkout flow.
6. Verify that the provider checkout opens and the extension handles the checkout flow normally.

## **Screenshots/Recordings**

<!--
### **Before**

Not available. The reported issue was validated from the provider list behavior without a recording.

### **After**

Not available. The change is an API request-context fix and no screenshot was captured.
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented code using JSDoc format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> It changes on-ramp API request context for the extension buy flow, which affects provider selection and checkout behavior, though the change is a single aligned parameter plus test updates.
> 
> **Overview**
> The extension **Buy** flow was calling the on-ramp API with `context: 'extension'`, which steers provider/partner behavior (including PayPal’s browser configuration) away from what the extension actually needs—leading to incorrect provider handling such as duplicated providers.
> 
> This PR **switches `RampsService` initialization to `context: 'browser'`** in `ramps-service-init.ts`, updates the unit test expectation, and aligns the BTC E2E mock’s `regions/networks` query to expect `context=browser` so tests match production requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b14e729972762120321a8895b8ed1bab71686f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->