### PR TITLE
chore: exclude known-feature-flag-constants.mts from CO

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -301,18 +301,18 @@ ui/selectors/money/                  @MetaMask/earn
 # CI
 /.github/workflows/                                   @MetaMask/extension-platform @HowardBraham @itsyoboieltr
 /.github/scripts/                                     @MetaMask/extension-platform @HowardBraham @itsyoboieltr
-
-# Store submission
-/.github/workflows/upload-extension-to-cws.yml             @MetaMask/extension-security-team @MetaMask/release-team
-/.github/workflows/adjust-cws-rollout.yml                  @MetaMask/extension-security-team @MetaMask/release-team
-/.github/workflows/upload-extension-to-amo.yml             @MetaMask/extension-security-team @MetaMask/release-team
-/.github/scripts/release-create-gh-release.sh              @MetaMask/extension-security-team @MetaMask/release-team
 /.github/rules/                                       @MetaMask/extension-platform @HowardBraham @itsyoboieltr
 /.github/dependabot.yml                               @MetaMask/extension-platform
 development/fitness-functions/                        @MetaMask/extension-platform @HowardBraham @itsyoboieltr
 development/metamaskbot-build-announce/               @MetaMask/extension-platform @HowardBraham @itsyoboieltr
 /codecov.yml                                          @MetaMask/extension-platform
 /sonar-project.properties                             @MetaMask/extension-platform
+
+# Store submission
+/.github/workflows/upload-extension-to-cws.yml             @MetaMask/extension-security-team @MetaMask/release-team
+/.github/workflows/adjust-cws-rollout.yml                  @MetaMask/extension-security-team @MetaMask/release-team
+/.github/workflows/upload-extension-to-amo.yml             @MetaMask/extension-security-team @MetaMask/release-team
+/.github/scripts/release-create-gh-release.sh              @MetaMask/extension-security-team @MetaMask/release-team
 
 # Build
 development/build/                                    @MetaMask/extension-platform @itsyoboieltr
@@ -341,11 +341,6 @@ app/scripts/wallet-init/instance-options/network-controller*             @MetaMa
 app/scripts/wallet-init/instance-options/remote-feature-flag-controller* @MetaMask/extension-platform @MetaMask/core-platform
 app/scripts/wallet-init/instance-options/storage-service*                @MetaMask/extension-platform @MetaMask/core-platform
 
-# Snapshots – no code owners assigned
-# This allows anyone with write access to approve changes to any *.snap files.
-# ⚠️ Note: Leaving this rule unassigned disables Code Owner review enforcement for snapshot files.
-**/*.snap
-
 # Deep-link security boundary
 #
 # These files control whether external input can bypass the deep-link security
@@ -362,3 +357,9 @@ app/scripts/wallet-init/instance-options/storage-service*                @MetaMa
 /shared/lib/deep-links/routes/route*                          @MetaMask/extension-security-team
 /ui/helpers/utils/resolve-deep-link-href*                     @MetaMask/extension-security-team
 /ui/pages/deep-link/                                          @MetaMask/extension-security-team
+
+# Exclusions (no codeowners are assigned to these files)
+# ⚠️--------------Keep this section last--------------⚠️
+/.github/scripts/known-feature-flag-constants.mts
+# Snapshots – *.snap files
+**/*.snap


### PR DESCRIPTION
## **Description**

- As discovered in #45761, `known-feature-flag-constants.mts` should not have a codeowner
- Cleaned up a change made in #44017 that put the `# Store submission` section right in the middle of the `# CI` section
- Moved the `Snapshots` section into the `Exclusions` section

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CODEOWNERS metadata and section ordering change; no runtime or release workflow logic is modified.
> 
> **Overview**
> Updates **`.github/CODEOWNERS`** only: reorganizes sections and changes who must review certain paths.
> 
> The **`# Store submission`** block (CWS/AMO upload workflows and `release-create-gh-release.sh`) is moved out of the middle of **`# CI`** so CI entries stay grouped, with store submission still listed before **`# Build`**.
> 
> Snapshot and feature-flag exclusions are consolidated in a new trailing **`# Exclusions`** section. **`/.github/scripts/known-feature-flag-constants.mts`** is listed there so it is no longer required to match the broad **`/.github/scripts/`** platform ownership (addressing review friction from #45761). The **`**/*.snap`** rule is moved from the old standalone Snapshots block into the same exclusions section, with a note to keep exclusions last so overrides apply correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e7b3a8fb9ab177771d7caefc8906fc140a0eaf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->