### PR TITLE
fix(ramps): show most reliable provider tag

### DIFF
--- a/ui/pages/ramps/provider-selection/provider-selection.tsx
+++ b/ui/pages/ramps/provider-selection/provider-selection.tsx
@@ -35,7 +35,6 @@ import RampsProviderListItem from './components/ramps-provider-list-item';
 import {
   buildProviderListItems,
   findProviderQuote,
-  findProviderTagQuote,
   getProviderTag,
   type ProviderListItem,
   type ProviderTag,
@@ -105,10 +104,9 @@ function buildProviderListRows({
       provider.id,
       selectedPaymentMethodId,
     );
-    const providerMetadataQuote = findProviderTagQuote(quotes, provider.id);
     const tag =
       showQuotes && !quotesLoading
-        ? getProviderTag(provider.id, providerMetadataQuote, ordersProviders, t)
+        ? getProviderTag(provider.id, quotes, ordersProviders, t)
         : null;
 
     return {

--- a/ui/pages/ramps/provider-selection/provider-selection.tsx
+++ b/ui/pages/ramps/provider-selection/provider-selection.tsx
@@ -104,9 +104,10 @@ function buildProviderListRows({
       provider.id,
       selectedPaymentMethodId,
     );
+    const providerMetadataQuote = findProviderQuote(quotes, provider.id);
     const tag =
       showQuotes && !quotesLoading
-        ? getProviderTag(provider.id, matchedQuote, ordersProviders, t)
+        ? getProviderTag(provider.id, providerMetadataQuote, ordersProviders, t)
         : null;
 
     return {

--- a/ui/pages/ramps/provider-selection/provider-selection.tsx
+++ b/ui/pages/ramps/provider-selection/provider-selection.tsx
@@ -35,6 +35,7 @@ import RampsProviderListItem from './components/ramps-provider-list-item';
 import {
   buildProviderListItems,
   findProviderQuote,
+  findProviderTagQuote,
   getProviderTag,
   type ProviderListItem,
   type ProviderTag,
@@ -104,7 +105,7 @@ function buildProviderListRows({
       provider.id,
       selectedPaymentMethodId,
     );
-    const providerMetadataQuote = findProviderQuote(quotes, provider.id);
+    const providerMetadataQuote = findProviderTagQuote(quotes, provider.id);
     const tag =
       showQuotes && !quotesLoading
         ? getProviderTag(provider.id, providerMetadataQuote, ordersProviders, t)

--- a/ui/pages/ramps/provider-selection/utils/build-provider-list-items.test.ts
+++ b/ui/pages/ramps/provider-selection/utils/build-provider-list-items.test.ts
@@ -122,6 +122,41 @@ describe('findProviderQuote', () => {
         ?.amountOut,
     ).toBe('0.05');
   });
+
+  it('supports a provider-wide quote lookup for provider metadata', () => {
+    const quotes: QuotesResponse = {
+      success: [
+        {
+          provider: transak.id,
+          quote: {
+            amountIn: 100,
+            amountOut: '0.04',
+            paymentMethod: 'bank-transfer',
+          },
+          metadata: { tags: { isMostReliable: true } },
+        },
+        {
+          provider: transak.id,
+          quote: {
+            amountIn: 100,
+            amountOut: '0.05',
+            paymentMethod: 'debit-credit-card',
+          },
+        },
+      ],
+      sorted: [],
+      error: [],
+      customActions: [],
+    };
+
+    expect(
+      findProviderQuote(quotes, transak.id, 'debit-credit-card')?.quote
+        ?.amountOut,
+    ).toBe('0.05');
+    expect(
+      findProviderQuote(quotes, transak.id)?.metadata?.tags?.isMostReliable,
+    ).toBe(true);
+  });
 });
 
 describe('getProviderTag', () => {

--- a/ui/pages/ramps/provider-selection/utils/build-provider-list-items.test.ts
+++ b/ui/pages/ramps/provider-selection/utils/build-provider-list-items.test.ts
@@ -2,7 +2,6 @@ import type { Provider, QuotesResponse } from '@metamask/ramps-controller';
 import {
   buildProviderListItems,
   findProviderQuote,
-  findProviderTagQuote,
   getProviderTag,
 } from './build-provider-list-items';
 
@@ -124,7 +123,7 @@ describe('findProviderQuote', () => {
     ).toBe('0.05');
   });
 
-  it('supports a provider-wide quote lookup for provider metadata', () => {
+  it('gets provider tags from all of the provider quotes', () => {
     const quotes: QuotesResponse = {
       success: [
         {
@@ -154,39 +153,9 @@ describe('findProviderQuote', () => {
       findProviderQuote(quotes, transak.id, 'debit-credit-card')?.quote
         ?.amountOut,
     ).toBe('0.05');
-    expect(
-      findProviderQuote(quotes, transak.id)?.metadata?.tags?.isMostReliable,
-    ).toBe(true);
-  });
-
-  it('finds provider metadata when it is on a later quote', () => {
-    const quotes: QuotesResponse = {
-      success: [
-        {
-          provider: transak.id,
-          quote: {
-            amountIn: 100,
-            amountOut: '0.04',
-            paymentMethod: 'debit-credit-card',
-          },
-        },
-        {
-          provider: transak.id,
-          quote: {
-            amountIn: 100,
-            amountOut: '0.05',
-            paymentMethod: 'bank-transfer',
-          },
-          metadata: { tags: { isMostReliable: true } },
-        },
-      ],
-      sorted: [],
-      error: [],
-      customActions: [],
-    };
-
-    expect(findProviderTagQuote(quotes, transak.id)?.metadata?.tags).toEqual({
-      isMostReliable: true,
+    expect(getProviderTag(transak.id, quotes, [], t)).toStrictEqual({
+      label: 'rampsMostReliable',
+      severity: 'neutral',
     });
   });
 });
@@ -197,9 +166,22 @@ describe('getProviderTag', () => {
       getProviderTag(
         transak.id,
         {
-          provider: transak.id,
-          quote: { amountIn: 1, amountOut: '1', paymentMethod: 'card' },
-          metadata: { tags: { isBestRate: true, isMostReliable: true } },
+          success: [
+            {
+              provider: transak.id,
+              quote: {
+                amountIn: 1,
+                amountOut: '1',
+                paymentMethod: 'card',
+              },
+              metadata: {
+                tags: { isBestRate: true, isMostReliable: true },
+              },
+            },
+          ],
+          sorted: [],
+          error: [],
+          customActions: [],
         },
         [transak.id],
         t,
@@ -212,9 +194,16 @@ describe('getProviderTag', () => {
       getProviderTag(
         transak.id,
         {
-          provider: transak.id,
-          quote: { amountIn: 1, amountOut: '1', paymentMethod: 'card' },
-          metadata: { tags: { isMostReliable: true } },
+          success: [
+            {
+              provider: transak.id,
+              quote: { amountIn: 1, amountOut: '1', paymentMethod: 'card' },
+              metadata: { tags: { isMostReliable: true } },
+            },
+          ],
+          sorted: [],
+          error: [],
+          customActions: [],
         },
         [],
         t,
@@ -225,9 +214,16 @@ describe('getProviderTag', () => {
       getProviderTag(
         transak.id,
         {
-          provider: transak.id,
-          quote: { amountIn: 1, amountOut: '1', paymentMethod: 'card' },
-          metadata: { tags: { isBestRate: true } },
+          success: [
+            {
+              provider: transak.id,
+              quote: { amountIn: 1, amountOut: '1', paymentMethod: 'card' },
+              metadata: { tags: { isBestRate: true } },
+            },
+          ],
+          sorted: [],
+          error: [],
+          customActions: [],
         },
         [],
         t,

--- a/ui/pages/ramps/provider-selection/utils/build-provider-list-items.test.ts
+++ b/ui/pages/ramps/provider-selection/utils/build-provider-list-items.test.ts
@@ -2,6 +2,7 @@ import type { Provider, QuotesResponse } from '@metamask/ramps-controller';
 import {
   buildProviderListItems,
   findProviderQuote,
+  findProviderTagQuote,
   getProviderTag,
 } from './build-provider-list-items';
 
@@ -156,6 +157,37 @@ describe('findProviderQuote', () => {
     expect(
       findProviderQuote(quotes, transak.id)?.metadata?.tags?.isMostReliable,
     ).toBe(true);
+  });
+
+  it('finds provider metadata when it is on a later quote', () => {
+    const quotes: QuotesResponse = {
+      success: [
+        {
+          provider: transak.id,
+          quote: {
+            amountIn: 100,
+            amountOut: '0.04',
+            paymentMethod: 'debit-credit-card',
+          },
+        },
+        {
+          provider: transak.id,
+          quote: {
+            amountIn: 100,
+            amountOut: '0.05',
+            paymentMethod: 'bank-transfer',
+          },
+          metadata: { tags: { isMostReliable: true } },
+        },
+      ],
+      sorted: [],
+      error: [],
+      customActions: [],
+    };
+
+    expect(findProviderTagQuote(quotes, transak.id)?.metadata?.tags).toEqual({
+      isMostReliable: true,
+    });
   });
 });
 

--- a/ui/pages/ramps/provider-selection/utils/build-provider-list-items.ts
+++ b/ui/pages/ramps/provider-selection/utils/build-provider-list-items.ts
@@ -132,3 +132,32 @@ export function findProviderQuote(
     null
   );
 }
+
+/**
+ * Finds a quote containing provider tag metadata.
+ *
+ * Tag metadata can be returned on any quote for a provider, regardless of its
+ * payment method.
+ *
+ * @param quotes - Quotes response.
+ * @param providerId - Provider id.
+ * @returns Quote containing provider tag metadata, or null.
+ */
+export function findProviderTagQuote(
+  quotes: QuotesResponse | null,
+  providerId: string,
+): Quote | null {
+  if (!quotes?.success?.length) {
+    return null;
+  }
+
+  return (
+    quotes.success.find(
+      (quote) =>
+        quote.provider === providerId &&
+        (quote.metadata?.tags?.isMostReliable ||
+          quote.metadata?.tags?.isBestRate) &&
+        !(quote.quote as { isCustomAction?: boolean })?.isCustomAction,
+    ) ?? null
+  );
+}

--- a/ui/pages/ramps/provider-selection/utils/build-provider-list-items.ts
+++ b/ui/pages/ramps/provider-selection/utils/build-provider-list-items.ts
@@ -22,24 +22,28 @@ export type ProviderTag = {
  * `Info` aliases the `primary-muted` / `primary-default` design tokens.
  *
  * @param providerId - Provider id.
- * @param matchedQuote - Quote matched to this provider, when available.
+ * @param quotes - Quotes response containing provider quotes.
  * @param ordersProviders - Provider ids from completed orders.
  * @param t - i18n translate function.
  * @returns Localized tag with its severity, or null.
  */
 export function getProviderTag(
   providerId: string,
-  matchedQuote: Quote | null,
+  quotes: QuotesResponse | null,
   ordersProviders: string[],
   t: TranslateFn,
 ): ProviderTag | null {
   if (ordersProviders.includes(providerId)) {
     return { label: t('rampsPreviouslyUsed'), severity: TagSeverity.Info };
   }
-  if (matchedQuote?.metadata?.tags?.isMostReliable) {
+  const providerQuotes = quotes?.success?.filter(
+    (quote) => quote.provider === providerId,
+  );
+
+  if (providerQuotes?.some((quote) => quote.metadata?.tags?.isMostReliable)) {
     return { label: t('rampsMostReliable'), severity: TagSeverity.Neutral };
   }
-  if (matchedQuote?.metadata?.tags?.isBestRate) {
+  if (providerQuotes?.some((quote) => quote.metadata?.tags?.isBestRate)) {
     return { label: t('rampsBestRate'), severity: TagSeverity.Success };
   }
   return null;
@@ -130,34 +134,5 @@ export function findProviderQuote(
       (quote) => quote.provider === providerId && !isCustomActionQuote(quote),
     ) ??
     null
-  );
-}
-
-/**
- * Finds a quote containing provider tag metadata.
- *
- * Tag metadata can be returned on any quote for a provider, regardless of its
- * payment method.
- *
- * @param quotes - Quotes response.
- * @param providerId - Provider id.
- * @returns Quote containing provider tag metadata, or null.
- */
-export function findProviderTagQuote(
-  quotes: QuotesResponse | null,
-  providerId: string,
-): Quote | null {
-  if (!quotes?.success?.length) {
-    return null;
-  }
-
-  return (
-    quotes.success.find(
-      (quote) =>
-        quote.provider === providerId &&
-        (quote.metadata?.tags?.isMostReliable ||
-          quote.metadata?.tags?.isBestRate) &&
-        !(quote.quote as { isCustomAction?: boolean })?.isCustomAction,
-    ) ?? null
   );
 }


### PR DESCRIPTION
## **Description**

The `Most reliable` tag was missing from some Ramps providers because the tag was derived from the quote selected for the active payment method. Reliability metadata can be attached to a different quote for the same provider.

This change derives provider tags from the provider-wide quote metadata while keeping the displayed quote specific to the selected payment method.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TRAM-3932](https://consensyssoftware.atlassian.net/browse/TRAM-3932)

## **Manual testing steps**

1. Start the extension with the production Ramps API using `yarn start`.
2. Open the Ramps buy flow and select an asset and payment method that return provider quotes.
3. Open the provider selection screen.
4. Verify that the provider marked as most reliable displays the `Most reliable` tag.
5. Change the selected payment method and verify that the displayed quote updates while the `Most reliable` tag remains visible when the provider metadata identifies it as most reliable.

## **Screenshots/Recordings**


### **After**
<img width="422" height="646" alt="Screenshot 2026-08-27 at 13 46 13" src="https://github.com/user-attachments/assets/664ae151-1510-4350-9871-1a981dccc8e9" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TRAM-3932]: https://consensyssoftware.atlassian.net/browse/TRAM-3932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tag logic in the Ramps provider selection screen; quote display and selection behavior are unchanged aside from more accurate tags.
> 
> **Overview**
> Fixes missing **Most reliable** (and **Best rate**) pills on the Ramps provider list when tag metadata lives on a quote for a *different* payment method than the one currently selected.
> 
> **`getProviderTag`** now takes the full **`quotes`** response and scans **all successful quotes for that provider** for `isMostReliable` / `isBestRate`, instead of only the payment-method–matched quote. The row still shows the quote for the selected payment method via **`findProviderQuote`**; only tag derivation is provider-wide.
> 
> Tests cover the case where reliability is on bank-transfer but the displayed quote is debit/credit card.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82385c28541e2eb0d4aff7dfa8e4acb8aac3da95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->