### PR TITLE
test: mock PRD rewards host so RC-build e2e fixture validation passes cp-13.45.1

### DIFF
--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -119,6 +119,7 @@
   "raw.githubusercontent.com",
   "registry.npmjs.org",
   "responsive-rpc.test",
+  "rewards.api.cx.metamask.io",
   "rewards.uat-api.cx.metamask.io",
   "rpc.gnosischain.com",
   "rpc.pulsechain.com",

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -6,6 +6,7 @@ const { RulePriority } = require('mockttp');
 const {
   ACCOUNTS_PROD_API_BASE_URL,
 } = require('../../shared/constants/accounts');
+const { REWARDS_API_URL } = require('../../shared/constants/rewards');
 const {
   GAS_API_BASE_URL,
   SWAPS_API_V2_BASE_URL,
@@ -498,11 +499,13 @@ async function setupMocking(
     });
 
   // Rewards API
-  await server
-    .forPost('https://rewards.uat-api.cx.metamask.io/public/rewards/ois')
-    .thenCallback(() => {
-      return { statusCode: 200, json: { ois: [], sids: [] } };
-    });
+  for (const rewardsApiUrl of [REWARDS_API_URL.UAT, REWARDS_API_URL.PRD]) {
+    await server
+      .forPost(`${rewardsApiUrl}/public/rewards/ois`)
+      .thenCallback(() => {
+        return { statusCode: 200, json: { ois: [], sids: [] } };
+      });
+  }
 
   // User Profile Lineage
   await server


### PR DESCRIPTION
## **Description**

The rewards API base URL is environment-dependent: [`RewardsDataService.getRewardsApiBaseUrl`](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/controllers/rewards/rewards-data-service.ts#L139-L147) resolves to the **PRD** host (`rewards.api.cx.metamask.io`) for `release-candidate` and `production` builds, and to the **UAT** host (`rewards.uat-api.cx.metamask.io`) otherwise. The e2e mocks only covered the UAT host.

As a result, on **release-candidate dist builds** the unprompted startup `POST /public/rewards/ois` request went to the PRD host, which had no mock, so it fell through to the catch-all pass-through rule (200 with an empty body). Without the real response body, `RewardsController` never populated the non-EVM (BTC/Solana/Tron) `rewardsAccounts` entries, and `test/e2e/dist/wallet-fixture-validation.spec.ts` failed with `Detected missing keys compared to the existing fixture`.

This blocked every PR targeting a `release/*` branch (e.g. [Runway cherry-pick PRs](https://github.com/MetaMask/metamask-extension/pull/45812)), because those PRs run the dist e2e job against a release-candidate build.

This PR mocks `POST /public/rewards/ois` on **both** hosts, sourced from the shared `REWARDS_API_URL` constant so the mock cannot drift from the app. Both return the **same** body (`{ ois: [], sids: [] }`) — this is load-bearing: it produces `hasOptedIn: undefined` (dropped on JSON serialization), which is exactly the committed fixture shape. A "more correct" body would change the fixture.

Because mockttp emits `request-initiated` *before* rule matching, mocking an endpoint does **not** keep its host out of the privacy report. So `rewards.api.cx.metamask.io` is also added to `privacy-snapshot.json`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: unblocks the 13.45.1 hotfix cherry-pick (https://github.com/MetaMask/metamask-extension/pull/45812), which failed `wallet-fixture-validation` on the dist e2e job.

## **Manual testing steps**

1. Check out this branch.
2. Build a release-candidate dist build (env `METAMASK_ENVIRONMENT=release-candidate`), or run the dist e2e job on a `release/*` branch.
3. Run `yarn test:e2e:single test/e2e/dist/wallet-fixture-validation.spec.ts --browser chrome`.
4. It should pass; `RewardsController.rewardsAccounts` includes the BTC/Solana/Tron entries and no new privacy-snapshot host is reported.

## **Screenshots/Recordings**

N/A — CI/test-tooling change only.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and privacy-snapshot tooling only; no production app logic changes.
> 
> **Overview**
> Fixes **dist e2e** failures on release-candidate builds where startup hits the **production** rewards host instead of UAT.
> 
> E2E mocking now registers **`POST /public/rewards/ois`** for both **`REWARDS_API_URL.UAT`** and **`REWARDS_API_URL.PRD`** (via shared constants), each returning `{ ois: [], sids: [] }` so **`RewardsController`** state matches the committed wallet fixture. **`rewards.api.cx.metamask.io`** is added to **`privacy-snapshot.json`** because mocked requests still appear in the privacy report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d877e009192576fe8ff655af12d0d1cdfd6e1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->