### PR TITLE
chore: bump core packages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 const consoleReporterRules = require('./test/jest/console-reporter-rules-unit');
 
+// TODO: Find a way to share this list with `jest.integration.config.js`.
 const ESM_DEPENDENCIES_TO_TRANSPILE = [
   '@metamask/base-controller',
   '@metamask/base-data-service',

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ const ESM_DEPENDENCIES_TO_TRANSPILE = [
   '@metamask/base-controller',
   '@metamask/base-data-service',
   '@metamask/messenger',
+  'lodash-es',
 ];
 
 module.exports = {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,11 @@
 const consoleReporterRules = require('./test/jest/console-reporter-rules-unit');
 
+const ESM_DEPENDENCIES_TO_TRANSPILE = [
+  '@metamask/base-controller',
+  '@metamask/base-data-service',
+  '@metamask/messenger',
+];
+
 module.exports = {
   collectCoverageFrom: [
     '<rootDir>/app/scripts/**/*.(js|ts|tsx)',
@@ -108,6 +114,9 @@ module.exports = {
       },
     ],
   },
+  transformIgnorePatterns: [
+    `/node_modules/(?!(${ESM_DEPENDENCIES_TO_TRANSPILE.join('|')})/)`,
+  ],
   workerIdleMemoryLimit: '500MB',
   // Ensure console output is buffered (not streamed) so reporters can access testResult.console
   // Without this, Jest uses verbose mode for single-file runs which bypasses buffering

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,5 @@
 const consoleReporterRules = require('./test/jest/console-reporter-rules-unit');
-
-// TODO: Find a way to share this list with `jest.integration.config.js`.
-const ESM_DEPENDENCIES_TO_TRANSPILE = [
-  '@metamask/base-controller',
-  '@metamask/base-data-service',
-  '@metamask/messenger',
-  'lodash-es',
-];
+const { ESM_DEPENDENCIES_TO_TRANSPILE } = require('./test/jest/constants');
 
 module.exports = {
   collectCoverageFrom: [

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,5 +1,13 @@
 const consoleReporterRules = require('./test/jest/console-reporter-rules-integration');
 
+// TODO: Find a way to share this list with `jest.config.js`.
+const ESM_DEPENDENCIES_TO_TRANSPILE = [
+  '@metamask/base-controller',
+  '@metamask/base-data-service',
+  '@metamask/messenger',
+  'lodash-es',
+];
+
 module.exports = {
   collectCoverageFrom: [
     '<rootDir>/shared/**/*.(js|ts|tsx)',
@@ -74,7 +82,9 @@ module.exports = {
     '^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)':
       'jest-preview/transforms/file',
   },
-  transformIgnorePatterns: ['/node_modules/'],
+  transformIgnorePatterns: [
+    `/node_modules/(?!(${ESM_DEPENDENCIES_TO_TRANSPILE.join('|')})/)`,
+  ],
   // Ensure console output is buffered (not streamed) so reporters can access testResult.console
   // Without this, Jest uses verbose mode for single-file runs which bypasses buffering
   verbose: false,

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,12 +1,5 @@
 const consoleReporterRules = require('./test/jest/console-reporter-rules-integration');
-
-// TODO: Find a way to share this list with `jest.config.js`.
-const ESM_DEPENDENCIES_TO_TRANSPILE = [
-  '@metamask/base-controller',
-  '@metamask/base-data-service',
-  '@metamask/messenger',
-  'lodash-es',
-];
+const { ESM_DEPENDENCIES_TO_TRANSPILE } = require('./test/jest/constants');
 
 module.exports = {
   collectCoverageFrom: [

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -953,13 +953,12 @@
     },
     "@metamask/base-data-service": {
       "packages": {
-        "@metamask/messenger": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@tanstack/react-query>@tanstack/query-core": true,
         "cockatiel": true,
         "eslint>fast-deep-equal": true,
-        "lodash": true
+        "@metamask/base-data-service>lodash-es": true
       }
     },
     "@metamask/bridge-controller": {
@@ -5536,6 +5535,12 @@
     "lodash": {
       "globals": {
         "define": true
+      }
+    },
+    "@metamask/base-data-service>lodash-es": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
       }
     },
     "loglevel": {

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -953,13 +953,12 @@
     },
     "@metamask/base-data-service": {
       "packages": {
-        "@metamask/messenger": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@tanstack/react-query>@tanstack/query-core": true,
         "cockatiel": true,
         "eslint>fast-deep-equal": true,
-        "lodash": true
+        "@metamask/base-data-service>lodash-es": true
       }
     },
     "@metamask/bridge-controller": {
@@ -5536,6 +5535,12 @@
     "lodash": {
       "globals": {
         "define": true
+      }
+    },
+    "@metamask/base-data-service>lodash-es": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
       }
     },
     "loglevel": {

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -953,13 +953,12 @@
     },
     "@metamask/base-data-service": {
       "packages": {
-        "@metamask/messenger": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@tanstack/react-query>@tanstack/query-core": true,
         "cockatiel": true,
         "eslint>fast-deep-equal": true,
-        "lodash": true
+        "@metamask/base-data-service>lodash-es": true
       }
     },
     "@metamask/bridge-controller": {
@@ -5536,6 +5535,12 @@
     "lodash": {
       "globals": {
         "define": true
+      }
+    },
+    "@metamask/base-data-service>lodash-es": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
       }
     },
     "loglevel": {

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -953,13 +953,12 @@
     },
     "@metamask/base-data-service": {
       "packages": {
-        "@metamask/messenger": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@tanstack/react-query>@tanstack/query-core": true,
         "cockatiel": true,
         "eslint>fast-deep-equal": true,
-        "lodash": true
+        "@metamask/base-data-service>lodash-es": true
       }
     },
     "@metamask/bridge-controller": {
@@ -5536,6 +5535,12 @@
     "lodash": {
       "globals": {
         "define": true
+      }
+    },
+    "@metamask/base-data-service>lodash-es": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
       }
     },
     "loglevel": {

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -1133,13 +1133,12 @@
     },
     "@metamask/base-data-service": {
       "packages": {
-        "@metamask/messenger": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@tanstack/react-query>@tanstack/query-core": true,
         "cockatiel": true,
         "eslint>fast-deep-equal": true,
-        "lodash": true
+        "@metamask/base-data-service>lodash-es": true
       }
     },
     "@metamask/bridge-controller": {
@@ -5811,6 +5810,12 @@
     "lodash": {
       "globals": {
         "define": true
+      }
+    },
+    "@metamask/base-data-service>lodash-es": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
       }
     },
     "loglevel": {

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -1133,13 +1133,12 @@
     },
     "@metamask/base-data-service": {
       "packages": {
-        "@metamask/messenger": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@tanstack/react-query>@tanstack/query-core": true,
         "cockatiel": true,
         "eslint>fast-deep-equal": true,
-        "lodash": true
+        "@metamask/base-data-service>lodash-es": true
       }
     },
     "@metamask/bridge-controller": {
@@ -5811,6 +5810,12 @@
     "lodash": {
       "globals": {
         "define": true
+      }
+    },
+    "@metamask/base-data-service>lodash-es": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
       }
     },
     "loglevel": {

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -1133,13 +1133,12 @@
     },
     "@metamask/base-data-service": {
       "packages": {
-        "@metamask/messenger": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@tanstack/react-query>@tanstack/query-core": true,
         "cockatiel": true,
         "eslint>fast-deep-equal": true,
-        "lodash": true
+        "@metamask/base-data-service>lodash-es": true
       }
     },
     "@metamask/bridge-controller": {
@@ -5811,6 +5810,12 @@
     "lodash": {
       "globals": {
         "define": true
+      }
+    },
+    "@metamask/base-data-service>lodash-es": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
       }
     },
     "loglevel": {

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -1133,13 +1133,12 @@
     },
     "@metamask/base-data-service": {
       "packages": {
-        "@metamask/messenger": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "@tanstack/react-query>@tanstack/query-core": true,
         "cockatiel": true,
         "eslint>fast-deep-equal": true,
-        "lodash": true
+        "@metamask/base-data-service>lodash-es": true
       }
     },
     "@metamask/bridge-controller": {
@@ -5811,6 +5810,12 @@
     "lodash": {
       "globals": {
         "define": true
+      }
+    },
+    "@metamask/base-data-service>lodash-es": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
       }
     },
     "loglevel": {

--- a/package.json
+++ b/package.json
@@ -912,15 +912,15 @@
   "previewBuilds": {
     "@metamask/base-controller": {
       "type": "breaking",
-      "previewVersion": "9.1.0-preview-4f4c98e"
+      "previewVersion": "9.1.0-preview-3866c0ff1"
     },
     "@metamask/base-data-service": {
       "type": "breaking",
-      "previewVersion": "1.0.0-preview-4f4c98e"
+      "previewVersion": "1.0.0-preview-3866c0ff1"
     },
     "@metamask/messenger": {
       "type": "breaking",
-      "previewVersion": "2.0.0-preview-4f4c98e"
+      "previewVersion": "2.0.0-preview-3866c0ff1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -908,5 +908,19 @@
       }
     },
     "version": "v0.3.0"
+  },
+  "previewBuilds": {
+    "@metamask/base-controller": {
+      "type": "breaking",
+      "previewVersion": "9.1.0-preview-4f4c98e"
+    },
+    "@metamask/base-data-service": {
+      "type": "breaking",
+      "previewVersion": "1.0.0-preview-4f4c98e"
+    },
+    "@metamask/messenger": {
+      "type": "breaking",
+      "previewVersion": "2.0.0-preview-4f4c98e"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -337,7 +337,9 @@
     "@metamask/keyring-api": "^24.1.0",
     "@metamask/accounts-controller": "^39.1.0",
     "@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.11": "patch:@pmmmwh/react-refresh-webpack-plugin@npm%3A0.5.13#~/.yarn/patches/@pmmmwh-react-refresh-webpack-plugin-npm-0.5.13-25d13d4186.patch",
-    "@metamask/messenger": "^2.0.0",
+    "@metamask/base-controller": "^10.0.0",
+    "@metamask/base-data-service": "^2.0.0",
+    "@metamask/messenger": "^3.0.0",
     "@ledgerhq/context-module/ethers": "^6.15.0",
     "@ledgerhq/device-signer-kit-ethereum/ethers": "^6.15.0",
     "@metamask/profile-sync-controller": "^30.0.0",
@@ -382,8 +384,8 @@
     "@metamask/assets-controller": "^15.0.0",
     "@metamask/assets-controllers": "^111.1.2",
     "@metamask/authenticated-user-storage": "^3.0.2",
-    "@metamask/base-controller": "^9.0.1",
-    "@metamask/base-data-service": "^1.0.0",
+    "@metamask/base-controller": "^10.0.0",
+    "@metamask/base-data-service": "^2.0.0",
     "@metamask/bitcoin-wallet-snap": "^2.0.1",
     "@metamask/bitcoin-wallet-standard": "^1.1.0",
     "@metamask/bridge-controller": "^80.1.1",
@@ -440,7 +442,7 @@
     "@metamask/logo": "^4.0.0",
     "@metamask/message-manager": "^14.0.0",
     "@metamask/message-signing-snap": "1.1.4",
-    "@metamask/messenger": "^2.0.0",
+    "@metamask/messenger": "^3.0.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-dapp-client": "^0.3.0",
@@ -908,19 +910,5 @@
       }
     },
     "version": "v0.3.0"
