### PR TITLE
fix: Update `eth-sig-util` to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "yarn-binary:hydrate": "corepack hydrate .yarn/yarn-corepack.tgz --activate"
   },
   "resolutions": {
+    "@metamask/eth-sig-util": "^9.0.0",
     "@grpc/grpc-js": "^1.9.16",
     "@metamask/network-controller": "35.0.0",
     "follow-redirects": "^1.16.0",
@@ -406,7 +407,7 @@
     "@metamask/eth-ledger-bridge-keyring": "^13.1.0",
     "@metamask/eth-money-keyring": "3.0.0",
     "@metamask/eth-qr-keyring": "^3.0.0",
-    "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/eth-snap-keyring": "^24.0.0",
     "@metamask/eth-token-tracker": "^10.0.2",
     "@metamask/eth-trezor-keyring": "^11.0.0",
@@ -849,6 +850,24 @@
   "engines": {
     "node": ">=24.13.0",
     "yarn": "^4.14.1"
+  },
+  "previewBuilds": {
+    "@metamask/eth-json-rpc-middleware": {
+      "type": "non-breaking",
+      "previewVersion": "24.0.1-preview-3e34650c2"
+    },
+    "@metamask/keyring-controller": {
+      "type": "non-breaking",
+      "previewVersion": "27.1.1-preview-3e34650c2"
+    },
+    "@metamask/signature-controller": {
+      "type": "non-breaking",
+      "previewVersion": "39.2.10-preview-3e34650c2"
+    },
+    "@metamask/message-manager": {
+      "type": "non-breaking",
+      "previewVersion": "14.1.2-preview-3e34650c2"
+    }
   },
   "lavamoat": {
     "allowScripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6690,6 +6690,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-json-rpc-middleware@npm:@metamask-previews/eth-json-rpc-middleware@24.0.1-preview-3e34650c2":
+  version: 24.0.1-preview-3e34650c2
+  resolution: "@metamask-previews/eth-json-rpc-middleware@npm:24.0.1-preview-3e34650c2"
+  dependencies:
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
+    "@metamask/json-rpc-engine": "npm:^10.5.0"
+    "@metamask/message-manager": "npm:^14.1.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    klona: "npm:^2.0.6"
+    safe-stable-stringify: "npm:^2.4.3"
+  checksum: 10/4501da0aecf0dba3ef1607025a6b32bad3faa77b52c6107f9f88e576c1a6623f4f3ec8c45a0c0dc10cd79d6ce40f3bacfa3ca12bea53fc4a1319b6cd22ae493c
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-json-rpc-middleware@npm:^23.1.3":
   version: 23.1.3
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.3"
@@ -6706,24 +6724,6 @@ __metadata:
     pify: "npm:^5.0.0"
     safe-stable-stringify: "npm:^2.4.3"
   checksum: 10/aee4866afa78cb21aed9daa1211ee9a3515cb9549d9b325d5904b8769fb54790296224b58ec3555eb34a7125d2fd5180d6cba915bb1ca8dc3f04bf75e502c6b0
-  languageName: node
-  linkType: hard
-
-"@metamask/eth-json-rpc-middleware@npm:^24.0.1":
-  version: 24.0.1
-  resolution: "@metamask/eth-json-rpc-middleware@npm:24.0.1"
-  dependencies:
-    "@metamask/eth-block-tracker": "npm:^15.0.1"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/json-rpc-engine": "npm:^10.5.0"
-    "@metamask/message-manager": "npm:^14.1.2"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
-    klona: "npm:^2.0.6"
-    safe-stable-stringify: "npm:^2.4.3"
-  checksum: 10/54ebe641625c1dec7c8d2e9b46551ca9b0006b2b0f0cbdb6aa79644334222711b15cc660250710c4d5bfd0767e5a5e27a35f62dc93e63d90e35e1cf83727be28
   languageName: node
   linkType: hard
 
@@ -6844,9 +6844,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-sig-util@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "@metamask/eth-sig-util@npm:8.2.0"
+"@metamask/eth-sig-util@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/eth-sig-util@npm:9.0.0"
   dependencies:
     "@ethereumjs/rlp": "npm:^4.0.1"
     "@ethereumjs/util": "npm:^8.1.0"
@@ -6855,7 +6855,7 @@ __metadata:
     "@scure/base": "npm:~1.1.3"
     ethereum-cryptography: "npm:^2.1.2"
     tweetnacl: "npm:^1.0.3"
-  checksum: 10/385df1ec541116e1bd725a1df1a519996bad167f99d1b2677126e398cdfda6fc3f03d2ff8f1ca523966bc0aae3ea92a9050953a45d5a7711f4128aacf9242bfc
+  checksum: 10/b4e0bc59fd306ee7d6308e9a21920ade79efbb2d157af06a71cf3fab2621e7373ea5e14159a18e28b21208ef5b949fef68e98ae54874ed07cef728f3a38f7d46
   languageName: node
   linkType: hard
 
@@ -7251,16 +7251,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-controller@npm:^27.0.0, @metamask/keyring-controller@npm:^27.1.0, @metamask/keyring-controller@npm:^27.1.1":
-  version: 27.1.1
-  resolution: "@metamask/keyring-controller@npm:27.1.1"
+"@metamask/keyring-controller@npm:@metamask-previews/keyring-controller@27.1.1-preview-3e34650c2":
+  version: 27.1.1-preview-3e34650c2
+  resolution: "@metamask-previews/keyring-controller@npm:27.1.1-preview-3e34650c2"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/browser-passworder": "npm:^6.0.0"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/eth-hd-keyring": "npm:^15.0.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/eth-simple-keyring": "npm:^13.0.0"
     "@metamask/keyring-api": "npm:^24.0.0"
     "@metamask/keyring-internal-api": "npm:^12.0.0"
@@ -7271,7 +7271,7 @@ __metadata:
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
     ulid: "npm:^2.3.0"
-  checksum: 10/c4a1a3b40f98d179dfadba128c9135e795a7440a6d2cc5cd107644716e931cd71d6e7407211cb5eacd2ffb37e38d22f48d4123da0ed6b462e10a59a902fe0ece
+  checksum: 10/41c6c3caec5a53e34d70054a62394718d2e768c2756c8e2fcaf038e80247a8c3284c09ff73392e8d4c1b524ae06c9d4e10faca6c3de0580945e3ec262efaf4ef
   languageName: node
   linkType: hard
 
@@ -7478,19 +7478,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/message-manager@npm:^14.0.0, @metamask/message-manager@npm:^14.1.1, @metamask/message-manager@npm:^14.1.2":
-  version: 14.1.2
-  resolution: "@metamask/message-manager@npm:14.1.2"
+"@metamask/message-manager@npm:@metamask-previews/message-manager@14.1.2-preview-3e34650c2":
+  version: 14.1.2-preview-3e34650c2
+  resolution: "@metamask-previews/message-manager@npm:14.1.2-preview-3e34650c2"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.0.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/utils": "npm:^11.9.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/utils": "npm:^11.11.0"
     "@types/uuid": "npm:^8.3.0"
     jsonschema: "npm:^1.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/82e3965069f0eb34e2141ca4dff452c118f54502d0b5d6b832af1906c6413ba1d923b13f1ed6af7f8a7b3087ef7f3b1a700bcffa56b10b06df53972ff2cf9a4f
+  checksum: 10/5377865ba0f1cc2de943587e5af45ebe72861aded6b311a6e61ab73b9ba81709aed8dc03791ec33286b22a31aa3dcb3756f5816bbc8d7a2ca9b1f08f3143cfa3
   languageName: node
   linkType: hard
 
@@ -8414,15 +8414,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/signature-controller@npm:^39.2.10, @metamask/signature-controller@npm:^39.2.6":
-  version: 39.2.10
-  resolution: "@metamask/signature-controller@npm:39.2.10"
+"@metamask/signature-controller@npm:@metamask-previews/signature-controller@39.2.10-preview-3e34650c2":
+  version: 39.2.10-preview-3e34650c2
+  resolution: "@metamask-previews/signature-controller@npm:39.2.10-preview-3e34650c2"
   dependencies:
     "@metamask/accounts-controller": "npm:^39.1.1"
     "@metamask/approval-controller": "npm:^9.0.2"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/gator-permissions-controller": "npm:^5.0.2"
     "@metamask/keyring-controller": "npm:^27.1.1"
     "@metamask/logging-controller": "npm:^9.0.0"
@@ -8432,7 +8432,7 @@ __metadata:
     jsonschema: "npm:^1.4.1"
     lodash: "npm:^4.17.21"
     uuid: "npm:^8.3.2"
-  checksum: 10/404e514eb5a4959742f144785624ad41e42dd3ec88e132ee685dc2f6def8bc7643013a13d8514a971e4bcbd03ef7c08c05f57b69cfc422cb254e8ee3905bacce
+  checksum: 10/f4e832aa71e4558c411b5c30dfce34d285aa57997c02a8c0ca866a529904c680e370b1e4d6239d104d6b7576135ef8a47705f4972ea713b19829799766c1b7a3
   languageName: node
   linkType: hard
 
@@ -33321,7 +33321,7 @@ __metadata:
     "@metamask/eth-ledger-bridge-keyring": "npm:^13.1.0"
     "@metamask/eth-money-keyring": "npm:3.0.0"
     "@metamask/eth-qr-keyring": "npm:^3.0.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/eth-snap-keyring": "npm:^24.0.0"
     "@metamask/eth-token-tracker": "npm:^10.0.2"
     "@metamask/eth-trezor-keyring": "npm:^11.0.0"


### PR DESCRIPTION
## **Description**

`@metamask/eth-sig-util` v9.0.0 introduces strict `bool` validation in `signTypedData`: ambiguous values like `0`, `1`, `'0'`, `'1'`, `''`, and `'False'` are now rejected instead of being silently coerced via `Boolean()`. This was a signing integrity footgun — a dApp could supply `flag: 'false'` (which `Boolean()` coerces to `true`) and get a user to sign the opposite of what was displayed in the confirmation UI.

This PR adds a Yarn resolution to force `@metamask/eth-sig-util@^9.0.0` across all transitive dependencies while the upstream cascade lands. The immediate blocker is `@metamask/eth-simple-keyring` (and other keyrings in [MetaMask/accounts#626](https://github.com/MetaMask/accounts/pull/626)) which still declare `^8.2.0` — without the resolution, `eth-simple-keyring` installs its own nested copy of v8.2.0 and `normalizeBool()` is never reached during signing.

**Dependency update cascade:**
- `eth-sig-util@9.0.0` update: [MetaMask/eth-sig-util CHANGELOG](https://github.com/MetaMask/eth-sig-util/blob/main/CHANGELOG.md#900)
- Core controllers: [MetaMask/core#9999](https://github.com/MetaMask/core/pull/9999)
- Keyring updates: [MetaMask/accounts#626](https://github.com/MetaMask/accounts/pull/626)
- Mobile resolution: [MetaMask/metamask-mobile#35410](https://github.com/MetaMask/metamask-mobile/pull/35410)
- Extension resolution: this PR

The resolution will be removed in a follow-up PR once the upstream packages ship and are consumed here.

## **Changelog**

CHANGELOG entry: null

## **Test results**

<img width="1086" height="1731" alt="1" src="https://github.com/user-attachments/assets/98163300-b13f-451d-9dd8-0329ce0a914c" />
<img width="1080" height="1742" alt="2" src="https://github.com/user-attachments/assets/555c2b5f-b73f-4149-9837-70745349fcf1" />
<img width="1089" height="684" alt="3" src="https://github.com/user-attachments/assets/39caa174-a686-43ba-9ed2-b30ae5475063" />


## **Related issues**

Fixes: CONF-1807

## **Manual testing steps**

1. Install the extension from this branch
2. Navigate to any dApp that uses `eth_signTypedData_v4` with a `bool` field (e.g. a local test page served over `localhost`)
3. Attempt to sign a typed message where a `bool` field is set to an ambiguous value such as `0`, `1`, `'0'`, or `'1'`
4. Verify the signing request is rejected with an error — MetaMask should not present a confirmation dialog for invalid bool values
5. Attempt to sign with valid values (`true`, `false`, `'true'`, `'false'`) and verify the signing confirmation appears and completes successfully

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the signing and keyring dependency graph with preview packages; behavior changes for invalid EIP-712 bool fields and could affect dApps that relied on loose coercion.
> 
> **Overview**
> Forces **`@metamask/eth-sig-util@^9.0.0`** everywhere (direct dependency plus a new Yarn **resolution**) so typed-data signing uses v9’s stricter **`bool`** handling in `signTypedData`—ambiguous values like `0`, `1`, and `'false'` are rejected instead of being coerced with `Boolean()`.
> 
> Because several controllers still pull **v8.2.0** transitively (e.g. via keyrings), the lockfile also wires **non-breaking preview builds** for `@metamask/eth-json-rpc-middleware`, `@metamask/keyring-controller`, `@metamask/signature-controller`, and `@metamask/message-manager` so the signing/RPC stack resolves against **`eth-sig-util` v9** until upstream releases land. No extension application source changes—**`package.json`** and **`yarn.lock`** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0997ff6d53897aee7ac2c5d1be8f501392e97001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->