### PR TITLE
refactor(rewards): source API base URL from builds.yml instead of environment string

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -37,6 +37,11 @@ INFURA_STORYBOOK_PROJECT_ID=
 ;ANALYTICS_DATA_DELETION_SOURCE_ID=
 ;ANALYTICS_DATA_DELETION_ENDPOINT=
 ;SWAPS_USE_DEV_APIS=
+; Which Rewards API host to use. Leave unset for the default: UAT on local
+; development builds, production everywhere else. Set to `true` to force UAT on
+; a dist build, or `false` to force production on a development build. Test
+; builds always use production regardless of this value.
+;REWARDS_USE_UAT_APIS=
 ;PORTFOLIO_URL=
 ;TRANSACTION_SECURITY_PROVIDER=
 

--- a/app/scripts/controllers/rewards/rewards-data-service.test.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.test.ts
@@ -91,6 +91,7 @@ describe('RewardsDataService', () => {
 
     // Set environment variables for testing
     delete process.env.METAMASK_ENVIRONMENT;
+    delete process.env.REWARDS_USE_UAT_APIS;
   });
 
   afterAll(() => {
@@ -540,7 +541,7 @@ describe('RewardsDataService', () => {
 
       expect(result).toEqual(mockLoginResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/auth/mobile-login`,
+        `${REWARDS_API_URL.PRD}/auth/mobile-login`,
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(mockLoginRequest),
@@ -822,7 +823,7 @@ describe('RewardsDataService', () => {
 
       expect(result).toEqual(mockSeasonStateResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/seasons/${mockSeasonId}/state`,
+        `${REWARDS_API_URL.PRD}/seasons/${mockSeasonId}/state`,
         {
           credentials: 'omit',
           method: 'GET',
@@ -1096,7 +1097,7 @@ describe('RewardsDataService', () => {
       // Assert
       expect(result).toEqual(mockOptInStatusResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/public/rewards/ois`,
+        `${REWARDS_API_URL.PRD}/public/rewards/ois`,
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(mockOptInStatusRequest),
@@ -1373,8 +1374,7 @@ describe('RewardsDataService', () => {
   });
 
   describe('API URL configuration', () => {
-    it('uses production URL for production environment', async () => {
-      process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.PRODUCTION;
+    it('uses the production URL by default', async () => {
       service = createService();
 
       const mockResponse = {
@@ -1395,8 +1395,8 @@ describe('RewardsDataService', () => {
       );
     });
 
-    it('uses production URL for release candidate environment', async () => {
-      process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.RELEASE_CANDIDATE;
+    it('ignores METAMASK_ENVIRONMENT when resolving the host', async () => {
+      process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.DEVELOPMENT;
       service = createService();
 
       const mockResponse = {
@@ -1408,17 +1408,13 @@ describe('RewardsDataService', () => {
       await service.validateReferralCode('TEST');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining(REWARDS_API_URL.PRD),
-        expect.any(Object),
-      );
-      expect(mockFetch).toHaveBeenCalledWith(
         `${REWARDS_API_URL.PRD}/referral/validate?code=TEST`,
         expect.any(Object),
       );
     });
 
-    it('uses UAT URL for non-production environments', async () => {
-      delete process.env.METAMASK_ENVIRONMENT;
+    it('uses the UAT URL when REWARDS_USE_UAT_APIS is set', async () => {
+      process.env.REWARDS_USE_UAT_APIS = 'true';
       service = createService();
 
       const mockResponse = {
@@ -1911,7 +1907,7 @@ describe('RewardsDataService', () => {
 
       expect(result).toEqual(mockLoginResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/auth/login`,
+        `${REWARDS_API_URL.PRD}/auth/login`,
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(mockSiweLoginBody),
@@ -2028,7 +2024,7 @@ describe('RewardsDataService', () => {
 
       expect(result).toEqual(mockSubscriptionResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/wr/subscriptions/join`,
+        `${REWARDS_API_URL.PRD}/wr/subscriptions/join`,
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(mockSiweJoinBody),
@@ -2140,7 +2136,7 @@ describe('RewardsDataService', () => {
       expect(result.message).toBe(mockChallengeResponse.message);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/auth/challenge/generate`,
+        `${REWARDS_API_URL.PRD}/auth/challenge/generate`,
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ address: mockAddress }),
@@ -2264,7 +2260,7 @@ describe('RewardsDataService', () => {
 
       expect(result).toEqual(mockVipFees);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/vip/fees`,
+        `${REWARDS_API_URL.PRD}/vip/fees`,
         expect.objectContaining({
           method: 'GET',
           credentials: 'omit',

--- a/app/scripts/controllers/rewards/rewards-data-service.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.ts
@@ -1,7 +1,6 @@
 // TODO: find similar functionality in extession
 // import { getSubscriptionToken } from '../utils/multi-subscription-token-vault';
 import log from 'loglevel';
-import { ENVIRONMENT } from '../../../../shared/constants/build';
 import ExtensionPlatform from '../../platforms/extension';
 import {
   REWARDS_API_URL,
@@ -136,14 +135,22 @@ export class RewardsDataService {
     );
   }
 
+  /**
+   * Resolve the Rewards API host from build configuration.
+   *
+   * The host is configured by the `REWARDS_USE_UAT_APIS` variable declared in
+   * `builds.yml`, not by inspecting the build environment string. Production is
+   * the default for anything that ships, local development builds default to
+   * UAT, either default can be overridden through configuration, and test
+   * builds always resolve to production so that e2e requests are matched by the
+   * mocks registered in `test/e2e/mock-e2e.js`.
+   *
+   * @returns The Rewards API base URL for this build.
+   */
   getRewardsApiBaseUrl() {
-    if (
-      process.env.METAMASK_ENVIRONMENT === ENVIRONMENT.PRODUCTION ||
-      process.env.METAMASK_ENVIRONMENT === ENVIRONMENT.RELEASE_CANDIDATE
-    ) {
-      return REWARDS_API_URL.PRD;
-    }
-    return REWARDS_API_URL.UAT;
+    return process.env.REWARDS_USE_UAT_APIS
+      ? REWARDS_API_URL.UAT
+      : REWARDS_API_URL.PRD;
   }
 
   /**

--- a/builds.yml
+++ b/builds.yml
@@ -186,6 +186,12 @@ env:
   - ENABLE_SENTRY: true
   - ACCOUNTS_USE_DEV_APIS: false
   - BRIDGE_USE_CUSTOM_BASE_URL: null
+  # Point the Rewards API at the UAT host instead of production. Leave unset to
+  # get the default: UAT for local development builds, production for everything
+  # else. Setting it to true or false overrides that default in either
+  # direction. Test builds always use production, where the requests are mocked
+  # at the network layer.
+  - REWARDS_USE_UAT_APIS: null
   - SWAPS_USE_DEV_APIS: false
   - PORTFOLIO_URL: https://app.metamask.io
   - TOKEN_ALLOWANCE_IMPROVEMENTS: false

--- a/development/build/set-environment-variables.js
+++ b/development/build/set-environment-variables.js
@@ -24,6 +24,20 @@ function setEnvironmentVariables({
   variables,
   version,
 }) {
+  // Rewards API host selection. Explicit configuration (`.metamaskrc`, the
+  // environment, or builds.yml) wins in either direction. When nothing is set,
+  // local development builds default to UAT so engineers don't point their
+  // day-to-day builds at production Rewards data, and everything else defaults
+  // to production.
+  const configuredRewardsUseUatApis = variables.getMaybe(
+    'REWARDS_USE_UAT_APIS',
+  );
+  const rewardsUseUatApis =
+    configuredRewardsUseUatApis === null ||
+    configuredRewardsUseUatApis === undefined
+      ? isDevBuild
+      : Boolean(configuredRewardsUseUatApis);
+
   variables.set({
     DEBUG: isDevBuild || isTestBuild ? variables.getMaybe('DEBUG') : undefined,
     EIP_4337_ENTRYPOINT: isTestBuild
@@ -76,6 +90,10 @@ function setEnvironmentVariables({
     ASSETS_UNIFIED_STATE_ENABLED: variables.getMaybe(
       'ASSETS_UNIFIED_STATE_ENABLED',
     ),
+    // Test builds always use production, the host mocked in
+    // `test/e2e/mock-e2e.js`. Anything else leaves the requests unmatched and
+    // they fall through to the catch-all rule.
+    REWARDS_USE_UAT_APIS: !isTestBuild && rewardsUseUatApis,
     COMPLIANCE_API_URL: variables.getMaybe('COMPLIANCE_API_URL'),
   });
 }

--- a/development/build/set-environment-variables.test.ts
+++ b/development/build/set-environment-variables.test.ts
@@ -31,6 +31,7 @@ const SET_ENVIRONMENT_VARIABLES_DECLARED_VARIABLES = [
   'QR_SYNC_ENABLED',
   'ASSETS_UNIFIED_STATE_ENABLED',
   'COMPLIANCE_API_URL',
+  'REWARDS_USE_UAT_APIS',
 ];
 
 function getVariablesForSetEnvironmentVariables() {
@@ -57,6 +58,7 @@ function getVariablesForSetEnvironmentVariables() {
     QR_SYNC_ENABLED: 'false',
     ASSETS_UNIFIED_STATE_ENABLED: 'false',
     COMPLIANCE_API_URL: 'https://compliance.example.test',
+    REWARDS_USE_UAT_APIS: null,
   });
 
   return variables;
@@ -120,5 +122,95 @@ describe('setEnvironmentVariables', () => {
     });
 
     expect(variables.get('QR_SYNC_ENABLED')).toBe('true');
+  });
+
+  it('forces the production Rewards API in test builds, even when configured for UAT', () => {
+    const variables = getVariablesForSetEnvironmentVariables();
+
+    variables.set('REWARDS_USE_UAT_APIS', true);
+
+    setEnvironmentVariables({
+      buildName: 'MetaMask',
+      isDevBuild: false,
+      isTestBuild: true,
+      buildType: 'main',
+      environment: ENVIRONMENT.TESTING,
+      variables,
+      version: '1.0.0',
+    });
+
+    expect(variables.get('REWARDS_USE_UAT_APIS')).toBe(false);
+  });
+
+  it('defaults local development builds to the UAT Rewards API', () => {
+    const variables = getVariablesForSetEnvironmentVariables();
+
+    variables.set('REWARDS_USE_UAT_APIS', null);
+
+    setEnvironmentVariables({
+      buildName: 'MetaMask',
+      isDevBuild: true,
+      isTestBuild: false,
+      buildType: 'main',
+      environment: ENVIRONMENT.DEVELOPMENT,
+      variables,
+      version: '1.0.0',
+    });
+
+    expect(variables.get('REWARDS_USE_UAT_APIS')).toBe(true);
+  });
+
+  it('defaults shipped builds to the production Rewards API', () => {
+    const variables = getVariablesForSetEnvironmentVariables();
+
+    variables.set('REWARDS_USE_UAT_APIS', null);
+
+    setEnvironmentVariables({
+      buildName: 'MetaMask',
+      isDevBuild: false,
+      isTestBuild: false,
+      buildType: 'main',
+      environment: ENVIRONMENT.PRODUCTION,
+      variables,
+      version: '1.0.0',
+    });
+
+    expect(variables.get('REWARDS_USE_UAT_APIS')).toBe(false);
+  });
+
+  it('lets config force the production Rewards API on a development build', () => {
+    const variables = getVariablesForSetEnvironmentVariables();
+
+    variables.set('REWARDS_USE_UAT_APIS', false);
+
+    setEnvironmentVariables({
+      buildName: 'MetaMask',
+      isDevBuild: true,
+      isTestBuild: false,
+      buildType: 'main',
+      environment: ENVIRONMENT.DEVELOPMENT,
+      variables,
+      version: '1.0.0',
+    });
+
+    expect(variables.get('REWARDS_USE_UAT_APIS')).toBe(false);
+  });
+
+  it('lets config force the UAT Rewards API on a shipped build', () => {
+    const variables = getVariablesForSetEnvironmentVariables();
+
+    variables.set('REWARDS_USE_UAT_APIS', true);
+
+    setEnvironmentVariables({
+      buildName: 'MetaMask',
+      isDevBuild: false,
+      isTestBuild: false,
+      buildType: 'main',
+      environment: ENVIRONMENT.PRODUCTION,
+      variables,
+      version: '1.0.0',
+    });
+
+    expect(variables.get('REWARDS_USE_UAT_APIS')).toBe(true);
   });
 });

--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -121,7 +121,6 @@
   "registry.npmjs.org",
   "responsive-rpc.test",
   "rewards.api.cx.metamask.io",
-  "rewards.uat-api.cx.metamask.io",
   "rpc.gnosischain.com",
   "rpc.pulsechain.com",
   "ruleset-engine.api.cx.metamask.io",

--- a/test/e2e/helpers/shield/constants.ts
+++ b/test/e2e/helpers/shield/constants.ts
@@ -1,3 +1,5 @@
+import { REWARDS_API_URL } from '../../../../shared/constants/rewards';
+
 export const BASE_SUBSCRIPTION_API_URL =
   'https://subscription.api.cx.metamask.io/v1';
 
@@ -6,8 +8,9 @@ export const BASE_RULESET_ENGINE_API_URL =
 
 export const BASE_CLAIMS_API_URL = 'https://claims.api.cx.metamask.io';
 
-// Rewards uses UAT API in test & dev environments
-export const BASE_REWARDS_API_URL = 'https://rewards.uat-api.cx.metamask.io';
+// Test builds always resolve to the production Rewards host; the requests are
+// mocked at the network layer.
+export const BASE_REWARDS_API_URL = REWARDS_API_URL.PRD;
 
 export const SUBSCRIPTION_API = {
   PRICING: `${BASE_SUBSCRIPTION_API_URL}/pricing`,

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -578,14 +578,13 @@ async function setupMocking(
       };
     });
 
-  // Rewards API
-  for (const rewardsApiUrl of [REWARDS_API_URL.UAT, REWARDS_API_URL.PRD]) {
-    await server
-      .forPost(`${rewardsApiUrl}/public/rewards/ois`)
-      .thenCallback(() => {
-        return { statusCode: 200, json: { ois: [], sids: [] } };
-      });
-  }
+  // Rewards API. Test builds always resolve to the production host, so only
+  // that host needs a mock.
+  await server
+    .forPost(`${REWARDS_API_URL.PRD}/public/rewards/ois`)
+    .thenCallback(() => {
+      return { statusCode: 200, json: { ois: [], sids: [] } };
+    });
 
   // User Profile Lineage
   await server

--- a/test/e2e/tests/deep-link/helpers.ts
+++ b/test/e2e/tests/deep-link/helpers.ts
@@ -7,6 +7,7 @@ import {
 import { emptyHtmlPage } from '../../mock-e2e';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { BaseUrl } from '../../../../shared/constants/urls';
+import { REWARDS_API_URL } from '../../../../shared/constants/rewards';
 
 /**
  * Generates an ECDSA key pair for signing deep links for testing purposes.
@@ -279,14 +280,14 @@ export const shouldRenderCheckbox = (
  */
 export const mockRewardsApi = async (server: Mockttp): Promise<void> => {
   await server
-    .forPost('https://rewards.uat-api.cx.metamask.io/public/rewards/ois')
+    .forPost(`${REWARDS_API_URL.PRD}/public/rewards/ois`)
     .thenJson(200, {
       ois: [false],
       sids: [null],
     });
 
   await server
-    .forPost('https://rewards.uat-api.cx.metamask.io/auth/mobile-login')
+    .forPost(`${REWARDS_API_URL.PRD}/auth/mobile-login`)
     .thenJson(200, {
       sessionId: 'yErC0OBAAh9BlS7frZYkjGz6RVyoo4p3R6nz3THmQlc=',
       accessToken: 'yErC0OBAAh9BlS7frZYkjGz6RVyoo4p3R6nz3THmQlc=',


### PR DESCRIPTION
## **Description**

Follow-up to the 13.45.1 hotfix incident (#45812 / #45827).

The Rewards API host was chosen inside the application, by inspecting `METAMASK_ENVIRONMENT` in `RewardsDataService.getRewardsApiBaseUrl`: production for `production` and `release-candidate` builds, UAT for everything else.

That caused the release-branch breakage. The `test/e2e/dist/*` job builds as `release-candidate`, so the app resolved to the production host while `mock-e2e.js` only mocked UAT. The unmocked `POST /public/rewards/ois` fell through to the catch-all pass-through rule and returned an empty 200, `RewardsController` never populated the BTC/Solana/Tron `rewardsAccounts` entries, and `wallet-fixture-validation` failed on every PR targeting a `release/*` branch. #45827 unblocked that by mocking both hosts.

This PR removes the underlying cause rather than the symptom, per the ask in the release thread.

**Config moves to `builds.yml`.** A new `REWARDS_USE_UAT_APIS` variable (default `false`) replaces the environment-string branching. The data service now just reads it, following the same shape as `ACCOUNTS_USE_DEV_APIS` / `SWAPS_USE_DEV_APIS` and their consumer in `shared/constants/accounts.ts`.

**Host selection is now decided by build target, in `set-environment-variables.js`:**

| Build | `REWARDS_USE_UAT_APIS` | Host |
|---|---|---|
| Test builds (`--test`) | anything | Production — always, cannot be overridden |
| Local development (`yarn start`) | unset | UAT |
| Anything that ships (dist/prod) | unset | Production |
| Any non-test build | `true` / `false` | UAT / Production — explicit config wins |

Forcing test builds is the actual fix: production is the mocked host, so a test build can no longer drift onto an unmocked one. This matches the existing `PERPS_ENABLED` / `QR_SYNC_ENABLED` / `METAMASK_SHIELD_ENABLED` precedent in that file, and the dev-build default keeps engineers off production Rewards data day to day.

The variable is tri-state: `null` in `builds.yml` means "not configured, use the per-build-target default", following the existing `BRIDGE_USE_CUSTOM_BASE_URL: null` idiom. Setting it explicitly overrides that default in either direction, so a developer can force production on a local build with `REWARDS_USE_UAT_APIS=false`. `.metamaskrc` values are already coerced to real booleans by `coerce()` in `development/webpack/utils/config.ts`, so `false` doesn't hit the "false"-string-is-truthy trap.

**The e2e side collapses back down.** The dual-host mock loop from #45827 returns to a single production mock, and `rewards.uat-api.cx.metamask.io` is dropped from `privacy-snapshot.json` — no test build can reach it now. The two e2e helpers that hardcoded the UAT host (`test/e2e/helpers/shield/constants.ts`, `test/e2e/tests/deep-link/helpers.ts`) use the shared constant instead.

### Notes for reviewers

**Why the dev/prod split keys off build target, not build type.** I looked at whether the UAT default belonged in `builds.yml` as a per-build-type override, and it doesn't fit: `main` is simultaneously the default local dev build type and the one that ships to the store, and `beta` / `experimental` / `flask` all ship to real users too. There's no "internal only" build type to hang it on, and no existing `*_USE_DEV_APIS` variable is overridden per build type anywhere in `builds.yml`. The axis that actually means "a developer's local build" is the build target (`isDevBuild`), which is already what `DEBUG`, `METAMASK_DEBUG`, `NODE_ENV` and `TEST_GAS_FEE_FLOWS` key off in this file.

**Naming.** `REWARDS_USE_UAT_APIS` rather than `..._USE_DEV_APIS`, because `REWARDS_API_URL` has three hosts (`DEV`, `UAT`, `PRD`) and the non-production one actually in use is UAT — `USE_DEV_APIS` would have named the wrong constant.

**Escape hatch.** Both defaults are overridable from `.metamaskrc` in either direction — `REWARDS_USE_UAT_APIS=false` forces production on a local dev build, `=true` forces UAT on a dist build. Test builds are the only case that ignores configuration, deliberately, since that's what caused the incident.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-extension/pull/45827

## **Manual testing steps**

1. Check out this branch.
2. Run `yarn test:e2e:single test/e2e/dist/wallet-fixture-validation.spec.ts --browser chrome` against a release-candidate dist build. It should pass without the UAT mock present.
3. Run `yarn start` and confirm Rewards requests go to `rewards.uat-api.cx.metamask.io`.
4. Build a dist build and confirm Rewards requests go to `rewards.api.cx.metamask.io`.
5. Set `REWARDS_USE_UAT_APIS=true` in `.metamaskrc`, rebuild the dist build, and confirm requests go to the UAT host.
6. Set `REWARDS_USE_UAT_APIS=false` in `.metamaskrc`, run `yarn start`, and confirm requests go to the production host.

## **Screenshots/Recordings**

N/A — build configuration and test tooling only, no UI change.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which live Rewards backend every build hits (including shipped dist vs local dev), with a hard override for test builds; misconfiguration could point dev builds at prod or vice versa, though tests and docs reduce that risk.
> 
> **Overview**
> **Rewards API host selection moves out of runtime environment checks** and into build-time config via new `REWARDS_USE_UAT_APIS` (`builds.yml`, `.metamaskrc.dist`). `RewardsDataService.getRewardsApiBaseUrl()` no longer branches on `METAMASK_ENVIRONMENT`; it picks UAT vs production from that injected flag only.
> 
> **Defaults and overrides are applied in `set-environment-variables.js`:** local dev builds default to UAT when unset, shipped builds default to production, and **test builds always force production** (even if config says UAT) so e2e traffic matches the mocks in `mock-e2e.js`. Explicit `true`/`false` in config can override the dev/shipped defaults.
> 
> **E2e and privacy tooling follow the same rule:** the dual UAT+PRD Rewards mock loop is removed in favor of a single production host mock; shield/deep-link helpers use `REWARDS_API_URL.PRD`, and `rewards.uat-api.cx.metamask.io` is dropped from `privacy-snapshot.json`. Unit tests cover the new env wiring and updated URL expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4dbdd1964082a5f53faf067b418ccc42fe4387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->