### PR TITLE
chore: Bump remote feature flag controller to v6x and resolve breaking changes

### DIFF
--- a/app/scripts/migrations/224.test.ts
+++ b/app/scripts/migrations/224.test.ts
@@ -10,8 +10,8 @@ describe(`migration #${VERSION}`, () => {
       meta: { version: OLD_VERSION },
       data: {
         RemoteFeatureFlagController: {
-          remoteFeatureFlags: { otaUpdatesEnabled: true },
-          rawRemoteFeatureFlags: { otaUpdatesEnabled: true },
+          remoteFeatureFlags: { addBitcoinAccountDummyFlag: true },
+          rawRemoteFeatureFlags: { addBitcoinAccountDummyFlag: true },
           cacheTimestamp: 123,
         },
         OtherController: { preserved: true },
@@ -26,7 +26,7 @@ describe(`migration #${VERSION}`, () => {
       meta: { version: VERSION },
       data: {
         RemoteFeatureFlagController: {
-          remoteFeatureFlags: { otaUpdatesEnabled: true },
+          remoteFeatureFlags: { addBitcoinAccountDummyFlag: true },
           cacheTimestamp: 123,
         },
         OtherController: { preserved: true },

--- a/app/scripts/migrations/224.test.ts
+++ b/app/scripts/migrations/224.test.ts
@@ -1,0 +1,80 @@
+import { cloneDeep } from 'lodash';
+import { migrate, version } from './224';
+
+const VERSION = version;
+const OLD_VERSION = VERSION - 1;
+
+describe(`migration #${VERSION}`, () => {
+  it('removes rawRemoteFeatureFlags from RemoteFeatureFlagController', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: { otaUpdatesEnabled: true },
+          rawRemoteFeatureFlags: { otaUpdatesEnabled: true },
+          cacheTimestamp: 123,
+        },
+        OtherController: { preserved: true },
+      },
+    };
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData).toStrictEqual({
+      meta: { version: VERSION },
+      data: {
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: { otaUpdatesEnabled: true },
+          cacheTimestamp: 123,
+        },
+        OtherController: { preserved: true },
+      },
+    });
+    expect(changedControllers).toStrictEqual(
+      new Set(['RemoteFeatureFlagController']),
+    );
+  });
+
+  it('does not mark RemoteFeatureFlagController changed when rawRemoteFeatureFlags is absent', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: {},
+          cacheTimestamp: 0,
+        },
+      },
+    };
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData).toStrictEqual({
+      meta: { version: VERSION },
+      data: oldStorage.data,
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+  });
+
+  it('does nothing when RemoteFeatureFlagController is missing', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        AppStateController: {},
+      },
+    };
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData).toStrictEqual({
+      meta: { version: VERSION },
+      data: oldStorage.data,
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+  });
+});

--- a/app/scripts/migrations/224.ts
+++ b/app/scripts/migrations/224.ts
@@ -1,0 +1,40 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import type { Migrate } from './types';
+
+export const version = 224;
+
+/**
+ * Deletes persisted `rawRemoteFeatureFlags` from RemoteFeatureFlagController.
+ *
+ * `@metamask/remote-feature-flag-controller` 6.0.0 stops redacting IDs from
+ * `rawRemoteFeatureFlags`. Existing persisted (redacted) values must not be
+ * used to recompute flags.
+ *
+ * @param versionedData - The versioned data object to migrate.
+ * @param changedControllers - A set used to record controllers that were modified.
+ */
+export const migrate = (async (versionedData, changedControllers) => {
+  versionedData.meta.version = version;
+
+  if (removeRawRemoteFeatureFlags(versionedData.data)) {
+    changedControllers.add('RemoteFeatureFlagController');
+  }
+}) satisfies Migrate;
+
+function removeRawRemoteFeatureFlags(state: Record<string, unknown>): boolean {
+  if (
+    !hasProperty(state, 'RemoteFeatureFlagController') ||
+    !isObject(state.RemoteFeatureFlagController)
+  ) {
+    return false;
+  }
+
+  if (
+    !hasProperty(state.RemoteFeatureFlagController, 'rawRemoteFeatureFlags')
+  ) {
+    return false;
+  }
+
+  delete state.RemoteFeatureFlagController.rawRemoteFeatureFlags;
+  return true;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -259,6 +259,7 @@ const migrations = [
   require('./221'),
   require('./222'),
   require('./223'),
+  require('./224'),
 ];
 
 export default migrations;

--- a/app/scripts/wallet-init/initialization.test.ts
+++ b/app/scripts/wallet-init/initialization.test.ts
@@ -285,6 +285,7 @@ describe('initializeWallet — RemoteFeatureFlagController toggle', () => {
       // `useExternalServices` is absent, so it defaults to on, matching the
       // live `PreferencesController` default.
       preferencesState: { useExternalServices: true },
+      authenticationState: { srpSessionData: undefined },
     });
   });
 
@@ -304,6 +305,29 @@ describe('initializeWallet — RemoteFeatureFlagController toggle', () => {
       expect.objectContaining({
         onboardingState: { completedOnboarding: false },
         preferencesState: { useExternalServices: false },
+      }),
+    );
+  });
+
+  it('seeds the canonical-id comparison from persisted AuthenticationController state', () => {
+    const srpSessionData = {
+      'srp-1': { profile: { canonicalProfileId: 'canonical-id' } },
+    };
+
+    initializeWallet({
+      connectivityAdapter,
+      getFlatState,
+      getPermittedAccounts,
+      getTransactionMetricsRequest,
+      infuraProjectId: 'fake-infura-project-id',
+      messenger: createMockMessenger(),
+      platform,
+      state: { AuthenticationController: { srpSessionData } },
+    });
+
+    expect(mockSetupToggle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authenticationState: { srpSessionData },
       }),
     );
   });

