### PR TITLE
feat(perps): persist order form state and trading UI prefs

### DIFF
--- a/app/scripts/controllers/preferences-controller.test.ts
+++ b/app/scripts/controllers/preferences-controller.test.ts
@@ -564,6 +564,26 @@ describe('preferences controller', () => {
       expect(controller.getPreferences().perpsSelectedCandlePeriod).toBe('1h');
     });
 
+    it('stores perpsSelectedOrderType as a string preference', () => {
+      const { controller } = setupController({});
+      controller.setPreference('perpsSelectedOrderType', 'limit');
+      expect(controller.getPreferences().perpsSelectedOrderType).toBe('limit');
+    });
+
+    it('stores perps order-book listed-by preferences', () => {
+      const { controller } = setupController({});
+      controller.setPreference('perpsOrderBookCurrency', 'base');
+      controller.setPreference('perpsOrderBookMetric', 'size');
+      expect(controller.getPreferences().perpsOrderBookCurrency).toBe('base');
+      expect(controller.getPreferences().perpsOrderBookMetric).toBe('size');
+    });
+
+    it('stores perpsVisibleCandleCount as a number preference', () => {
+      const { controller } = setupController({});
+      controller.setPreference('perpsVisibleCandleCount', 60);
+      expect(controller.getPreferences().perpsVisibleCandleCount).toBe(60);
+    });
+
     it('enables side panel default when disabling full screen view', () => {
       const { controller: defaultController } = setupController({});
       const { controller } = setupController({

--- a/shared/types/preferences.ts
+++ b/shared/types/preferences.ts
@@ -29,5 +29,13 @@ export type Preferences = {
   useNativeCurrencyAsPrimaryCurrency: boolean;
   useSidePanelAsDefault?: boolean;
   perpsSelectedCandlePeriod?: string;
+  /** Session-wide perps order type. Market-agnostic; survives the 60s draft TTL. */
+  perpsSelectedOrderType?: 'market' | 'limit';
+  /** Order-book listed-by currency. Market-agnostic. */
+  perpsOrderBookCurrency?: 'base' | 'usd';
+  /** Order-book listed-by metric. Market-agnostic. */
+  perpsOrderBookMetric?: 'size' | 'total';
+  /** Number of candles shown on the perps chart. Session- and market-agnostic. */
+  perpsVisibleCandleCount?: number;
   gasSponsorshipOptOutByChainId: Record<string, boolean>;
 };

--- a/ui/components/app/perps/constants/chartConfig.ts
+++ b/ui/components/app/perps/constants/chartConfig.ts
@@ -69,6 +69,22 @@ export const ZOOM_CONFIG = {
   MAX_CANDLES: CANDLE_COUNT.MAX,
 } as const;
 
+/**
+ * Clamp a user or persisted candle count into the supported zoom range.
+ *
+ * @param count - Candidate visible-candle count.
+ * @returns A finite count between MIN and MAX, or the default when invalid.
+ */
+export function clampVisibleCandleCount(count: number): number {
+  if (!Number.isFinite(count)) {
+    return CANDLE_COUNT.DEFAULT;
+  }
+  return Math.max(
+    CANDLE_COUNT.MIN,
+    Math.min(CANDLE_COUNT.MAX, Math.round(count)),
+  );
+}
+
 // Period to minutes mapping for candle count calculations
 export const PERIOD_TO_MINUTES: Record<CandlePeriod, number> = {
   [CandlePeriod.OneMinute]: 1,

--- a/ui/components/app/perps/order-book/order-book.test.tsx
+++ b/ui/components/app/perps/order-book/order-book.test.tsx
@@ -60,12 +60,32 @@ const mockOrderBook = {
   maxTotal: '0.62',
 };
 
-function makeStore(orderBookPosition?: 'left' | 'right') {
+function makeStore({
+  orderBookPosition,
+  orderBookGrouping,
+  preferences,
+}: {
+  orderBookPosition?: 'left' | 'right';
+  orderBookGrouping?: number;
+  preferences?: Record<string, unknown>;
+} = {}) {
   return configureStore({
     metamask: {
       ...mockState.metamask,
       ...(orderBookPosition && {
         proLayoutPreferences: { orderBookPosition },
+      }),
+      ...(orderBookGrouping !== undefined && {
+        tradeConfigurations: {
+          mainnet: { BTC: { orderBookGrouping } },
+          testnet: {},
+        },
+      }),
+      ...(preferences && {
+        preferences: {
+          ...mockState.metamask.preferences,
+          ...preferences,
+        },
       }),
     },
   });
@@ -76,6 +96,8 @@ function renderOrderBook(props?: {
   marketPrice?: number;
   onSelectPrice?: (price: string) => void;
   orderBookPosition?: 'left' | 'right';
+  orderBookGrouping?: number;
+  preferences?: Record<string, unknown>;
 }) {
   return renderWithProvider(
     <PerpsOrderBook
@@ -84,7 +106,11 @@ function renderOrderBook(props?: {
       marketPrice={props?.marketPrice ?? 73776}
       onSelectPrice={props?.onSelectPrice}
     />,
-    makeStore(props?.orderBookPosition),
+    makeStore({
+      orderBookPosition: props?.orderBookPosition,
+      orderBookGrouping: props?.orderBookGrouping,
+      preferences: props?.preferences,
+    }),
   );
 }
 
@@ -465,6 +491,60 @@ describe('PerpsOrderBook', () => {
       expect(
         screen.queryByText(messages.perpsOrderBookConfigTitle.message),
       ).not.toBeInTheDocument();
+    });
+
+    it('persists grouping and listed-by preferences on apply', () => {
+      renderOrderBook();
+
+      fireEvent.click(screen.getByTestId('perps-order-book-grouping-trigger'));
+      fireEvent.click(
+        screen.getByTestId('perps-order-book-config-modal-currency-base'),
+      );
+      fireEvent.click(
+        screen.getByTestId('perps-order-book-config-modal-metric-size'),
+      );
+      fireEvent.click(
+        screen.getByTestId('perps-order-book-config-modal-grouping-1'),
+      );
+      fireEvent.click(
+        screen.getByTestId('perps-order-book-config-modal-apply'),
+      );
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'perpsSaveOrderBookGrouping',
+        ['BTC', 1],
+      );
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'setPreference',
+        ['perpsOrderBookCurrency', 'base'],
+      );
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'setPreference',
+        ['perpsOrderBookMetric', 'size'],
+      );
+    });
+
+    it('seeds listed-by currency and metric from preferences', () => {
+      renderOrderBook({
+        preferences: {
+          perpsOrderBookCurrency: 'base',
+          perpsOrderBookMetric: 'size',
+        },
+      });
+
+      expect(
+        screen.getByText(`${messages.perpsOrderBookSize.message} (BTC)`),
+      ).toBeInTheDocument();
+    });
+
+    it('seeds grouping from the saved per-market configuration', () => {
+      renderOrderBook({ orderBookGrouping: 1 });
+
+      fireEvent.click(screen.getByTestId('perps-order-book-grouping-trigger'));
+
+      expect(
+        screen.getByTestId('perps-order-book-config-modal-grouping-1'),
+      ).toHaveAttribute('aria-checked', 'true');
     });
 
     it('does not persist a layout the user did not change', () => {

--- a/ui/components/app/perps/order-book/order-book.tsx
+++ b/ui/components/app/perps/order-book/order-book.tsx
@@ -20,7 +20,13 @@ import {
 } from '@metamask/design-system-react';
 import type { OrderBookLevel } from '@metamask/perps-controller';
 import { submitRequestToBackground } from '../../../../store/background-connection';
-import { selectOrderBookPosition } from '../../../../selectors/perps-controller';
+import {
+  type PerpsState,
+  selectOrderBookPosition,
+  selectPerpsOrderBookGrouping,
+} from '../../../../selectors/perps-controller';
+import type { MetaMaskReduxState } from '../../../../store/store';
+import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import {
   formatPerpsFiat,
   PRICE_RANGES_UNIVERSAL,
@@ -271,11 +277,36 @@ export const PerpsOrderBook = ({
 }: PerpsOrderBookProps) => {
   const t = useI18nContext();
   const configModalId = `${dataTestId}-config-modal`;
-  const [currency, setCurrency] = useState<OrderBookListCurrency>('usd');
-  const [metric, setMetric] = useState<OrderBookListMetric>('total');
-  const [selectedGrouping, setSelectedGrouping] = useState<number | null>(null);
+  const {
+    perpsOrderBookCurrency: persistedCurrency,
+    perpsOrderBookMetric: persistedMetric,
+  } = useSelector(getPreferences);
+  const savedGrouping = useSelector((state: MetaMaskReduxState) =>
+    selectPerpsOrderBookGrouping(state as PerpsState, symbol),
+  );
+  const [currency, setCurrency] = useState<OrderBookListCurrency>(
+    persistedCurrency === 'base' || persistedCurrency === 'usd'
+      ? persistedCurrency
+      : 'usd',
+  );
+  const [metric, setMetric] = useState<OrderBookListMetric>(
+    persistedMetric === 'size' || persistedMetric === 'total'
+      ? persistedMetric
+      : 'total',
+  );
+  const [selectedGrouping, setSelectedGrouping] = useState<number | null>(
+    savedGrouping ?? null,
+  );
   const [isConfigOpen, setIsConfigOpen] = useState(false);
   const [viewMode, setViewMode] = useState<OrderBookViewMode>('default');
+  const [groupingSeed, setGroupingSeed] = useState(
+    `${symbol}:${savedGrouping ?? ''}`,
+  );
+  const nextGroupingSeed = `${symbol}:${savedGrouping ?? ''}`;
+  if (nextGroupingSeed !== groupingSeed) {
+    setGroupingSeed(nextGroupingSeed);
+    setSelectedGrouping(savedGrouping ?? null);
+  }
 
   const orderBookLayout: OrderBookLayoutPosition = useSelector(
     selectOrderBookPosition,
@@ -457,8 +488,26 @@ export const PerpsOrderBook = ({
       ]).catch((error) =>
         console.error('Failed to persist order book layout', error),
       );
+      submitRequestToBackground('perpsSaveOrderBookGrouping', [
+        symbol,
+        next.grouping,
+      ]).catch((error) =>
+        console.error('Failed to persist order book grouping', error),
+      );
+      submitRequestToBackground('setPreference', [
+        'perpsOrderBookCurrency',
+        next.currency,
+      ]).catch((error) =>
+        console.error('Failed to persist order book currency', error),
+      );
+      submitRequestToBackground('setPreference', [
+        'perpsOrderBookMetric',
+        next.metric,
+      ]).catch((error) =>
+        console.error('Failed to persist order book metric', error),
+      );
     },
-    [],
+    [symbol],
   );
 
   const hasLadder = Boolean(

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -62,6 +62,7 @@ import { OrderTypeToggle } from './components/order-type-toggle';
  * @param props.autoFocusLimitPrice
  * @param props.usdPlaceholder
  * @param props.limitPricePrefill
+ * @param props.pendingDraft
  * @param props.onInputMethodChange
  */
 export const OrderEntry = ({
@@ -89,6 +90,7 @@ export const OrderEntry = ({
   autoFocusLimitPrice = false,
   usdPlaceholder,
   limitPricePrefill,
+  pendingDraft,
 }: OrderEntryProps) => {
   const t = useI18nContext();
   const activeProvider = useSelector(selectPerpsActiveProvider);
@@ -141,6 +143,7 @@ export const OrderEntry = ({
     markPrice,
     feeRate,
     limitPricePrefill,
+    pendingDraft,
   });
 
   const isLong = formState.direction === 'long';

--- a/ui/components/app/perps/order-entry/order-entry.types.ts
+++ b/ui/components/app/perps/order-entry/order-entry.types.ts
@@ -150,6 +150,17 @@ export type OrderEntryProps = {
    * price input while manual edits between selections are preserved.
    */
   limitPricePrefill?: { price: string };
+  /**
+   * Fresh per-market draft restored when returning to this symbol inside the
+   * product TTL. Overlays size, leverage, TP/SL, and limit price.
+   */
+  pendingDraft?: {
+    amount?: string;
+    leverage?: number;
+    takeProfitPrice?: string;
+    stopLossPrice?: string;
+    limitPrice?: string;
+  };
 };
 
 /**

--- a/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.test.tsx
+++ b/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
+import {
+  CANDLE_COUNT,
+  CandlePeriod,
+  clampVisibleCandleCount,
+} from '../constants/chartConfig';
 import PerpsCandlestickChart from './perps-candlestick-chart';
 
 const mockUseTheme = jest.fn();
@@ -18,8 +23,15 @@ type CrosshairParam = {
 };
 
 let mockCrosshairCallback: ((param: CrosshairParam) => void) | undefined;
+let mockRangeChangeCallback:
+  | ((range: { from: number; to: number } | null) => void)
+  | undefined;
 let mockCreatedSeries: { ref: object }[] = [];
-let mockCreatedCharts: { panes: jest.Mock; remove: jest.Mock }[] = [];
+let mockCreatedCharts: {
+  panes: jest.Mock;
+  remove: jest.Mock;
+  timeScale: jest.Mock;
+}[] = [];
 
 jest.mock('lightweight-charts', () => ({
   createChart: () => {
@@ -45,7 +57,9 @@ jest.mock('lightweight-charts', () => ({
         scrollToRealTime: jest.fn(),
         getVisibleLogicalRange: jest.fn(),
         setVisibleLogicalRange: jest.fn(),
-        subscribeVisibleLogicalRangeChange: jest.fn(),
+        subscribeVisibleLogicalRangeChange: jest.fn((cb) => {
+          mockRangeChangeCallback = cb;
+        }),
         unsubscribeVisibleLogicalRangeChange: jest.fn(),
         applyOptions: jest.fn(),
       }),
@@ -354,5 +368,82 @@ describe('PerpsCandlestickChart — chart disposal (TAT-3462)', () => {
     const panes = getPanesOf(secondChart);
     expect(panes[0].setHeight).toHaveBeenCalledWith(DEFAULT_MAIN_PANE_HEIGHT);
     expect(panes[1].setHeight).toHaveBeenCalledWith(DEFAULT_VOLUME_PANE_HEIGHT);
+  });
+});
+
+describe('clampVisibleCandleCount', () => {
+  it('clamps to the supported zoom range', () => {
+    expect(clampVisibleCandleCount(60)).toBe(60);
+    expect(clampVisibleCandleCount(1)).toBe(CANDLE_COUNT.MIN);
+    expect(clampVisibleCandleCount(10_000)).toBe(CANDLE_COUNT.MAX);
+    expect(clampVisibleCandleCount(Number.NaN)).toBe(CANDLE_COUNT.DEFAULT);
+  });
+});
+
+describe('PerpsCandlestickChart — visible candle count', () => {
+  const buildCandleData = (count: number) => ({
+    symbol: 'ETH',
+    interval: CandlePeriod.FiveMinutes,
+    candles: Array.from({ length: count }, (_, index) => ({
+      time: 1_700_000_000_000 + index * 60_000,
+      open: '100',
+      high: '110',
+      low: '90',
+      close: '105',
+      volume: '10',
+    })),
+  });
+
+  beforeEach(() => {
+    mockCrosshairCallback = undefined;
+    mockRangeChangeCallback = undefined;
+    mockCreatedSeries = [];
+    mockCreatedCharts = [];
+    mockUseTheme.mockReturnValue('light');
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('applies the persisted visible candle count on first data load', () => {
+    renderWithProvider(
+      <PerpsCandlestickChart
+        visibleCandleCount={60}
+        candleData={buildCandleData(80)}
+      />,
+      mockStore,
+    );
+
+    const timeScale = mockCreatedCharts.at(-1)?.timeScale();
+    expect(timeScale.setVisibleLogicalRange).toHaveBeenCalledWith({
+      from: 20,
+      to: 81,
+    });
+  });
+
+  it('reports a user zoom after debounce', () => {
+    const onVisibleCandleCountChange = jest.fn();
+    renderWithProvider(
+      <PerpsCandlestickChart
+        candleData={buildCandleData(80)}
+        onVisibleCandleCountChange={onVisibleCandleCountChange}
+      />,
+      mockStore,
+    );
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    mockRangeChangeCallback?.({ from: 20, to: 81 });
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(onVisibleCandleCountChange).toHaveBeenCalledWith(60);
   });
 });

--- a/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
+++ b/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
@@ -21,7 +21,11 @@ import {
   formatVolume,
   PRICE_THRESHOLD,
 } from '../../../../../shared/lib/perps-formatters';
-import { CandlePeriod, ZOOM_CONFIG } from '../constants/chartConfig';
+import {
+  CandlePeriod,
+  ZOOM_CONFIG,
+  clampVisibleCandleCount,
+} from '../constants/chartConfig';
 import { useTheme } from '../../../../hooks/useTheme';
 import { getIntlLocale } from '../../../../ducks/locale/locale';
 import {
@@ -80,6 +84,9 @@ export function getPriceFormatForPrice(price: number): {
 /** Cooldown in ms between load-more requests to avoid spamming */
 const LOAD_MORE_COOLDOWN_MS = 2000;
 
+/** Debounce zoom-persist so pinch/scroll does not write on every tick. */
+const VISIBLE_CANDLE_COUNT_PERSIST_MS = 250;
+
 /** Logical range threshold: request more history when user scrolls this close to left edge */
 const EDGE_DETECTION_THRESHOLD = 5;
 
@@ -129,6 +136,13 @@ type PerpsCandlestickChartProps = {
   onNeedMoreHistory?: () => void;
   /** Callback when crosshair moves over a candle (for OHLCV bar). null = crosshair left chart. */
   onCrosshairMove?: (candle: CandleStick | null) => void;
+  /**
+   * How many candles to show. Used on first load and full data replacement.
+   * Persist the value the user pinches to across markets via the parent.
+   */
+  visibleCandleCount?: number;
+  /** Fired after the user changes zoom, already clamped to the supported range. */
+  onVisibleCandleCountChange?: (count: number) => void;
 };
 
 export type PerpsCandlestickChartRef = {
@@ -167,6 +181,8 @@ const PerpsCandlestickChart = forwardRef<
       onPeriodDataRequest,
       onNeedMoreHistory,
       onCrosshairMove,
+      visibleCandleCount = ZOOM_CONFIG.DEFAULT_CANDLES,
+      onVisibleCandleCountChange,
     },
     ref,
   ) => {
@@ -216,6 +232,13 @@ const PerpsCandlestickChart = forwardRef<
     // Suppress crosshair callback during our own data updates to avoid update loop:
     // update()/setData() can cause the library to emit crosshair move → parent setState → re-render → effect runs again.
     const isApplyingDataUpdateRef = useRef<boolean>(false);
+    const isApplyingZoomRef = useRef(false);
+    const lastReportedVisibleCandleCountRef = useRef(
+      clampVisibleCandleCount(visibleCandleCount),
+    );
+    const visibleCandleCountPersistTimeoutRef = useRef<
+      ReturnType<typeof setTimeout> | undefined
+    >(undefined);
 
     // Track created price line objects for cleanup
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -226,6 +249,8 @@ const PerpsCandlestickChart = forwardRef<
     onNeedMoreHistoryRef.current = onNeedMoreHistory;
     const onCrosshairMoveRef = useRef(onCrosshairMove);
     onCrosshairMoveRef.current = onCrosshairMove;
+    const onVisibleCandleCountChangeRef = useRef(onVisibleCandleCountChange);
+    onVisibleCandleCountChangeRef.current = onVisibleCandleCountChange;
 
     // Handle window resize
     const handleResize = useCallback(() => {
@@ -242,20 +267,21 @@ const PerpsCandlestickChart = forwardRef<
         return;
       }
 
-      const actualCount = Math.max(
-        ZOOM_CONFIG.MIN_CANDLES,
-        Math.min(ZOOM_CONFIG.MAX_CANDLES, candleCount),
-      );
+      const actualCount = clampVisibleCandleCount(candleCount);
 
       const dataLength = dataLengthRef.current;
       const from = Math.max(0, dataLength - actualCount);
       const to = dataLength - 1 + 2; // +2 for right padding
 
+      isApplyingZoomRef.current = true;
       chartRef.current.timeScale().setVisibleLogicalRange({ from, to });
 
       if (forceReset) {
         chartRef.current.timeScale().scrollToRealTime();
       }
+      setTimeout(() => {
+        isApplyingZoomRef.current = false;
+      }, 0);
     }, []);
 
     // Scroll to most recent candles
@@ -402,19 +428,51 @@ const PerpsCandlestickChart = forwardRef<
         }
       }, PANE_HEIGHT_APPLY_DELAY_MS);
 
-      // Edge detection: request more history when user scrolls near left edge
+      // Edge detection: request more history when user scrolls near left edge.
+      // Also persist the visible candle count after the user pinches/scrolls.
       chart.timeScale().subscribeVisibleLogicalRangeChange((logicalRange) => {
-        if (!logicalRange || !onNeedMoreHistoryRef.current) {
+        if (!logicalRange) {
           return;
         }
 
-        if (logicalRange.from <= EDGE_DETECTION_THRESHOLD) {
+        if (
+          onNeedMoreHistoryRef.current &&
+          logicalRange.from <= EDGE_DETECTION_THRESHOLD
+        ) {
           const now = Date.now();
           if (now - lastLoadMoreTimeRef.current >= LOAD_MORE_COOLDOWN_MS) {
             lastLoadMoreTimeRef.current = now;
             onNeedMoreHistoryRef.current();
           }
         }
+
+        if (
+          isApplyingZoomRef.current ||
+          isApplyingDataUpdateRef.current ||
+          !onVisibleCandleCountChangeRef.current
+        ) {
+          return;
+        }
+
+        // applyZoom sets `to = dataLength - 1 + 2`, so `to - from - 1` recovers
+        // the candle count that was requested.
+        const nextCount = clampVisibleCandleCount(
+          logicalRange.to - logicalRange.from - 1,
+        );
+        if (nextCount === lastReportedVisibleCandleCountRef.current) {
+          return;
+        }
+        if (visibleCandleCountPersistTimeoutRef.current) {
+          clearTimeout(visibleCandleCountPersistTimeoutRef.current);
+        }
+        visibleCandleCountPersistTimeoutRef.current = setTimeout(() => {
+          visibleCandleCountPersistTimeoutRef.current = undefined;
+          if (isApplyingZoomRef.current || isApplyingDataUpdateRef.current) {
+            return;
+          }
+          lastReportedVisibleCandleCountRef.current = nextCount;
+          onVisibleCandleCountChangeRef.current?.(nextCount);
+        }, VISIBLE_CANDLE_COUNT_PERSIST_MS);
       });
 
       // Crosshair move:
@@ -489,6 +547,10 @@ const PerpsCandlestickChart = forwardRef<
       // Cleanup on unmount / before effect re-runs (e.g. theme change)
       return () => {
         clearTimeout(paneHeightTimeoutId);
+        if (visibleCandleCountPersistTimeoutRef.current) {
+          clearTimeout(visibleCandleCountPersistTimeoutRef.current);
+          visibleCandleCountPersistTimeoutRef.current = undefined;
+        }
         window.removeEventListener('resize', handleResize);
         if (chartRef.current) {
           chartRef.current.remove();
@@ -603,9 +665,9 @@ const PerpsCandlestickChart = forwardRef<
             volumeSeriesRef.current.setData(volumeData as any);
           }
 
-          // Apply default zoom
+          // Apply persisted zoom (or the default candle count)
           const visibleCandles = Math.min(
-            ZOOM_CONFIG.DEFAULT_CANDLES,
+            clampVisibleCandleCount(visibleCandleCount),
             formattedData.length,
           );
           const dataLength = formattedData.length;
@@ -644,6 +706,7 @@ const PerpsCandlestickChart = forwardRef<
       onPeriodDataRequest,
       volumeUpColor,
       volumeDownColor,
+      visibleCandleCount,
     ]);
 
     // Update y-axis price format when the asset's price range changes.

--- a/ui/hooks/perps/index.ts
+++ b/ui/hooks/perps/index.ts
@@ -1,4 +1,5 @@
 export { usePerpsOrderForm } from './usePerpsOrderForm';
+export { usePerpsSavePendingConfig } from './usePerpsSavePendingConfig';
 export { usePerpsEligibility } from './usePerpsEligibility';
 export { usePerpsMeasurement } from './usePerpsMeasurement';
 export { usePerpsLifecycleBreadcrumbs } from './usePerpsLifecycleBreadcrumbs';

--- a/ui/hooks/perps/perps-pending-trade-config.test.ts
+++ b/ui/hooks/perps/perps-pending-trade-config.test.ts
@@ -1,0 +1,84 @@
+import type { OrderFormState } from '../../components/app/perps/order-entry/order-entry.types';
+import {
+  PERPS_PENDING_TRADE_CONFIG_TTL_MS,
+  isPendingTradeConfigFresh,
+  pendingDraftFromFormState,
+} from './perps-pending-trade-config';
+
+const formState = (
+  overrides: Partial<OrderFormState> = {},
+): OrderFormState => ({
+  asset: 'BTC',
+  direction: 'long',
+  closePercent: 100,
+  amount: '1,000',
+  leverage: 10,
+  balancePercent: 20,
+  takeProfitPrice: '50000',
+  stopLossPrice: '40000',
+  limitPrice: '45000',
+  type: 'limit',
+  autoCloseEnabled: true,
+  ...overrides,
+});
+
+describe('isPendingTradeConfigFresh', () => {
+  it('returns true inside the restore window', () => {
+    expect(
+      isPendingTradeConfigFresh(
+        1_000,
+        1_000 + PERPS_PENDING_TRADE_CONFIG_TTL_MS,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false after the restore window', () => {
+    expect(
+      isPendingTradeConfigFresh(
+        1_000,
+        1_000 + PERPS_PENDING_TRADE_CONFIG_TTL_MS + 1,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for a non-finite timestamp', () => {
+    expect(isPendingTradeConfigFresh(Number.NaN)).toBe(false);
+  });
+});
+
+describe('pendingDraftFromFormState', () => {
+  it('strips grouping separators from amount and keeps TP/SL when auto-close is on', () => {
+    expect(pendingDraftFromFormState(formState())).toStrictEqual({
+      amount: '1000',
+      leverage: 10,
+      takeProfitPrice: '50000',
+      stopLossPrice: '40000',
+      limitPrice: '45000',
+      orderType: 'limit',
+      direction: 'long',
+    });
+  });
+
+  it('omits TP/SL when auto-close is off', () => {
+    expect(
+      pendingDraftFromFormState(
+        formState({ autoCloseEnabled: false, type: 'market', limitPrice: '' }),
+      ),
+    ).toStrictEqual({
+      amount: '1000',
+      leverage: 10,
+      takeProfitPrice: undefined,
+      stopLossPrice: undefined,
+      limitPrice: undefined,
+      orderType: 'market',
+      direction: 'long',
+    });
+  });
+
+  it('omits a zero amount', () => {
+    expect(
+      pendingDraftFromFormState(formState({ amount: '0', type: 'market' }))
+        .amount,
+    ).toBeUndefined();
+  });
+});

--- a/ui/hooks/perps/perps-pending-trade-config.ts
+++ b/ui/hooks/perps/perps-pending-trade-config.ts
@@ -1,0 +1,85 @@
+import type { OrderType } from '@metamask/perps-controller';
+import type {
+  OrderDirection,
+  OrderFormState,
+} from '../../components/app/perps/order-entry/order-entry.types';
+
+/**
+ * Restore a trade draft only during a brief navigation away from
+ * `/perps/trade/:symbol` (chart check, glance at another market).
+ *
+ * Core 13.x expires drafts at 30s; this 60s window is the Extension v1
+ * product choice. The controller still stores the record — we enforce the
+ * product TTL on read.
+ */
+export const PERPS_PENDING_TRADE_CONFIG_TTL_MS = 60_000;
+
+export type PerpsPendingTradeDraft = {
+  amount?: string;
+  leverage?: number;
+  takeProfitPrice?: string;
+  stopLossPrice?: string;
+  limitPrice?: string;
+  orderType?: OrderType;
+  direction?: OrderDirection;
+};
+
+export type PerpsPendingTradeConfigRecord = PerpsPendingTradeDraft & {
+  timestamp: number;
+};
+
+/**
+ * Whether a saved draft is still inside the restore window.
+ *
+ * @param timestamp - When the draft was saved, in ms.
+ * @param now - Clock used for the age check.
+ * @returns True when the draft should still be restored.
+ */
+export function isPendingTradeConfigFresh(
+  timestamp: number,
+  now: number = Date.now(),
+): boolean {
+  if (!Number.isFinite(timestamp)) {
+    return false;
+  }
+  return now - timestamp <= PERPS_PENDING_TRADE_CONFIG_TTL_MS;
+}
+
+/**
+ * Build the payload written to `savePendingTradeConfiguration`.
+ *
+ * Empty TP/SL/limit fields are omitted so a later restore cannot re-enable
+ * auto-close from leftover blanks. Amount is the raw USD string without
+ * grouping separators.
+ *
+ * @param formState - Live order form snapshot.
+ * @returns Draft fields to persist for the current market.
+ */
+export function pendingDraftFromFormState(
+  formState: OrderFormState,
+): PerpsPendingTradeDraft {
+  const amount = formState.amount.replace(/,/gu, '').trim();
+  const parsedAmount = Number.parseFloat(amount);
+  const takeProfitPrice =
+    formState.autoCloseEnabled && formState.takeProfitPrice.trim()
+      ? formState.takeProfitPrice
+      : undefined;
+  const stopLossPrice =
+    formState.autoCloseEnabled && formState.stopLossPrice.trim()
+      ? formState.stopLossPrice
+      : undefined;
+  const limitPrice =
+    formState.type === 'limit' && formState.limitPrice.trim()
+      ? formState.limitPrice
+      : undefined;
+
+  return {
+    ...(Number.isFinite(parsedAmount) && parsedAmount > 0 ? { amount } : {}),
+    leverage: formState.leverage,
+    takeProfitPrice,
+    stopLossPrice,
+    limitPrice,
+    orderType: formState.type,
+    direction: formState.direction,
+  };
+}

--- a/ui/hooks/perps/usePerpsOrderForm.test.ts
+++ b/ui/hooks/perps/usePerpsOrderForm.test.ts
@@ -24,6 +24,7 @@ describe('usePerpsOrderForm', () => {
   };
 
   beforeEach(() => {
+    jest.mocked(submitRequestToBackground).mockClear();
     jest.mocked(submitRequestToBackground).mockImplementation((method) => {
       const immediate = <ResolvedValue>(
         value: ResolvedValue,
@@ -415,6 +416,47 @@ describe('usePerpsOrderForm', () => {
       });
 
       expect(result.current.formState.leverage).toBe(10);
+    });
+
+    it('persists leverage for new orders', () => {
+      const { result } = renderHookWithProvider(
+        () => usePerpsOrderForm(defaultOptions),
+        mockStateWithLocale,
+      );
+
+      act(() => {
+        result.current.handleLeverageChange(10);
+      });
+
+      expect(submitRequestToBackground).toHaveBeenCalledWith(
+        'perpsSaveTradeConfiguration',
+        ['BTC', 10],
+      );
+    });
+
+    it('does not persist leverage in modify mode', () => {
+      const { result } = renderHookWithProvider(
+        () =>
+          usePerpsOrderForm({
+            ...defaultOptions,
+            mode: 'modify',
+            existingPosition: {
+              size: '1',
+              leverage: 3,
+              entryPrice: '44000',
+            },
+          }),
+        mockStateWithLocale,
+      );
+
+      act(() => {
+        result.current.handleLeverageChange(10);
+      });
+
+      expect(submitRequestToBackground).not.toHaveBeenCalledWith(
+        'perpsSaveTradeConfiguration',
+        expect.anything(),
+      );
     });
 
     it('handleAutoCloseEnabledChange updates autoCloseEnabled', () => {
@@ -849,6 +891,65 @@ describe('usePerpsOrderForm', () => {
           amount: '500',
         }),
       );
+    });
+  });
+
+  describe('pending draft restore', () => {
+    const pendingDraft = {
+      amount: '250',
+      leverage: 8,
+      takeProfitPrice: '50000',
+      stopLossPrice: '40000',
+      limitPrice: '45000',
+    };
+
+    it('restores size, leverage, TP/SL, and limit price', () => {
+      const { result } = renderHookWithProvider(
+        () =>
+          usePerpsOrderForm({
+            ...defaultOptions,
+            availableBalance: 1000,
+            pendingDraft,
+          }),
+        mockStateWithLocale,
+      );
+
+      expect(result.current.formState).toMatchObject({
+        amount: '250',
+        leverage: 8,
+        takeProfitPrice: '50000',
+        stopLossPrice: '40000',
+        limitPrice: '45000',
+        autoCloseEnabled: true,
+      });
+    });
+
+    it('does not re-apply the draft when only direction changes', () => {
+      let initialDirection: 'long' | 'short' = 'long';
+      const { result, rerender } = renderHookWithProvider(
+        () =>
+          usePerpsOrderForm({
+            ...defaultOptions,
+            availableBalance: 1000,
+            szDecimals: 6,
+            initialDirection,
+            pendingDraft,
+          }),
+        mockStateWithLocale,
+      );
+
+      expect(result.current.formState.amount).toBe('250');
+
+      initialDirection = 'short';
+      act(() => {
+        rerender();
+      });
+
+      expect(result.current.formState.direction).toBe('short');
+      expect(result.current.formState.amount).not.toBe('250');
+      expect(result.current.formState.takeProfitPrice).toBe('');
+      expect(result.current.formState.stopLossPrice).toBe('');
+      expect(result.current.formState.limitPrice).toBe('');
     });
   });
 });

--- a/ui/hooks/perps/usePerpsOrderForm.ts
+++ b/ui/hooks/perps/usePerpsOrderForm.ts
@@ -22,6 +22,8 @@ import type {
   ExistingPositionData,
 } from '../../components/app/perps/order-entry/order-entry.types';
 import { selectPerpsIsTestnet } from '../../selectors/perps-controller';
+import { submitRequestToBackground } from '../../store/background-connection';
+import type { PerpsPendingTradeDraft } from './perps-pending-trade-config';
 import { usePerpsLiquidationPrice } from './usePerpsLiquidationPrice';
 
 function calculateFallbackLiquidationPrice(
@@ -79,6 +81,33 @@ function buildDefaultNewOrderAmountFields(
     // writer of balancePercent (slider, size input, percent field, leverage)
     // already yields a whole number, which is why only initial load was wrong.
     balancePercent: Math.round(initialBalancePercent),
+  };
+}
+
+function applyPendingDraft(
+  base: OrderFormState,
+  pending: PerpsPendingTradeDraft,
+  availableBalance: number,
+): OrderFormState {
+  const leverage = pending.leverage ?? base.leverage;
+  const rawAmount = pending.amount?.replace(/,/gu, '');
+  const amountFields = rawAmount
+    ? buildDefaultNewOrderAmountFields(rawAmount, leverage, availableBalance)
+    : {};
+  const takeProfitPrice = pending.takeProfitPrice ?? base.takeProfitPrice;
+  const stopLossPrice = pending.stopLossPrice ?? base.stopLossPrice;
+
+  return {
+    ...base,
+    leverage,
+    ...amountFields,
+    takeProfitPrice: takeProfitPrice ?? '',
+    stopLossPrice: stopLossPrice ?? '',
+    limitPrice: pending.limitPrice ?? base.limitPrice,
+    autoCloseEnabled: Boolean(
+      (takeProfitPrice && takeProfitPrice !== '') ||
+      (stopLossPrice && stopLossPrice !== ''),
+    ),
   };
 }
 
@@ -147,6 +176,13 @@ export type UsePerpsOrderFormOptions = {
    * fresh object per selection; a stable reference is ignored on re-render.
    */
   limitPricePrefill?: { price: string };
+  /**
+   * Fresh per-market draft restored when returning to this symbol inside the
+   * product TTL. Size/TP/SL/limit/leverage overlay the default new-order
+   * seed. Direction and order type are applied by the caller via
+   * `initialDirection` / `orderType` so a URL direction change can skip this.
+   */
+  pendingDraft?: PerpsPendingTradeDraft;
 };
 
 export type UsePerpsOrderFormReturn = {
@@ -208,6 +244,7 @@ export type UsePerpsOrderFormReturn = {
  * @param options.markPrice - Oracle mark price for margin calculation (falls back to currentPrice)
  * @param options.feeRate - Dynamic fee rate from usePerpsOrderFees (falls back to static constant)
  * @param options.limitPricePrefill - One-shot limit-price prefill (fresh object per selection)
+ * @param options.pendingDraft - Fresh per-market draft to restore on this symbol
  * @returns Form state, handlers, and calculated values
  */
 export function usePerpsOrderForm({
@@ -227,11 +264,14 @@ export function usePerpsOrderForm({
   markPrice,
   feeRate,
   limitPricePrefill,
+  pendingDraft,
 }: UsePerpsOrderFormOptions): UsePerpsOrderFormReturn {
   const displayAssetSymbol = getDisplaySymbol(asset);
   const isTestnet = useSelector(selectPerpsIsTestnet);
   const defaultLeverage = initialLeverage ?? TRADING_DEFAULTS.leverage;
-  const hasUserEditedAmount = useRef(false);
+  const hasUserEditedAmount = useRef(
+    mode === 'new' && Boolean(pendingDraft?.amount),
+  );
 
   const computeInitialAmountValue = useCallback(
     (leverage: number): string => {
@@ -297,7 +337,7 @@ export function usePerpsOrderForm({
         ...deriveModifyFields(existingPosition),
       };
     }
-    return {
+    const initial = {
       ...mockOrderFormDefaults,
       asset,
       direction: initialDirection,
@@ -309,6 +349,9 @@ export function usePerpsOrderForm({
         availableBalance,
       ),
     };
+    return mode === 'new' && pendingDraft
+      ? applyPendingDraft(initial, pendingDraft, availableBalance)
+      : initial;
   });
 
   // Update order type when prop changes (from dropdown)
@@ -357,6 +400,14 @@ export function usePerpsOrderForm({
       initialLeverage,
     });
 
+    const directionChanged =
+      prevResetDeps !== null &&
+      prevResetDeps.initialDirection !== initialDirection &&
+      prevResetDeps.asset === asset &&
+      prevResetDeps.mode === mode;
+    const shouldRestorePending =
+      mode === 'new' && Boolean(pendingDraft) && !directionChanged;
+
     const resetLeverage = initialLeverage ?? TRADING_DEFAULTS.leverage;
     const defaultAmountFields =
       mode === 'new'
@@ -367,7 +418,9 @@ export function usePerpsOrderForm({
           )
         : {};
 
-    hasUserEditedAmount.current = false;
+    hasUserEditedAmount.current = Boolean(
+      shouldRestorePending && pendingDraft?.amount,
+    );
     if (mode === 'modify' && existingPosition) {
       setFormState({
         ...mockOrderFormDefaults,
@@ -377,14 +430,19 @@ export function usePerpsOrderForm({
         ...deriveModifyFields(existingPosition),
       });
     } else {
-      setFormState({
+      const resetState: OrderFormState = {
         ...mockOrderFormDefaults,
         asset,
         direction: initialDirection,
         type: orderType,
         ...(initialLeverage !== undefined && { leverage: initialLeverage }),
         ...defaultAmountFields,
-      });
+      };
+      setFormState(
+        shouldRestorePending && pendingDraft
+          ? applyPendingDraft(resetState, pendingDraft, availableBalance)
+          : resetState,
+      );
     }
   }
 
@@ -613,8 +671,16 @@ export function usePerpsOrderForm({
           maxSize > 0 ? Math.min(Math.round((amount / maxSize) * 100), 100) : 0;
         return { ...prev, leverage, balancePercent };
       });
+      if (mode === 'new' && asset) {
+        submitRequestToBackground('perpsSaveTradeConfiguration', [
+          asset,
+          leverage,
+        ]).catch((error) => {
+          console.warn('[Perps] Save trade configuration failed:', error);
+        });
+      }
     },
-    [availableBalance],
+    [availableBalance, asset, mode],
   );
 
   const handleAutoCloseEnabledChange = useCallback((enabled: boolean) => {

--- a/ui/hooks/perps/usePerpsSavePendingConfig.test.ts
+++ b/ui/hooks/perps/usePerpsSavePendingConfig.test.ts
@@ -1,0 +1,126 @@
+import { renderHook } from '@testing-library/react';
+import type { OrderFormState } from '../../components/app/perps/order-entry/order-entry.types';
+import { submitRequestToBackground } from '../../store/background-connection';
+import { usePerpsSavePendingConfig } from './usePerpsSavePendingConfig';
+
+jest.mock('../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockSubmitRequestToBackground = jest.mocked(submitRequestToBackground);
+
+const formState: OrderFormState = {
+  asset: 'BTC',
+  direction: 'long',
+  closePercent: 100,
+  amount: '250',
+  leverage: 8,
+  balancePercent: 10,
+  takeProfitPrice: '',
+  stopLossPrice: '',
+  limitPrice: '',
+  type: 'market',
+  autoCloseEnabled: false,
+};
+
+describe('usePerpsSavePendingConfig', () => {
+  beforeEach(() => {
+    mockSubmitRequestToBackground.mockClear();
+  });
+
+  it('saves the draft for the current asset on unmount', () => {
+    const skipRef = { current: false };
+    const { unmount } = renderHook(() =>
+      usePerpsSavePendingConfig({
+        asset: 'BTC',
+        formState,
+        enabled: true,
+        skipRef,
+      }),
+    );
+
+    unmount();
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'perpsSavePendingTradeConfiguration',
+      [
+        'BTC',
+        expect.objectContaining({
+          amount: '250',
+          leverage: 8,
+          orderType: 'market',
+          direction: 'long',
+        }),
+      ],
+    );
+  });
+
+  it('saves the previous asset when the symbol changes', () => {
+    const skipRef = { current: false };
+    const { rerender } = renderHook(
+      ({ asset }: { asset: string }) =>
+        usePerpsSavePendingConfig({
+          asset,
+          formState,
+          enabled: true,
+          skipRef,
+        }),
+      { initialProps: { asset: 'BTC' } },
+    );
+
+    rerender({ asset: 'ETH' });
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'perpsSavePendingTradeConfiguration',
+      ['BTC', expect.objectContaining({ amount: '250' })],
+    );
+  });
+
+  it('does not save when skipRef is set', () => {
+    const skipRef = { current: true };
+    const { unmount } = renderHook(() =>
+      usePerpsSavePendingConfig({
+        asset: 'BTC',
+        formState,
+        enabled: true,
+        skipRef,
+      }),
+    );
+
+    unmount();
+
+    expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
+  });
+
+  it('does not save when disabled', () => {
+    const skipRef = { current: false };
+    const { unmount } = renderHook(() =>
+      usePerpsSavePendingConfig({
+        asset: 'BTC',
+        formState,
+        enabled: false,
+        skipRef,
+      }),
+    );
+
+    unmount();
+
+    expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
+  });
+
+  it('does not save when the form has not hydrated', () => {
+    const skipRef = { current: false };
+    const { unmount } = renderHook(() =>
+      usePerpsSavePendingConfig({
+        asset: 'BTC',
+        formState: null,
+        enabled: true,
+        skipRef,
+      }),
+    );
+
+    unmount();
+
+    expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
+  });
+});

--- a/ui/hooks/perps/usePerpsSavePendingConfig.ts
+++ b/ui/hooks/perps/usePerpsSavePendingConfig.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import type { MutableRefObject } from 'react';
+import type { OrderFormState } from '../../components/app/perps/order-entry/order-entry.types';
+import { submitRequestToBackground } from '../../store/background-connection';
+import { pendingDraftFromFormState } from './perps-pending-trade-config';
+
+export type UsePerpsSavePendingConfigOptions = {
+  /** Market the draft belongs to. */
+  asset?: string;
+  /** Latest form snapshot; ignored while null. */
+  formState: OrderFormState | null;
+  /** When false, unmount/symbol-change must not write a draft (close/modify). */
+  enabled: boolean;
+  /** Set true after a successful order so unmount does not re-save the filled form. */
+  skipRef: MutableRefObject<boolean>;
+};
+
+/**
+ * Persist the live order form when the user leaves `/perps/trade/:symbol`
+ * or switches markets. Restored by `selectPendingTradeConfiguration` if they
+ * return to the same symbol inside the product TTL.
+ *
+ * Writes only on unmount / symbol change — not on every keystroke — so the
+ * TTL clock starts at the moment they leave, matching mobile.
+ *
+ * @param options - Asset, form snapshot, and skip/enabled flags.
+ * @param options.asset
+ * @param options.formState
+ * @param options.enabled
+ * @param options.skipRef
+ */
+export function usePerpsSavePendingConfig({
+  asset,
+  formState,
+  enabled,
+  skipRef,
+}: UsePerpsSavePendingConfigOptions): void {
+  const formStateRef = useRef(formState);
+  const enabledRef = useRef(enabled);
+
+  useLayoutEffect(() => {
+    formStateRef.current = formState;
+    enabledRef.current = enabled;
+  });
+
+  const saveForAsset = useCallback(
+    (symbol: string | undefined) => {
+      if (skipRef.current || !enabledRef.current || !symbol) {
+        return;
+      }
+      const { current } = formStateRef;
+      if (!current) {
+        return;
+      }
+      submitRequestToBackground('perpsSavePendingTradeConfiguration', [
+        symbol,
+        pendingDraftFromFormState(current),
+      ]).catch((error) => {
+        console.warn('[Perps] Save pending trade configuration failed:', error);
+      });
+    },
+    [skipRef],
+  );
+
+  useEffect(() => {
+    return () => {
+      saveForAsset(asset);
+    };
+  }, [asset, saveForAsset]);
+}

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -91,6 +91,7 @@ import {
   CandlePeriod,
   TimeDuration,
   ZOOM_CONFIG,
+  clampVisibleCandleCount,
 } from '../../components/app/perps/constants/chartConfig';
 import {
   getDisplaySymbol,
@@ -576,11 +577,11 @@ const PerpsMarketDetailPage = () => {
 
   // Candle period: persisted in PreferencesController across sessions/markets.
   // Local override gives instant UI feedback; background save persists for next visit.
-  const { perpsSelectedCandlePeriod: persistedCandlePeriod, privacyMode } =
-    useSelector(getPreferences) as {
-      perpsSelectedCandlePeriod?: string;
-      privacyMode?: boolean;
-    };
+  const {
+    perpsSelectedCandlePeriod: persistedCandlePeriod,
+    perpsVisibleCandleCount: persistedVisibleCandleCount,
+    privacyMode,
+  } = useSelector(getPreferences);
 
   const positionPnlColor = getPrivacyAwareColor(
     position && parseFloat(position.unrealizedPnl) < 0
@@ -602,6 +603,14 @@ const PerpsMarketDetailPage = () => {
   const [localPeriodOverride, setLocalPeriodOverride] =
     useState<CandlePeriod | null>(null);
   const selectedPeriod = localPeriodOverride ?? resolvedPersistedPeriod;
+  const [localVisibleCandleCount, setLocalVisibleCandleCount] = useState<
+    number | null
+  >(null);
+  const visibleCandleCount =
+    localVisibleCandleCount ??
+    clampVisibleCandleCount(
+      persistedVisibleCandleCount ?? ZOOM_CONFIG.DEFAULT_CANDLES,
+    );
   const chartRef = useRef<PerpsCandlestickChartRef>(null);
 
   // Live candle data from CandleStreamChannel
@@ -811,17 +820,31 @@ const PerpsMarketDetailPage = () => {
   //
   // 5. MOBILE REFERENCE: See usePerpsLiveCandles hook, CandleStreamChannel,
   // and HyperLiquidClientService.subscribeToCandles() in the mobile app.
-  const handlePeriodChange = useCallback((period: CandlePeriod) => {
-    setLocalPeriodOverride(period);
+  const handlePeriodChange = useCallback(
+    (period: CandlePeriod) => {
+      setLocalPeriodOverride(period);
+      submitRequestToBackground('setPreference', [
+        'perpsSelectedCandlePeriod',
+        period,
+      ]).catch(() => {
+        // Preference save is best-effort; chart still updates via local state.
+      });
+      if (chartRef.current) {
+        chartRef.current.applyZoom(visibleCandleCount, true);
+      }
+    },
+    [visibleCandleCount],
+  );
+
+  const handleVisibleCandleCountChange = useCallback((count: number) => {
+    const next = clampVisibleCandleCount(count);
+    setLocalVisibleCandleCount(next);
     submitRequestToBackground('setPreference', [
-      'perpsSelectedCandlePeriod',
-      period,
+      'perpsVisibleCandleCount',
+      next,
     ]).catch(() => {
-      // Preference save is best-effort; chart still updates via local state.
+      // Preference save is best-effort; the live chart already reflects zoom.
     });
-    if (chartRef.current) {
-      chartRef.current.applyZoom(ZOOM_CONFIG.DEFAULT_CANDLES, true);
-    }
   }, []);
 
   const handleBackClick = useCallback(() => {
@@ -1164,6 +1187,8 @@ const PerpsMarketDetailPage = () => {
         currentPrice={currentPrice}
         priceLines={chartPriceLines}
         onNeedMoreHistory={fetchMoreHistory}
+        visibleCandleCount={visibleCandleCount}
+        onVisibleCandleCountChange={handleVisibleCandleCountChange}
         // onCrosshairMove={setHoveredCandle}
       />
     );

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -410,6 +410,35 @@ describe('PerpsOrderEntryPage', () => {
     },
   });
 
+  const createMockStateWithPending = (
+    pendingConfig: Record<string, unknown>,
+    extra?: {
+      preferences?: Record<string, unknown>;
+      leverage?: number;
+    },
+  ) => {
+    const state = createMockState();
+    (state.metamask as Record<string, unknown>).tradeConfigurations = {
+      mainnet: {
+        ETH: {
+          ...(extra?.leverage !== undefined && { leverage: extra.leverage }),
+          pendingConfig,
+        },
+      },
+      testnet: {},
+    };
+    if (extra?.preferences) {
+      (
+        state.metamask as { preferences?: Record<string, unknown> }
+      ).preferences = {
+        ...((state.metamask as { preferences?: Record<string, unknown> })
+          .preferences ?? {}),
+        ...extra.preferences,
+      };
+    }
+    return state;
+  };
+
   afterEach(async () => {
     // The abandon emit is deferred one macrotask (StrictMode probe guard). RTL
     // has already unmounted by now, so drain it here — otherwise it fires
@@ -1299,6 +1328,156 @@ describe('PerpsOrderEntryPage', () => {
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       expect(screen.getByTestId('limit-price-input')).toBeInTheDocument();
+    });
+
+    it('restores session order type from preferences when the URL omits it', () => {
+      const store = mockStore(
+        createMockStateWithPending(
+          { timestamp: Date.now() },
+          { preferences: { perpsSelectedOrderType: 'limit' } },
+        ),
+      );
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      expect(screen.getByTestId('limit-price-input')).toBeInTheDocument();
+      expect(screen.getByTestId('order-type-limit')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+  });
+
+  describe('order form persistence', () => {
+    const freshPending = {
+      amount: '250',
+      leverage: 8,
+      orderType: 'limit' as const,
+      direction: 'short' as const,
+      limitPrice: '3000',
+      takeProfitPrice: '3500',
+      stopLossPrice: '2500',
+      timestamp: Date.now(),
+    };
+
+    it('restores a fresh pending draft for the same market', () => {
+      const store = mockStore(createMockStateWithPending(freshPending));
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountInput = screen
+        .getByTestId('amount-input-field')
+        .querySelector('input');
+      const leverageInput = screen
+        .getByTestId('leverage-input')
+        .querySelector('input');
+      const limitInput = screen
+        .getByTestId('limit-price-input')
+        .querySelector('input');
+      const tpInput = screen
+        .getByTestId('tp-price-input')
+        .querySelector('input');
+
+      expect(amountInput).toHaveValue('250');
+      expect(leverageInput).toHaveValue('8');
+      expect(limitInput).toHaveValue('3000');
+      expect(tpInput).toHaveValue('3500');
+      expect(screen.getByTestId('submit-order-button')).toHaveTextContent(
+        'Open short',
+      );
+    });
+
+    it('does not restore an expired pending draft', () => {
+      const store = mockStore(
+        createMockStateWithPending({
+          ...freshPending,
+          timestamp: Date.now() - 61_000,
+        }),
+      );
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountInput = screen
+        .getByTestId('amount-input-field')
+        .querySelector('input');
+      expect(amountInput).not.toHaveValue('250');
+      expect(screen.queryByTestId('limit-price-input')).not.toBeInTheDocument();
+      expect(screen.getByTestId('submit-order-button')).toHaveTextContent(
+        'Open long',
+      );
+    });
+
+    it('does not restore a pending draft when the URL direction conflicts', () => {
+      mockSearchParams.set('direction', 'long');
+      const store = mockStore(createMockStateWithPending(freshPending));
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountInput = screen
+        .getByTestId('amount-input-field')
+        .querySelector('input');
+      expect(amountInput).not.toHaveValue('250');
+      expect(screen.getByTestId('submit-order-button')).toHaveTextContent(
+        'Open long',
+      );
+    });
+
+    it('saves the live form when leaving the market', () => {
+      const { unmount } = renderWithProvider(
+        <PerpsOrderEntryPage />,
+        mockStore(createMockState()),
+      );
+
+      enterAmount('100');
+      unmount();
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'perpsSavePendingTradeConfiguration',
+        [
+          'ETH',
+          expect.objectContaining({
+            amount: '100',
+            direction: 'long',
+            orderType: 'market',
+          }),
+        ],
+      );
+    });
+
+    it('clears the draft after a successful order and does not re-save on unmount', async () => {
+      mockSubmitRequestToBackground.mockResolvedValue({ success: true });
+      const { unmount } = renderWithProvider(
+        <PerpsOrderEntryPage />,
+        mockStore(createMockState()),
+      );
+
+      enterAmount('100');
+      await waitFor(() =>
+        expect(screen.getByTestId('submit-order-button')).not.toBeDisabled(),
+      );
+      mockSubmitRequestToBackground.mockClear();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit-order-button'));
+      });
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'perpsClearPendingTradeConfiguration',
+        ['ETH'],
+      );
+
+      unmount();
+
+      expect(mockSubmitRequestToBackground).not.toHaveBeenCalledWith(
+        'perpsSavePendingTradeConfiguration',
+        expect.anything(),
+      );
+    });
+
+    it('persists the chosen order type for the session', () => {
+      renderWithProvider(<PerpsOrderEntryPage />, mockStore(createMockState()));
+
+      fireEvent.click(screen.getByTestId('order-type-limit'));
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'setPreference',
+        ['perpsSelectedOrderType', 'limit'],
+      );
     });
   });
 
@@ -2645,6 +2824,10 @@ describe('PerpsOrderEntryPage', () => {
           key: 'perpsToastOrderSubmitted',
           autoHideTime: 3000,
         }),
+      );
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'perpsClearPendingTradeConfiguration',
+        ['ETH'],
       );
     });
 

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -54,6 +54,7 @@ import {
   getIsPerpsSlippageConfigEnabled,
 } from '../../selectors/perps/feature-flags';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
+import { getPreferences } from '../../../shared/lib/selectors/preferences';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import {
   DEFAULT_ROUTE,
@@ -67,12 +68,14 @@ import {
   usePerpsLiveCandles,
 } from '../../hooks/perps/stream';
 import {
+  type PerpsState,
   selectPerpsDepositPending,
   selectPerpsTradeConfigurations,
   selectPerpsIsTestnet,
   selectPerpsActiveProvider,
   selectOrderBookPosition,
   selectOrderBookExpanded,
+  selectPendingTradeConfiguration,
 } from '../../selectors/perps-controller';
 import {
   CandlePeriod,
@@ -83,6 +86,7 @@ import {
   usePerpsEstimatedSlippage,
   usePerpsEventTracking,
   usePerpsMaxSlippage,
+  usePerpsSavePendingConfig,
 } from '../../hooks/perps';
 import { usePerpsAttribution } from '../../hooks/perps/usePerpsAttribution';
 import { usePerpsAbandonOrderTracking } from '../../hooks/perps/usePerpsAbandonOrderTracking';
@@ -99,6 +103,7 @@ import { useSelectedAccountComplianceGate } from '../../components/app/complianc
 import { usePerpsDepositConfirmation } from '../../components/app/perps/hooks/usePerpsDepositConfirmation';
 import { getPerpsStreamManager } from '../../providers/perps';
 import { submitRequestToBackground } from '../../store/background-connection';
+import type { MetaMaskReduxState } from '../../store/store';
 import type { PerpsBackgroundResult } from '../../components/app/perps/types';
 import {
   getDisplaySymbol,
@@ -184,6 +189,18 @@ export function shouldShowPerpsOrderSubmissionToasts(
   hasPendingPerpsDeposit: boolean,
 ) {
   return !hasPendingPerpsDeposit;
+}
+
+function isOrderDirection(
+  value: string | null | undefined,
+): value is OrderDirection {
+  return value === 'long' || value === 'short';
+}
+
+function isPerpsOrderType(
+  value: string | null | undefined,
+): value is OrderType {
+  return value === 'market' || value === 'limit';
 }
 
 /**
@@ -347,6 +364,8 @@ const PerpsOrderEntryPage = () => {
   const activeProvider = useSelector(selectPerpsActiveProvider);
   const hasPendingPerpsDeposit = useSelector(selectPerpsDepositPending);
   const orderBookPosition = useSelector(selectOrderBookPosition);
+  const { perpsSelectedOrderType: persistedOrderTypePreference } =
+    useSelector(getPreferences);
   const isOrderBookOnLeft = orderBookPosition === 'left';
   const { trigger: triggerDeposit, isLoading: isDepositLoading } =
     usePerpsDepositConfirmation();
@@ -367,6 +386,10 @@ const PerpsOrderEntryPage = () => {
     }
     return safeDecodeURIComponent(symbol);
   }, [symbol]);
+
+  const pendingTradeConfig = useSelector((state: MetaMaskReduxState) =>
+    selectPendingTradeConfiguration(state as PerpsState, decodedSymbol ?? ''),
+  );
 
   // Computed before the screen-view tracking below so the trading event can be
   // gated on the market existing (an unknown symbol renders the error state).
@@ -450,12 +473,24 @@ const PerpsOrderEntryPage = () => {
   const directionParam = searchParams.get('direction');
   const modeParam = searchParams.get('mode');
   const orderTypeParam = searchParams.get('orderType');
+  const urlDirection = isOrderDirection(directionParam)
+    ? directionParam
+    : undefined;
+  const urlOrderType = isPerpsOrderType(orderTypeParam)
+    ? orderTypeParam
+    : undefined;
+  const persistedOrderType = isPerpsOrderType(persistedOrderTypePreference)
+    ? persistedOrderTypePreference
+    : undefined;
+  const pendingOrderType = isPerpsOrderType(pendingTradeConfig?.orderType)
+    ? pendingTradeConfig.orderType
+    : undefined;
 
   const [orderDirection, setOrderDirection] = useState<OrderDirection>(
-    (directionParam === 'short' ? 'short' : 'long') as OrderDirection,
+    urlDirection ?? pendingTradeConfig?.direction ?? 'long',
   );
   const [orderType, setOrderType] = useState<OrderType>(
-    (orderTypeParam === 'limit' ? 'limit' : 'market') as OrderType,
+    urlOrderType ?? persistedOrderType ?? pendingOrderType ?? 'market',
   );
   // One-shot limit-price prefill from tapping an order-book price row. A fresh
   // object per tap lets the form re-apply the same price after a manual edit.
@@ -470,11 +505,24 @@ const PerpsOrderEntryPage = () => {
   const [orderFormState, setOrderFormState] = useState<OrderFormState | null>(
     null,
   );
+  const shouldRestorePendingDraft =
+    orderMode === 'new' &&
+    Boolean(pendingTradeConfig) &&
+    (!urlDirection ||
+      !pendingTradeConfig?.direction ||
+      urlDirection === pendingTradeConfig.direction);
   const [orderCalculations, setOrderCalculations] =
     useState<OrderCalculations | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSlippageModalOpen, setIsSlippageModalOpen] = useState(false);
+
+  usePerpsSavePendingConfig({
+    asset: decodedSymbol,
+    formState: orderFormState,
+    enabled: orderMode === 'new',
+    skipRef: hasSubmittedOrderRef,
+  });
   const {
     maxSlippageBps,
     maxSlippageSource,
@@ -1320,6 +1368,16 @@ const PerpsOrderEntryPage = () => {
     [],
   );
 
+  const persistOrderType = useCallback((nextType: OrderType) => {
+    setOrderType(nextType);
+    submitRequestToBackground('setPreference', [
+      'perpsSelectedOrderType',
+      nextType,
+    ]).catch((error) => {
+      console.warn('[Perps] Save order type preference failed:', error);
+    });
+  }, []);
+
   const handleDirectionChange = useCallback(
     (direction: OrderDirection) => {
       track(MetaMetricsEventName.PerpsUiInteraction, {
@@ -1471,10 +1529,13 @@ const PerpsOrderEntryPage = () => {
 
   // Tapping an order-book price turns the order into a limit order prefilled
   // with that price. Switching the type is a no-op when already on limit.
-  const handleOrderBookPriceSelect = useCallback((price: string) => {
-    setOrderType('limit');
-    setLimitPricePrefill({ price });
-  }, []);
+  const handleOrderBookPriceSelect = useCallback(
+    (price: string) => {
+      persistOrderType('limit');
+      setLimitPricePrefill({ price });
+    },
+    [persistOrderType],
+  );
 
   const handleOrderSubmit = useCallback(async () => {
     if (!isEligible) {
@@ -1875,6 +1936,14 @@ const PerpsOrderEntryPage = () => {
             PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
             PERPS_EVENT_VALUE.SCREEN_NAME.PERPS_ORDER,
           );
+          submitRequestToBackground('perpsClearPendingTradeConfiguration', [
+            orderFormState.asset,
+          ]).catch((error) => {
+            console.warn(
+              '[Perps] Clear pending trade configuration failed:',
+              error,
+            );
+          });
           handleBackClick();
           return;
         }
@@ -1883,6 +1952,14 @@ const PerpsOrderEntryPage = () => {
       // block's failure toast renders on the current page. Navigating before
       // the await previously unmounted this page and orphaned the Promise
       // response, leaving the "Submitting your trade" toast stuck forever.
+      submitRequestToBackground('perpsClearPendingTradeConfiguration', [
+        orderFormState.asset,
+      ]).catch((error) => {
+        console.warn(
+          '[Perps] Clear pending trade configuration failed:',
+          error,
+        );
+      });
       handleBackClick(
         orderFormState.type === 'market'
           ? {
@@ -2129,13 +2206,16 @@ const PerpsOrderEntryPage = () => {
           orderType={orderType}
           existingPosition={existingPositionForOrder}
           midPrice={topOfBook?.midPrice}
-          onOrderTypeChange={setOrderType}
+          onOrderTypeChange={persistOrderType}
           onAddFunds={handleAddFunds}
           initialLeverage={initialLeverage}
           autoFocusUsd={orderMode !== 'close'}
           autoFocusLimitPrice={orderMode !== 'close'}
           sizeDecimals={marketInfo?.szDecimals}
           limitPricePrefill={limitPricePrefill ?? undefined}
+          pendingDraft={
+            shouldRestorePendingDraft ? pendingTradeConfig : undefined
+          }
         />
       </Box>
 

--- a/ui/selectors/perps-controller.test.ts
+++ b/ui/selectors/perps-controller.test.ts
@@ -2,6 +2,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { PERPS_PENDING_TRADE_CONFIG_TTL_MS } from '../hooks/perps/perps-pending-trade-config';
 import {
   selectPerpsIsEligible,
   selectPerpsInitializationState,
@@ -32,6 +33,8 @@ import {
   selectProLayoutPreferences,
   selectOrderBookPosition,
   selectOrderBookExpanded,
+  selectPendingTradeConfiguration,
+  selectPerpsOrderBookGrouping,
 } from './perps-controller';
 
 function buildState(overrides: Record<string, unknown> = {}) {
@@ -871,6 +874,82 @@ describe('perps-controller selectors', () => {
       expect(
         selectOrderBookExpanded(buildState({ proLayoutPreferences: {} })),
       ).toBe(false);
+    });
+  });
+
+  describe('selectPendingTradeConfiguration', () => {
+    const pendingConfig = {
+      amount: '250',
+      leverage: 8,
+      orderType: 'limit' as const,
+      direction: 'short' as const,
+      timestamp: 1_000,
+    };
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('returns a fresh draft for the active network', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1_000 + 1_000);
+
+      expect(
+        selectPendingTradeConfiguration(
+          buildState({
+            isTestnet: false,
+            tradeConfigurations: {
+              mainnet: { BTC: { pendingConfig } },
+              testnet: {},
+            },
+          }),
+          'BTC',
+        ),
+      ).toStrictEqual(pendingConfig);
+    });
+
+    it('returns undefined when the draft has expired', () => {
+      jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(1_000 + PERPS_PENDING_TRADE_CONFIG_TTL_MS + 1);
+
+      expect(
+        selectPendingTradeConfiguration(
+          buildState({
+            tradeConfigurations: {
+              mainnet: { BTC: { pendingConfig } },
+              testnet: {},
+            },
+          }),
+          'BTC',
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when the symbol has no draft', () => {
+      expect(
+        selectPendingTradeConfiguration(buildState(), 'BTC'),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('selectPerpsOrderBookGrouping', () => {
+    it('returns the saved grouping for the active network', () => {
+      expect(
+        selectPerpsOrderBookGrouping(
+          buildState({
+            isTestnet: true,
+            tradeConfigurations: {
+              mainnet: { BTC: { orderBookGrouping: 1 } },
+              testnet: { BTC: { orderBookGrouping: 10 } },
+            },
+          }),
+          'BTC',
+        ),
+      ).toBe(10);
+    });
+
+    it('returns undefined when none is saved', () => {
+      expect(selectPerpsOrderBookGrouping(buildState(), 'BTC')).toBeUndefined();
     });
   });
 });

--- a/ui/selectors/perps-controller.ts
+++ b/ui/selectors/perps-controller.ts
@@ -9,6 +9,10 @@ import {
   DEFAULT_PRO_LAYOUT_PREFERENCES,
   type ProLayoutPreferences,
 } from '@metamask/perps-controller';
+import {
+  isPendingTradeConfigFresh,
+  type PerpsPendingTradeConfigRecord,
+} from '../hooks/perps/perps-pending-trade-config';
 
 /**
  * The PerpsController state is flattened into state.metamask by
@@ -253,3 +257,47 @@ export const selectOrderBookExpanded = (state: PerpsState) =>
 
 export const selectPerpsTradeConfigurations = (state: PerpsState) =>
   state.metamask.tradeConfigurations ?? EMPTY_TRADE_CONFIGURATIONS;
+
+/**
+ * Pending trade draft for `symbol` on the current network, if it is still
+ * inside the restore window. Returns the controller record (including
+ * `timestamp`) so callers share the Redux object identity.
+ *
+ * @param state - Flattened Perps controller state.
+ * @param symbol - Market symbol, e.g. `BTC`.
+ * @returns The draft, or undefined when missing/expired.
+ */
+export const selectPendingTradeConfiguration = (
+  state: PerpsState,
+  symbol: string,
+): PerpsPendingTradeConfigRecord | undefined => {
+  if (!symbol) {
+    return undefined;
+  }
+  const env = selectPerpsIsTestnet(state) ? 'testnet' : 'mainnet';
+  const pending =
+    selectPerpsTradeConfigurations(state)[env]?.[symbol]?.pendingConfig;
+  if (!pending || !isPendingTradeConfigFresh(pending.timestamp)) {
+    return undefined;
+  }
+  return pending as PerpsPendingTradeConfigRecord;
+};
+
+/**
+ * Persisted order-book price grouping for `symbol` on the current network.
+ *
+ * @param state - Flattened Perps controller state.
+ * @param symbol - Market symbol, e.g. `BTC`.
+ * @returns The grouping step, or undefined when none is saved.
+ */
+export const selectPerpsOrderBookGrouping = (
+  state: PerpsState,
+  symbol: string,
+): number | undefined => {
+  if (!symbol) {
+    return undefined;
+  }
+  const env = selectPerpsIsTestnet(state) ? 'testnet' : 'mainnet';
+  return selectPerpsTradeConfigurations(state)[env]?.[symbol]
+    ?.orderBookGrouping;
+};


### PR DESCRIPTION
## **Description**

Leaving `/perps/trade/:symbol` (to check the chart or glance at another market) currently wipes the order form. Returning to the same symbol meant re-entering size, leverage, TP/SL, limit price, and direction.

This PR restores a **pending trade draft** for the same symbol if the user comes back within **60 seconds**, and persists a few trading UI prefs that should survive that short window (and, for some, last across markets/sessions):

- **Draft (per market, 60s TTL on read):** amount, leverage, TP/SL, limit price, order type, direction.
- **Order type:** Preferences `perpsSelectedOrderType` (market-agnostic; not tied to the draft TTL). Priority: URL → preference → pending type → `'market'`.
- **Order book:** listed-by currency/metric in Preferences (agnostic); grouping via existing `perpsSaveOrderBookGrouping` (per market).
- **Chart zoom:** Preferences `perpsVisibleCandleCount`.

Drafts are written **on leave / symbol change**, not on every keystroke, so the TTL starts when the user actually leaves. A successful new order clears the pending config **before** navigation and skips the unmount save. Direction is restored like Mobile unless the URL direction **conflicts** with the draft. Toggling Long/Short still does a full form reset and does **not** re-apply the pending draft.

Controller 13.x is **out of scope**; Extension stays on the already-wired 10/12 pending APIs, with Preferences standing in for fields that only exist on 13 (`setSelectedOrderType`, order-book listed-by, visible candle count). Core 13 expires drafts at 30s; Extension v1 uses 60s on read.

## **Changelog**

CHANGELOG entry: Restored perps order form values when returning to the same market, and remembered order type, order-book settings, and chart zoom.

## **Related issues**

Fixes:

## **Manual testing steps**

Feature: Persist perps order form and trading UI prefs

Scenario: Restore a draft after a short leave
  Given I am on `/perps/trade/BTC` in new-order mode
  And I set size, leverage, TP/SL, and (optionally) a limit price
  When I leave the trade screen (chart or another market) and return to BTC within 60 seconds
  Then the form shows the values I entered, including direction when the URL does not conflict

Scenario: Do not restore an expired draft
  Given I have a draft for BTC
  When I wait more than 60 seconds and open `/perps/trade/BTC` again
  Then the form is a fresh default (not the expired draft)

Scenario: URL direction conflict
  Given I left a short BTC draft
  When I open the trade URL with `direction=long`
  Then the pending short draft is not applied

Scenario: Successful order does not come back as a draft
  Given I submit a new order successfully
  When I return to the same symbol
  Then the previous form is not restored

Scenario: Session order type
  Given I switch the order type to Limit on any market
  When I open a different market’s trade screen (no order-type URL param)
  Then Limit is still selected

Scenario: Order-book listed-by vs grouping
  Given I change listed-by (currency/metric) and grouping on BTC
  When I open ETH then return to BTC
  Then listed-by is still my last choice on both markets
  And BTC grouping is restored while ETH uses its own (or default)

Scenario: Chart visible candle count
  Given I zoom the perps candlestick chart
  When I leave and return to a market detail / trade chart
  Then the chart uses the same visible candle count (clamped to supported zoom)

## **Screenshots/Recordings**

N/A — UI behavior change; recordings to be attached after manual QA.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
