### PR TITLE
docs(e2e): restore TokensTab page object JSDoc

### DIFF
--- a/test/e2e/page-objects/pages/home/tokens-tab.ts
+++ b/test/e2e/page-objects/pages/home/tokens-tab.ts
@@ -17,6 +17,23 @@ const SEARCH_TOKEN_ASSET_IDS: Record<string, string> = {
   MUSD: 'eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
 };
 
+/**
+ * Home Tokens tab: asset list, import/manage tokens, sort, and token details.
+ *
+ * Screen: `#/` Tokens tab (`account-overview__asset-tab`), the default home
+ * tab; also reached via `HomePage.goToTokensTab()`.
+ * Owns: token rows (name, balance, fiat, position), low-value expand/sort,
+ * import via search or custom address, manage-tokens toggles, hide token,
+ * and opening a row for price/chart/address checks.
+ * Boundaries: homepage balance and Send/Swap/Bridge CTAs stay on `HomePage`.
+ * Network filter control-bar chrome belongs to `NetworkFilter` /
+ * `SelectNetworkModal`. Full `#/asset/...` journeys beyond open checks are
+ * outside this object.
+ * Related: `HomePage` (`goToTokensTab`), `NonEvmHomepage`, `NetworkFilter`,
+ * `flows/multi-srp.flow.ts` / `flows/bitcoin-send.flow.ts`.
+ *
+ * @see ui/components/app/assets/asset-list/asset-list.tsx
+ */
 class TokensTab extends HomePage {
   private readonly assetMarketCapInDetailsModal =
     '[data-testid="asset-market-cap"]';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Context

PR [#45495](https://github.com/MetaMask/metamask-extension/pull/45495) added the custom-network E2E harness and also removed the class-level JSDoc on the `TokensTab` page object (originally added in [#45424](https://github.com/MetaMask/metamask-extension/pull/45424)).

### Problem

`TokensTab` no longer documents its screen ownership, boundaries, and related page objects / flows, which makes the page object harder to use and maintain.

### Solution

Restore the `TokensTab` class-level JSDoc exactly as it existed before that removal.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Open `test/e2e/page-objects/pages/home/tokens-tab.ts`.
2. Confirm the class-level JSDoc is present immediately above `class TokensTab`.
3. Confirm the wording matches the block removed in #45495 (Screen / Owns / Boundaries / Related / `@see`).

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in E2E page object code with no runtime or test logic impact.
> 
> **Overview**
> Restores the **class-level JSDoc** on the E2E `TokensTab` page object in `tokens-tab.ts`, re-adding the block that was dropped in an earlier harness PR.
> 
> The comment documents which home screen/tab the object targets, what flows and UI it owns (asset list, import/manage, sort, details), what stays on sibling page objects (`HomePage`, `NetworkFilter`, etc.), and links to related flows plus `@see` `asset-list.tsx`. **No test or product behavior changes**—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6745fc66010e90e901b6d8911cdbca499801e123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->