### PR TITLE
fix: Correct ENS `sourceId` in `AddressBookPetnamesBridge` cp-13.47.0

### DIFF
--- a/app/scripts/lib/AddressBookPetnamesBridge.test.ts
+++ b/app/scripts/lib/AddressBookPetnamesBridge.test.ts
@@ -156,7 +156,7 @@ describe('AddressBookPetnamesBridge', () => {
         value: ADDRESS_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
         name: NAME_MOCK,
-        sourceId: 'ens',
+        sourceId: 'npm:@metamask/ens-resolver-snap',
         variation: CHAIN_ID_MOCK,
         origin: NameOrigin.ADDRESS_BOOK,
       } as SetNameRequest);

--- a/app/scripts/lib/AddressBookPetnamesBridge.ts
+++ b/app/scripts/lib/AddressBookPetnamesBridge.ts
@@ -72,7 +72,7 @@ export class AddressBookPetnamesBridge extends AbstractPetnamesBridge<
           name,
           variation: normalizedChainId,
           type: NameType.ETHEREUM_ADDRESS,
-          sourceId: isEns ? 'ens' : undefined,
+          sourceId: isEns ? 'npm:@metamask/ens-resolver-snap' : undefined,
           origin: NameOrigin.ADDRESS_BOOK,
         });
       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When removing the duplicate ENS resolver, I missed updating the `sourceId` when address book entries are synced with the petnames system. This PR rectifies that.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/45848

## **Manual testing steps**

See ticket above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow metadata fix for ENS-tagged address book sync; no auth, payments, or broad behavior changes.
> 
> **Overview**
> When address book entries marked as ENS sync into petnames, **`sourceId` now uses `npm:@metamask/ens-resolver-snap`** instead of the legacy `'ens'` string, matching the post–duplicate-resolver-removal naming.
> 
> The unit test for adding an ENS address book entry is updated to expect the new `sourceId`. Non-ENS entries still pass `sourceId: undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15222dd0fa10133b014fb3e226cce606e7da7409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->