-  },
-  "previewBuilds": {
-    "@metamask/base-controller": {
-      "type": "breaking",
-      "previewVersion": "9.1.0-preview-3866c0ff1"
-    },
-    "@metamask/base-data-service": {
-      "type": "breaking",
-      "previewVersion": "1.0.0-preview-3866c0ff1"
-    },
-    "@metamask/messenger": {
-      "type": "breaking",
-      "previewVersion": "2.0.0-preview-3866c0ff1"
-    }
   }
 }

--- a/test/jest/constants.js
+++ b/test/jest/constants.js
@@ -1,2 +1,9 @@
 export const METASWAP_BASE_URL = 'https://bridge.api.cx.metamask.io';
 export const GAS_API_URL = 'https://gas.api.cx.metamask.io';
+
+export const ESM_DEPENDENCIES_TO_TRANSPILE = [
+  '@metamask/base-controller',
+  '@metamask/base-data-service',
+  '@metamask/messenger',
+  'lodash-es',
+];

--- a/ui/messengers/route-messenger.test.ts
+++ b/ui/messengers/route-messenger.test.ts
@@ -6,6 +6,15 @@ import {
   getRouteMessengerNamespace,
 } from './route-messenger';
 
+jest.mock('@metamask/messenger', () => {
+  const originalModule = jest.requireActual('@metamask/messenger');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+  };
+});
+
 describe('getRouteMessengerNamespace', () => {
   it.each([
     ['/some/path', 'SomePathRoute'],

--- a/ui/messengers/route-messenger.test.ts
+++ b/ui/messengers/route-messenger.test.ts
@@ -10,6 +10,7 @@ jest.mock('@metamask/messenger', () => {
   const originalModule = jest.requireActual('@metamask/messenger');
 
   return {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     __esModule: true,
     ...originalModule,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5910,14 +5910,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:@metamask-previews/base-controller@9.1.0-preview-4f4c98e":
-  version: 9.1.0-preview-4f4c98e
-  resolution: "@metamask-previews/base-controller@npm:9.1.0-preview-4f4c98e"
+"@metamask/base-controller@npm:@metamask-previews/base-controller@9.1.0-preview-3866c0ff1":
+  version: 9.1.0-preview-3866c0ff1
+  resolution: "@metamask-previews/base-controller@npm:9.1.0-preview-3866c0ff1"
   dependencies:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/utils": "npm:^11.11.0"
     immer: "npm:^9.0.6"
-  checksum: 10/7f366de444ee3bda326f935904763718a62db62e5e89fc0be7417cd9524acfbe325b1e5a807b3fcfd33f44e7a4fdcecfee2e42b1bd3fbbfddf4cef6299cbd6fc
+  checksum: 10/15d954aaa77e3afb802bcbe2e34bee5e6e1a02b69ef161436e2b1bfef7aa93c139f752ee5d3e0c185a8c20f0a168cd8101171ec51600eb6556c7f5ddc80b9017
   languageName: node
   linkType: hard
 
@@ -5932,9 +5932,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-data-service@npm:@metamask-previews/base-data-service@1.0.0-preview-4f4c98e":
-  version: 1.0.0-preview-4f4c98e
-  resolution: "@metamask-previews/base-data-service@npm:1.0.0-preview-4f4c98e"
+"@metamask/base-data-service@npm:@metamask-previews/base-data-service@1.0.0-preview-3866c0ff1":
+  version: 1.0.0-preview-3866c0ff1
+  resolution: "@metamask-previews/base-data-service@npm:1.0.0-preview-3866c0ff1"
   dependencies:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/storage-service": "npm:^1.0.2"
@@ -5944,7 +5944,7 @@ __metadata:
     cockatiel: "npm:^3.1.2"
     fast-deep-equal: "npm:^3.1.3"
     lodash-es: "npm:^4.17.21"
-  checksum: 10/4c00ce11f7a842f131cb3aafb320eefc19f57984148032fd060671a7e33c2c62df85bdf7ac8345cef82ad962e2b04d42e04339f307b4f8468ded01972c7a0234
+  checksum: 10/d9837f164bc534849809c0ec590c96c11a4d8b36e5c58748d63ec5ec8d28ebb662f2bc17b49e356a5fb34aa1d74cd1f2b03ef1543615d435b4999e73a14aba37
   languageName: node
   linkType: hard
 
@@ -7431,14 +7431,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/messenger@npm:@metamask-previews/messenger@2.0.0-preview-4f4c98e":
-  version: 2.0.0-preview-4f4c98e
-  resolution: "@metamask-previews/messenger@npm:2.0.0-preview-4f4c98e"
+"@metamask/messenger@npm:@metamask-previews/messenger@2.0.0-preview-3866c0ff1":
+  version: 2.0.0-preview-3866c0ff1
+  resolution: "@metamask-previews/messenger@npm:2.0.0-preview-3866c0ff1"
   dependencies:
     "@metamask/utils": "npm:^11.11.0"
   peerDependencies:
     typescript: ">=5.0.0"
-  checksum: 10/991f7c0aebfe1b8142e2edc3639ef8946a5f13260ff5b85b441d06e34e0285989db2930a0e4cf85d0334d1b8683d8ac837b5f748382ddf36fec1785ccb667733
+  checksum: 10/5e2230a7a50b1219ea0e72ba3e5df358fdae0f8d7d154e06dd2c7bcbee20a383ea56ce08b414442238534e7cfd3c8616a3f924b233ff7dc7754e9d152c95ddaa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5910,6 +5910,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/base-controller@npm:@metamask-previews/base-controller@9.1.0-preview-4f4c98e":
+  version: 9.1.0-preview-4f4c98e
+  resolution: "@metamask-previews/base-controller@npm:9.1.0-preview-4f4c98e"
+  dependencies:
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/utils": "npm:^11.11.0"
+    immer: "npm:^9.0.6"
+  checksum: 10/7f366de444ee3bda326f935904763718a62db62e5e89fc0be7417cd9524acfbe325b1e5a807b3fcfd33f44e7a4fdcecfee2e42b1bd3fbbfddf4cef6299cbd6fc
+  languageName: node
+  linkType: hard
+
 "@metamask/base-controller@npm:^9.0.0, @metamask/base-controller@npm:^9.0.1, @metamask/base-controller@npm:^9.1.0":
   version: 9.1.0
   resolution: "@metamask/base-controller@npm:9.1.0"
@@ -5918,6 +5929,22 @@ __metadata:
     "@metamask/utils": "npm:^11.9.0"
     immer: "npm:^9.0.6"
   checksum: 10/752b70b35026fdf31ea8feef638f06286dbbde8d17e1ba804085fdbedbb076d900d2d7b6db3d2af284b3aa8fa84c95a0ceea6a3a46ee7b7e29433f037e9afc69
+  languageName: node
+  linkType: hard
+
+"@metamask/base-data-service@npm:@metamask-previews/base-data-service@1.0.0-preview-4f4c98e":
+  version: 1.0.0-preview-4f4c98e
+  resolution: "@metamask-previews/base-data-service@npm:1.0.0-preview-4f4c98e"
+  dependencies:
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/storage-service": "npm:^1.0.2"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    "@tanstack/query-core": "npm:^5.62.16"
+    cockatiel: "npm:^3.1.2"
+    fast-deep-equal: "npm:^3.1.3"
+    lodash-es: "npm:^4.17.21"
+  checksum: 10/4c00ce11f7a842f131cb3aafb320eefc19f57984148032fd060671a7e33c2c62df85bdf7ac8345cef82ad962e2b04d42e04339f307b4f8468ded01972c7a0234
   languageName: node
   linkType: hard
 
@@ -7401,6 +7428,17 @@ __metadata:
   bin:
     messenger-action-types: ./dist/cli.mjs
   checksum: 10/db8e10215f45d42d165cb85cdbb666956d2cd208fedf65c041f278b5b278aaeec18ad62d0146e0dacac069c145cd1892d84fa9d90e764d544c828bd50b5349fe
+  languageName: node
+  linkType: hard
+
+"@metamask/messenger@npm:@metamask-previews/messenger@2.0.0-preview-4f4c98e":
+  version: 2.0.0-preview-4f4c98e
+  resolution: "@metamask-previews/messenger@npm:2.0.0-preview-4f4c98e"
+  dependencies:
+    "@metamask/utils": "npm:^11.11.0"
+  peerDependencies:
+    typescript: ">=5.0.0"
+  checksum: 10/991f7c0aebfe1b8142e2edc3639ef8946a5f13260ff5b85b441d06e34e0285989db2930a0e4cf85d0334d1b8683d8ac837b5f748382ddf36fec1785ccb667733
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5910,57 +5910,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:@metamask-previews/base-controller@9.1.0-preview-3866c0ff1":
-  version: 9.1.0-preview-3866c0ff1
-  resolution: "@metamask-previews/base-controller@npm:9.1.0-preview-3866c0ff1"
+"@metamask/base-controller@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@metamask/base-controller@npm:10.0.0"
   dependencies:
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/utils": "npm:^11.11.0"
+    "@metamask/messenger": "npm:^3.0.0"
+    "@metamask/utils": "npm:^11.12.0"
     immer: "npm:^9.0.6"
-  checksum: 10/15d954aaa77e3afb802bcbe2e34bee5e6e1a02b69ef161436e2b1bfef7aa93c139f752ee5d3e0c185a8c20f0a168cd8101171ec51600eb6556c7f5ddc80b9017
+  checksum: 10/b09bbf175fe248c592d1e66dcc7d65b324bfd5b16fa95c751ce163dedc97153f19419fca4bb84d2a1c6cfa7b308572cc8ea2ce88cefff1ab4504dba29e9015df
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^9.0.0, @metamask/base-controller@npm:^9.0.1, @metamask/base-controller@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "@metamask/base-controller@npm:9.1.0"
+"@metamask/base-data-service@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/base-data-service@npm:2.0.0"
   dependencies:
-    "@metamask/messenger": "npm:^1.1.1"
-    "@metamask/utils": "npm:^11.9.0"
-    immer: "npm:^9.0.6"
-  checksum: 10/752b70b35026fdf31ea8feef638f06286dbbde8d17e1ba804085fdbedbb076d900d2d7b6db3d2af284b3aa8fa84c95a0ceea6a3a46ee7b7e29433f037e9afc69
-  languageName: node
-  linkType: hard
-
-"@metamask/base-data-service@npm:@metamask-previews/base-data-service@1.0.0-preview-3866c0ff1":
-  version: 1.0.0-preview-3866c0ff1
-  resolution: "@metamask-previews/base-data-service@npm:1.0.0-preview-3866c0ff1"
-  dependencies:
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/storage-service": "npm:^1.0.2"
+    "@metamask/messenger": "npm:^3.0.0"
+    "@metamask/storage-service": "npm:^2.0.0"
     "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
+    "@metamask/utils": "npm:^11.12.0"
     "@tanstack/query-core": "npm:^5.62.16"
     cockatiel: "npm:^3.1.2"
     fast-deep-equal: "npm:^3.1.3"
     lodash-es: "npm:^4.17.21"
-  checksum: 10/d9837f164bc534849809c0ec590c96c11a4d8b36e5c58748d63ec5ec8d28ebb662f2bc17b49e356a5fb34aa1d74cd1f2b03ef1543615d435b4999e73a14aba37
-  languageName: node
-  linkType: hard
-
-"@metamask/base-data-service@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/base-data-service@npm:1.0.0"
-  dependencies:
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/storage-service": "npm:^1.0.2"
-    "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
-    "@tanstack/query-core": "npm:^5.62.16"
-    cockatiel: "npm:^3.1.2"
-    fast-deep-equal: "npm:^3.1.3"
-    lodash: "npm:^4.17.21"
-  checksum: 10/c965dc930a3c172c71624278499f4ec2da829def684c3923b2729d1a31dd2635d5c05230a9dc9ea8546adc029c4e2ed782fdc992be4692d47d9aafdb2d778deb
+  checksum: 10/5fd9a9e5f5c75c87e0d8de12714e7376eed8afeb2ddda87a5846344623c216406a7ca871402f55414bf890a8b965f5835f4aee346a2d2ad3875f5a09abb25b04
   languageName: node
   linkType: hard
 
@@ -7431,25 +7404,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/messenger@npm:@metamask-previews/messenger@2.0.0-preview-3866c0ff1":
-  version: 2.0.0-preview-3866c0ff1
-  resolution: "@metamask-previews/messenger@npm:2.0.0-preview-3866c0ff1"
+"@metamask/messenger@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/messenger@npm:3.0.0"
   dependencies:
-    "@metamask/utils": "npm:^11.11.0"
+    "@metamask/utils": "npm:^11.12.0"
   peerDependencies:
     typescript: ">=5.0.0"
-  checksum: 10/5e2230a7a50b1219ea0e72ba3e5df358fdae0f8d7d154e06dd2c7bcbee20a383ea56ce08b414442238534e7cfd3c8616a3f924b233ff7dc7754e9d152c95ddaa
-  languageName: node
-  linkType: hard
-
-"@metamask/messenger@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@metamask/messenger@npm:2.0.0"
-  dependencies:
-    "@metamask/utils": "npm:^11.11.0"
-  peerDependencies:
-    typescript: ">=5.0.0"
-  checksum: 10/c387511edd89db73b774f631fb4bb382c9254af2dd7f80f9bd45f776e618cf90f653cc0e9744b1bf491f71f99c8318b16e8230a847f619a4fca655ea3f6a08e1
+  checksum: 10/ea335702bc818f0ea42ca8af4dd7c5f77562e650b1b4de9df92614dacaae0c29d6956999ae3cc524038d9ffdcd866890b4dee141323fda5072ae70d3c7d05173
   languageName: node
   linkType: hard
 
@@ -8639,6 +8601,16 @@ __metadata:
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/utils": "npm:^11.9.0"
   checksum: 10/dda8f1a6c63c98bbd8fa61cd5863e54f8e9801389a96efc69fd8d10011cd194370990bac5b8693c7861e23769237e617946e0304a1dc9ea4da83b8d3fb6c8942
+  languageName: node
+  linkType: hard
+
+"@metamask/storage-service@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/storage-service@npm:2.0.0"
+  dependencies:
+    "@metamask/messenger": "npm:^3.0.0"
+    "@metamask/utils": "npm:^11.12.0"
+  checksum: 10/d59320e5d40e249d4e4789f3bcd3817e8cff2ddceb5f673a274a613313c9cc42280885358e519006067f37c011e754ce522d7e7ffbfd318f1c282d3f072f5be1
   languageName: node
   linkType: hard
 
@@ -31931,8 +31903,8 @@ __metadata:
     "@metamask/assets-controllers": "npm:^111.1.2"
     "@metamask/authenticated-user-storage": "npm:^3.0.2"
     "@metamask/auto-changelog": "npm:^6.2.0"
-    "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/base-data-service": "npm:^1.0.0"
+    "@metamask/base-controller": "npm:^10.0.0"
+    "@metamask/base-data-service": "npm:^2.0.0"
     "@metamask/bitcoin-regtest-up": "npm:^1.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^2.0.1"
     "@metamask/bitcoin-wallet-standard": "npm:^1.1.0"
@@ -32003,7 +31975,7 @@ __metadata:
     "@metamask/logo": "npm:^4.0.0"
     "@metamask/message-manager": "npm:^14.0.0"
     "@metamask/message-signing-snap": "npm:1.1.4"
-    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/messenger": "npm:^3.0.0"
     "@metamask/messenger-cli": "npm:^0.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This bumps a few `core` packages to their ESM-only versions. No functional changes expected.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core controller/messenger dependencies and LavaMoat supply-chain policy across all build flavors, though the PR targets parity with no intended product behavior changes.
> 
> **Overview**
> Upgrades **`@metamask/base-controller`** (^10), **`@metamask/base-data-service`** (^2), and **`@metamask/messenger`** (^3), along with **`@metamask/storage-service`** (^2) pulled in by base-data-service. **`base-data-service`** now depends on **`lodash-es`** instead of **`lodash`**.
> 
> Because these packages ship as ESM, unit and integration Jest configs share a new **`ESM_DEPENDENCIES_TO_TRANSPILE`** list and **`transformIgnorePatterns`** so Babel transpiles those modules (and **`lodash-es`**) under **`node_modules`**. Integration tests replace the previous blanket **`/node_modules/`** ignore with the same allowlist.
> 
> LavaMoat webpack policies (MV2/MV3 variants) are regenerated to drop the direct **`@metamask/messenger`** allowance on **`@metamask/base-data-service`**, swap **`lodash`** for **`@metamask/base-data-service>lodash-es`**, and grant **`lodash-es`** timer globals. **`route-messenger.test.ts`** wraps **`@metamask/messenger`** in a partial **`jest.mock`** so tests still load the real module under the new ESM layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ddfbbe09869791bb5cd69677fafc57e2fd1b254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->