### PR TITLE
feat(confirmations): fund perps deposits from the money account

### DIFF
--- a/app/scripts/lib/money/pay/amount-commit.test.ts
+++ b/app/scripts/lib/money/pay/amount-commit.test.ts
@@ -1,6 +1,7 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
 import {
   commitTransactionPayUpdates,
   parseMusdHumanAmount,
@@ -39,8 +40,14 @@ describe('parseMusdHumanAmount', () => {
     expect(parseMusdHumanAmount('1')).toBe(1_000_000n);
   });
 
-  it('rounds fractional mUSD up to the next base unit', () => {
+  it('rounds fractional mUSD up to the next base unit by default', () => {
     expect(parseMusdHumanAmount('1.0000001')).toBe(1_000_001n);
+  });
+
+  it('rounds fractional mUSD down when ROUND_DOWN is requested', () => {
+    expect(parseMusdHumanAmount('1.0000001', BigNumber.ROUND_DOWN)).toBe(
+      1_000_000n,
+    );
   });
 
   it('returns undefined for zero, negative, or non-numeric input', () => {

--- a/app/scripts/lib/money/pay/amount-commit.ts
+++ b/app/scripts/lib/money/pay/amount-commit.ts
@@ -19,13 +19,19 @@ const latestIntentByTransactionId = new Map<string, number>();
  * for zero, negative, or non-numeric input so callers can skip a commit
  * rather than encoding a no-op vault call.
  *
- * Sub-base-unit fractions round **up** (`BigNumber.ROUND_UP`) so the vault
- * call never under-delivers relative to the typed amount.
+ * Sub-base-unit fractions round with `roundingMode` (default
+ * `BigNumber.ROUND_UP`) so vault calls never under-deliver relative to the
+ * typed amount. Use `ROUND_DOWN` when the amount must not exceed a known
+ * balance (e.g. Max against withdrawable funds).
  *
  * @param amountHuman - Exact human-readable mUSD amount.
+ * @param roundingMode - BigNumber rounding mode applied after scaling.
  * @returns The amount in mUSD base units, or `undefined` when unusable.
  */
-export function parseMusdHumanAmount(amountHuman: string): bigint | undefined {
+export function parseMusdHumanAmount(
+  amountHuman: string,
+  roundingMode: BigNumber.RoundingMode = BigNumber.ROUND_UP,
+): bigint | undefined {
   // BigNumber is configured to throw on non-numeric input in this repo.
   let value: BigNumber;
   try {
@@ -38,7 +44,7 @@ export function parseMusdHumanAmount(amountHuman: string): bigint | undefined {
     return undefined;
   }
 
-  const raw = value.times(MUSD_UNIT).round(0, BigNumber.ROUND_UP);
+  const raw = value.times(MUSD_UNIT).round(0, roundingMode);
   if (raw.lte(0)) {
     return undefined;
   }

--- a/app/scripts/lib/money/pay/amount-commit.ts
+++ b/app/scripts/lib/money/pay/amount-commit.ts
@@ -30,7 +30,7 @@ const latestIntentByTransactionId = new Map<string, number>();
  */
 export function parseMusdHumanAmount(
   amountHuman: string,
-  roundingMode: BigNumber.RoundingMode = BigNumber.ROUND_UP,
+  roundingMode: number = BigNumber.ROUND_UP,
 ): bigint | undefined {
   // BigNumber is configured to throw on non-numeric input in this repo.
   let value: BigNumber;

--- a/app/scripts/lib/money/pay/pay-context.ts
+++ b/app/scripts/lib/money/pay/pay-context.ts
@@ -18,8 +18,9 @@ import {
   getMoneyAccountVaultConfig,
   type MoneyAccountVaultConfig,
 } from '../../../../../shared/lib/money/vault-config';
+import type { DelegationMessengerActions } from '../../transaction/delegation';
 
-type MoneyPayActions =
+export type MoneyPayActions =
   | AccountsControllerGetSelectedAccountAction
   | RemoteFeatureFlagControllerGetStateAction
   | NetworkControllerFindNetworkClientIdByChainIdAction
@@ -37,6 +38,17 @@ type MoneyPayEvents = TransactionControllerUnapprovedTransactionAddedEvent;
 export type MoneyPayMessenger = Messenger<
   string,
   MoneyPayActions,
+  MoneyPayEvents
+>;
+
+/**
+ * Messenger required by `getPaymentOverrideData`: Money Pay context actions
+ * plus the delegation / EIP-7702 signing capabilities used when wrapping
+ * vault calls for Relay.
+ */
+export type PaymentOverrideMessenger = Messenger<
+  string,
+  MoneyPayActions | DelegationMessengerActions,
   MoneyPayEvents
 >;
 

--- a/app/scripts/lib/money/pay/payment-override-callback.test.ts
+++ b/app/scripts/lib/money/pay/payment-override-callback.test.ts
@@ -132,25 +132,25 @@ describe('getPaymentOverrideData', () => {
     expect(buildWithdrawBatchMock).not.toHaveBeenCalled();
   });
 
-  it('returns empty calls when the money account is unavailable', async () => {
+  it('throws when the money account is unavailable', async () => {
     const { messenger } = createMoneyPayMessengerMock({
       moneyAccountAddress: undefined,
     });
 
-    const result = await getPaymentOverrideData(buildRequest(), messenger);
-
-    expect(result).toStrictEqual({ calls: [] });
+    await expect(
+      getPaymentOverrideData(buildRequest(), messenger),
+    ).rejects.toThrow('Money account payment override is not available');
     expect(buildWithdrawBatchMock).not.toHaveBeenCalled();
   });
 
-  it('returns empty calls when the vault config is missing', async () => {
+  it('throws when the vault config is missing', async () => {
     const { messenger } = createMoneyPayMessengerMock({
       remoteFeatureFlags: {},
     });
 
-    const result = await getPaymentOverrideData(buildRequest(), messenger);
-
-    expect(result).toStrictEqual({ calls: [] });
+    await expect(
+      getPaymentOverrideData(buildRequest(), messenger),
+    ).rejects.toThrow('Money account payment override is not available');
   });
 
   it('returns empty calls when the transaction has no from', async () => {
@@ -211,6 +211,7 @@ describe('getPaymentOverrideData', () => {
       }),
     );
     expect(result).toStrictEqual({
+      authorizationList: MOCK_AUTHORIZATION_LIST,
       calls: [
         {
           to: DELEGATION_MANAGER,
@@ -316,17 +317,14 @@ describe('getPaymentOverrideData', () => {
       });
     });
 
-    it('returns empty calls when the money account is unavailable', async () => {
+    it('throws when the money account is unavailable', async () => {
       const { messenger } = createMoneyPayMessengerMock({
         moneyAccountAddress: undefined,
       });
 
-      const result = await getPaymentOverrideData(
-        buildPostQuoteRequest(),
-        messenger,
-      );
-
-      expect(result).toStrictEqual({ calls: [] });
+      await expect(
+        getPaymentOverrideData(buildPostQuoteRequest(), messenger),
+      ).rejects.toThrow('Money account payment override is not available');
     });
 
     it('returns raw approve and deposit calls without delegation when non-atomic', async () => {

--- a/app/scripts/lib/money/pay/payment-override-callback.test.ts
+++ b/app/scripts/lib/money/pay/payment-override-callback.test.ts
@@ -1,0 +1,358 @@
+import {
+  TransactionStatus,
+  type AuthorizationList,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import {
+  PaymentOverride,
+  type GetPaymentOverrideDataRequest,
+} from '@metamask/transaction-pay-controller';
+import {
+  buildMoneyAccountDepositBatch,
+  buildMoneyAccountWithdrawBatch,
+} from '@metamask/money-account-utils';
+import type { Hex } from '@metamask/utils';
+import { getDelegationTransaction } from '../../transaction/delegation';
+import { getPaymentOverrideData } from './payment-override-callback';
+import {
+  createMoneyPayMessengerMock,
+  MONEY_ACCOUNT_ADDRESS_MOCK,
+  NETWORK_CLIENT_ID_MOCK,
+  VAULT_CONFIG_MOCK,
+} from './test-mocks';
+
+jest.mock('@metamask/money-account-utils', () => ({
+  ...jest.requireActual('@metamask/money-account-utils'),
+  buildMoneyAccountDepositBatch: jest.fn(),
+  buildMoneyAccountWithdrawBatch: jest.fn(),
+}));
+jest.mock('../../transaction/delegation', () => ({
+  getDelegationTransaction: jest.fn(),
+}));
+
+const USER_EOA = '0x178239802520a9c99dcbd791f81326b70298d629' as Hex;
+const DELEGATION_MANAGER = '0xdb9b1e94b5b69df7e401ddbede43491141047db3' as Hex;
+const DELEGATION_DATA = '0xdelegation' as Hex;
+const MOCK_AUTHORIZATION_LIST = [
+  { chainId: '0x1' as Hex, nonce: '0x2' as Hex, yParity: '0x1' as Hex },
+];
+
+const MOCK_WITHDRAW_BATCH = {
+  withdrawTx: {
+    params: {
+      to: VAULT_CONFIG_MOCK.tellerAddress,
+      data: '0xwithdraw' as Hex,
+      value: '0x0' as Hex,
+    },
+  },
+  transferTx: {
+    params: {
+      to: VAULT_CONFIG_MOCK.underlyingToken,
+      data: '0xtransfer' as Hex,
+      value: '0x0' as Hex,
+    },
+  },
+};
+
+const MOCK_DEPOSIT_BATCH = {
+  approveTx: {
+    params: {
+      to: VAULT_CONFIG_MOCK.underlyingToken,
+      data: '0xapprove' as Hex,
+      value: '0x0' as Hex,
+    },
+  },
+  depositTx: {
+    params: {
+      to: VAULT_CONFIG_MOCK.tellerAddress,
+      data: '0xdeposit' as Hex,
+      value: '0x0' as Hex,
+    },
+  },
+};
+
+const AMOUNT_HUMAN = '10.5';
+const AMOUNT_RAW = 10_500_000n;
+
+const TRANSACTION_META_MOCK = {
+  id: 'tx-1',
+  txParams: { from: USER_EOA },
+} as TransactionMeta;
+
+const VALID_TX_DATA = {
+  isLoading: false,
+  paymentOverride: PaymentOverride.MoneyAccount,
+  tokens: [],
+};
+
+const buildWithdrawBatchMock = jest.mocked(buildMoneyAccountWithdrawBatch);
+const buildDepositBatchMock = jest.mocked(buildMoneyAccountDepositBatch);
+const getDelegationTransactionMock = jest.mocked(getDelegationTransaction);
+
+function buildRequest(
+  overrides?: Partial<GetPaymentOverrideDataRequest>,
+): GetPaymentOverrideDataRequest {
+  return {
+    amount: AMOUNT_HUMAN,
+    transaction: TRANSACTION_META_MOCK,
+    transactionData:
+      VALID_TX_DATA as GetPaymentOverrideDataRequest['transactionData'],
+    ...overrides,
+  };
+}
+
+describe('getPaymentOverrideData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    buildWithdrawBatchMock.mockResolvedValue(MOCK_WITHDRAW_BATCH as never);
+    buildDepositBatchMock.mockResolvedValue(MOCK_DEPOSIT_BATCH as never);
+    getDelegationTransactionMock.mockResolvedValue({
+      authorizationList: MOCK_AUTHORIZATION_LIST as AuthorizationList,
+      data: DELEGATION_DATA,
+      to: DELEGATION_MANAGER,
+      value: '0x0' as Hex,
+      type: '0x04' as never,
+    });
+  });
+
+  it('returns empty calls when paymentOverride is not MoneyAccount', async () => {
+    const { messenger } = createMoneyPayMessengerMock();
+
+    const result = await getPaymentOverrideData(
+      buildRequest({
+        transactionData: {
+          ...VALID_TX_DATA,
+          paymentOverride: undefined,
+        } as GetPaymentOverrideDataRequest['transactionData'],
+      }),
+      messenger,
+    );
+
+    expect(result).toStrictEqual({ calls: [] });
+    expect(buildWithdrawBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns empty calls when the money account is unavailable', async () => {
+    const { messenger } = createMoneyPayMessengerMock({
+      moneyAccountAddress: undefined,
+    });
+
+    const result = await getPaymentOverrideData(buildRequest(), messenger);
+
+    expect(result).toStrictEqual({ calls: [] });
+    expect(buildWithdrawBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns empty calls when the vault config is missing', async () => {
+    const { messenger } = createMoneyPayMessengerMock({
+      remoteFeatureFlags: {},
+    });
+
+    const result = await getPaymentOverrideData(buildRequest(), messenger);
+
+    expect(result).toStrictEqual({ calls: [] });
+  });
+
+  it('returns empty calls when the transaction has no from', async () => {
+    const { messenger } = createMoneyPayMessengerMock();
+
+    const result = await getPaymentOverrideData(
+      buildRequest({
+        transaction: { id: 'tx-1', txParams: {} } as TransactionMeta,
+      }),
+      messenger,
+    );
+
+    expect(result).toStrictEqual({ calls: [] });
+  });
+
+  it('builds the withdraw batch with the parsed amount and EOA recipient', async () => {
+    const { messenger } = createMoneyPayMessengerMock();
+
+    await getPaymentOverrideData(buildRequest(), messenger);
+
+    expect(buildWithdrawBatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: AMOUNT_RAW,
+        chainId: VAULT_CONFIG_MOCK.chainId,
+        tellerAddress: VAULT_CONFIG_MOCK.tellerAddress,
+        accountantAddress: VAULT_CONFIG_MOCK.accountantAddress,
+        moneyAccountAddress: MONEY_ACCOUNT_ADDRESS_MOCK,
+        recipient: USER_EOA,
+      }),
+    );
+  });
+
+  it('wraps withdraw calls in a delegation and returns the redeem call', async () => {
+    const { messenger } = createMoneyPayMessengerMock();
+
+    const result = await getPaymentOverrideData(buildRequest(), messenger);
+
+    expect(getDelegationTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ messenger }),
+      expect.objectContaining({
+        chainId: VAULT_CONFIG_MOCK.chainId,
+        networkClientId: NETWORK_CLIENT_ID_MOCK,
+        status: TransactionStatus.unapproved,
+        id: expect.stringMatching(/^money-account-withdraw-\d+$/u),
+        txParams: { from: MONEY_ACCOUNT_ADDRESS_MOCK },
+        nestedTransactions: [
+          {
+            to: VAULT_CONFIG_MOCK.tellerAddress,
+            data: '0xwithdraw',
+            value: '0x0',
+          },
+          {
+            to: VAULT_CONFIG_MOCK.underlyingToken,
+            data: '0xtransfer',
+            value: '0x0',
+          },
+        ],
+      }),
+    );
+    expect(result).toStrictEqual({
+      calls: [
+        {
+          to: DELEGATION_MANAGER,
+          data: DELEGATION_DATA,
+          value: '0x0',
+        },
+      ],
+    });
+  });
+
+  describe('non-atomic withdraw path', () => {
+    function buildNonAtomicRequest(): GetPaymentOverrideDataRequest {
+      return buildRequest({
+        transactionData: {
+          ...VALID_TX_DATA,
+          atomic: false,
+        } as GetPaymentOverrideDataRequest['transactionData'],
+      });
+    }
+
+    it('returns raw withdraw and transfer calls without delegation wrap', async () => {
+      const { messenger } = createMoneyPayMessengerMock();
+
+      const result = await getPaymentOverrideData(
+        buildNonAtomicRequest(),
+        messenger,
+      );
+
+      expect(result).toStrictEqual({
+        calls: [
+          {
+            to: VAULT_CONFIG_MOCK.tellerAddress,
+            data: '0xwithdraw',
+            value: '0x0',
+          },
+          {
+            to: VAULT_CONFIG_MOCK.underlyingToken,
+            data: '0xtransfer',
+            value: '0x0',
+          },
+        ],
+      });
+    });
+
+    it('does not call getDelegationTransaction on the non-atomic path', async () => {
+      const { messenger } = createMoneyPayMessengerMock();
+
+      await getPaymentOverrideData(buildNonAtomicRequest(), messenger);
+
+      expect(getDelegationTransactionMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isPostQuote deposit path', () => {
+    function buildPostQuoteRequest(
+      extra?: Record<string, unknown>,
+    ): GetPaymentOverrideDataRequest {
+      return buildRequest({
+        transactionData: {
+          ...VALID_TX_DATA,
+          isPostQuote: true,
+          ...extra,
+        } as GetPaymentOverrideDataRequest['transactionData'],
+      });
+    }
+
+    it('builds the deposit batch with vault config', async () => {
+      const { messenger } = createMoneyPayMessengerMock();
+
+      await getPaymentOverrideData(buildPostQuoteRequest(), messenger);
+
+      expect(buildDepositBatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: AMOUNT_RAW,
+          chainId: VAULT_CONFIG_MOCK.chainId,
+          boringVault: VAULT_CONFIG_MOCK.boringVault,
+          tellerAddress: VAULT_CONFIG_MOCK.tellerAddress,
+          accountantAddress: VAULT_CONFIG_MOCK.accountantAddress,
+          lensAddress: VAULT_CONFIG_MOCK.lensAddress,
+        }),
+      );
+      expect(buildWithdrawBatchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns deposit calls with delegation data and the money-account recipient', async () => {
+      const { messenger } = createMoneyPayMessengerMock();
+
+      const result = await getPaymentOverrideData(
+        buildPostQuoteRequest(),
+        messenger,
+      );
+
+      expect(result).toStrictEqual({
+        recipient: MONEY_ACCOUNT_ADDRESS_MOCK,
+        authorizationList: MOCK_AUTHORIZATION_LIST,
+        calls: [
+          {
+            to: DELEGATION_MANAGER,
+            data: DELEGATION_DATA,
+            value: '0x0',
+          },
+        ],
+      });
+    });
+
+    it('returns empty calls when the money account is unavailable', async () => {
+      const { messenger } = createMoneyPayMessengerMock({
+        moneyAccountAddress: undefined,
+      });
+
+      const result = await getPaymentOverrideData(
+        buildPostQuoteRequest(),
+        messenger,
+      );
+
+      expect(result).toStrictEqual({ calls: [] });
+    });
+
+    it('returns raw approve and deposit calls without delegation when non-atomic', async () => {
+      const { messenger } = createMoneyPayMessengerMock();
+
+      const result = await getPaymentOverrideData(
+        buildPostQuoteRequest({ atomic: false }),
+        messenger,
+      );
+
+      expect(result).toStrictEqual({
+        recipient: MONEY_ACCOUNT_ADDRESS_MOCK,
+        calls: [
+          {
+            to: VAULT_CONFIG_MOCK.underlyingToken,
+            data: '0xapprove',
+            value: '0x0',
+          },
+          {
+            to: VAULT_CONFIG_MOCK.tellerAddress,
+            data: '0xdeposit',
+            value: '0x0',
+          },
+        ],
+      });
+      expect(getDelegationTransactionMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/scripts/lib/money/pay/payment-override-callback.ts
+++ b/app/scripts/lib/money/pay/payment-override-callback.ts
@@ -2,7 +2,6 @@ import { BigNumber } from 'bignumber.js';
 import {
   buildMoneyAccountDepositBatch,
   buildMoneyAccountWithdrawBatch,
-  MUSD_DECIMALS,
 } from '@metamask/money-account-utils';
 import {
   TransactionStatus,
@@ -10,56 +9,101 @@ import {
   type TransactionMeta,
 } from '@metamask/transaction-controller';
 import {
-  PaymentOverride,
   type GetPaymentOverrideDataRequest,
   type GetPaymentOverrideDataResponse,
+  PaymentOverride,
 } from '@metamask/transaction-pay-controller';
 import { isStrictHexString, type Hex } from '@metamask/utils';
+import { getDelegationTransaction } from '../../transaction/delegation';
+import { parseMusdHumanAmount } from './amount-commit';
 import {
-  getDelegationTransaction,
-  type DelegationMessenger,
-} from '../../transaction/delegation';
-import { getMoneyPayContext, type MoneyPayMessenger } from './pay-context';
+  getMoneyPayContext,
+  type PaymentOverrideMessenger,
+} from './pay-context';
 
-const MUSD_UNIT = 10 ** MUSD_DECIMALS;
+const LOG_TAG = 'PaymentOverride';
 
 /**
- * Parses a human-readable mUSD amount into base units, rounding down so Max
- * never requests more atomic units than the withdrawable money-account
- * balance. Returns `undefined` for zero, negative, or non-numeric input.
+ * Converts prevalidated nested-transaction params into
+ * {@link BatchTransactionParams} for Transaction Pay. Callers must only pass
+ * values already produced by money-account batch builders (`to` is required;
+ * `data` / `value` are optional hex strings). Unchecked `Hex` assertions match
+ * that trusted builder contract.
  *
- * @param amountHuman - Exact human-readable mUSD amount.
- * @returns The amount in mUSD base units, or `undefined` when unusable.
+ * @param params - Prevalidated nested call params from a vault batch builder.
+ * @param params.to - Call destination address.
+ * @param params.data - Optional calldata.
+ * @param params.value - Optional native value.
+ * @returns Batch call params for Transaction Pay.
  */
-function parseMusdHumanAmountDown(amountHuman: string): bigint | undefined {
-  let value: BigNumber;
-  try {
-    value = new BigNumber(amountHuman);
-  } catch {
-    return undefined;
-  }
-
-  if (!value.isFinite() || value.lte(0)) {
-    return undefined;
-  }
-
-  const raw = value.times(MUSD_UNIT).round(0, BigNumber.ROUND_DOWN);
-  if (raw.lte(0)) {
-    return undefined;
-  }
-
-  return BigInt(raw.toString(10));
-}
-
 function toBatchCall(params: {
   to?: string;
   data?: string;
   value?: string;
 }): BatchTransactionParams {
   return {
-    to: params.to as Hex,
     data: params.data as Hex | undefined,
+    to: params.to as Hex,
     value: params.value as Hex | undefined,
+  };
+}
+
+/**
+ * Wraps raw vault calls in a fresh EIP-7702 delegation redeem call so Relay
+ * can embed them. Preserves `authorizationList` from
+ * {@link getDelegationTransaction} for accounts that still need an upgrade.
+ *
+ * @param messenger - Messenger with Money Pay and delegation capabilities.
+ * @param options - Synthetic transaction identity for the delegation request.
+ * @param options.chainId - Vault chain id.
+ * @param options.from - Money account address that executes the batch.
+ * @param options.idPrefix - Prefix for the synthetic transaction id.
+ * @param options.nestedTransactions - Raw vault calls to wrap.
+ * @param options.networkClientId - Network client for the vault chain.
+ * @returns Redeem call plus optional authorization list.
+ */
+async function wrapCallsInDelegation(
+  messenger: PaymentOverrideMessenger,
+  {
+    chainId,
+    from,
+    idPrefix,
+    nestedTransactions,
+    networkClientId,
+  }: {
+    chainId: Hex;
+    from: Hex;
+    idPrefix: string;
+    nestedTransactions: BatchTransactionParams[];
+    networkClientId: string;
+  },
+): Promise<Pick<GetPaymentOverrideDataResponse, 'authorizationList' | 'calls'>> {
+  const transactionMeta = {
+    chainId,
+    id: `${idPrefix}-${Date.now()}`,
+    nestedTransactions,
+    networkClientId,
+    status: TransactionStatus.unapproved,
+    time: Date.now(),
+    txParams: {
+      from,
+    },
+  } as TransactionMeta;
+
+  const delegation = await getDelegationTransaction(
+    { messenger },
+    transactionMeta,
+  );
+
+  return {
+    authorizationList: delegation.authorizationList,
+    calls: [
+      {
+        data: delegation.data,
+        to: delegation.to,
+        value: delegation.value,
+      },
+    ],
   };
 }
 
@@ -75,34 +119,34 @@ function toBatchCall(params: {
  * @param recipient - Address that receives the redeemed mUSD.
  * @param amountHuman - Human-readable mUSD amount.
  * @param atomic - Whether to wrap the calls in an EIP-7702 delegation.
- * @returns Batch calls to prepend, or an empty list when unavailable.
+ * @returns Batch calls (and optional authorization) to prepend.
  */
 async function getMoneyAccountWithdrawPaymentOverrideData(
-  messenger: MoneyPayMessenger,
+  messenger: PaymentOverrideMessenger,
   recipient: Hex,
   amountHuman: string,
   atomic: boolean,
-): Promise<BatchTransactionParams[]> {
+): Promise<GetPaymentOverrideDataResponse> {
   const context = getMoneyPayContext(messenger);
   if (!context) {
-    return [];
+    throw new Error(`${LOG_TAG} Money account payment override is not available`);
   }
 
-  const amount = parseMusdHumanAmountDown(amountHuman);
+  const amount = parseMusdHumanAmount(amountHuman, BigNumber.ROUND_DOWN);
   if (amount === undefined) {
-    return [];
+    return { calls: [] };
   }
 
-  const { moneyAccountAddress, vaultConfig, networkClientId, provider } =
+  const { moneyAccountAddress, networkClientId, provider, vaultConfig } =
     context;
-  const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
+  const { transferTx, withdrawTx } = await buildMoneyAccountWithdrawBatch({
+    accountantAddress: vaultConfig.accountantAddress,
     amount,
     chainId: vaultConfig.chainId,
-    tellerAddress: vaultConfig.tellerAddress,
-    accountantAddress: vaultConfig.accountantAddress,
     moneyAccountAddress,
-    recipient,
     provider,
+    recipient,
+    tellerAddress: vaultConfig.tellerAddress,
   });
 
   const rawCalls: BatchTransactionParams[] = [
@@ -111,33 +155,16 @@ async function getMoneyAccountWithdrawPaymentOverrideData(
   ];
 
   if (!atomic) {
-    return rawCalls;
+    return { calls: rawCalls };
   }
 
-  const transactionMeta = {
-    id: `money-account-withdraw-${Date.now()}`,
+  return await wrapCallsInDelegation(messenger, {
     chainId: vaultConfig.chainId,
-    networkClientId,
-    status: TransactionStatus.unapproved,
-    time: Date.now(),
-    txParams: {
-      from: moneyAccountAddress,
-    },
+    from: moneyAccountAddress,
+    idPrefix: 'money-account-withdraw',
     nestedTransactions: rawCalls,
-  } as TransactionMeta;
-
-  const delegation = await getDelegationTransaction(
-    { messenger: messenger as unknown as DelegationMessenger },
-    transactionMeta,
-  );
-
-  return [
-    {
-      to: delegation.to,
-      data: delegation.data,
-      value: delegation.value,
-    },
-  ];
+    networkClientId,
+  });
 }
 
 /**
@@ -150,30 +177,30 @@ async function getMoneyAccountWithdrawPaymentOverrideData(
  * @returns Deposit calls, the money-account recipient, and optional auth list.
  */
 async function getMoneyAccountDepositPaymentOverrideData(
-  messenger: MoneyPayMessenger,
+  messenger: PaymentOverrideMessenger,
   amountHuman: string,
   atomic: boolean,
 ): Promise<GetPaymentOverrideDataResponse> {
   const context = getMoneyPayContext(messenger);
   if (!context) {
-    return { calls: [] };
+    throw new Error(`${LOG_TAG} Money account payment override is not available`);
   }
 
-  const amount = parseMusdHumanAmountDown(amountHuman);
+  const amount = parseMusdHumanAmount(amountHuman, BigNumber.ROUND_DOWN);
   if (amount === undefined) {
     return { calls: [] };
   }
 
-  const { moneyAccountAddress, vaultConfig, networkClientId, provider } =
+  const { moneyAccountAddress, networkClientId, provider, vaultConfig } =
     context;
   const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
-    amount,
-    chainId: vaultConfig.chainId,
-    boringVault: vaultConfig.boringVault,
-    tellerAddress: vaultConfig.tellerAddress,
     accountantAddress: vaultConfig.accountantAddress,
+    amount,
+    boringVault: vaultConfig.boringVault,
+    chainId: vaultConfig.chainId,
     lensAddress: vaultConfig.lensAddress,
     provider,
+    tellerAddress: vaultConfig.tellerAddress,
   });
 
   const rawCalls: BatchTransactionParams[] = [
@@ -185,33 +212,17 @@ async function getMoneyAccountDepositPaymentOverrideData(
     return { calls: rawCalls, recipient: moneyAccountAddress };
   }
 
-  const transactionMeta = {
-    id: `money-account-deposit-${Date.now()}`,
+  const wrapped = await wrapCallsInDelegation(messenger, {
     chainId: vaultConfig.chainId,
-    networkClientId,
-    status: TransactionStatus.unapproved,
-    time: Date.now(),
-    txParams: {
-      from: moneyAccountAddress,
-    },
+    from: moneyAccountAddress,
+    idPrefix: 'money-account-deposit',
     nestedTransactions: rawCalls,
-  } as TransactionMeta;
-
-  const delegation = await getDelegationTransaction(
-    { messenger: messenger as unknown as DelegationMessenger },
-    transactionMeta,
-  );
+    networkClientId,
+  });
 
   return {
+    ...wrapped,
     recipient: moneyAccountAddress,
-    authorizationList: delegation.authorizationList,
-    calls: [
-      {
-        to: delegation.to,
-        data: delegation.data,
-        value: delegation.value,
-      },
-    ],
   };
 }
 
@@ -229,7 +240,7 @@ async function getMoneyAccountDepositPaymentOverrideData(
  */
 export async function getPaymentOverrideData(
   request: GetPaymentOverrideDataRequest,
-  messenger: MoneyPayMessenger,
+  messenger: PaymentOverrideMessenger,
 ): Promise<GetPaymentOverrideDataResponse> {
   const { amount, transaction, transactionData } = request;
 
@@ -252,11 +263,10 @@ export async function getPaymentOverrideData(
     return { calls: [] };
   }
 
-  const calls = await getMoneyAccountWithdrawPaymentOverrideData(
+  return await getMoneyAccountWithdrawPaymentOverrideData(
     messenger,
     recipient,
     amount,
     atomic,
   );
-  return { calls };
 }

--- a/app/scripts/lib/money/pay/payment-override-callback.ts
+++ b/app/scripts/lib/money/pay/payment-override-callback.ts
@@ -77,7 +77,9 @@ async function wrapCallsInDelegation(
     nestedTransactions: BatchTransactionParams[];
     networkClientId: string;
   },
-): Promise<Pick<GetPaymentOverrideDataResponse, 'authorizationList' | 'calls'>> {
+): Promise<
+  Pick<GetPaymentOverrideDataResponse, 'authorizationList' | 'calls'>
+> {
   const transactionMeta = {
     chainId,
     id: `${idPrefix}-${Date.now()}`,
@@ -129,7 +131,9 @@ async function getMoneyAccountWithdrawPaymentOverrideData(
 ): Promise<GetPaymentOverrideDataResponse> {
   const context = getMoneyPayContext(messenger);
   if (!context) {
-    throw new Error(`${LOG_TAG} Money account payment override is not available`);
+    throw new Error(
+      `${LOG_TAG} Money account payment override is not available`,
+    );
   }
 
   const amount = parseMusdHumanAmount(amountHuman, BigNumber.ROUND_DOWN);
@@ -183,7 +187,9 @@ async function getMoneyAccountDepositPaymentOverrideData(
 ): Promise<GetPaymentOverrideDataResponse> {
   const context = getMoneyPayContext(messenger);
   if (!context) {
-    throw new Error(`${LOG_TAG} Money account payment override is not available`);
+    throw new Error(
+      `${LOG_TAG} Money account payment override is not available`,
+    );
   }
 
   const amount = parseMusdHumanAmount(amountHuman, BigNumber.ROUND_DOWN);

--- a/app/scripts/lib/money/pay/payment-override-callback.ts
+++ b/app/scripts/lib/money/pay/payment-override-callback.ts
@@ -1,0 +1,262 @@
+import { BigNumber } from 'bignumber.js';
+import {
+  buildMoneyAccountDepositBatch,
+  buildMoneyAccountWithdrawBatch,
+  MUSD_DECIMALS,
+} from '@metamask/money-account-utils';
+import {
+  TransactionStatus,
+  type BatchTransactionParams,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import {
+  PaymentOverride,
+  type GetPaymentOverrideDataRequest,
+  type GetPaymentOverrideDataResponse,
+} from '@metamask/transaction-pay-controller';
+import { isStrictHexString, type Hex } from '@metamask/utils';
+import {
+  getDelegationTransaction,
+  type DelegationMessenger,
+} from '../../transaction/delegation';
+import { getMoneyPayContext, type MoneyPayMessenger } from './pay-context';
+
+const MUSD_UNIT = 10 ** MUSD_DECIMALS;
+
+/**
+ * Parses a human-readable mUSD amount into base units, rounding down so Max
+ * never requests more atomic units than the withdrawable money-account
+ * balance. Returns `undefined` for zero, negative, or non-numeric input.
+ *
+ * @param amountHuman - Exact human-readable mUSD amount.
+ * @returns The amount in mUSD base units, or `undefined` when unusable.
+ */
+function parseMusdHumanAmountDown(amountHuman: string): bigint | undefined {
+  let value: BigNumber;
+  try {
+    value = new BigNumber(amountHuman);
+  } catch {
+    return undefined;
+  }
+
+  if (!value.isFinite() || value.lte(0)) {
+    return undefined;
+  }
+
+  const raw = value.times(MUSD_UNIT).round(0, BigNumber.ROUND_DOWN);
+  if (raw.lte(0)) {
+    return undefined;
+  }
+
+  return BigInt(raw.toString(10));
+}
+
+function toBatchCall(params: {
+  to?: string;
+  data?: string;
+  value?: string;
+}): BatchTransactionParams {
+  return {
+    to: params.to as Hex,
+    data: params.data as Hex | undefined,
+    value: params.value as Hex | undefined,
+  };
+}
+
+/**
+ * Builds the Money Account vault-withdraw + mUSD-transfer calls that fund a
+ * confirmation (e.g. Perps deposit) from the money account.
+ *
+ * Atomic flows wrap the pair in a fresh EIP-7702 delegation so Relay can
+ * embed it. Non-atomic flows return the raw calls for a sponsored batch after
+ * Relay completes — the money account is already delegated.
+ *
+ * @param messenger - Messenger used to resolve vault context and sign.
+ * @param recipient - Address that receives the redeemed mUSD.
+ * @param amountHuman - Human-readable mUSD amount.
+ * @param atomic - Whether to wrap the calls in an EIP-7702 delegation.
+ * @returns Batch calls to prepend, or an empty list when unavailable.
+ */
+async function getMoneyAccountWithdrawPaymentOverrideData(
+  messenger: MoneyPayMessenger,
+  recipient: Hex,
+  amountHuman: string,
+  atomic: boolean,
+): Promise<BatchTransactionParams[]> {
+  const context = getMoneyPayContext(messenger);
+  if (!context) {
+    return [];
+  }
+
+  const amount = parseMusdHumanAmountDown(amountHuman);
+  if (amount === undefined) {
+    return [];
+  }
+
+  const { moneyAccountAddress, vaultConfig, networkClientId, provider } =
+    context;
+  const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
+    amount,
+    chainId: vaultConfig.chainId,
+    tellerAddress: vaultConfig.tellerAddress,
+    accountantAddress: vaultConfig.accountantAddress,
+    moneyAccountAddress,
+    recipient,
+    provider,
+  });
+
+  const rawCalls: BatchTransactionParams[] = [
+    toBatchCall(withdrawTx.params),
+    toBatchCall(transferTx.params),
+  ];
+
+  if (!atomic) {
+    return rawCalls;
+  }
+
+  const transactionMeta = {
+    id: `money-account-withdraw-${Date.now()}`,
+    chainId: vaultConfig.chainId,
+    networkClientId,
+    status: TransactionStatus.unapproved,
+    time: Date.now(),
+    txParams: {
+      from: moneyAccountAddress,
+    },
+    nestedTransactions: rawCalls,
+  } as TransactionMeta;
+
+  const delegation = await getDelegationTransaction(
+    { messenger: messenger as unknown as DelegationMessenger },
+    transactionMeta,
+  );
+
+  return [
+    {
+      to: delegation.to,
+      data: delegation.data,
+      value: delegation.value,
+    },
+  ];
+}
+
+/**
+ * Builds the Money Account approve + vault-deposit calls used when a
+ * confirmation pays *into* the money account after Relay (post-quote).
+ *
+ * @param messenger - Messenger used to resolve vault context and sign.
+ * @param amountHuman - Human-readable mUSD amount.
+ * @param atomic - Whether to wrap the calls in an EIP-7702 delegation.
+ * @returns Deposit calls, the money-account recipient, and optional auth list.
+ */
+async function getMoneyAccountDepositPaymentOverrideData(
+  messenger: MoneyPayMessenger,
+  amountHuman: string,
+  atomic: boolean,
+): Promise<GetPaymentOverrideDataResponse> {
+  const context = getMoneyPayContext(messenger);
+  if (!context) {
+    return { calls: [] };
+  }
+
+  const amount = parseMusdHumanAmountDown(amountHuman);
+  if (amount === undefined) {
+    return { calls: [] };
+  }
+
+  const { moneyAccountAddress, vaultConfig, networkClientId, provider } =
+    context;
+  const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
+    amount,
+    chainId: vaultConfig.chainId,
+    boringVault: vaultConfig.boringVault,
+    tellerAddress: vaultConfig.tellerAddress,
+    accountantAddress: vaultConfig.accountantAddress,
+    lensAddress: vaultConfig.lensAddress,
+    provider,
+  });
+
+  const rawCalls: BatchTransactionParams[] = [
+    toBatchCall(approveTx.params),
+    toBatchCall(depositTx.params),
+  ];
+
+  if (!atomic) {
+    return { calls: rawCalls, recipient: moneyAccountAddress };
+  }
+
+  const transactionMeta = {
+    id: `money-account-deposit-${Date.now()}`,
+    chainId: vaultConfig.chainId,
+    networkClientId,
+    status: TransactionStatus.unapproved,
+    time: Date.now(),
+    txParams: {
+      from: moneyAccountAddress,
+    },
+    nestedTransactions: rawCalls,
+  } as TransactionMeta;
+
+  const delegation = await getDelegationTransaction(
+    { messenger: messenger as unknown as DelegationMessenger },
+    transactionMeta,
+  );
+
+  return {
+    recipient: moneyAccountAddress,
+    authorizationList: delegation.authorizationList,
+    calls: [
+      {
+        to: delegation.to,
+        data: delegation.data,
+        value: delegation.value,
+      },
+    ],
+  };
+}
+
+/**
+ * TransactionPayController callback: when `paymentOverride` is Money Account,
+ * returns the vault calls that fund (withdraw) or receive (post-quote deposit)
+ * the confirmation. Other overrides return an empty call list.
+ *
+ * `isPostQuote` selects deposit-into-vault; otherwise this is the withdraw
+ * path used to fund Perps / Predict deposits from the money account.
+ *
+ * @param request - Pay-controller request with amount and transaction config.
+ * @param messenger - Messenger used to resolve vault context and sign.
+ * @returns Batch calls (and optional recipient / authorization) to prepend.
+ */
+export async function getPaymentOverrideData(
+  request: GetPaymentOverrideDataRequest,
+  messenger: MoneyPayMessenger,
+): Promise<GetPaymentOverrideDataResponse> {
+  const { amount, transaction, transactionData } = request;
+
+  if (transactionData?.paymentOverride !== PaymentOverride.MoneyAccount) {
+    return { calls: [] };
+  }
+
+  const atomic = transactionData.atomic !== false;
+
+  if (transactionData.isPostQuote) {
+    return await getMoneyAccountDepositPaymentOverrideData(
+      messenger,
+      amount,
+      atomic,
+    );
+  }
+
+  const recipient = transaction.txParams?.from;
+  if (!isStrictHexString(recipient)) {
+    return { calls: [] };
+  }
+
+  const calls = await getMoneyAccountWithdrawPaymentOverrideData(
+    messenger,
+    recipient,
+    amount,
+    atomic,
+  );
+  return { calls };
+}

--- a/app/scripts/lib/transaction/delegation.ts
+++ b/app/scripts/lib/transaction/delegation.ts
@@ -58,7 +58,7 @@ type EnforcedSegment = {
   value: Hex;
 };
 
-type DelegationMessengerActions =
+export type DelegationMessengerActions =
   | DelegationControllerSignDelegationAction
   | KeyringControllerSignEip7702AuthorizationAction
   | TransactionControllerGetNonceLockAction
@@ -144,7 +144,11 @@ type ConvertTransactionToRedeemDelegationsResult = {
 };
 
 type GetDelegationTransactionRequest = {
-  messenger: DelegationMessenger;
+  /**
+   * Messenger that can perform at least the delegation / EIP-7702 signing
+   * actions. Callers may pass a wider messenger (e.g. payment-override init).
+   */
+  messenger: Messenger<string, DelegationMessengerActions, never>;
   isSubsidized?: boolean;
 };
 

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
@@ -9,6 +9,7 @@ import {
   getMoneyAccountAmountData,
   updateMoneyAccountDepositAmount,
 } from '../lib/money/pay/update-deposit-amount';
+import { getPaymentOverrideData } from '../lib/money/pay/payment-override-callback';
 import { updateMoneyAccountWithdrawAmount } from '../lib/money/pay/update-withdraw-amount';
 import { getDelegationTransaction } from '../lib/transaction/delegation';
 import { MessengerClientInitRequest } from './types';
@@ -34,6 +35,9 @@ jest.mock('../lib/money/pay/update-deposit-amount', () => ({
   getMoneyAccountAmountData: jest.fn(),
   updateMoneyAccountDepositAmount: jest.fn(),
 }));
+jest.mock('../lib/money/pay/payment-override-callback', () => ({
+  getPaymentOverrideData: jest.fn(),
+}));
 jest.mock('../lib/money/pay/update-withdraw-amount', () => ({
   updateMoneyAccountWithdrawAmount: jest.fn(),
 }));
@@ -47,6 +51,7 @@ const createWithdrawTransactionMock = jest.mocked(
 const updateDepositAmountMock = jest.mocked(updateMoneyAccountDepositAmount);
 const updateWithdrawAmountMock = jest.mocked(updateMoneyAccountWithdrawAmount);
 const getMoneyAccountAmountDataMock = jest.mocked(getMoneyAccountAmountData);
+const getPaymentOverrideDataMock = jest.mocked(getPaymentOverrideData);
 
 function getInitRequestMock(): jest.Mocked<
   MessengerClientInitRequest<
@@ -79,6 +84,7 @@ describe('TransactionPayControllerInit', () => {
     expect(controllerMock).toHaveBeenCalledWith({
       getAmountData: expect.any(Function),
       getDelegationTransaction: expect.any(Function),
+      getPaymentOverrideData: expect.any(Function),
       getStrategy: expect.any(Function),
       messenger: expect.any(Object),
       state: undefined,
@@ -308,15 +314,39 @@ describe('TransactionPayControllerInit', () => {
       const config: {
         paymentOverride?: string;
         refundTo?: string;
+        atomic?: boolean;
       } = {
         paymentOverride: 'moneyAccount',
         refundTo: '0xabc',
+        atomic: false,
       };
       updater(config as never);
 
       expect(config).toEqual({
         paymentOverride: undefined,
         refundTo: undefined,
+        atomic: undefined,
+      });
+    });
+
+    it('writes atomic when supplied', () => {
+      const { api, setTransactionConfigMock } = initApi();
+
+      api.setTransactionPayPaymentOverride('tx-3', {
+        paymentOverride: 'moneyAccount' as never,
+        atomic: false,
+      });
+
+      const updater = setTransactionConfigMock.mock.calls[0][1];
+      const config: {
+        paymentOverride?: string;
+        atomic?: boolean;
+      } = {};
+      updater(config as never);
+
+      expect(config).toEqual({
+        paymentOverride: 'moneyAccount',
+        atomic: false,
       });
     });
   });
@@ -536,6 +566,27 @@ describe('TransactionPayControllerInit', () => {
     expect(getMoneyAccountAmountDataMock).toHaveBeenCalledWith(
       expect.anything(),
       request,
+    );
+  });
+
+  it('forwards getPaymentOverrideData to the money-account callback', async () => {
+    TransactionPayControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(TransactionPayController);
+    const lastCall =
+      controllerMock.mock.calls[controllerMock.mock.calls.length - 1][0];
+    getPaymentOverrideDataMock.mockResolvedValue({ calls: [] });
+
+    const request = {
+      amount: '10',
+      transaction: { id: 'tx-1' },
+      transactionData: {},
+    };
+    await lastCall.getPaymentOverrideData?.(request as never);
+
+    expect(getPaymentOverrideDataMock).toHaveBeenCalledWith(
+      request,
+      expect.anything(),
     );
   });
 });

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
@@ -12,6 +12,7 @@ import {
 } from '../lib/transaction/delegation';
 import { createMoneyAccountDepositTransaction } from '../lib/money/pay/create-deposit-transaction';
 import { createMoneyAccountWithdrawTransaction } from '../lib/money/pay/create-withdraw-transaction';
+import { getPaymentOverrideData } from '../lib/money/pay/payment-override-callback';
 import {
   getMoneyAccountAmountData,
   updateMoneyAccountDepositAmount,
@@ -53,6 +54,11 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
         amountDataRequest,
       ),
     getDelegationTransaction: getDelegationTransactionCallback,
+    getPaymentOverrideData: (paymentOverrideRequest) =>
+      getPaymentOverrideData(
+        paymentOverrideRequest,
+        initMessenger as MoneyPayMessenger,
+      ),
     getStrategy,
     messenger: controllerMessenger,
     state: persistedState.TransactionPayController,
@@ -157,19 +163,25 @@ function getApi(
       {
         paymentOverride,
         refundTo,
+        atomic,
       }: {
         paymentOverride?: PaymentOverride;
         refundTo?: Hex;
+        atomic?: boolean;
       } = {},
     ) => {
       messengerClient.setTransactionConfig(transactionId, (config) => {
         config.paymentOverride = paymentOverride;
         if (paymentOverride === undefined) {
           config.refundTo = undefined;
+          config.atomic = undefined;
           return;
         }
         if (refundTo !== undefined) {
           config.refundTo = refundTo;
+        }
+        if (atomic !== undefined) {
+          config.atomic = atomic;
         }
       });
     },

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
@@ -18,7 +18,10 @@ import {
   updateMoneyAccountDepositAmount,
 } from '../lib/money/pay/update-deposit-amount';
 import { updateMoneyAccountWithdrawAmount } from '../lib/money/pay/update-withdraw-amount';
-import type { MoneyPayMessenger } from '../lib/money/pay/pay-context';
+import type {
+  MoneyPayMessenger,
+  PaymentOverrideMessenger,
+} from '../lib/money/pay/pay-context';
 import type {
   MessengerClientInitFunction,
   MessengerClientInitResult,
@@ -57,7 +60,7 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
     getPaymentOverrideData: (paymentOverrideRequest) =>
       getPaymentOverrideData(
         paymentOverrideRequest,
-        initMessenger as MoneyPayMessenger,
+        initMessenger as PaymentOverrideMessenger,
       ),
     getStrategy,
     messenger: controllerMessenger,
@@ -161,27 +164,27 @@ function getApi(
     setTransactionPayPaymentOverride: (
       transactionId: string,
       {
+        atomic,
         paymentOverride,
         refundTo,
-        atomic,
       }: {
+        atomic?: boolean;
         paymentOverride?: PaymentOverride;
         refundTo?: Hex;
-        atomic?: boolean;
       } = {},
     ) => {
       messengerClient.setTransactionConfig(transactionId, (config) => {
         config.paymentOverride = paymentOverride;
         if (paymentOverride === undefined) {
-          config.refundTo = undefined;
           config.atomic = undefined;
+          config.refundTo = undefined;
           return;
-        }
-        if (refundTo !== undefined) {
-          config.refundTo = refundTo;
         }
         if (atomic !== undefined) {
           config.atomic = atomic;
+        }
+        if (refundTo !== undefined) {
+          config.refundTo = refundTo;
         }
       });
     },

--- a/app/scripts/wallet-init/messengers/transaction-controller-messenger.test.ts
+++ b/app/scripts/wallet-init/messengers/transaction-controller-messenger.test.ts
@@ -21,6 +21,7 @@ describe('getTransactionControllerInitMessenger', () => {
       expect.objectContaining({
         actions: expect.arrayContaining([
           'TransactionPayController:getDelegationTransaction',
+          'TransactionPayController:getPaymentOverrideData',
         ]),
       }),
     );

--- a/app/scripts/wallet-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/wallet-init/messengers/transaction-controller-messenger.ts
@@ -55,11 +55,7 @@ import {
   TransactionControllerUnapprovedTransactionAddedEvent,
   TransactionControllerUpdateTransactionAction,
 } from '@metamask/transaction-controller';
-import {
-  TransactionPayControllerGetDelegationTransactionAction,
-  TransactionPayControllerGetStateAction,
-  TransactionPayControllerGetStrategyAction,
-} from '@metamask/transaction-pay-controller';
+import { TransactionPayControllerActions } from '@metamask/transaction-pay-controller';
 import { RootMessenger } from '../../lib/messenger';
 import { AppStateControllerGetStateAction } from '../../controllers/app-state-controller';
 import { AppStateControllerSetDefaultHomeActiveTabNameAction } from '../../controllers/app-state-controller-method-action-types';
@@ -110,9 +106,7 @@ export type TransactionControllerInitMessengerActions =
   | TransactionControllerGetStateAction
   | TransactionControllerIsAtomicBatchSupportedAction
   | TransactionControllerUpdateTransactionAction
-  | TransactionPayControllerGetDelegationTransactionAction
-  | TransactionPayControllerGetStateAction
-  | TransactionPayControllerGetStrategyAction;
+  | TransactionPayControllerActions;
 
 export type TransactionControllerInitMessengerEvents =
   | BridgeStatusControllerStateChangeEvent
@@ -201,6 +195,7 @@ export function getTransactionControllerInitMessenger(
       'TransactionController:isAtomicBatchSupported',
       'TransactionController:updateTransaction',
       'TransactionPayController:getDelegationTransaction',
+      'TransactionPayController:getPaymentOverrideData',
       'TransactionPayController:getState',
       'TransactionPayController:getStrategy',
     ],

--- a/shared/lib/money/withdrawable-balance.ts
+++ b/shared/lib/money/withdrawable-balance.ts
@@ -1,0 +1,25 @@
+import { BigNumber } from 'bignumber.js';
+import { MUSD_DECIMALS } from '@metamask/money-account-utils';
+
+/**
+ * Divisor that converts mUSD / vmUSD base units into human-readable amounts.
+ * Shared so projection math cannot drift across Money Account surfaces.
+ */
+export const MUSD_UNIT = 10 ** MUSD_DECIMALS;
+
+/**
+ * Projects a vault `vmusdValueInMusd` balance (base units) into a human-readable
+ * BigNumber amount. mUSD is USD-pegged 1:1, so this value is also fiat.
+ *
+ * @param vmusdValueInMusd - Raw withdrawable balance in mUSD base units.
+ * @returns Human-readable amount, or `undefined` when the input is missing.
+ */
+export function projectVmusdValueInMusdToHuman(
+  vmusdValueInMusd: string | number | undefined | null,
+): BigNumber | undefined {
+  if (vmusdValueInMusd === undefined || vmusdValueInMusd === null) {
+    return undefined;
+  }
+
+  return new BigNumber(vmusdValueInMusd).dividedBy(MUSD_UNIT);
+}

--- a/ui/helpers/money/withdrawable-balance.ts
+++ b/ui/helpers/money/withdrawable-balance.ts
@@ -1,0 +1,56 @@
+import type BigNumber from 'bignumber.js';
+import { projectVmusdValueInMusdToHuman } from '../../../shared/lib/money/withdrawable-balance';
+import { moneyFormatUsd } from './format';
+
+export { MUSD_UNIT, projectVmusdValueInMusdToHuman } from '../../../shared/lib/money/withdrawable-balance';
+
+export type WithdrawableFiatProjection = {
+  withdrawableFiatFormatted: string | undefined;
+  withdrawableFiatRaw: string | undefined;
+};
+
+/**
+ * Projects vault `vmusdValueInMusd` into withdrawable fiat raw + formatted
+ * strings used by Money Account UI surfaces.
+ *
+ * @param vmusdValueInMusd - Raw withdrawable balance in mUSD base units.
+ * @returns Formatted and raw fiat strings, or both `undefined` when unavailable.
+ */
+export function projectWithdrawableFiat(
+  vmusdValueInMusd: string | number | undefined | null,
+): WithdrawableFiatProjection {
+  const withdrawableFiat = projectVmusdValueInMusdToHuman(vmusdValueInMusd);
+  if (!withdrawableFiat) {
+    return {
+      withdrawableFiatFormatted: undefined,
+      withdrawableFiatRaw: undefined,
+    };
+  }
+
+  return {
+    withdrawableFiatFormatted: moneyFormatUsd(withdrawableFiat),
+    withdrawableFiatRaw: withdrawableFiat.toString(),
+  };
+}
+
+/**
+ * Formats an already-projected human withdrawable amount.
+ *
+ * @param withdrawableFiat - Human-readable amount, or undefined.
+ * @returns Formatted and raw fiat strings, or both `undefined` when unavailable.
+ */
+export function formatWithdrawableFiat(
+  withdrawableFiat: BigNumber | undefined,
+): WithdrawableFiatProjection {
+  if (!withdrawableFiat) {
+    return {
+      withdrawableFiatFormatted: undefined,
+      withdrawableFiatRaw: undefined,
+    };
+  }
+
+  return {
+    withdrawableFiatFormatted: moneyFormatUsd(withdrawableFiat),
+    withdrawableFiatRaw: withdrawableFiat.toString(),
+  };
+}

--- a/ui/helpers/money/withdrawable-balance.ts
+++ b/ui/helpers/money/withdrawable-balance.ts
@@ -2,7 +2,10 @@ import type BigNumber from 'bignumber.js';
 import { projectVmusdValueInMusdToHuman } from '../../../shared/lib/money/withdrawable-balance';
 import { moneyFormatUsd } from './format';
 
-export { MUSD_UNIT, projectVmusdValueInMusdToHuman } from '../../../shared/lib/money/withdrawable-balance';
+export {
+  MUSD_UNIT,
+  projectVmusdValueInMusdToHuman,
+} from '../../../shared/lib/money/withdrawable-balance';
 
 export type WithdrawableFiatProjection = {
   withdrawableFiatFormatted: string | undefined;

--- a/ui/helpers/money/withdrawable-balance.ts
+++ b/ui/helpers/money/withdrawable-balance.ts
@@ -23,7 +23,7 @@ export function projectWithdrawableFiat(
   vmusdValueInMusd: string | number | undefined | null,
 ): WithdrawableFiatProjection {
   const withdrawableFiat = projectVmusdValueInMusdToHuman(vmusdValueInMusd);
-  if (!withdrawableFiat) {
+  if (withdrawableFiat === undefined) {
     return {
       withdrawableFiatFormatted: undefined,
       withdrawableFiatRaw: undefined,
@@ -45,7 +45,7 @@ export function projectWithdrawableFiat(
 export function formatWithdrawableFiat(
   withdrawableFiat: BigNumber | undefined,
 ): WithdrawableFiatProjection {
-  if (!withdrawableFiat) {
+  if (withdrawableFiat === undefined) {
     return {
       withdrawableFiatFormatted: undefined,
       withdrawableFiatRaw: undefined,

--- a/ui/hooks/money/useCachedMoneyAccountWithdrawableFiat.test.ts
+++ b/ui/hooks/money/useCachedMoneyAccountWithdrawableFiat.test.ts
@@ -1,0 +1,132 @@
+import { renderHook } from '@testing-library/react';
+import { BigNumber } from 'bignumber.js';
+import { useQuery } from '@metamask/react-data-query';
+import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-account-balance-service';
+import { DATA_SERVICES } from '../../../shared/constants/data-services';
+import { MoneyAccountBalanceServiceQueryKeys } from '../../../shared/lib/money/query-keys';
+import { selectPrimaryMoneyAccount } from '../../selectors/money-account';
+import { useCachedMoneyAccountWithdrawableFiat } from './useCachedMoneyAccountWithdrawableFiat';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+jest.mock('@metamask/react-data-query', () => ({
+  useQuery: jest.fn(),
+}));
+jest.mock('../../selectors/money-account', () => ({
+  selectPrimaryMoneyAccount: jest.fn(),
+}));
+
+const useQueryMock = jest.mocked(useQuery);
+const selectPrimaryMoneyAccountMock = jest.mocked(selectPrimaryMoneyAccount);
+
+const MONEY_ACCOUNT_ADDRESS = '0xabc0000000000000000000000000000000000001';
+
+function musdUnits(human: string): string {
+  return new BigNumber(human).times(1e6).toFixed(0);
+}
+
+function mockBalance({
+  vmusdHuman,
+  isLoading = false,
+  isError = false,
+}: {
+  vmusdHuman?: string;
+  isLoading?: boolean;
+  isError?: boolean;
+} = {}) {
+  useQueryMock.mockReturnValue({
+    data:
+      vmusdHuman === undefined
+        ? undefined
+        : ({
+            vmusdValueInMusd: musdUnits(vmusdHuman),
+          } as CanonicalMoneyAccountBalanceResponse),
+    isLoading,
+    isError,
+  } as ReturnType<typeof useQuery>);
+}
+
+describe('useCachedMoneyAccountWithdrawableFiat', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockBalance({ vmusdHuman: '12.34' });
+    selectPrimaryMoneyAccountMock.mockReturnValue({
+      address: MONEY_ACCOUNT_ADDRESS,
+    } as unknown as ReturnType<typeof selectPrimaryMoneyAccount>);
+  });
+
+  it('returns withdrawable fiat when active', () => {
+    const { result } = renderHook(() =>
+      useCachedMoneyAccountWithdrawableFiat(true),
+    );
+
+    expect(result.current.withdrawableFiatRaw).toBe('12.34');
+    expect(result.current.withdrawableFiatFormatted).toBe('$12.34');
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        queryKey: [
+          MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+          MONEY_ACCOUNT_ADDRESS,
+        ],
+      }),
+    );
+  });
+
+  it('returns undefined while the cached query is loading', () => {
+    mockBalance({ isLoading: true });
+
+    const { result } = renderHook(() =>
+      useCachedMoneyAccountWithdrawableFiat(true),
+    );
+
+    expect(result.current).toStrictEqual({
+      withdrawableFiatRaw: undefined,
+      withdrawableFiatFormatted: undefined,
+    });
+  });
+
+  it('returns undefined when the cached query errored', () => {
+    mockBalance({ isError: true });
+
+    const { result } = renderHook(() =>
+      useCachedMoneyAccountWithdrawableFiat(true),
+    );
+
+    expect(result.current).toStrictEqual({
+      withdrawableFiatRaw: undefined,
+      withdrawableFiatFormatted: undefined,
+    });
+  });
+
+  it('does not use a data service query key when inactive', () => {
+    const { result } = renderHook(() =>
+      useCachedMoneyAccountWithdrawableFiat(false),
+    );
+
+    expect(result.current).toStrictEqual({
+      withdrawableFiatRaw: undefined,
+      withdrawableFiatFormatted: undefined,
+    });
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        queryFn: expect.any(Function),
+      }),
+    );
+
+    const queryKey = useQueryMock.mock.calls[0][0].queryKey ?? [];
+
+    expect(queryKey).not.toContain(
+      MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+    );
+    expect(
+      DATA_SERVICES.some((service) =>
+        String(queryKey[0]).startsWith(`${service}:`),
+      ),
+    ).toBe(false);
+  });
+});

--- a/ui/hooks/money/useCachedMoneyAccountWithdrawableFiat.ts
+++ b/ui/hooks/money/useCachedMoneyAccountWithdrawableFiat.ts
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import BigNumber from 'bignumber.js';
+import { useQuery } from '@metamask/react-data-query';
+import { MUSD_DECIMALS } from '@metamask/money-account-utils';
+import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-account-balance-service';
+import { MoneyAccountBalanceServiceQueryKeys } from '../../../shared/lib/money/query-keys';
+import { moneyFormatUsd } from '../../helpers/money/format';
+import { selectPrimaryMoneyAccount } from '../../selectors/money-account';
+
+const MUSD_UNIT = 10 ** MUSD_DECIMALS;
+
+const DEFAULT_REFETCH_INTERVAL = 30 * 1000;
+
+/**
+ * Inert query key used when the caller does not need money-account balance.
+ * Deliberately not a `DATA_SERVICES` name so the query client does not open a
+ * background messenger subscription for it.
+ */
+const DISABLED_QUERY_KEY = 'money-account-withdrawable-fiat:disabled';
+
+/**
+ * Never-run `queryFn` for {@link DISABLED_QUERY_KEY}. TanStack Query logs
+ * "No queryFn was found" for observers that omit one, even when `enabled` is
+ * false — and this hook runs for every confirmation via pay/alert surfaces.
+ */
+function disabledWithdrawableFiatQueryFn(): never {
+  throw new Error('money-account-withdrawable-fiat is cache-only');
+}
+
+export type CachedMoneyAccountWithdrawableFiat = {
+  withdrawableFiatRaw: string | undefined;
+  withdrawableFiatFormatted: string | undefined;
+};
+
+/**
+ * Withdrawable money-account fiat for confirmation surfaces that cannot use
+ * `useMoneyAccountBalance` (that hook needs a money-account route messenger).
+ *
+ * When `isActive`, this fetches the same
+ * `fetchBalanceWithFallback` query money home writes. Perps deposit never
+ * visits money home first, so cache-only reads left the Pay-with row and
+ * modal blank. A dummy query key is used when inactive so unrelated
+ * confirmations (typed-sign, etc.) do not open a data-service subscription.
+ *
+ * @param isActive - When false, uses a dummy query key and returns undefined.
+ * @returns Withdrawable fiat, or undefined when inactive / unavailable.
+ */
+export function useCachedMoneyAccountWithdrawableFiat(
+  isActive: boolean,
+): CachedMoneyAccountWithdrawableFiat {
+  const primaryMoneyAccount = useSelector(selectPrimaryMoneyAccount);
+  const address = primaryMoneyAccount?.address;
+  const shouldFetch = Boolean(isActive && address);
+
+  const moneyBalanceQuery = useQuery<CanonicalMoneyAccountBalanceResponse>({
+    queryKey: shouldFetch
+      ? [
+          MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+          address ?? '',
+        ]
+      : [DISABLED_QUERY_KEY],
+    enabled: shouldFetch,
+    refetchInterval: shouldFetch ? DEFAULT_REFETCH_INTERVAL : false,
+    // Only the dummy key needs a queryFn. The fetch key is owned by
+    // DATA_SERVICES; attaching a local queryFn would overwrite that handler.
+    ...(shouldFetch ? {} : { queryFn: disabledWithdrawableFiatQueryFn }),
+  });
+
+  return useMemo(() => {
+    if (
+      !isActive ||
+      moneyBalanceQuery.isLoading ||
+      moneyBalanceQuery.isError ||
+      !moneyBalanceQuery.data?.vmusdValueInMusd
+    ) {
+      return {
+        withdrawableFiatRaw: undefined,
+        withdrawableFiatFormatted: undefined,
+      };
+    }
+
+    const withdrawableFiat = new BigNumber(
+      moneyBalanceQuery.data.vmusdValueInMusd,
+    ).dividedBy(MUSD_UNIT);
+
+    return {
+      withdrawableFiatRaw: withdrawableFiat.toString(),
+      withdrawableFiatFormatted: moneyFormatUsd(withdrawableFiat),
+    };
+  }, [
+    isActive,
+    moneyBalanceQuery.data,
+    moneyBalanceQuery.isError,
+    moneyBalanceQuery.isLoading,
+  ]);
+}

--- a/ui/hooks/money/useMoneyAccountBalance.ts
+++ b/ui/hooks/money/useMoneyAccountBalance.ts
@@ -3,13 +3,14 @@ import { useDispatch, useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@metamask/react-data-query';
-import { MUSD_DECIMALS } from '@metamask/money-account-utils';
 import type {
   CanonicalMoneyAccountBalanceResponse,
   NormalizedVaultApyResponse,
 } from '@metamask/money-account-balance-service';
 import { MoneyAccountBalanceServiceQueryKeys } from '../../../shared/lib/money/query-keys';
+import { MUSD_UNIT } from '../../../shared/lib/money/withdrawable-balance';
 import { moneyFormatUsd } from '../../helpers/money/format';
+import { projectVmusdValueInMusdToHuman } from '../../helpers/money/withdrawable-balance';
 import { invalidateMoneyAccountBalanceCaches } from '../../helpers/money/invalidate-balance-caches';
 import { setLastKnownMoneyBalance } from '../../ducks/money-balance';
 import {
@@ -27,15 +28,6 @@ const PERCENT = 100;
 
 /** Decimal places the APY percentage is presented to. */
 const APY_PERCENT_DP = 1;
-
-/**
- * The unit scale of an mUSD minimal unit, as a divisor.
- *
- * `dividedBy(10 ** MUSD_DECIMALS)` rather than mobile's `shiftedBy(-n)`:
- * `shiftedBy` does not exist in the `bignumber.js@4` this repo pins, and would
- * fail as a `TypeError` at runtime.
- */
-const MUSD_UNIT = 10 ** MUSD_DECIMALS;
 
 export type UseMoneyAccountBalanceResult = {
   moneyBalanceQuery: UseQueryResult<CanonicalMoneyAccountBalanceResponse>;
@@ -139,11 +131,10 @@ export function useMoneyAccountBalance({
         : new BigNumber(0);
 
       // the withdrawable amount.
-      const vmusdDecimal = moneyBalanceQuery.data?.vmusdValueInMusd
-        ? new BigNumber(moneyBalanceQuery.data.vmusdValueInMusd).dividedBy(
-            MUSD_UNIT,
-          )
-        : new BigNumber(0);
+      const vmusdDecimal =
+        projectVmusdValueInMusdToHuman(
+          moneyBalanceQuery.data?.vmusdValueInMusd,
+        ) ?? new BigNumber(0);
 
       // Undefined while loading or on error so callers can distinguish from a genuine zero.
       const computedWithdrawableMusd =

--- a/ui/hooks/money/useMoneyAccountWithdrawableFiat.test.ts
+++ b/ui/hooks/money/useMoneyAccountWithdrawableFiat.test.ts
@@ -73,6 +73,15 @@ describe('useMoneyAccountWithdrawableFiat', () => {
     );
   });
 
+  it('returns zero withdrawable fiat when the vault balance is zero', () => {
+    mockBalance({ vmusdHuman: '0' });
+
+    const { result } = renderHook(() => useMoneyAccountWithdrawableFiat(true));
+
+    expect(result.current.withdrawableFiatRaw).toBe('0');
+    expect(result.current.withdrawableFiatFormatted).toBe('$0.00');
+  });
+
   it('returns undefined while the cached query is loading', () => {
     mockBalance({ isLoading: true });
 

--- a/ui/hooks/money/useMoneyAccountWithdrawableFiat.test.ts
+++ b/ui/hooks/money/useMoneyAccountWithdrawableFiat.test.ts
@@ -5,7 +5,7 @@ import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-accou
 import { DATA_SERVICES } from '../../../shared/constants/data-services';
 import { MoneyAccountBalanceServiceQueryKeys } from '../../../shared/lib/money/query-keys';
 import { selectPrimaryMoneyAccount } from '../../selectors/money-account';
-import { useCachedMoneyAccountWithdrawableFiat } from './useCachedMoneyAccountWithdrawableFiat';
+import { useMoneyAccountWithdrawableFiat } from './useMoneyAccountWithdrawableFiat';
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -48,7 +48,7 @@ function mockBalance({
   } as ReturnType<typeof useQuery>);
 }
 
-describe('useCachedMoneyAccountWithdrawableFiat', () => {
+describe('useMoneyAccountWithdrawableFiat', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockBalance({ vmusdHuman: '12.34' });
@@ -59,7 +59,7 @@ describe('useCachedMoneyAccountWithdrawableFiat', () => {
 
   it('returns withdrawable fiat when active', () => {
     const { result } = renderHook(() =>
-      useCachedMoneyAccountWithdrawableFiat(true),
+      useMoneyAccountWithdrawableFiat(true),
     );
 
     expect(result.current.withdrawableFiatRaw).toBe('12.34');
@@ -79,12 +79,12 @@ describe('useCachedMoneyAccountWithdrawableFiat', () => {
     mockBalance({ isLoading: true });
 
     const { result } = renderHook(() =>
-      useCachedMoneyAccountWithdrawableFiat(true),
+      useMoneyAccountWithdrawableFiat(true),
     );
 
     expect(result.current).toStrictEqual({
-      withdrawableFiatRaw: undefined,
       withdrawableFiatFormatted: undefined,
+      withdrawableFiatRaw: undefined,
     });
   });
 
@@ -92,23 +92,23 @@ describe('useCachedMoneyAccountWithdrawableFiat', () => {
     mockBalance({ isError: true });
 
     const { result } = renderHook(() =>
-      useCachedMoneyAccountWithdrawableFiat(true),
+      useMoneyAccountWithdrawableFiat(true),
     );
 
     expect(result.current).toStrictEqual({
-      withdrawableFiatRaw: undefined,
       withdrawableFiatFormatted: undefined,
+      withdrawableFiatRaw: undefined,
     });
   });
 
   it('does not use a data service query key when inactive', () => {
     const { result } = renderHook(() =>
-      useCachedMoneyAccountWithdrawableFiat(false),
+      useMoneyAccountWithdrawableFiat(false),
     );
 
     expect(result.current).toStrictEqual({
-      withdrawableFiatRaw: undefined,
       withdrawableFiatFormatted: undefined,
+      withdrawableFiatRaw: undefined,
     });
 
     expect(useQueryMock).toHaveBeenCalledWith(

--- a/ui/hooks/money/useMoneyAccountWithdrawableFiat.test.ts
+++ b/ui/hooks/money/useMoneyAccountWithdrawableFiat.test.ts
@@ -58,9 +58,7 @@ describe('useMoneyAccountWithdrawableFiat', () => {
   });
 
   it('returns withdrawable fiat when active', () => {
-    const { result } = renderHook(() =>
-      useMoneyAccountWithdrawableFiat(true),
-    );
+    const { result } = renderHook(() => useMoneyAccountWithdrawableFiat(true));
 
     expect(result.current.withdrawableFiatRaw).toBe('12.34');
     expect(result.current.withdrawableFiatFormatted).toBe('$12.34');
@@ -78,9 +76,7 @@ describe('useMoneyAccountWithdrawableFiat', () => {
   it('returns undefined while the cached query is loading', () => {
     mockBalance({ isLoading: true });
 
-    const { result } = renderHook(() =>
-      useMoneyAccountWithdrawableFiat(true),
-    );
+    const { result } = renderHook(() => useMoneyAccountWithdrawableFiat(true));
 
     expect(result.current).toStrictEqual({
       withdrawableFiatFormatted: undefined,
@@ -91,9 +87,7 @@ describe('useMoneyAccountWithdrawableFiat', () => {
   it('returns undefined when the cached query errored', () => {
     mockBalance({ isError: true });
 
-    const { result } = renderHook(() =>
-      useMoneyAccountWithdrawableFiat(true),
-    );
+    const { result } = renderHook(() => useMoneyAccountWithdrawableFiat(true));
 
     expect(result.current).toStrictEqual({
       withdrawableFiatFormatted: undefined,
@@ -102,9 +96,7 @@ describe('useMoneyAccountWithdrawableFiat', () => {
   });
 
   it('does not use a data service query key when inactive', () => {
-    const { result } = renderHook(() =>
-      useMoneyAccountWithdrawableFiat(false),
-    );
+    const { result } = renderHook(() => useMoneyAccountWithdrawableFiat(false));
 
     expect(result.current).toStrictEqual({
       withdrawableFiatFormatted: undefined,

--- a/ui/hooks/money/useMoneyAccountWithdrawableFiat.ts
+++ b/ui/hooks/money/useMoneyAccountWithdrawableFiat.ts
@@ -1,19 +1,15 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import BigNumber from 'bignumber.js';
 import { useQuery } from '@metamask/react-data-query';
-import { MUSD_DECIMALS } from '@metamask/money-account-utils';
 import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-account-balance-service';
 import { MoneyAccountBalanceServiceQueryKeys } from '../../../shared/lib/money/query-keys';
-import { moneyFormatUsd } from '../../helpers/money/format';
+import { projectWithdrawableFiat } from '../../helpers/money/withdrawable-balance';
 import { selectPrimaryMoneyAccount } from '../../selectors/money-account';
-
-const MUSD_UNIT = 10 ** MUSD_DECIMALS;
 
 const DEFAULT_REFETCH_INTERVAL = 30 * 1000;
 
 /**
- * Inert query key used when the caller does not need money-account balance.
+ * Disabled query key used when the caller does not need money-account balance.
  * Deliberately not a `DATA_SERVICES` name so the query client does not open a
  * background messenger subscription for it.
  */
@@ -25,30 +21,34 @@ const DISABLED_QUERY_KEY = 'money-account-withdrawable-fiat:disabled';
  * false — and this hook runs for every confirmation via pay/alert surfaces.
  */
 function disabledWithdrawableFiatQueryFn(): never {
-  throw new Error('money-account-withdrawable-fiat is cache-only');
+  throw new Error(
+    'disabled money-account withdrawable-fiat query executed unexpectedly',
+  );
 }
 
-export type CachedMoneyAccountWithdrawableFiat = {
-  withdrawableFiatRaw: string | undefined;
+export type MoneyAccountWithdrawableFiat = {
   withdrawableFiatFormatted: string | undefined;
+  withdrawableFiatRaw: string | undefined;
 };
 
 /**
- * Withdrawable money-account fiat for confirmation surfaces that cannot use
- * `useMoneyAccountBalance` (that hook needs a money-account route messenger).
+ * Live withdrawable money-account fiat for confirmation surfaces that cannot
+ * use `useMoneyAccountBalance` (that hook needs a money-account route
+ * messenger).
  *
- * When `isActive`, this fetches the same
- * `fetchBalanceWithFallback` query money home writes. Perps deposit never
- * visits money home first, so cache-only reads left the Pay-with row and
- * modal blank. A dummy query key is used when inactive so unrelated
- * confirmations (typed-sign, etc.) do not open a data-service subscription.
+ * When `isActive`, this fetches and periodically refetches the same
+ * `fetchBalanceWithFallback` query money home writes. When inactive, a
+ * disabled query key is used so unrelated confirmations (typed-sign, etc.) do
+ * not open a data-service subscription.
  *
- * @param isActive - When false, uses a dummy query key and returns undefined.
- * @returns Withdrawable fiat, or undefined when inactive / unavailable.
+ * @param isActive - When false, disables the query and returns both fields as
+ * `undefined`.
+ * @returns Always an object. When inactive, loading, errored, or missing data,
+ * both `withdrawableFiatFormatted` and `withdrawableFiatRaw` are `undefined`.
  */
-export function useCachedMoneyAccountWithdrawableFiat(
+export function useMoneyAccountWithdrawableFiat(
   isActive: boolean,
-): CachedMoneyAccountWithdrawableFiat {
+): MoneyAccountWithdrawableFiat {
   const primaryMoneyAccount = useSelector(selectPrimaryMoneyAccount);
   const address = primaryMoneyAccount?.address;
   const shouldFetch = Boolean(isActive && address);
@@ -62,7 +62,7 @@ export function useCachedMoneyAccountWithdrawableFiat(
       : [DISABLED_QUERY_KEY],
     enabled: shouldFetch,
     refetchInterval: shouldFetch ? DEFAULT_REFETCH_INTERVAL : false,
-    // Only the dummy key needs a queryFn. The fetch key is owned by
+    // Only the disabled key needs a queryFn. The fetch key is owned by
     // DATA_SERVICES; attaching a local queryFn would overwrite that handler.
     ...(shouldFetch ? {} : { queryFn: disabledWithdrawableFiatQueryFn }),
   });
@@ -75,19 +75,12 @@ export function useCachedMoneyAccountWithdrawableFiat(
       !moneyBalanceQuery.data?.vmusdValueInMusd
     ) {
       return {
-        withdrawableFiatRaw: undefined,
         withdrawableFiatFormatted: undefined,
+        withdrawableFiatRaw: undefined,
       };
     }
 
-    const withdrawableFiat = new BigNumber(
-      moneyBalanceQuery.data.vmusdValueInMusd,
-    ).dividedBy(MUSD_UNIT);
-
-    return {
-      withdrawableFiatRaw: withdrawableFiat.toString(),
-      withdrawableFiatFormatted: moneyFormatUsd(withdrawableFiat),
-    };
+    return projectWithdrawableFiat(moneyBalanceQuery.data.vmusdValueInMusd);
   }, [
     isActive,
     moneyBalanceQuery.data,

--- a/ui/hooks/money/useMoneyAccountWithdrawableFiat.ts
+++ b/ui/hooks/money/useMoneyAccountWithdrawableFiat.ts
@@ -68,11 +68,13 @@ export function useMoneyAccountWithdrawableFiat(
   });
 
   return useMemo(() => {
+    const vmusdValueInMusd = moneyBalanceQuery.data?.vmusdValueInMusd;
     if (
       !isActive ||
       moneyBalanceQuery.isLoading ||
       moneyBalanceQuery.isError ||
-      !moneyBalanceQuery.data?.vmusdValueInMusd
+      vmusdValueInMusd === undefined ||
+      vmusdValueInMusd === null
     ) {
       return {
         withdrawableFiatFormatted: undefined,
@@ -80,7 +82,7 @@ export function useMoneyAccountWithdrawableFiat(
       };
     }
 
-    return projectWithdrawableFiat(moneyBalanceQuery.data.vmusdValueInMusd);
+    return projectWithdrawableFiat(vmusdValueInMusd);
   }, [
     isActive,
     moneyBalanceQuery.data,

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -28,14 +28,11 @@ jest.mock('../../../hooks/send/useSendTokens');
 jest.mock('../../../context/confirm');
 jest.mock('../../../../multichain-accounts/account-details/account-type-utils');
 jest.mock('../../../../../hooks/useAlerts');
-jest.mock(
-  '../../../../../hooks/money/useMoneyAccountWithdrawableFiat',
-  () => ({
-    useMoneyAccountWithdrawableFiat: jest.fn(() => ({
-      withdrawableFiatFormatted: '$12.34',
-    })),
-  }),
-);
+jest.mock('../../../../../hooks/money/useMoneyAccountWithdrawableFiat', () => ({
+  useMoneyAccountWithdrawableFiat: jest.fn(() => ({
+    withdrawableFiatFormatted: '$12.34',
+  })),
+}));
 
 jest.mock(
   '../../../../../components/app/alert-system/contexts/alertMetricsContext',

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -12,7 +12,7 @@ import { useSendTokens } from '../../../hooks/send/useSendTokens';
 import { useConfirmContext } from '../../../context/confirm';
 import useAlerts from '../../../../../hooks/useAlerts';
 import { AlertsName } from '../../../hooks/alerts/constants';
-import { useCachedMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import { useMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useMoneyAccountWithdrawableFiat';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { isHardwareAccount } from '../../../../multichain-accounts/account-details/account-type-utils';
 import { PayWithRow, PayWithRowSkeleton } from './pay-with-row';
@@ -29,9 +29,9 @@ jest.mock('../../../context/confirm');
 jest.mock('../../../../multichain-accounts/account-details/account-type-utils');
 jest.mock('../../../../../hooks/useAlerts');
 jest.mock(
-  '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat',
+  '../../../../../hooks/money/useMoneyAccountWithdrawableFiat',
   () => ({
-    useCachedMoneyAccountWithdrawableFiat: jest.fn(() => ({
+    useMoneyAccountWithdrawableFiat: jest.fn(() => ({
       withdrawableFiatFormatted: '$12.34',
     })),
   }),
@@ -161,8 +161,8 @@ describe('PayWithRow', () => {
   const useConfirmContextMock = jest.mocked(useConfirmContext);
   const useAlertsMock = jest.mocked(useAlerts);
   const isHardwareAccountMock = jest.mocked(isHardwareAccount);
-  const useMoneyAccountBalanceMock = jest.mocked(
-    useCachedMoneyAccountWithdrawableFiat,
+  const useMoneyAccountWithdrawableFiatMock = jest.mocked(
+    useMoneyAccountWithdrawableFiat,
   );
   const getFieldAlertsMock = jest.fn(
     (_field?: string | undefined): { key: string }[] => [],
@@ -175,9 +175,9 @@ describe('PayWithRow', () => {
     useTransactionPayAvailableTokensMock.mockReturnValue([]);
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
     getFieldAlertsMock.mockReturnValue([]);
-    useMoneyAccountBalanceMock.mockReturnValue({
-      withdrawableFiatRaw: '12.34',
+    useMoneyAccountWithdrawableFiatMock.mockReturnValue({
       withdrawableFiatFormatted: '$12.34',
+      withdrawableFiatRaw: '12.34',
     });
     useAlertsMock.mockReturnValue({
       getFieldAlerts: getFieldAlertsMock,

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -12,9 +12,9 @@ import { useSendTokens } from '../../../hooks/send/useSendTokens';
 import { useConfirmContext } from '../../../context/confirm';
 import useAlerts from '../../../../../hooks/useAlerts';
 import { AlertsName } from '../../../hooks/alerts/constants';
+import { useCachedMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { isHardwareAccount } from '../../../../multichain-accounts/account-details/account-type-utils';
-import { MONEY_ACCOUNT_DUMMY_BALANCE_FIAT } from '../../../hooks/pay/sections/usePayWithMoneyAccountSection';
 import { PayWithRow, PayWithRowSkeleton } from './pay-with-row';
 
 jest.mock('../../../hooks/pay/useTransactionPayToken');
@@ -28,6 +28,14 @@ jest.mock('../../../hooks/send/useSendTokens');
 jest.mock('../../../context/confirm');
 jest.mock('../../../../multichain-accounts/account-details/account-type-utils');
 jest.mock('../../../../../hooks/useAlerts');
+jest.mock(
+  '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat',
+  () => ({
+    useCachedMoneyAccountWithdrawableFiat: jest.fn(() => ({
+      withdrawableFiatFormatted: '$12.34',
+    })),
+  }),
+);
 
 jest.mock(
   '../../../../../components/app/alert-system/contexts/alertMetricsContext',
@@ -153,6 +161,9 @@ describe('PayWithRow', () => {
   const useConfirmContextMock = jest.mocked(useConfirmContext);
   const useAlertsMock = jest.mocked(useAlerts);
   const isHardwareAccountMock = jest.mocked(isHardwareAccount);
+  const useMoneyAccountBalanceMock = jest.mocked(
+    useCachedMoneyAccountWithdrawableFiat,
+  );
   const getFieldAlertsMock = jest.fn(
     (_field?: string | undefined): { key: string }[] => [],
   );
@@ -164,6 +175,10 @@ describe('PayWithRow', () => {
     useTransactionPayAvailableTokensMock.mockReturnValue([]);
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
     getFieldAlertsMock.mockReturnValue([]);
+    useMoneyAccountBalanceMock.mockReturnValue({
+      withdrawableFiatRaw: '12.34',
+      withdrawableFiatFormatted: '$12.34',
+    });
     useAlertsMock.mockReturnValue({
       getFieldAlerts: getFieldAlertsMock,
     } as never);
@@ -408,7 +423,7 @@ describe('PayWithRow', () => {
     });
   });
 
-  it('renders the Money account icon and dummy balance when selected', () => {
+  it('renders the Money account icon and balance when selected', () => {
     const store = mockStore(
       getMockState({ paymentOverride: PaymentOverride.MoneyAccount }),
     );
@@ -421,7 +436,7 @@ describe('PayWithRow', () => {
       'Money account',
     );
     expect(screen.getByTestId('pay-with-balance')).toHaveTextContent(
-      `(${MONEY_ACCOUNT_DUMMY_BALANCE_FIAT})`,
+      '($12.34)',
     );
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts
@@ -25,7 +25,7 @@ import { useTokenWithBalance } from '../../tokens/useTokenWithBalance';
 import { AlertsName } from '../constants';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../helpers/constants/design-system';
-import { useCachedMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import { useMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useMoneyAccountWithdrawableFiat';
 import { useInsufficientPayTokenBalanceAlert } from './useInsufficientPayTokenBalanceAlert';
 
 jest.mock('../../pay/useTransactionPayToken');
@@ -33,9 +33,9 @@ jest.mock('../../pay/useTransactionPayData');
 jest.mock('../../send/useSendTokens');
 jest.mock('../../tokens/useTokenWithBalance');
 jest.mock(
-  '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat',
+  '../../../../../hooks/money/useMoneyAccountWithdrawableFiat',
   () => ({
-    useCachedMoneyAccountWithdrawableFiat: jest.fn(() => ({
+    useMoneyAccountWithdrawableFiat: jest.fn(() => ({
       withdrawableFiatRaw: '10',
     })),
   }),
@@ -151,8 +151,8 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     useIsTransactionPayLoading,
   );
   const useSendTokensMock = jest.mocked(useSendTokens);
-  const useMoneyAccountBalanceMock = jest.mocked(
-    useCachedMoneyAccountWithdrawableFiat,
+  const useMoneyAccountWithdrawableFiatMock = jest.mocked(
+    useMoneyAccountWithdrawableFiat,
   );
 
   beforeEach(() => {
@@ -160,9 +160,9 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
 
     // Empty list so the alert falls back to the pay-token snapshot under test.
     useSendTokensMock.mockReturnValue([]);
-    useMoneyAccountBalanceMock.mockReturnValue({
-      withdrawableFiatRaw: '10',
+    useMoneyAccountWithdrawableFiatMock.mockReturnValue({
       withdrawableFiatFormatted: '$10.00',
+      withdrawableFiatRaw: '10',
     });
     useTransactionPayRequiredTokensMock.mockReturnValue([REQUIRED_TOKEN_MOCK]);
     useTransactionPayTotalsMock.mockReturnValue(TOTALS_MOCK);

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts
@@ -25,12 +25,21 @@ import { useTokenWithBalance } from '../../tokens/useTokenWithBalance';
 import { AlertsName } from '../constants';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../helpers/constants/design-system';
+import { useCachedMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
 import { useInsufficientPayTokenBalanceAlert } from './useInsufficientPayTokenBalanceAlert';
 
 jest.mock('../../pay/useTransactionPayToken');
 jest.mock('../../pay/useTransactionPayData');
 jest.mock('../../send/useSendTokens');
 jest.mock('../../tokens/useTokenWithBalance');
+jest.mock(
+  '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat',
+  () => ({
+    useCachedMoneyAccountWithdrawableFiat: jest.fn(() => ({
+      withdrawableFiatRaw: '10',
+    })),
+  }),
+);
 
 const PAY_TOKEN_MOCK = {
   address: '0x123' as Hex,
@@ -142,12 +151,19 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     useIsTransactionPayLoading,
   );
   const useSendTokensMock = jest.mocked(useSendTokens);
+  const useMoneyAccountBalanceMock = jest.mocked(
+    useCachedMoneyAccountWithdrawableFiat,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
 
     // Empty list so the alert falls back to the pay-token snapshot under test.
     useSendTokensMock.mockReturnValue([]);
+    useMoneyAccountBalanceMock.mockReturnValue({
+      withdrawableFiatRaw: '10',
+      withdrawableFiatFormatted: '$10.00',
+    });
     useTransactionPayRequiredTokensMock.mockReturnValue([REQUIRED_TOKEN_MOCK]);
     useTransactionPayTotalsMock.mockReturnValue(TOTALS_MOCK);
     useTransactionPayIsMaxAmountMock.mockReturnValue(false);

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts
@@ -32,14 +32,11 @@ jest.mock('../../pay/useTransactionPayToken');
 jest.mock('../../pay/useTransactionPayData');
 jest.mock('../../send/useSendTokens');
 jest.mock('../../tokens/useTokenWithBalance');
-jest.mock(
-  '../../../../../hooks/money/useMoneyAccountWithdrawableFiat',
-  () => ({
-    useMoneyAccountWithdrawableFiat: jest.fn(() => ({
-      withdrawableFiatRaw: '10',
-    })),
-  }),
-);
+jest.mock('../../../../../hooks/money/useMoneyAccountWithdrawableFiat', () => ({
+  useMoneyAccountWithdrawableFiat: jest.fn(() => ({
+    withdrawableFiatRaw: '10',
+  })),
+}));
 
 const PAY_TOKEN_MOCK = {
   address: '0x123' as Hex,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.ts
@@ -10,7 +10,7 @@ import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { useCachedMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import { useMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useMoneyAccountWithdrawableFiat';
 import {
   selectPaymentOverrideByTransactionId,
   type TransactionPayState,
@@ -51,7 +51,7 @@ export function useInsufficientPayTokenBalanceAlert({
   );
   const isMoneyPaymentOverride =
     paymentOverride === PaymentOverride.MoneyAccount;
-  const { withdrawableFiatRaw } = useCachedMoneyAccountWithdrawableFiat(
+  const { withdrawableFiatRaw } = useMoneyAccountWithdrawableFiat(
     isMoneyPaymentOverride,
   );
 
@@ -99,12 +99,14 @@ export function useInsufficientPayTokenBalanceAlert({
 
   // Live funding-account balance (USD already reconciles snapshot vs live
   // rate inside `usePayTokenAccountBalance`). Money-account funding uses
-  // withdrawable fiat instead of the selected pay-token wallet balance.
+  // withdrawable fiat instead of the selected pay-token wallet balance;
+  // keep `undefined` while that query is loading or failed so we do not
+  // treat unknown balance as zero and block confirm transiently.
   const { balanceUsd: payTokenBalanceUsd, balanceRaw } =
     usePayTokenAccountBalance();
   const balanceUsd = useMemo(() => {
     if (isMoneyPaymentOverride) {
-      return withdrawableFiatRaw ?? '0';
+      return withdrawableFiatRaw;
     }
     return payTokenBalanceUsd;
   }, [isMoneyPaymentOverride, payTokenBalanceUsd, withdrawableFiatRaw]);
@@ -148,7 +150,11 @@ export function useInsufficientPayTokenBalanceAlert({
   }, [isLoading, totals]);
 
   const isInsufficientForInput = useMemo(
-    () => !isPostQuote && payToken && totalAmountUsd.gt(balanceUsd ?? '0'),
+    () =>
+      !isPostQuote &&
+      payToken &&
+      balanceUsd !== undefined &&
+      totalAmountUsd.gt(balanceUsd),
     [balanceUsd, isPostQuote, payToken, totalAmountUsd],
   );
 
@@ -195,8 +201,9 @@ export function useInsufficientPayTokenBalanceAlert({
       !isMax &&
       !isPostQuote &&
       !isPendingAlert &&
+      balanceUsd !== undefined &&
       totals?.total?.usd !== undefined &&
-      new BigNumber(totals.total.usd).gt(balanceUsd ?? '0'),
+      new BigNumber(totals.total.usd).gt(balanceUsd),
     [
       balanceUsd,
       isMax,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.ts
@@ -10,6 +10,7 @@ import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useCachedMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
 import {
   selectPaymentOverrideByTransactionId,
   type TransactionPayState,
@@ -50,6 +51,9 @@ export function useInsufficientPayTokenBalanceAlert({
   );
   const isMoneyPaymentOverride =
     paymentOverride === PaymentOverride.MoneyAccount;
+  const { withdrawableFiatRaw } = useCachedMoneyAccountWithdrawableFiat(
+    isMoneyPaymentOverride,
+  );
 
   // Post-quote withdraws: `payToken` is the destination, not the source —
   // skip input/fees checks; gas check runs against the tx chain. Gate on the
@@ -94,8 +98,16 @@ export function useInsufficientPayTokenBalanceAlert({
     );
 
   // Live funding-account balance (USD already reconciles snapshot vs live
-  // rate inside `usePayTokenAccountBalance`).
-  const { balanceUsd, balanceRaw } = usePayTokenAccountBalance();
+  // rate inside `usePayTokenAccountBalance`). Money-account funding uses
+  // withdrawable fiat instead of the selected pay-token wallet balance.
+  const { balanceUsd: payTokenBalanceUsd, balanceRaw } =
+    usePayTokenAccountBalance();
+  const balanceUsd = useMemo(() => {
+    if (isMoneyPaymentOverride) {
+      return withdrawableFiatRaw ?? '0';
+    }
+    return payTokenBalanceUsd;
+  }, [isMoneyPaymentOverride, payTokenBalanceUsd, withdrawableFiatRaw]);
   const nativeBalanceRaw = nativeToken?.balanceRaw ?? '0';
 
   const totalAmountUsd = useMemo(() => {

--- a/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
@@ -3,6 +3,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import { useSelector } from 'react-redux';
 import { useConfirmContext } from '../../../context/confirm';
+import { useCachedMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
 import { applyMoneyAccountOverride } from '../../../utils/transaction-pay';
 import {
   PAY_WITH_MONEY_ACCOUNT_ROW_TEST_ID,
@@ -25,13 +26,41 @@ jest.mock('../../../../../hooks/useI18nContext', () => ({
     return messages[key] ?? key;
   },
 }));
+jest.mock(
+  '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat',
+  () => ({
+    useCachedMoneyAccountWithdrawableFiat: jest.fn(),
+  }),
+);
 jest.mock('../../../utils/transaction-pay', () => ({
   applyMoneyAccountOverride: jest.fn(),
 }));
 
+const MONEY_ACCOUNT_ADDRESS = '0xc4ff9e84b5754570812d891ade0bad3952bb5946';
+
+function mockSelectors({
+  primaryMoneyAccount = { address: MONEY_ACCOUNT_ADDRESS },
+  isEnabled = true,
+  paymentOverride = undefined as PaymentOverride | undefined,
+}: {
+  primaryMoneyAccount?: { address: string } | null;
+  isEnabled?: boolean;
+  paymentOverride?: PaymentOverride | undefined;
+} = {}) {
+  let callIndex = 0;
+  const sequence = [primaryMoneyAccount, isEnabled, paymentOverride];
+  jest.mocked(useSelector).mockImplementation(() => {
+    const value = sequence[callIndex % sequence.length];
+    callIndex += 1;
+    return value;
+  });
+}
+
 describe('usePayWithMoneyAccountSection', () => {
-  const useSelectorMock = jest.mocked(useSelector);
   const useConfirmContextMock = jest.mocked(useConfirmContext);
+  const useCachedBalanceMock = jest.mocked(
+    useCachedMoneyAccountWithdrawableFiat,
+  );
   const applyMoneyAccountOverrideMock = jest.mocked(applyMoneyAccountOverride);
   const onClose = jest.fn();
 
@@ -44,20 +73,25 @@ describe('usePayWithMoneyAccountSection', () => {
         type: TransactionType.perpsDeposit,
       },
     } as ReturnType<typeof useConfirmContext>);
-
-    // First selector call is isEnabled; second is paymentOverride.
-    let call = 0;
-    useSelectorMock.mockImplementation(() => {
-      call += 1;
-      if (call === 1) {
-        return true;
-      }
-      return undefined;
+    useCachedBalanceMock.mockReturnValue({
+      withdrawableFiatRaw: undefined,
+      withdrawableFiatFormatted: '$12.34',
     });
+    mockSelectors();
   });
 
   it('returns null when money account transactions are disabled', () => {
-    useSelectorMock.mockImplementation(() => false);
+    mockSelectors({ isEnabled: false });
+
+    const { result } = renderHook(() =>
+      usePayWithMoneyAccountSection({ onClose }),
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when there is no money account', () => {
+    mockSelectors({ primaryMoneyAccount: null });
 
     const { result } = renderHook(() =>
       usePayWithMoneyAccountSection({ onClose }),
@@ -76,7 +110,7 @@ describe('usePayWithMoneyAccountSection', () => {
       rows: [
         expect.objectContaining({
           title: 'Money account',
-          subtitle: '$7.05 available',
+          subtitle: '$12.34 available',
           testId: PAY_WITH_MONEY_ACCOUNT_ROW_TEST_ID,
           isSelected: false,
         }),
@@ -118,7 +152,7 @@ describe('usePayWithMoneyAccountSection', () => {
 
     expect(applyMoneyAccountOverrideMock).toHaveBeenCalledWith(
       'tx-1',
-      undefined,
+      MONEY_ACCOUNT_ADDRESS,
       expect.objectContaining({
         id: 'tx-1',
         type: TransactionType.perpsDeposit,
@@ -128,14 +162,7 @@ describe('usePayWithMoneyAccountSection', () => {
   });
 
   it('marks the row selected when paymentOverride is MoneyAccount', () => {
-    let call = 0;
-    useSelectorMock.mockImplementation(() => {
-      call += 1;
-      if (call === 1) {
-        return true;
-      }
-      return PaymentOverride.MoneyAccount;
-    });
+    mockSelectors({ paymentOverride: PaymentOverride.MoneyAccount });
 
     const { result } = renderHook(() =>
       usePayWithMoneyAccountSection({ onClose }),

--- a/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
@@ -3,7 +3,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import { useSelector } from 'react-redux';
 import { useConfirmContext } from '../../../context/confirm';
-import { useCachedMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import { useMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useMoneyAccountWithdrawableFiat';
 import { applyMoneyAccountOverride } from '../../../utils/transaction-pay';
 import {
   PAY_WITH_MONEY_ACCOUNT_ROW_TEST_ID,
@@ -27,9 +27,9 @@ jest.mock('../../../../../hooks/useI18nContext', () => ({
   },
 }));
 jest.mock(
-  '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat',
+  '../../../../../hooks/money/useMoneyAccountWithdrawableFiat',
   () => ({
-    useCachedMoneyAccountWithdrawableFiat: jest.fn(),
+    useMoneyAccountWithdrawableFiat: jest.fn(),
   }),
 );
 jest.mock('../../../utils/transaction-pay', () => ({
@@ -59,7 +59,7 @@ function mockSelectors({
 describe('usePayWithMoneyAccountSection', () => {
   const useConfirmContextMock = jest.mocked(useConfirmContext);
   const useCachedBalanceMock = jest.mocked(
-    useCachedMoneyAccountWithdrawableFiat,
+    useMoneyAccountWithdrawableFiat,
   );
   const applyMoneyAccountOverrideMock = jest.mocked(applyMoneyAccountOverride);
   const onClose = jest.fn();

--- a/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
@@ -26,12 +26,9 @@ jest.mock('../../../../../hooks/useI18nContext', () => ({
     return messages[key] ?? key;
   },
 }));
-jest.mock(
-  '../../../../../hooks/money/useMoneyAccountWithdrawableFiat',
-  () => ({
-    useMoneyAccountWithdrawableFiat: jest.fn(),
-  }),
-);
+jest.mock('../../../../../hooks/money/useMoneyAccountWithdrawableFiat', () => ({
+  useMoneyAccountWithdrawableFiat: jest.fn(),
+}));
 jest.mock('../../../utils/transaction-pay', () => ({
   applyMoneyAccountOverride: jest.fn(),
 }));
@@ -58,9 +55,7 @@ function mockSelectors({
 
 describe('usePayWithMoneyAccountSection', () => {
   const useConfirmContextMock = jest.mocked(useConfirmContext);
-  const useCachedBalanceMock = jest.mocked(
-    useMoneyAccountWithdrawableFiat,
-  );
+  const useCachedBalanceMock = jest.mocked(useMoneyAccountWithdrawableFiat);
   const applyMoneyAccountOverrideMock = jest.mocked(applyMoneyAccountOverride);
   const onClose = jest.fn();
 

--- a/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
+++ b/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
@@ -9,7 +9,7 @@ import {
 import { getConfirmationTransactionType } from '../../../utils/confirm';
 import { selectIsMoneyAccountTransactionEnabled } from '../../../selectors/feature-flags';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { useCachedMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import { useMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useMoneyAccountWithdrawableFiat';
 import { selectPrimaryMoneyAccount } from '../../../../../selectors/money-account';
 import { useConfirmContext } from '../../../context/confirm';
 import { applyMoneyAccountOverride } from '../../../utils/transaction-pay';
@@ -35,7 +35,7 @@ export function usePayWithMoneyAccountSection({
   const isEnabled = useSelector((state) =>
     selectIsMoneyAccountTransactionEnabled(state, transactionType),
   );
-  const { withdrawableFiatFormatted } = useCachedMoneyAccountWithdrawableFiat(
+  const { withdrawableFiatFormatted } = useMoneyAccountWithdrawableFiat(
     Boolean(isEnabled && primaryMoneyAccount),
   );
 

--- a/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
+++ b/ui/pages/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
@@ -9,6 +9,8 @@ import {
 import { getConfirmationTransactionType } from '../../../utils/confirm';
 import { selectIsMoneyAccountTransactionEnabled } from '../../../selectors/feature-flags';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useCachedMoneyAccountWithdrawableFiat } from '../../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import { selectPrimaryMoneyAccount } from '../../../../../selectors/money-account';
 import { useConfirmContext } from '../../../context/confirm';
 import { applyMoneyAccountOverride } from '../../../utils/transaction-pay';
 import type { PayWithSectionConfig } from '../../../components/modals/pay-with-modal/pay-with-modal.types';
@@ -16,9 +18,6 @@ import type { PayWithSectionConfig } from '../../../components/modals/pay-with-m
 export const PAY_WITH_MONEY_ACCOUNT_SECTION_TEST_ID =
   'pay-with-section-money-account';
 export const PAY_WITH_MONEY_ACCOUNT_ROW_TEST_ID = 'pay-with-money-account-row';
-
-/** Temporary placeholder until Money account balance wiring lands. */
-export const MONEY_ACCOUNT_DUMMY_BALANCE_FIAT = '$7.05';
 
 type UsePayWithMoneyAccountSectionArgs = {
   onClose: () => void;
@@ -31,9 +30,13 @@ export function usePayWithMoneyAccountSection({
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const transactionId = currentConfirmation?.id ?? '';
   const transactionType = getConfirmationTransactionType(currentConfirmation);
+  const primaryMoneyAccount = useSelector(selectPrimaryMoneyAccount);
 
   const isEnabled = useSelector((state) =>
     selectIsMoneyAccountTransactionEnabled(state, transactionType),
+  );
+  const { withdrawableFiatFormatted } = useCachedMoneyAccountWithdrawableFiat(
+    Boolean(isEnabled && primaryMoneyAccount),
   );
 
   const paymentOverride = useSelector((state: TransactionPayState) =>
@@ -46,14 +49,27 @@ export function usePayWithMoneyAccountSection({
     if (!transactionId) {
       return;
     }
-    applyMoneyAccountOverride(transactionId, undefined, currentConfirmation);
+    applyMoneyAccountOverride(
+      transactionId,
+      primaryMoneyAccount?.address,
+      currentConfirmation,
+    );
     onClose();
-  }, [currentConfirmation, onClose, transactionId]);
+  }, [
+    currentConfirmation,
+    onClose,
+    primaryMoneyAccount?.address,
+    transactionId,
+  ]);
 
   return useMemo(() => {
-    if (!isEnabled) {
+    if (!isEnabled || !primaryMoneyAccount) {
       return null;
     }
+
+    const subtitle = withdrawableFiatFormatted
+      ? `${withdrawableFiatFormatted} ${t('available')}`
+      : undefined;
 
     return {
       id: 'money-account',
@@ -72,7 +88,7 @@ export function usePayWithMoneyAccountSection({
             />
           ),
           title: t('payWithMoneyAccount'),
-          subtitle: `${MONEY_ACCOUNT_DUMMY_BALANCE_FIAT} ${t('available')}`,
+          subtitle,
           isSelected: isMoneyAccountSelected,
           trailingElement: isMoneyAccountSelected ? 'checkmark' : 'none',
           onPress: handlePress,
@@ -80,5 +96,12 @@ export function usePayWithMoneyAccountSection({
         },
       ],
     };
-  }, [handlePress, isEnabled, isMoneyAccountSelected, t]);
+  }, [
+    handlePress,
+    isEnabled,
+    isMoneyAccountSelected,
+    primaryMoneyAccount,
+    t,
+    withdrawableFiatFormatted,
+  ]);
 }

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
@@ -4,13 +4,18 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import React from 'react';
 import { TransactionType } from '@metamask/transaction-controller';
-import type { TransactionPayRequiredToken } from '@metamask/transaction-pay-controller';
+import {
+  PaymentOverride,
+  type TransactionPayRequiredToken,
+} from '@metamask/transaction-pay-controller';
 import type { Hex } from '@metamask/utils';
 import { ConfirmContext } from '../../context/confirm';
 import { Asset } from '../../types/send';
 import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
 import { selectMinimumRequiredTokenBalance } from '../../selectors/feature-flags';
 import { ARBITRUM_USDC } from '../../constants/perps';
+import { MUSD_TOKEN_ADDRESS } from '../../constants/musd';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import {
   ACCOUNT_RESELECT_EMPTY_TIMEOUT_MS,
   useAutomaticTransactionPayToken,
@@ -68,6 +73,7 @@ function renderHookWithProvider({
   transactionId = TRANSACTION_ID_MOCK,
   from = '0x123',
   remoteFeatureFlags,
+  paymentOverride,
   confirmContextValue: confirmContextValueOverride,
 }: {
   disable?: boolean;
@@ -76,6 +82,7 @@ function renderHookWithProvider({
   transactionId?: string;
   from?: string;
   remoteFeatureFlags?: Record<string, unknown>;
+  paymentOverride?: PaymentOverride;
   confirmContextValue?: {
     currentConfirmation: {
       id: string;
@@ -90,6 +97,9 @@ function renderHookWithProvider({
     metamask: {
       ...STATE_MOCK.metamask,
       remoteFeatureFlags: remoteFeatureFlags ?? {},
+      transactionData: {
+        [transactionId]: paymentOverride ? { paymentOverride } : {},
+      },
     },
   });
 
@@ -275,6 +285,49 @@ describe('useAutomaticTransactionPayToken', () => {
     renderHookWithProvider({ transactionType: TransactionType.perpsDeposit });
 
     expect(setPayTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('selects Monad mUSD when paying with Money Account', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_2_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
+      },
+    ] as Asset[]);
+
+    renderHookWithProvider({
+      paymentOverride: PaymentOverride.MoneyAccount,
+    });
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: MUSD_TOKEN_ADDRESS,
+      chainId: CHAIN_IDS.MONAD,
+    });
+  });
+
+  it('re-selects Monad mUSD when the user switches to Money Account', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_2_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
+      },
+    ] as Asset[]);
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: {
+        address: TOKEN_ADDRESS_2_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
+      } as never,
+      setPayToken: setPayTokenMock,
+    });
+
+    renderHookWithProvider({
+      paymentOverride: PaymentOverride.MoneyAccount,
+    });
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: MUSD_TOKEN_ADDRESS,
+      chainId: CHAIN_IDS.MONAD,
+    });
   });
 
   it('selects preferred payment token when provided with available tokens', () => {

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -8,7 +8,6 @@ import {
   getTransactionType,
   isPostQuoteWithdrawTransaction,
 } from '../../../../../shared/lib/transactions.utils';
-import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { getMoneyAccountTransactionType } from '../../utils/confirm';
 import { Asset } from '../../types/send';
 import { useConfirmContext } from '../../context/confirm';
@@ -19,11 +18,15 @@ import {
   type PreferredPayToken,
 } from '../../selectors/feature-flags';
 import { type RelayFixedSpreadConfig } from '../../utils/relay-fixed-spread';
-import { MUSD_TOKEN_ADDRESS } from '../../constants/musd';
 import {
   selectPaymentOverrideByTransactionId,
   type TransactionPayState,
 } from '../../../../selectors/transactionPayController';
+import { selectMoneyAccountVaultConfig } from '../../../../selectors/money/money-account-feature-flags';
+import {
+  getMoneyAccountPayToken,
+  type MoneyAccountPayToken,
+} from '../../utils/money-account-pay-token';
 import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
 import { useImportPayToken } from './useImportPayToken';
 import { useIsMoneyAccountFlagDefault } from './useIsMoneyAccountFlagDefault';
@@ -63,6 +66,11 @@ export function useAutomaticTransactionPayToken({
   );
   const isMoneyPaymentOverride =
     paymentOverride === PaymentOverride.MoneyAccount;
+  const vaultConfig = useSelector(selectMoneyAccountVaultConfig);
+  const moneyAccountPayToken = useMemo(
+    () => getMoneyAccountPayToken(vaultConfig),
+    [vaultConfig],
+  );
   // Batch txs use top-level type `batch`. Prefer the money-account nested type
   // when present — deposits are `[approve, deposit]`, so plain
   // `getTransactionType` would resolve them to `tokenMethodApprove`.
@@ -144,6 +152,7 @@ export function useAutomaticTransactionPayToken({
         isPostQuoteWithdrawTokenFilterApplied,
         isPostQuoteWithdrawTokenAllowed,
         minimumRequiredTokenBalance,
+        moneyAccountPayToken,
         preferredToken,
         preferredTokensFromFlags,
         relayFixedSpread,
@@ -157,6 +166,7 @@ export function useAutomaticTransactionPayToken({
       isPostQuoteWithdrawTokenFilterApplied,
       isPostQuoteWithdrawTokenAllowed,
       minimumRequiredTokenBalance,
+      moneyAccountPayToken,
       preferredToken,
       preferredTokensFromFlags,
       relayFixedSpread,
@@ -314,6 +324,9 @@ export function useAutomaticTransactionPayToken({
 
   const prevIsMoneyPaymentOverrideRef = useRef(false);
   useEffect(() => {
+    // Only handle the transition *into* Money Account funding. Reselect the
+    // vault pay token (typically Monad mUSD) because a manually chosen token
+    // would otherwise remain selected after the override flips on.
     const prev = prevIsMoneyPaymentOverrideRef.current;
     prevIsMoneyPaymentOverrideRef.current = Boolean(isMoneyPaymentOverride);
 
@@ -342,6 +355,7 @@ function getBestToken({
   isPostQuoteWithdrawTokenFilterApplied,
   isPostQuoteWithdrawTokenAllowed,
   minimumRequiredTokenBalance,
+  moneyAccountPayToken,
   preferredToken,
   preferredTokensFromFlags,
   relayFixedSpread,
@@ -357,6 +371,7 @@ function getBestToken({
     address: string,
   ) => boolean;
   minimumRequiredTokenBalance: number;
+  moneyAccountPayToken: MoneyAccountPayToken;
   preferredToken?: SetPayTokenRequest;
   preferredTokensFromFlags: PreferredPayToken[];
   relayFixedSpread: RelayFixedSpreadConfig;
@@ -375,7 +390,7 @@ function getBestToken({
   }
 
   if (isMoneyPaymentOverride) {
-    return { address: MUSD_TOKEN_ADDRESS, chainId: CHAIN_IDS.MONAD };
+    return moneyAccountPayToken;
   }
 
   // Without a post-quote withdraw allowlist, `preferredToken` is the

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -1,12 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { TransactionMeta } from '@metamask/transaction-controller';
+import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import type { Hex } from '@metamask/utils';
 import { getHardwareWalletType } from '../../../../../shared/lib/selectors/keyring';
 import {
   getTransactionType,
   isPostQuoteWithdrawTransaction,
 } from '../../../../../shared/lib/transactions.utils';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { getMoneyAccountTransactionType } from '../../utils/confirm';
 import { Asset } from '../../types/send';
 import { useConfirmContext } from '../../context/confirm';
@@ -17,6 +19,11 @@ import {
   type PreferredPayToken,
 } from '../../selectors/feature-flags';
 import { type RelayFixedSpreadConfig } from '../../utils/relay-fixed-spread';
+import { MUSD_TOKEN_ADDRESS } from '../../constants/musd';
+import {
+  selectPaymentOverrideByTransactionId,
+  type TransactionPayState,
+} from '../../../../selectors/transactionPayController';
 import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
 import { useImportPayToken } from './useImportPayToken';
 import { useIsMoneyAccountFlagDefault } from './useIsMoneyAccountFlagDefault';
@@ -51,6 +58,11 @@ export function useAutomaticTransactionPayToken({
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const transactionId = currentConfirmation?.id;
   const isDefaultMoneyAccount = useIsMoneyAccountFlagDefault();
+  const paymentOverride = useSelector((state: TransactionPayState) =>
+    selectPaymentOverrideByTransactionId(state, transactionId ?? ''),
+  );
+  const isMoneyPaymentOverride =
+    paymentOverride === PaymentOverride.MoneyAccount;
   // Batch txs use top-level type `batch`. Prefer the money-account nested type
   // when present — deposits are `[approve, deposit]`, so plain
   // `getTransactionType` would resolve them to `tokenMethodApprove`.
@@ -127,6 +139,7 @@ export function useAutomaticTransactionPayToken({
     () =>
       getBestToken({
         isHardwareWallet,
+        isMoneyPaymentOverride,
         isPostQuoteWithdraw,
         isPostQuoteWithdrawTokenFilterApplied,
         isPostQuoteWithdrawTokenAllowed,
@@ -139,6 +152,7 @@ export function useAutomaticTransactionPayToken({
       }),
     [
       isHardwareWallet,
+      isMoneyPaymentOverride,
       isPostQuoteWithdraw,
       isPostQuoteWithdrawTokenFilterApplied,
       isPostQuoteWithdrawTokenAllowed,
@@ -297,10 +311,33 @@ export function useAutomaticTransactionPayToken({
     isPostQuoteWithdraw,
     tokensWithBalance.length,
   ]);
+
+  const prevIsMoneyPaymentOverrideRef = useRef(false);
+  useEffect(() => {
+    const prev = prevIsMoneyPaymentOverrideRef.current;
+    prevIsMoneyPaymentOverrideRef.current = Boolean(isMoneyPaymentOverride);
+
+    if (
+      disable ||
+      !from ||
+      isMoneyPaymentOverride !== true ||
+      isMoneyPaymentOverride === prev
+    ) {
+      return;
+    }
+
+    if (automaticToken) {
+      setPayToken({
+        address: automaticToken.address,
+        chainId: automaticToken.chainId,
+      });
+    }
+  }, [automaticToken, disable, from, isMoneyPaymentOverride, setPayToken]);
 }
 
 function getBestToken({
   isHardwareWallet,
+  isMoneyPaymentOverride,
   isPostQuoteWithdraw,
   isPostQuoteWithdrawTokenFilterApplied,
   isPostQuoteWithdrawTokenAllowed,
@@ -312,6 +349,7 @@ function getBestToken({
   tokens,
 }: {
   isHardwareWallet: boolean;
+  isMoneyPaymentOverride: boolean;
   isPostQuoteWithdraw: boolean;
   isPostQuoteWithdrawTokenFilterApplied: boolean;
   isPostQuoteWithdrawTokenAllowed: (
@@ -334,6 +372,10 @@ function getBestToken({
 
   if (isHardwareWallet) {
     return targetTokenFallback;
+  }
+
+  if (isMoneyPaymentOverride) {
+    return { address: MUSD_TOKEN_ADDRESS, chainId: CHAIN_IDS.MONAD };
   }
 
   // Without a post-quote withdraw allowlist, `preferredToken` is the

--- a/ui/pages/confirmations/hooks/pay/usePayWithToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePayWithToken.test.tsx
@@ -54,12 +54,9 @@ jest.mock('../../../../hooks/useI18nContext', () => ({
     return messages[key] ?? key;
   },
 }));
-jest.mock(
-  '../../../../hooks/money/useMoneyAccountWithdrawableFiat',
-  () => ({
-    useMoneyAccountWithdrawableFiat: jest.fn(),
-  }),
-);
+jest.mock('../../../../hooks/money/useMoneyAccountWithdrawableFiat', () => ({
+  useMoneyAccountWithdrawableFiat: jest.fn(),
+}));
 jest.mock('../../../../hooks/useFiatFormatter', () => ({
   useFiatFormatter: () => (value: number) => `$${value.toFixed(2)}`,
 }));

--- a/ui/pages/confirmations/hooks/pay/usePayWithToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePayWithToken.test.tsx
@@ -12,10 +12,10 @@ import { useSelector } from 'react-redux';
 import { useConfirmContext } from '../../context/confirm';
 import { getInternalAccountByAddress } from '../../../../selectors/accounts';
 import { selectPaymentOverrideByTransactionId } from '../../../../selectors/transactionPayController';
+import { useCachedMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
-import { MONEY_ACCOUNT_DUMMY_BALANCE_FIAT } from './sections/usePayWithMoneyAccountSection';
 import { useIsMoneyAccountFlagDefault } from './useIsMoneyAccountFlagDefault';
 import { usePayWithToken } from './usePayWithToken';
 
@@ -54,6 +54,12 @@ jest.mock('../../../../hooks/useI18nContext', () => ({
     return messages[key] ?? key;
   },
 }));
+jest.mock(
+  '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat',
+  () => ({
+    useCachedMoneyAccountWithdrawableFiat: jest.fn(),
+  }),
+);
 jest.mock('../../../../hooks/useFiatFormatter', () => ({
   useFiatFormatter: () => (value: number) => `$${value.toFixed(2)}`,
 }));
@@ -99,6 +105,9 @@ describe('usePayWithToken', () => {
   const useIsMoneyAccountFlagDefaultMock = jest.mocked(
     useIsMoneyAccountFlagDefault,
   );
+  const useMoneyAccountBalanceMock = jest.mocked(
+    useCachedMoneyAccountWithdrawableFiat,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -121,6 +130,10 @@ describe('usePayWithToken', () => {
     getInternalAccountByAddressMock.mockReturnValue(ACCOUNT as never);
     selectPaymentOverrideByTransactionIdMock.mockReturnValue(undefined);
     useIsMoneyAccountFlagDefaultMock.mockReturnValue(false);
+    useMoneyAccountBalanceMock.mockReturnValue({
+      withdrawableFiatRaw: '12.34',
+      withdrawableFiatFormatted: '$12.34',
+    });
 
     useSelectorMock.mockImplementation(
       (selector: (state: unknown) => unknown) => selector({}),
@@ -151,11 +164,9 @@ describe('usePayWithToken', () => {
     expect(result.current.displayToken).toMatchObject({
       address: '',
       symbol: 'Money account',
-      balanceUsd: MONEY_ACCOUNT_DUMMY_BALANCE_FIAT,
+      balanceUsd: '$12.34',
     });
-    expect(result.current.balanceUsdFormatted).toBe(
-      MONEY_ACCOUNT_DUMMY_BALANCE_FIAT,
-    );
+    expect(result.current.balanceUsdFormatted).toBe('$12.34');
   });
 
   it('returns Money account display values when the flag default is set and no crypto token is selected', () => {

--- a/ui/pages/confirmations/hooks/pay/usePayWithToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePayWithToken.test.tsx
@@ -12,7 +12,7 @@ import { useSelector } from 'react-redux';
 import { useConfirmContext } from '../../context/confirm';
 import { getInternalAccountByAddress } from '../../../../selectors/accounts';
 import { selectPaymentOverrideByTransactionId } from '../../../../selectors/transactionPayController';
-import { useCachedMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import { useMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useMoneyAccountWithdrawableFiat';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
@@ -55,9 +55,9 @@ jest.mock('../../../../hooks/useI18nContext', () => ({
   },
 }));
 jest.mock(
-  '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat',
+  '../../../../hooks/money/useMoneyAccountWithdrawableFiat',
   () => ({
-    useCachedMoneyAccountWithdrawableFiat: jest.fn(),
+    useMoneyAccountWithdrawableFiat: jest.fn(),
   }),
 );
 jest.mock('../../../../hooks/useFiatFormatter', () => ({
@@ -105,8 +105,8 @@ describe('usePayWithToken', () => {
   const useIsMoneyAccountFlagDefaultMock = jest.mocked(
     useIsMoneyAccountFlagDefault,
   );
-  const useMoneyAccountBalanceMock = jest.mocked(
-    useCachedMoneyAccountWithdrawableFiat,
+  const useMoneyAccountWithdrawableFiatMock = jest.mocked(
+    useMoneyAccountWithdrawableFiat,
   );
 
   beforeEach(() => {
@@ -130,9 +130,9 @@ describe('usePayWithToken', () => {
     getInternalAccountByAddressMock.mockReturnValue(ACCOUNT as never);
     selectPaymentOverrideByTransactionIdMock.mockReturnValue(undefined);
     useIsMoneyAccountFlagDefaultMock.mockReturnValue(false);
-    useMoneyAccountBalanceMock.mockReturnValue({
-      withdrawableFiatRaw: '12.34',
+    useMoneyAccountWithdrawableFiatMock.mockReturnValue({
       withdrawableFiatFormatted: '$12.34',
+      withdrawableFiatRaw: '12.34',
     });
 
     useSelectorMock.mockImplementation(

--- a/ui/pages/confirmations/hooks/pay/usePayWithToken.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePayWithToken.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../../../selectors/transactionPayController';
 import { useConfirmContext } from '../../context/confirm';
 import { PayWithModal } from '../../components/modals/pay-with-modal';
-import { useCachedMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import { useMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useMoneyAccountWithdrawableFiat';
 import { useIsMoneyAccountFlagDefault } from './useIsMoneyAccountFlagDefault';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
@@ -70,7 +70,7 @@ export function usePayWithToken(): PayWithToken {
   const isMoneyAccountSelected =
     paymentOverride === PaymentOverride.MoneyAccount ||
     (isDefaultMoneyAccount && !payToken);
-  const { withdrawableFiatFormatted } = useCachedMoneyAccountWithdrawableFiat(
+  const { withdrawableFiatFormatted } = useMoneyAccountWithdrawableFiat(
     isMoneyAccountSelected,
   );
 

--- a/ui/pages/confirmations/hooks/pay/usePayWithToken.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePayWithToken.tsx
@@ -18,11 +18,11 @@ import {
 } from '../../../../selectors/transactionPayController';
 import { useConfirmContext } from '../../context/confirm';
 import { PayWithModal } from '../../components/modals/pay-with-modal';
+import { useCachedMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
 import { useIsMoneyAccountFlagDefault } from './useIsMoneyAccountFlagDefault';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
-import { MONEY_ACCOUNT_DUMMY_BALANCE_FIAT } from './sections/usePayWithMoneyAccountSection';
 
 export type PayWithDisplayToken = {
   chainId: string;
@@ -70,6 +70,9 @@ export function usePayWithToken(): PayWithToken {
   const isMoneyAccountSelected =
     paymentOverride === PaymentOverride.MoneyAccount ||
     (isDefaultMoneyAccount && !payToken);
+  const { withdrawableFiatFormatted } = useCachedMoneyAccountWithdrawableFiat(
+    isMoneyAccountSelected,
+  );
 
   const isPostQuoteWithdraw =
     isPostQuoteWithdrawTransaction(currentConfirmation);
@@ -103,12 +106,17 @@ export function usePayWithToken(): PayWithToken {
 
   const balanceUsdFormatted = useMemo(() => {
     if (isMoneyAccountSelected) {
-      return MONEY_ACCOUNT_DUMMY_BALANCE_FIAT;
+      return withdrawableFiatFormatted ?? '';
     }
     return fiatFormatter(
       new BigNumber(resolvedToken?.balanceUsd ?? '0').toNumber(),
     );
-  }, [fiatFormatter, isMoneyAccountSelected, resolvedToken?.balanceUsd]);
+  }, [
+    fiatFormatter,
+    isMoneyAccountSelected,
+    resolvedToken?.balanceUsd,
+    withdrawableFiatFormatted,
+  ]);
 
   let displayToken: PayWithDisplayToken | undefined;
   if (isMoneyAccountSelected) {
@@ -116,7 +124,7 @@ export function usePayWithToken(): PayWithToken {
       chainId: resolvedToken?.chainId ?? '',
       address: '',
       symbol: t('payWithMoneyAccount'),
-      balanceUsd: MONEY_ACCOUNT_DUMMY_BALANCE_FIAT,
+      balanceUsd: withdrawableFiatFormatted ?? '',
     };
   } else if (resolvedToken?.chainId) {
     displayToken = {

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -30,14 +30,11 @@ jest.mock('../pay/usePayWithNoFeeToken');
 jest.mock('../pay/useTransactionPayData');
 jest.mock('../pay/useTransactionPayToken');
 jest.mock('../pay/usePayTokenAccountBalance');
-jest.mock(
-  '../../../../hooks/money/useMoneyAccountWithdrawableFiat',
-  () => ({
-    useMoneyAccountWithdrawableFiat: jest.fn(() => ({
-      withdrawableFiatRaw: undefined,
-    })),
-  }),
-);
+jest.mock('../../../../hooks/money/useMoneyAccountWithdrawableFiat', () => ({
+  useMoneyAccountWithdrawableFiat: jest.fn(() => ({
+    withdrawableFiatRaw: undefined,
+  })),
+}));
 jest.mock('./useDepositPrefillAmount');
 jest.mock('./useUpdateTokenAmount');
 jest.mock('../../../../store/actions', () => ({

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -3,6 +3,7 @@ import {
   TransactionType,
   type TransactionMeta,
 } from '@metamask/transaction-controller';
+import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import { act } from '@testing-library/react';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
 import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
@@ -14,6 +15,7 @@ import * as usePayWithNoFeeTokenModule from '../pay/usePayWithNoFeeToken';
 import * as useTransactionPayDataModule from '../pay/useTransactionPayData';
 import * as useTransactionPayTokenModule from '../pay/useTransactionPayToken';
 import * as usePayTokenAccountBalanceModule from '../pay/usePayTokenAccountBalance';
+import { useCachedMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
 import { MUSD_TOKEN_ADDRESS } from '../../constants/musd';
 import {
   useTransactionCustomAmount,
@@ -28,6 +30,14 @@ jest.mock('../pay/usePayWithNoFeeToken');
 jest.mock('../pay/useTransactionPayData');
 jest.mock('../pay/useTransactionPayToken');
 jest.mock('../pay/usePayTokenAccountBalance');
+jest.mock(
+  '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat',
+  () => ({
+    useCachedMoneyAccountWithdrawableFiat: jest.fn(() => ({
+      withdrawableFiatRaw: undefined,
+    })),
+  }),
+);
 jest.mock('./useDepositPrefillAmount');
 jest.mock('./useUpdateTokenAmount');
 jest.mock('../../../../store/actions', () => ({
@@ -65,6 +75,8 @@ function runHook({
   prefillMaxOnLoad = false,
   transactionMeta = MOCK_TRANSACTION_META,
   depositPrefill = DISABLED_DEPOSIT_PREFILL,
+  paymentOverride,
+  moneyAccountWithdrawableFiatRaw,
 }: {
   currency?: string;
   disableUpdate?: boolean;
@@ -84,6 +96,8 @@ function runHook({
   prefillMaxOnLoad?: boolean;
   transactionMeta?: TransactionMeta;
   depositPrefill?: ReturnType<typeof useDepositPrefillAmount>;
+  paymentOverride?: PaymentOverride;
+  moneyAccountWithdrawableFiatRaw?: string;
 } = {}) {
   jest
     .mocked(useTokenFiatRatesModule.useTokenFiatRate)
@@ -150,6 +164,10 @@ function runHook({
     isUpdating: false,
   });
   useDepositPrefillAmountMock.mockReturnValue(depositPrefill);
+  jest.mocked(useCachedMoneyAccountWithdrawableFiat).mockReturnValue({
+    withdrawableFiatRaw: moneyAccountWithdrawableFiatRaw,
+    withdrawableFiatFormatted: undefined,
+  });
 
   return renderHookWithConfirmContextProvider(
     () =>
@@ -159,7 +177,15 @@ function runHook({
         disableUpdate,
         prefillMaxOnLoad,
       }),
-    getMockConfirmStateForTransaction(transactionMeta),
+    getMockConfirmStateForTransaction(transactionMeta, {
+      metamask: paymentOverride
+        ? {
+            transactionData: {
+              [transactionMeta.id]: { paymentOverride },
+            },
+          }
+        : {},
+    }),
   );
 }
 
@@ -460,6 +486,33 @@ describe('useTransactionCustomAmount', () => {
         false,
         { isMoneyAccountDeposit: false },
       );
+    });
+
+    it('uses money account withdrawable balance when payment override is MoneyAccount', () => {
+      const { result } = runHook({
+        paymentOverride: PaymentOverride.MoneyAccount,
+        moneyAccountWithdrawableFiatRaw: '12.349',
+        payTokenBalanceUsd: 100,
+      });
+
+      act(() => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      expect(result.current.amountFiat).toBe('12.34');
+    });
+
+    it('returns 0 for Max when payment override is MoneyAccount but withdrawable balance is missing', () => {
+      const { result } = runHook({
+        paymentOverride: PaymentOverride.MoneyAccount,
+        payTokenBalanceUsd: 100,
+      });
+
+      act(() => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      expect(result.current.amountFiat).toBe('0');
     });
 
     it('does not inflate max amount with token fiat rate when balanceUsdOverride is provided', () => {

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -15,7 +15,7 @@ import * as usePayWithNoFeeTokenModule from '../pay/usePayWithNoFeeToken';
 import * as useTransactionPayDataModule from '../pay/useTransactionPayData';
 import * as useTransactionPayTokenModule from '../pay/useTransactionPayToken';
 import * as usePayTokenAccountBalanceModule from '../pay/usePayTokenAccountBalance';
-import { useCachedMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import { useMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useMoneyAccountWithdrawableFiat';
 import { MUSD_TOKEN_ADDRESS } from '../../constants/musd';
 import {
   useTransactionCustomAmount,
@@ -31,9 +31,9 @@ jest.mock('../pay/useTransactionPayData');
 jest.mock('../pay/useTransactionPayToken');
 jest.mock('../pay/usePayTokenAccountBalance');
 jest.mock(
-  '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat',
+  '../../../../hooks/money/useMoneyAccountWithdrawableFiat',
   () => ({
-    useCachedMoneyAccountWithdrawableFiat: jest.fn(() => ({
+    useMoneyAccountWithdrawableFiat: jest.fn(() => ({
       withdrawableFiatRaw: undefined,
     })),
   }),
@@ -164,7 +164,7 @@ function runHook({
     isUpdating: false,
   });
   useDepositPrefillAmountMock.mockReturnValue(depositPrefill);
-  jest.mocked(useCachedMoneyAccountWithdrawableFiat).mockReturnValue({
+  jest.mocked(useMoneyAccountWithdrawableFiat).mockReturnValue({
     withdrawableFiatRaw: moneyAccountWithdrawableFiatRaw,
     withdrawableFiatFormatted: undefined,
   });

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../../store/controller-actions/transaction-pay-controller';
 import { upsertTransactionUIMetricsFragment } from '../../../../store/actions';
 import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
-import { useCachedMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import { useMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useMoneyAccountWithdrawableFiat';
 import {
   selectPaymentOverrideByTransactionId,
   type TransactionPayState,
@@ -577,7 +577,7 @@ function usePayTokenBalanceUsd(balanceUsdOverride?: number) {
   );
   const isMoneyPaymentOverride =
     paymentOverride === PaymentOverride.MoneyAccount;
-  const { withdrawableFiatRaw } = useCachedMoneyAccountWithdrawableFiat(
+  const { withdrawableFiatRaw } = useMoneyAccountWithdrawableFiat(
     isMoneyPaymentOverride,
   );
   const { balanceUsd } = usePayTokenAccountBalance();

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { debounce, type DebouncedFunc } from 'lodash';
 import { BigNumber } from 'bignumber.js';
 import {
   TransactionType,
   type TransactionMeta,
 } from '@metamask/transaction-controller';
+import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import type { Hex } from '@metamask/utils';
 import {
   setIsMaxAmount,
@@ -12,6 +14,11 @@ import {
 } from '../../../../store/controller-actions/transaction-pay-controller';
 import { upsertTransactionUIMetricsFragment } from '../../../../store/actions';
 import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
+import { useCachedMoneyAccountWithdrawableFiat } from '../../../../hooks/money/useCachedMoneyAccountWithdrawableFiat';
+import {
+  selectPaymentOverrideByTransactionId,
+  type TransactionPayState,
+} from '../../../../selectors/transactionPayController';
 import { useTokenFiatRate } from '../tokens/useTokenFiatRates';
 import { useConfirmContext } from '../../context/confirm';
 import { usePayWithNoFeeToken } from '../pay/usePayWithNoFeeToken';
@@ -562,10 +569,34 @@ export function useTransactionCustomAmount({
 }
 
 function usePayTokenBalanceUsd(balanceUsdOverride?: number) {
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
+  const transactionId = transactionMeta?.id ?? '';
+  const paymentOverride = useSelector((state: TransactionPayState) =>
+    selectPaymentOverrideByTransactionId(state, transactionId),
+  );
+  const isMoneyPaymentOverride =
+    paymentOverride === PaymentOverride.MoneyAccount;
+  const { withdrawableFiatRaw } = useCachedMoneyAccountWithdrawableFiat(
+    isMoneyPaymentOverride,
+  );
   const { balanceUsd } = usePayTokenAccountBalance();
 
   if (balanceUsdOverride !== undefined) {
     return balanceUsdOverride;
+  }
+
+  if (isMoneyPaymentOverride) {
+    if (!withdrawableFiatRaw) {
+      return 0;
+    }
+    // ROUND_DOWN to cents before Max/percentage math so we never set an
+    // amount above the spendable withdrawable balance after display rounding.
+    // `round(dp, rm)`, not `decimalPlaces`: this repo pins `bignumber.js@4`
+    // where `decimalPlaces` is a getter that returns the place *count*.
+    return new BigNumber(withdrawableFiatRaw)
+      .round(2, BigNumber.ROUND_DOWN)
+      .toNumber();
   }
 
   return new BigNumber(balanceUsd ?? 0).toNumber();

--- a/ui/pages/confirmations/utils/money-account-pay-token.ts
+++ b/ui/pages/confirmations/utils/money-account-pay-token.ts
@@ -1,0 +1,27 @@
+import type { Hex } from '@metamask/utils';
+import { MUSD_TOKEN_ADDRESS } from '@metamask/money-account-utils';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+import type { MoneyAccountVaultConfig } from '../../../../shared/lib/money/vault-config';
+
+export type MoneyAccountPayToken = {
+  address: Hex;
+  chainId: Hex;
+};
+
+/**
+ * Resolves the pay token used when funding a confirmation from the Money
+ * Account. Prefers the vault config's underlying token and chain so UI
+ * selection matches the background funding batch; falls back to Monad mUSD
+ * when the vault flag is unserved.
+ *
+ * @param vaultConfig - Parsed money-account vault config, when available.
+ * @returns Pay-token address and chain id.
+ */
+export function getMoneyAccountPayToken(
+  vaultConfig: MoneyAccountVaultConfig | undefined,
+): MoneyAccountPayToken {
+  return {
+    address: vaultConfig?.underlyingToken ?? MUSD_TOKEN_ADDRESS,
+    chainId: vaultConfig?.chainId ?? CHAIN_IDS.MONAD,
+  };
+}

--- a/ui/pages/confirmations/utils/transaction-pay-money-account.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay-money-account.test.ts
@@ -41,8 +41,8 @@ describe('money account payment override helpers', () => {
       } as never);
 
       expect(setPaymentOverrideMock).toHaveBeenCalledWith('tx-2', {
-        paymentOverride: PaymentOverride.MoneyAccount,
         atomic: false,
+        paymentOverride: PaymentOverride.MoneyAccount,
       });
     });
   });

--- a/ui/pages/confirmations/utils/transaction-pay-money-account.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay-money-account.test.ts
@@ -34,7 +34,7 @@ describe('money account payment override helpers', () => {
       });
     });
 
-    it('sets MoneyAccount override without refundTo for withdraw flows', () => {
+    it('sets MoneyAccount override without refundTo and with atomic false for withdraw flows', () => {
       applyMoneyAccountOverride('tx-2', moneyAddress, {
         id: 'tx-2',
         type: TransactionType.perpsWithdraw,
@@ -42,6 +42,7 @@ describe('money account payment override helpers', () => {
 
       expect(setPaymentOverrideMock).toHaveBeenCalledWith('tx-2', {
         paymentOverride: PaymentOverride.MoneyAccount,
+        atomic: false,
       });
     });
   });

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -1,5 +1,6 @@
 import {
   TransactionMeta,
+  TransactionType,
   type NestedTransactionMetadata,
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
@@ -10,7 +11,10 @@ import {
 } from '@metamask/transaction-pay-controller';
 import { BigNumber } from 'bignumber.js';
 import { isTestNetwork } from '../../../helpers/utils/network-helper';
-import { isPostQuoteWithdrawTransaction } from '../../../../shared/lib/transactions.utils';
+import {
+  hasTransactionType,
+  isPostQuoteWithdrawTransaction,
+} from '../../../../shared/lib/transactions.utils';
 import { updateAtomicBatchData } from '../../../store/controller-actions/transaction-controller';
 import { setPaymentOverride } from '../../../store/controller-actions/transaction-pay-controller';
 import type { BlockedPayTokensListConfig } from '../selectors/feature-flags';
@@ -247,7 +251,8 @@ export function isTokenBlocked(
 /**
  * Selects Money Account as the payment method for a confirmation.
  * Sets `paymentOverride` and, for deposit flows, refunds leftover funds to the
- * money account address.
+ * money account address. Perps/Predict withdraws to Money Account run
+ * non-atomically so the post-Relay transfer is submitted after the quote.
  *
  * @param transactionId - Confirmation transaction id.
  * @param moneyAccountAddress - Derived money account address, when known.
@@ -258,10 +263,15 @@ export function applyMoneyAccountOverride(
   moneyAccountAddress: string | undefined,
   transactionMeta: TransactionMeta | undefined,
 ): void {
+  const isPerpsOrPredictWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.perpsWithdraw,
+    TransactionType.predictWithdraw,
+  ]);
   const isWithdraw = isPostQuoteWithdrawTransaction(transactionMeta);
 
   setPaymentOverride(transactionId, {
     paymentOverride: PaymentOverride.MoneyAccount,
+    ...(isPerpsOrPredictWithdraw ? { atomic: false } : {}),
     ...(!isWithdraw && moneyAccountAddress
       ? { refundTo: moneyAccountAddress as Hex }
       : {}),

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -267,12 +267,12 @@ export function applyMoneyAccountOverride(
     TransactionType.perpsWithdraw,
     TransactionType.predictWithdraw,
   ]);
-  const isWithdraw = isPostQuoteWithdrawTransaction(transactionMeta);
+  const isPostQuoteWithdraw = isPostQuoteWithdrawTransaction(transactionMeta);
 
   setPaymentOverride(transactionId, {
-    paymentOverride: PaymentOverride.MoneyAccount,
     ...(isPerpsOrPredictWithdraw ? { atomic: false } : {}),
-    ...(!isWithdraw && moneyAccountAddress
+    paymentOverride: PaymentOverride.MoneyAccount,
+    ...(!isPostQuoteWithdraw && moneyAccountAddress
       ? { refundTo: moneyAccountAddress as Hex }
       : {}),
   }).catch((error) => {

--- a/ui/store/controller-actions/transaction-pay-controller.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.ts
@@ -28,14 +28,16 @@ export async function setPaymentOverride(
   {
     paymentOverride,
     refundTo,
+    atomic,
   }: {
     paymentOverride?: PaymentOverride;
     refundTo?: Hex;
+    atomic?: boolean;
   } = {},
 ): Promise<void> {
   return await submitRequestToBackground('setTransactionPayPaymentOverride', [
     transactionId,
-    { paymentOverride, refundTo },
+    { paymentOverride, refundTo, atomic },
   ]);
 }
 

--- a/ui/store/controller-actions/transaction-pay-controller.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.ts
@@ -26,18 +26,18 @@ export async function updateTransactionPaymentToken({
 export async function setPaymentOverride(
   transactionId: string,
   {
+    atomic,
     paymentOverride,
     refundTo,
-    atomic,
   }: {
+    atomic?: boolean;
     paymentOverride?: PaymentOverride;
     refundTo?: Hex;
-    atomic?: boolean;
   } = {},
 ): Promise<void> {
   return await submitRequestToBackground('setTransactionPayPaymentOverride', [
     transactionId,
-    { paymentOverride, refundTo, atomic },
+    { atomic, paymentOverride, refundTo },
   ]);
 }
 


### PR DESCRIPTION
## **Description**

Allow Perps deposits to be funded from the Money Account, matching mobile.

Selecting Money Account on a Perps deposit confirmation now:

- Sets `paymentOverride` to Money Account, with `refundTo` as the Money Account address
- Auto-selects mUSD on Monad as the pay token
- Shows the live withdrawable Money Account balance in the Pay-with row and modal
- On submit, TransactionPayController prepends a vault withdraw plus mUSD transfer to the selected account so the Perps deposit can be funded

## **Changelog**

CHANGELOG entry: Added the option to fund Perps deposits with the Money Account

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1823

## **Manual testing steps**

1. Enable Money Account transactions for Perps deposits (`confirmations_pay_extended.enableMoneyAccountTransactions.perpsDeposit`).
2. Open a Perps deposit confirmation (from Perps Add funds, or from Money home into Perps).
3. Open Pay with and select **Money account**.
4. Verify the Money account row and the Pay-with selector show the withdrawable balance (not empty parentheses).
5. Enter an amount within the withdrawable balance and confirm.
6. Verify the deposit is funded from the Money Account (vault withdraw + mUSD transfer) rather than a wallet token.
7. Enter an amount above the withdrawable balance and verify the insufficient-funds alert blocks confirm.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes on-chain funding paths (vault withdraw/deposit, EIP-7702 delegation) and amount rounding that directly affect whether users can confirm and how much mUSD moves.
> 
> **Overview**
> Enables **Perps (and related) confirmations** to pay from the Money Account: choosing Money Account sets `paymentOverride`, auto-selects vault mUSD, and shows **live withdrawable balance** instead of placeholders.
> 
> **Background / Relay:** `TransactionPayController` now receives `getPaymentOverrideData`, which prepends vault **withdraw + mUSD transfer** to the user EOA for deposits (default **atomic** path wraps calls in EIP-7702 delegation for Relay). Post-quote flows use **approve + deposit** into the vault. Perps/Predict **withdraw-to-money-account** sets `atomic: false` so follow-up transfers can run after Relay. `parseMusdHumanAmount` gains an optional rounding mode; override amounts use **ROUND_DOWN** so funding never exceeds spendable balance.
> 
> **Confirmation UI:** Shared withdrawable-balance projection powers Pay-with row/modal, insufficient-funds checks, and Max (cents rounded down). Selecting Money Account passes the primary money account address into `applyMoneyAccountOverride` and re-selects the vault pay token when the override turns on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7276905fcc9fae1a92874d7be3b3d2f231a998b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->