--- a/app/scripts/wallet-init/initialization.ts
+++ b/app/scripts/wallet-init/initialization.ts
@@ -1,3 +1,4 @@
+import type { AuthenticationControllerState } from '@metamask/profile-sync-controller/auth';
 import { Wallet } from '@metamask/wallet';
 import { setupRemoteFeatureFlagToggle } from './remote-feature-flags';
 import { getApprovalControllerInstanceOptions } from './instance-options/approval-controller';
@@ -108,6 +109,11 @@ export function initializeWallet(request: InitializeWalletRequest) {
     preferencesState: {
       useExternalServices:
         state.PreferencesController?.useExternalServices !== false,
+    },
+    authenticationState: {
+      srpSessionData: state.AuthenticationController?.srpSessionData as
+        | AuthenticationControllerState['srpSessionData']
+        | undefined,
     },
   });
 

--- a/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.test.ts
+++ b/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.test.ts
@@ -1,4 +1,5 @@
 import type { Json } from '@metamask/utils';
+import type { AuthenticationControllerState } from '@metamask/profile-sync-controller/auth';
 import { ClientConfigApiService } from '@metamask/remote-feature-flag-controller';
 import { ENVIRONMENT } from '../../../../shared/constants/build';
 import { getBaseSemVerVersion } from '../../../../shared/lib/feature-flags/version-gating';
