### PR TITLE
test: fix flaky test `Wallet State matches the committed default fixture schema`

### DIFF
--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -100,6 +100,7 @@
   "oidc.dev-api.cx.metamask.io",
   "on-ramp.api.cx.metamask.io",
   "on-ramp.dev-api.cx.metamask.io",
+  "on-ramp-cache.api.cx.metamask.io",
   "on-ramp-cache.uat-api.cx.metamask.io",
   "on-ramp.uat-api.cx.metamask.io",
   "on-ramp-content.api.cx.metamask.io",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The wallet export fixture test is flaky as sometimes we get a new host:

<img width="1002" height="197" alt="image" src="https://github.com/user-attachments/assets/2a0439da-fbfc-405a-822e-2d263faca583" />

This happens because depending on how fast/slow this request is made, it can be captured during the time window of the test, as we also have a delay to stabilize state.

  await driver.delay(STATE_SETTLE_DELAY_MS);

This doesn't happen to regular tests as the dev API `"on-ramp-cache.uat-api.cx.metamask.io",` is already included in the privacy snapshot. However, the fixture test runs agains the dist build, leading to use the `"on-ramp-cache.api.cx.metamask.io",` endpoint instead.


It seems this is also happening to other endpoints as well, so maybe for a separate task we could have 2 privacy snapshots files, one to use on all tests that run against test builds and another to use in the case of prod (dist) builds.

For now, creating this 1 line change to stabilize test and reduce flakiness in ci.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only allowlist change with no application logic or user-facing privacy behavior changes.
> 
> **Overview**
> Adds **`on-ramp-cache.api.cx.metamask.io`** to **`privacy-snapshot.json`** so wallet state / privacy fixture checks accept the production on-ramp cache host.
> 
> Dist-based fixture runs can hit that endpoint during the settle delay while the snapshot already listed the UAT host (`on-ramp-cache.uat-api.cx.metamask.io`), which caused intermittent schema mismatches in CI. This is a one-line allowlist update to align the snapshot with prod dist behavior—not a runtime or privacy-policy change for users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e38261f0b159425681af1e954d006ad58e051f81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->