@@ -21,6 +22,23 @@ jest.mock('../../../../shared/lib/feature-flags/version-gating', () => ({
  * @param analyticsId - The metaMetrics id the messenger resolves.
  * @returns The built instance options.
  */
+function mockAuthState(
+  overrides: Record<string, unknown> = {},
+): AuthenticationControllerState {
+  return {
+    isSignedIn: false,
+    ...overrides,
+  } as AuthenticationControllerState;
+}
+
+/**
+ * Build the `RemoteFeatureFlagController` instance options with a messenger
+ * whose `AnalyticsController:getState` resolves to the given metaMetrics id.
+ *
+ * @param state - The persisted state passed to the builder.
+ * @param analyticsId - The metaMetrics id the messenger resolves.
+ * @returns The built instance options.
+ */
 function buildOptions(
   state: Record<string, Record<string, Json>>,
   analyticsId = 'metrics-id',
@@ -31,6 +49,21 @@ function buildOptions(
     optedIn: false,
   }));
   return getRemoteFeatureFlagControllerInstanceOptions({ messenger, state });
+}
+
+function buildOptionsWithAuthState(authState: Record<string, unknown>) {
+  const messenger = createMockMessenger();
+  messenger.registerActionHandler('AnalyticsController:getState', () => ({
+    analyticsId: 'metrics-id',
+    optedIn: false,
+  }));
+  messenger.registerActionHandler('AuthenticationController:getState', () =>
+    mockAuthState(authState),
+  );
+  return getRemoteFeatureFlagControllerInstanceOptions({
+    messenger,
+    state: {},
+  });
 }
 
 describe('getRemoteFeatureFlagControllerInstanceOptions', () => {
@@ -50,6 +83,36 @@ describe('getRemoteFeatureFlagControllerInstanceOptions', () => {
     const options = buildOptions({}, 'metrics-id');
 
     expect(options.getMetaMetricsId?.()).toBe('metrics-id');
+  });
+
+  it('resolves the canonical profile id from AuthenticationController via the messenger', () => {
+    const options = buildOptionsWithAuthState({
+      isSignedIn: true,
+      srpSessionData: {
+        'srp-1': { profile: { canonicalProfileId: 'canonical-id' } },
+      },
+    });
+
+    expect(options.getCanonicalProfileId?.()).toBe('canonical-id');
+  });
+
+  it('returns an empty canonical profile id when no session profile is present', () => {
+    const options = buildOptionsWithAuthState({ srpSessionData: {} });
+
+    expect(options.getCanonicalProfileId?.()).toBe('');
+  });
+
+  it('returns an empty canonical profile id when srpSessionData is absent', () => {
+    const options = buildOptionsWithAuthState({});
+
+    expect(options.getCanonicalProfileId?.()).toBe('');
+  });
+
+  it('includes empty defaultFeatureFlags and metaMetricsFlags stubs', () => {
+    const options = buildOptions({});
+
+    expect(options.defaultFeatureFlags).toStrictEqual({});
+    expect(options.metaMetricsFlags).toStrictEqual([]);
   });
 
   it('uses the configured client version and 15-minute fetch interval', () => {

--- a/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.test.ts
+++ b/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.test.ts
@@ -15,12 +15,10 @@ jest.mock('../../../../shared/lib/feature-flags/version-gating', () => ({
 }));
 
 /**
- * Build the `RemoteFeatureFlagController` instance options with a messenger
- * whose `AnalyticsController:getState` resolves to the given metaMetrics id.
+ * Build a minimal `AuthenticationController` state object for messenger mocks.
  *
- * @param state - The persisted state passed to the builder.
- * @param analyticsId - The metaMetrics id the messenger resolves.
- * @returns The built instance options.
+ * @param overrides - Fields merged onto the default unsigned-in state.
+ * @returns The mocked authentication state.
  */
 function mockAuthState(
   overrides: Record<string, unknown> = {},

--- a/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.test.ts
+++ b/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.test.ts
@@ -94,16 +94,16 @@ describe('getRemoteFeatureFlagControllerInstanceOptions', () => {
     expect(options.getCanonicalProfileId?.()).toBe('canonical-id');
   });
 
-  it('returns an empty canonical profile id when no session profile is present', () => {
+  it('falls back to the MetaMetrics id when no session profile is present', () => {
     const options = buildOptionsWithAuthState({ srpSessionData: {} });
 
-    expect(options.getCanonicalProfileId?.()).toBe('');
+    expect(options.getCanonicalProfileId?.()).toBe('metrics-id');
   });
 
-  it('returns an empty canonical profile id when srpSessionData is absent', () => {
+  it('falls back to the MetaMetrics id when srpSessionData is absent', () => {
     const options = buildOptionsWithAuthState({});
 
-    expect(options.getCanonicalProfileId?.()).toBe('');
+    expect(options.getCanonicalProfileId?.()).toBe('metrics-id');
   });
 
   it('returns an empty MetaMetrics id when AnalyticsController is not registered', () => {
@@ -124,6 +124,12 @@ describe('getRemoteFeatureFlagControllerInstanceOptions', () => {
     });
 
     expect(options.getCanonicalProfileId?.()).toBe('');
+  });
+
+  it('falls back to the MetaMetrics id when AuthenticationController is not registered', () => {
+    const options = buildOptions({});
+
+    expect(options.getCanonicalProfileId?.()).toBe('metrics-id');
   });
 
   it('includes empty defaultFeatureFlags and metaMetricsFlags stubs', () => {

--- a/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.test.ts
+++ b/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.test.ts
@@ -106,6 +106,26 @@ describe('getRemoteFeatureFlagControllerInstanceOptions', () => {
     expect(options.getCanonicalProfileId?.()).toBe('');
   });
 
+  it('returns an empty MetaMetrics id when AnalyticsController is not registered', () => {
+    const messenger = createMockMessenger();
+    const options = getRemoteFeatureFlagControllerInstanceOptions({
+      messenger,
+      state: {},
+    });
+
+    expect(options.getMetaMetricsId?.()).toBe('');
+  });
+
+  it('returns an empty canonical profile id when AuthenticationController is not registered', () => {
+    const messenger = createMockMessenger();
+    const options = getRemoteFeatureFlagControllerInstanceOptions({
+      messenger,
+      state: {},
+    });
+
+    expect(options.getCanonicalProfileId?.()).toBe('');
+  });
+
   it('includes empty defaultFeatureFlags and metaMetricsFlags stubs', () => {
     const options = buildOptions({});
 

--- a/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.ts
+++ b/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.ts
@@ -94,7 +94,9 @@ type RemoteFeatureFlagControllerInstanceOptions =
  * @param options - Options bag.
  * @param options.messenger - Root messenger; resolves the MetaMetrics id from
  * `AnalyticsController` and the canonical profile id from
- * `AuthenticationController` lazily at fetch / init time.
+ * `AuthenticationController` lazily at fetch / init time. Falls back to the
+ * MetaMetrics id when no profile id is available so threshold flags still
+ * resolve for pre-auth and E2E sessions.
  * @param options.state - Initial persisted state; `prevClientVersion` is read
  * from `AppMetadataController` so the controller can invalidate cached flags
  * when the client version changes between sessions, and the initial `disabled`
@@ -133,13 +135,21 @@ export function getRemoteFeatureFlagControllerInstanceOptions({
         const { srpSessionData } = messenger.call(
           'AuthenticationController:getState',
         );
-
-        return (
+        const canonicalProfileId =
           Object.entries(srpSessionData ?? {})?.[0]?.[1]?.profile
-            ?.canonicalProfileId ?? ''
-        );
+            ?.canonicalProfileId ?? '';
+        if (canonicalProfileId) {
+          return canonicalProfileId;
+        }
       } catch {
         // `wallet.init()` runs before AuthenticationController is registered.
+      }
+      // RFFC 6 leaves threshold flags as raw arrays when this is ''. E2E and
+      // pre-auth users have a MetaMetrics id but no profile; fall back so
+      // those flags still resolve the way they did in RFFC 5.
+      try {
+        return messenger.call('AnalyticsController:getState').analyticsId ?? '';
+      } catch {
         return '';
       }
     },

--- a/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.ts
+++ b/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.ts
@@ -120,17 +120,30 @@ export function getRemoteFeatureFlagControllerInstanceOptions({
       // Example:
       // 'feature-flag-name',
     ],
-    getMetaMetricsId: () =>
-      messenger.call('AnalyticsController:getState').analyticsId,
+    getMetaMetricsId: () => {
+      try {
+        return (
+          messenger.call('AnalyticsController:getState').analyticsId ?? ''
+        );
+      } catch {
+        // `wallet.init()` runs before AnalyticsController is registered.
+        return '';
+      }
+    },
     getCanonicalProfileId: () => {
-      const { srpSessionData } = messenger.call(
-        'AuthenticationController:getState',
-      );
+      try {
+        const { srpSessionData } = messenger.call(
+          'AuthenticationController:getState',
+        );
 
-      return (
-        Object.entries(srpSessionData ?? {})?.[0]?.[1]?.profile
-          ?.canonicalProfileId ?? ''
-      );
+        return (
+          Object.entries(srpSessionData ?? {})?.[0]?.[1]?.profile
+            ?.canonicalProfileId ?? ''
+        );
+      } catch {
+        // `wallet.init()` runs before AuthenticationController is registered.
+        return '';
+      }
     },
     clientVersion: getBaseSemVerVersion(),
     prevClientVersion: state.AppMetadataController?.currentAppVersion as

--- a/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.ts
+++ b/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.ts
@@ -93,7 +93,8 @@ type RemoteFeatureFlagControllerInstanceOptions =
  *
  * @param options - Options bag.
  * @param options.messenger - Root messenger; resolves the MetaMetrics id from
- * `AnalyticsController` lazily at fetch time.
+ * `AnalyticsController` and the canonical profile id from
+ * `AuthenticationController` lazily at fetch / init time.
  * @param options.state - Initial persisted state; `prevClientVersion` is read
  * from `AppMetadataController` so the controller can invalidate cached flags
  * when the client version changes between sessions, and the initial `disabled`
@@ -109,8 +110,28 @@ export function getRemoteFeatureFlagControllerInstanceOptions({
 }): RemoteFeatureFlagControllerInstanceOptions {
   return {
     clientConfigApiService: getRemoteFeatureFlagClientConfigApiService(),
+    // Apply default feature flag values here.
+    defaultFeatureFlags: {
+      // Example:
+      // 'feature-flag-name': true,
+    },
+    // Flags that are used in flows prior to authentication should be added here.
+    metaMetricsFlags: [
+      // Example:
+      // 'feature-flag-name',
+    ],
     getMetaMetricsId: () =>
       messenger.call('AnalyticsController:getState').analyticsId,
+    getCanonicalProfileId: () => {
+      const { srpSessionData } = messenger.call(
+        'AuthenticationController:getState',
+      );
+
+      return (
+        Object.entries(srpSessionData ?? {})?.[0]?.[1]?.profile
+          ?.canonicalProfileId ?? ''
+      );
+    },
     clientVersion: getBaseSemVerVersion(),
     prevClientVersion: state.AppMetadataController?.currentAppVersion as
       | string

--- a/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.ts
+++ b/app/scripts/wallet-init/instance-options/remote-feature-flag-controller.ts
@@ -122,9 +122,7 @@ export function getRemoteFeatureFlagControllerInstanceOptions({
     ],
     getMetaMetricsId: () => {
       try {
-        return (
-          messenger.call('AnalyticsController:getState').analyticsId ?? ''
-        );
+        return messenger.call('AnalyticsController:getState').analyticsId ?? '';
       } catch {
         // `wallet.init()` runs before AnalyticsController is registered.
         return '';

--- a/app/scripts/wallet-init/remote-feature-flags.test.ts
+++ b/app/scripts/wallet-init/remote-feature-flags.test.ts
@@ -201,13 +201,16 @@ describe('setupRemoteFeatureFlagToggle', () => {
   });
 
   describe('canonical profile id refresh', () => {
-    const authStateWithCanonicalId = (canonicalProfileId?: string) => ({
-      srpSessionData: canonicalProfileId
-        ? {
-            'srp-1': { profile: { canonicalProfileId } },
-          }
-        : {},
-    });
+    const authStateWithCanonicalId = (
+      canonicalProfileId?: string,
+    ): ToggleArgs['authenticationState'] =>
+      ({
+        srpSessionData: canonicalProfileId
+          ? {
+              'srp-1': { profile: { canonicalProfileId } },
+            }
+          : {},
+      }) as ToggleArgs['authenticationState'];
 
     it('force-refreshes flags when a canonical profile id first becomes available', () => {
       const { handlers, call } = setupToggle(

--- a/app/scripts/wallet-init/remote-feature-flags.test.ts
+++ b/app/scripts/wallet-init/remote-feature-flags.test.ts
@@ -18,12 +18,14 @@ const UPDATE_ACTION = 'RemoteFeatureFlagController:updateRemoteFeatureFlags';
  *
  * @param preferencesState - The initial PreferencesController state.
  * @param onboardingState - The initial OnboardingController state.
+ * @param authenticationState - The initial AuthenticationController state.
  * @returns The captured stateChange handlers, the child messenger `call` mock,
  * and the parent `delegate` mock.
  */
 function setupToggle(
   preferencesState: Partial<ToggleArgs['preferencesState']>,
   onboardingState: Partial<ToggleArgs['onboardingState']>,
+  authenticationState: Partial<ToggleArgs['authenticationState']> = {},
 ) {
   const handlers: Record<string, (state: unknown) => void> = {};
   // The toggle drives the controller over a namespaced child messenger it
@@ -48,6 +50,8 @@ function setupToggle(
     messenger,
     preferencesState: preferencesState as ToggleArgs['preferencesState'],
     onboardingState: onboardingState as ToggleArgs['onboardingState'],
+    authenticationState:
+      authenticationState as ToggleArgs['authenticationState'],
   });
 
   return { handlers, call, delegate };
@@ -58,7 +62,7 @@ describe('setupRemoteFeatureFlagToggle', () => {
     jest.clearAllMocks();
   });
 
-  it('delegates the watched actions and events and subscribes to Preferences and Onboarding state changes', () => {
+  it('delegates the watched actions and events and subscribes to Preferences, Onboarding, and Authentication state changes', () => {
     const { handlers, delegate } = setupToggle(
       { useExternalServices: true },
       { completedOnboarding: true },
@@ -74,12 +78,14 @@ describe('setupRemoteFeatureFlagToggle', () => {
         events: [
           'PreferencesController:stateChange',
           'OnboardingController:stateChange',
+          'AuthenticationController:stateChange',
         ],
       }),
     );
     expect(Object.keys(handlers)).toStrictEqual([
       'PreferencesController:stateChange',
       'OnboardingController:stateChange',
+      'AuthenticationController:stateChange',
     ]);
   });
 
@@ -192,5 +198,97 @@ describe('setupRemoteFeatureFlagToggle', () => {
       error,
     );
     consoleErrorSpy.mockRestore();
+  });
+
+  describe('canonical profile id refresh', () => {
+    const authStateWithCanonicalId = (canonicalProfileId?: string) => ({
+      srpSessionData: canonicalProfileId
+        ? {
+            'srp-1': { profile: { canonicalProfileId } },
+          }
+        : {},
+    });
+
+    it('force-refreshes flags when a canonical profile id first becomes available', () => {
+      const { handlers, call } = setupToggle(
+        { useExternalServices: true },
+        { completedOnboarding: true },
+      );
+
+      handlers['AuthenticationController:stateChange'](
+        authStateWithCanonicalId('canonical-id'),
+      );
+
+      expect(call).toHaveBeenCalledWith(UPDATE_ACTION, true);
+    });
+
+    it('does not refresh flags when the canonical profile id is unchanged', () => {
+      const { handlers, call } = setupToggle(
+        { useExternalServices: true },
+        { completedOnboarding: true },
+        authStateWithCanonicalId('canonical-id'),
+      );
+
+      handlers['AuthenticationController:stateChange'](
+        authStateWithCanonicalId('canonical-id'),
+      );
+
+      expect(call).not.toHaveBeenCalled();
+    });
+
+    it('force-refreshes flags when the canonical profile id changes', () => {
+      const { handlers, call } = setupToggle(
+        { useExternalServices: true },
+        { completedOnboarding: true },
+        authStateWithCanonicalId('canonical-id-1'),
+      );
+
+      handlers['AuthenticationController:stateChange'](
+        authStateWithCanonicalId('canonical-id-2'),
+      );
+
+      expect(call).toHaveBeenCalledWith(UPDATE_ACTION, true);
+    });
+
+    it('force-refreshes flags when the canonical profile id is cleared', () => {
+      const { handlers, call } = setupToggle(
+        { useExternalServices: true },
+        { completedOnboarding: true },
+        authStateWithCanonicalId('canonical-id'),
+      );
+
+      handlers['AuthenticationController:stateChange'](
+        authStateWithCanonicalId(),
+      );
+
+      expect(call).toHaveBeenCalledWith(UPDATE_ACTION, true);
+    });
+
+    it('logs and swallows a failed force refresh instead of throwing', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+      const error = new Error('network down');
+      const { handlers, call } = setupToggle(
+        { useExternalServices: true },
+        { completedOnboarding: true },
+      );
+      call.mockImplementation((action: string) =>
+        action === UPDATE_ACTION ? Promise.reject(error) : undefined,
+      );
+
+      expect(() =>
+        handlers['AuthenticationController:stateChange'](
+          authStateWithCanonicalId('canonical-id'),
+        ),
+      ).not.toThrow();
+      await flushPromises();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to update remote feature flags:',
+        error,
+      );
+      consoleErrorSpy.mockRestore();
+    });
   });
 });

--- a/app/scripts/wallet-init/remote-feature-flags.ts
+++ b/app/scripts/wallet-init/remote-feature-flags.ts
@@ -1,4 +1,8 @@
 import { Messenger } from '@metamask/messenger';
+import type {
+  AuthenticationControllerState,
+  AuthenticationControllerStateChangeEvent,
+} from '@metamask/profile-sync-controller/auth';
 import {
   type RemoteFeatureFlagControllerEnableAction,
   type RemoteFeatureFlagControllerDisableAction,
@@ -20,10 +24,30 @@ type RemoteFeatureFlagToggleActions =
   | RemoteFeatureFlagControllerDisableAction
   | RemoteFeatureFlagControllerUpdateRemoteFeatureFlagsAction;
 
+type RemoteFeatureFlagToggleEvents =
+  | PreferencesControllerStateChangeEvent
+  | OnboardingControllerStateChangeEvent
+  | AuthenticationControllerStateChangeEvent;
+
 type RemoteFeatureFlagToggleParentMessenger = RootMessenger<
   RemoteFeatureFlagToggleActions,
-  PreferencesControllerStateChangeEvent | OnboardingControllerStateChangeEvent
+  RemoteFeatureFlagToggleEvents
 >;
+
+/**
+ * Read the canonical profile id used for threshold flag segmentation.
+ *
+ * @param srpSessionData - Persisted SRP session map from AuthenticationController.
+ * @returns The first session's canonical profile id, or an empty string.
+ */
+function getCanonicalProfileId(
+  srpSessionData: AuthenticationControllerState['srpSessionData'],
+): string {
+  return (
+    Object.entries(srpSessionData ?? {})?.[0]?.[1]?.profile
+      ?.canonicalProfileId ?? ''
+  );
+}
 
 /**
  * Wire the extension-side enable/disable orchestration for the wallet-owned
@@ -33,8 +57,10 @@ type RemoteFeatureFlagToggleParentMessenger = RootMessenger<
  * `disabled` value; this keeps it in sync as the user completes onboarding or
  * toggles the external-services preference, and refreshes the flags whenever
  * the controller is (re-)enabled. Flags are only fetched once onboarding is
- * complete and external services are enabled. The controller is driven entirely
- * over the messenger, so no controller instance needs to be passed in.
+ * complete and external services are enabled. When a canonical profile id
+ * becomes available (or changes), flags are force-refreshed so threshold
+ * segmentation can reprocess against that id. The controller is driven
+ * entirely over the messenger, so no controller instance needs to be passed in.
  *
  * @param options - Options bag.
  * @param options.messenger - The root messenger to delegate from; a namespaced
@@ -42,21 +68,25 @@ type RemoteFeatureFlagToggleParentMessenger = RootMessenger<
  * `RemoteFeatureFlagController` enable/disable/update actions.
  * @param options.preferencesState - The initial `PreferencesController` state.
  * @param options.onboardingState - The initial `OnboardingController` state.
+ * @param options.authenticationState - The initial `AuthenticationController`
+ * state, used to seed the canonical-profile-id comparison so a returning
+ * signed-in user does not trigger a redundant force refresh.
  */
 export function setupRemoteFeatureFlagToggle({
   messenger,
   preferencesState,
   onboardingState,
+  authenticationState,
 }: {
   messenger: RemoteFeatureFlagToggleParentMessenger;
   preferencesState: Pick<PreferencesControllerState, 'useExternalServices'>;
   onboardingState: Pick<OnboardingControllerState, 'completedOnboarding'>;
+  authenticationState: Pick<AuthenticationControllerState,'srpSessionData'>;
 }): void {
   const toggleMessenger = new Messenger<
     'RemoteFeatureFlagToggle',
     RemoteFeatureFlagToggleActions,
-    | PreferencesControllerStateChangeEvent
-    | OnboardingControllerStateChangeEvent,
+    RemoteFeatureFlagToggleEvents,
     RemoteFeatureFlagToggleParentMessenger
   >({
     namespace: 'RemoteFeatureFlagToggle',
@@ -72,6 +102,7 @@ export function setupRemoteFeatureFlagToggle({
     events: [
       'PreferencesController:stateChange',
       'OnboardingController:stateChange',
+      'AuthenticationController:stateChange',
     ],
   });
 
@@ -115,5 +146,24 @@ export function setupRemoteFeatureFlagToggle({
       }
       return true;
     }, onboardingState),
+  );
+
+  // Force-refresh flags when a canonical profile id first becomes available
+  // or later changes. `force: true` bypasses the fetch cache so threshold
+  // flags reprocess against the new id; a no-op if the controller is disabled.
+  toggleMessenger.subscribe(
+    'AuthenticationController:stateChange',
+    previousValueComparator((prevState, currState) => {
+      const prev = getCanonicalProfileId(prevState.srpSessionData);
+      const curr = getCanonicalProfileId(currState.srpSessionData);
+      if (curr !== prev) {
+        toggleMessenger
+          .call('RemoteFeatureFlagController:updateRemoteFeatureFlags', true)
+          .catch((error) => {
+            console.error('Failed to update remote feature flags:', error);
+          });
+      }
+      return true;
+    }, authenticationState),
   );
 }

--- a/app/scripts/wallet-init/remote-feature-flags.ts
+++ b/app/scripts/wallet-init/remote-feature-flags.ts
@@ -81,7 +81,7 @@ export function setupRemoteFeatureFlagToggle({
   messenger: RemoteFeatureFlagToggleParentMessenger;
   preferencesState: Pick<PreferencesControllerState, 'useExternalServices'>;
   onboardingState: Pick<OnboardingControllerState, 'completedOnboarding'>;
-  authenticationState: Pick<AuthenticationControllerState,'srpSessionData'>;
+  authenticationState: Pick<AuthenticationControllerState, 'srpSessionData'>;
 }): void {
   const toggleMessenger = new Messenger<
     'RemoteFeatureFlagToggle',

--- a/app/scripts/wallet-init/types.ts
+++ b/app/scripts/wallet-init/types.ts
@@ -2,7 +2,10 @@ import type { AnalyticsControllerGetStateAction } from '@metamask/analytics-cont
 import type { ShowApprovalRequest } from '@metamask/approval-controller';
 import type { ConnectivityAdapter } from '@metamask/connectivity-controller';
 import type { Encryptor } from '@metamask/keyring-controller';
-import type { AuthenticationControllerGetStateAction } from '@metamask/profile-sync-controller/auth';
+import type {
+  AuthenticationControllerGetStateAction,
+  AuthenticationControllerStateChangeEvent,
+} from '@metamask/profile-sync-controller/auth';
 import type { DefaultActions, DefaultEvents } from '@metamask/wallet';
 import type { Json } from '@metamask/utils';
 import { Browser } from 'webextension-polyfill';
@@ -24,8 +27,8 @@ import type {
  * The root messenger `initializeWallet` expects: the wallet defaults plus the
  * extra actions/events the extension-side wiring reads (the metaMetrics id from
  * `AnalyticsController`, the canonical profile id from `AuthenticationController`,
- * the remote feature flag toggle subscriptions, and the TransactionController
- * init messenger used by extension hooks/listeners).
+ * the remote feature flag toggle and canonical-id refresh subscriptions, and the
+ * TransactionController init messenger used by extension hooks/listeners).
  * The remote feature flag enable/disable/update actions the toggle calls are
  * already covered by `DefaultActions`.
  */
@@ -37,6 +40,7 @@ export type WalletInitMessenger = RootMessenger<
   | SeedlessOnboardingControllerInitMessengerActions
   | TransactionControllerInitMessengerActions,
   | DefaultEvents
+  | AuthenticationControllerStateChangeEvent
   | OnboardingControllerStateChangeEvent
   | PreferencesControllerStateChangeEvent
   | TransactionControllerInitMessengerEvents

--- a/app/scripts/wallet-init/types.ts
+++ b/app/scripts/wallet-init/types.ts
@@ -2,6 +2,7 @@ import type { AnalyticsControllerGetStateAction } from '@metamask/analytics-cont
 import type { ShowApprovalRequest } from '@metamask/approval-controller';
 import type { ConnectivityAdapter } from '@metamask/connectivity-controller';
 import type { Encryptor } from '@metamask/keyring-controller';
+import type { AuthenticationControllerGetStateAction } from '@metamask/profile-sync-controller/auth';
 import type { DefaultActions, DefaultEvents } from '@metamask/wallet';
 import type { Json } from '@metamask/utils';
 import { Browser } from 'webextension-polyfill';
@@ -22,13 +23,15 @@ import type {
 /**
  * The root messenger `initializeWallet` expects: the wallet defaults plus the
  * extra actions/events the extension-side wiring reads (the metaMetrics id from
- * `AnalyticsController`, the remote feature flag toggle subscriptions, and the
- * TransactionController init messenger used by extension hooks/listeners).
+ * `AnalyticsController`, the canonical profile id from `AuthenticationController`,
+ * the remote feature flag toggle subscriptions, and the TransactionController
+ * init messenger used by extension hooks/listeners).
  * The remote feature flag enable/disable/update actions the toggle calls are
  * already covered by `DefaultActions`.
  */
 export type WalletInitMessenger = RootMessenger<
   | AnalyticsControllerGetStateAction
+  | AuthenticationControllerGetStateAction
   | DefaultActions
   | OnboardingControllerGetStateAction
   | SeedlessOnboardingControllerInitMessengerActions

--- a/package.json
+++ b/package.json
@@ -465,7 +465,7 @@
     "@metamask/ramps-controller": "^15.0.0",
     "@metamask/rate-limit-controller": "^7.0.0",
     "@metamask/react-data-query": "^0.2.2",
-    "@metamask/remote-feature-flag-controller": "^6.0.0",
+    "@metamask/remote-feature-flag-controller": "^6.1.0",
     "@metamask/rpc-errors": "^7.0.0",
     "@metamask/safe-event-emitter": "^3.1.1",
     "@metamask/scure-bip39": "^2.0.3",

--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -344,8 +344,16 @@ export const MOCK_REMOTE_FEATURE_FLAGS_RESPONSE = {
   feature1: true,
   feature2: false,
   feature3: [
-    { value: 'valueA', name: 'groupA', scope: { type: 'threshold', value: 0.3 } },
-    { value: 'valueB', name: 'groupB', scope: { type: 'threshold', value: 0.5 } },
+    {
+      value: 'valueA',
+      name: 'groupA',
+      scope: { type: 'threshold', value: 0.3 },
+    },
+    {
+      value: 'valueB',
+      name: 'groupB',
+      scope: { type: 'threshold', value: 0.5 },
+    },
     { value: 'valueC', name: 'groupC', scope: { type: 'threshold', value: 1 } },
   ],
 };

--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -339,23 +339,11 @@ export const MOCK_DOWNSTREAM_EVENT_ENRICHMENT_PROPERTIES = {
   ...MOCK_PROFILE_IDENTITY_EVENT_PROPERTIES,
 } as const;
 
-/* Mock remote feature flags response */
+/* Processed remote feature flags for `MOCK_ANALYTICS_ID` (RFFC threshold group C). */
 export const MOCK_REMOTE_FEATURE_FLAGS_RESPONSE = {
   feature1: true,
   feature2: false,
-  feature3: [
-    {
-      value: 'valueA',
-      name: 'groupA',
-      scope: { type: 'threshold', value: 0.3 },
-    },
-    {
-      value: 'valueB',
-      name: 'groupB',
-      scope: { type: 'threshold', value: 0.5 },
-    },
-    { value: 'valueC', name: 'groupC', scope: { type: 'threshold', value: 1 } },
-  ],
+  feature3: 'valueC',
 };
 
 /* Mock customized remote feature flags response*/

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -1280,6 +1280,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 224,
+    "version": 224
   }
 }

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -179,7 +179,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 223,
+      "currentMigrationVersion": 224,
       "firstTimeInfo": {},
       "previousAppVersion": "",
       "previousMigrationVersion": 0
@@ -1280,6 +1280,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 223
+    "version": 224,
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -2258,6 +2258,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 224,
+    "version": 224
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -49,7 +49,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 223,
+      "currentMigrationVersion": 224,
       "firstTimeInfo": {
         "date": 0,
         "version": "13.17.0"
@@ -2258,6 +2258,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 223
+    "version": 224,
   }
 }

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -453,6 +453,7 @@ async function setupMocking(
       client: 'extension',
       distribution: 'main',
     })
+    .asPriority(RulePriority.FALLBACK)
     .thenCallback(() => {
       // E2E has no canonical profile id, so threshold flags stay unresolved
       // arrays and BackendWebSocketService treats them as off. Pin a boolean

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -454,10 +454,23 @@ async function setupMocking(
       distribution: 'main',
     })
     .thenCallback(() => {
+      // E2E has no canonical profile id, so threshold flags stay unresolved
+      // arrays and BackendWebSocketService treats them as off. Pin a boolean
+      // here (not in production code). Tests can still override this mock.
+      const flags = getProductionRemoteFlagApiResponse().map((entry) => {
+        if (
+          entry &&
+          typeof entry === 'object' &&
+          'backendWebSocketConnection' in entry
+        ) {
+          return { backendWebSocketConnection: true };
+        }
+        return entry;
+      });
       return {
         ok: true,
         statusCode: 200,
-        json: getProductionRemoteFlagApiResponse(),
+        json: flags,
       };
     });
 

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -339,32 +339,7 @@
     "remoteFeatureFlags": {
       "feature1": true,
       "feature2": false,
-      "feature3": [
-        {
-          "name": "groupA",
-          "scope": {
-            "type": "threshold",
-            "value": 0.3
-          },
-          "value": "valueA"
-        },
-        {
-          "name": "groupB",
-          "scope": {
-            "type": "threshold",
-            "value": 0.5
-          },
-          "value": "valueB"
-        },
-        {
-          "name": "groupC",
-          "scope": {
-            "type": "threshold",
-            "value": 1
-          },
-          "value": "valueC"
-        }
-      ]
+      "feature3": "valueC"
     },
     "thresholdCache": "object"
   },

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -345,32 +345,7 @@
     "remoteFeatureFlags": {
       "feature1": true,
       "feature2": false,
-      "feature3": [
-        {
-          "name": "groupA",
-          "scope": {
-            "type": "threshold",
-            "value": 0.3
-          },
-          "value": "valueA"
-        },
-        {
-          "name": "groupB",
-          "scope": {
-            "type": "threshold",
-            "value": 0.5
-          },
-          "value": "valueB"
-        },
-        {
-          "name": "groupC",
-          "scope": {
-            "type": "threshold",
-            "value": 1
-          },
-          "value": "valueC"
-        }
-      ]
+      "feature3": "valueC"
     },
     "requests": "object",
     "rewardsAccounts": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -257,19 +257,19 @@
         "feature2": false,
         "feature3": [
           {
-            "value": "valueA",
             "name": "groupA",
-            "scope": { "type": "threshold", "value": 0.3 }
+            "scope": { "type": "threshold", "value": 0.3 },
+            "value": "valueA"
           },
           {
-            "value": "valueB",
             "name": "groupB",
-            "scope": { "type": "threshold", "value": 0.5 }
+            "scope": { "type": "threshold", "value": 0.5 },
+            "value": "valueB"
           },
           {
+            "name": "groupC",
             "scope": { "type": "threshold", "value": 1 },
-            "value": "valueC",
-            "name": "groupC"
+            "value": "valueC"
           }
         ]
       }

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -300,32 +300,7 @@
       "remoteFeatureFlags": {
         "feature1": true,
         "feature2": false,
-        "feature3": [
-          {
-            "name": "groupA",
-            "scope": {
-              "type": "threshold",
-              "value": 0.3
-            },
-            "value": "valueA"
-          },
-          {
-            "name": "groupB",
-            "scope": {
-              "type": "threshold",
-              "value": 0.5
-            },
-            "value": "valueB"
-          },
-          {
-            "name": "groupC",
-            "scope": {
-              "type": "threshold",
-              "value": 1
-            },
-            "value": "valueC"
-          }
-        ]
+        "feature3": "valueA"
       },
       "thresholdCache": "object"
     },

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -392,6 +392,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 223
+    "version": 224
   }
 }

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -1010,7 +1010,9 @@
         "lastFetchedAt": "number"
       }
     },
-    "featureFlagThresholdGroups": {},
+    "featureFlagThresholdGroups": {
+      "feature3": "string"
+    },
     "remoteFeatureFlags": {
       "feature1": "boolean",
       "feature2": "boolean",

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -1014,16 +1014,7 @@
     "remoteFeatureFlags": {
       "feature1": "boolean",
       "feature2": "boolean",
-      "feature3": [
-        {
-          "name": "string",
-          "value": "string",
-          "scope": {
-            "type": "string",
-            "value": "number"
-          }
-        }
-      ]
+      "feature3": "string"
     },
     "rawRemoteFeatureFlags": {
       "feature1": "boolean",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8235,20 +8235,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/remote-feature-flag-controller@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@metamask/remote-feature-flag-controller@npm:6.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/utils": "npm:^11.11.0"
-    uuid: "npm:^8.3.2"
-  checksum: 10/4ae9fa72f2ba8b7d71b1c0cf7be60bbf0c143e5372a1ef9f58f0ee761cf782087de8e801b71b6b319581044bb41197ffdfee069def2983d12adb0b296e5fff7a
-  languageName: node
-  linkType: hard
-
-"@metamask/remote-feature-flag-controller@npm:^6.1.0":
+"@metamask/remote-feature-flag-controller@npm:^6.0.0, @metamask/remote-feature-flag-controller@npm:^6.1.0":
   version: 6.1.0
   resolution: "@metamask/remote-feature-flag-controller@npm:6.1.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8248,6 +8248,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/remote-feature-flag-controller@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@metamask/remote-feature-flag-controller@npm:6.1.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/utils": "npm:^11.11.0"
+    uuid: "npm:^8.3.2"
+  checksum: 10/d32c187c638416bd1535b464187b1184ecbfd80b8100597b86cf17704cb04887f283df900fdc538b483f2d5684f34b2442bae84f468fb150e0e053230222ca45
+  languageName: node
+  linkType: hard
+
 "@metamask/rpc-errors@npm:^6.3.1":
   version: 6.4.0
   resolution: "@metamask/rpc-errors@npm:6.4.0"
@@ -33338,7 +33351,7 @@ __metadata:
     "@metamask/ramps-controller": "npm:^15.0.0"
     "@metamask/rate-limit-controller": "npm:^7.0.0"
     "@metamask/react-data-query": "npm:^0.2.2"
-    "@metamask/remote-feature-flag-controller": "npm:^6.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^6.1.0"
     "@metamask/rpc-errors": "npm:^7.0.0"
     "@metamask/safe-event-emitter": "npm:^3.1.1"
     "@metamask/scure-bip39": "npm:^2.0.3"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change mirrors the mobile [PR](https://github.com/MetaMask/metamask-mobile/pull/35217) for bumping the remote feature flag controller to 6.1.0. This version introduces canonical ID for deriving flags based on thresholds and exposes an option to define default feature flags.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-662

## **Manual testing steps**

```
Feature: Flags are re-processed with canonical ID when canonical becomes available

  Scenario: A user creates or unlocks a wallet
    Given a new user
    When user opens the app
    A user creates a wallet
    When a user opens the wallet
    Then we re-process the flags with a defined canonical ID, which is defined
 ```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
After opening the wallet, auth is detected and the canonical ID is provided. At this point, the remote flags are re-processed with the canonical ID
<img width="288" height="127" alt="image" src="https://github.com/user-attachments/assets/85371bf5-6507-46d4-99d6-d64aaf098d52" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote feature flag identity, refresh timing, and persisted state via migration; incorrect canonical-id handling or stale cache could mis-assign threshold flags for signed-in users.
> 
> **Overview**
> Upgrades **`@metamask/remote-feature-flag-controller`** to **6.1.0** and wires extension wallet init for **canonical profile ID**–based threshold flag segmentation (aligned with mobile).
> 
> **Persistence:** Adds **migration 224** to delete persisted `rawRemoteFeatureFlags` so stale redacted values are not reused after RFFC 6.x behavior changes. Registers the migration and bumps E2E fixtures to version **224**.
> 
> **Runtime:** `getRemoteFeatureFlagControllerInstanceOptions` now supplies `getCanonicalProfileId` (from `AuthenticationController` SRP session data, falling back to MetaMetrics id), defensive `getMetaMetricsId` when controllers are not registered yet, and stub `defaultFeatureFlags` / `metaMetricsFlags`. `setupRemoteFeatureFlagToggle` seeds auth state, listens to `AuthenticationController:stateChange`, and **force-refreshes** remote flags when the canonical id appears, changes, or clears.
> 
> **Tests / E2E:** Unit coverage for migration, instance options, toggle refresh behavior, and wallet init auth seeding. E2E mocks and snapshots expect **resolved** threshold flags (e.g. `feature3` as a string) and pin `backendWebSocketConnection` in the flags mock where E2E has no canonical id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e616c41ffd9529d37128d40e7cf359f361ffb5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->