### PR TITLE
fix(ramps): keep polling pending orders while the UI is closed

### DIFF
--- a/app/scripts/lib/ramps/handleRampsOrderStatusChanged.ts
+++ b/app/scripts/lib/ramps/handleRampsOrderStatusChanged.ts
@@ -52,7 +52,7 @@ function getOrderKey(order?: RampsOrder): string | undefined {
  * `TERMINAL_ORDER_STATUSES` set (kept in lockstep with mobile's
  * `ramps-controller/event-handlers/analytics.ts`).
  */
-export const TERMINAL_ORDER_STATUSES = new Set<string>([
+const TERMINAL_ORDER_STATUSES = new Set<string>([
   'COMPLETED',
   'FAILED',
   'CANCELLED',

--- a/app/scripts/lib/ramps/handleRampsOrderStatusChanged.ts
+++ b/app/scripts/lib/ramps/handleRampsOrderStatusChanged.ts
@@ -52,7 +52,7 @@ function getOrderKey(order?: RampsOrder): string | undefined {
  * `TERMINAL_ORDER_STATUSES` set (kept in lockstep with mobile's
  * `ramps-controller/event-handlers/analytics.ts`).
  */
-const TERMINAL_ORDER_STATUSES = new Set<string>([
+export const TERMINAL_ORDER_STATUSES = new Set<string>([
   'COMPLETED',
   'FAILED',
   'CANCELLED',

--- a/app/scripts/messenger-client-init/ramps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/ramps-controller-init.test.ts
@@ -279,19 +279,26 @@ describe('RampsControllerInit', () => {
     expect(mockStopOrderPolling).not.toHaveBeenCalled();
   });
 
-  it.each(['PRECREATED', 'UNKNOWN'])(
-    'stops polling on UI close for a %s stub that may never resolve',
-    async (status) => {
-      mockRampsController.state = { orders: [{ status }] };
-      const { api } = RampsControllerInit(getInitRequestMock());
-      await Promise.resolve();
-      await Promise.resolve();
+  // A stub in one of these statuses may never resolve, so it must not hold the
+  // lifecycle open — see IN_FLIGHT_ORDER_STATUSES.
+  async function expectUiCloseStopsPollingFor(status: string): Promise<void> {
+    mockRampsController.state = { orders: [{ status }] };
+    const { api } = RampsControllerInit(getInitRequestMock());
+    await Promise.resolve();
+    await Promise.resolve();
 
-      api?.stopRampsLifecycle?.();
+    api?.stopRampsLifecycle?.();
 
-      expect(mockStopOrderPolling).toHaveBeenCalled();
-    },
-  );
+    expect(mockStopOrderPolling).toHaveBeenCalled();
+  }
+
+  it('stops polling on UI close for a PRECREATED stub', async () => {
+    await expectUiCloseStopsPollingFor('PRECREATED');
+  });
+
+  it('stops polling on UI close for an UNKNOWN stub', async () => {
+    await expectUiCloseStopsPollingFor('UNKNOWN');
+  });
 
   it('runs stale-stub cleanup again after a UI close/open cycle', async () => {
     mockRampsController.state = { orders: [{ status: 'PRECREATED' }] };

--- a/app/scripts/messenger-client-init/ramps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/ramps-controller-init.test.ts
@@ -279,6 +279,41 @@ describe('RampsControllerInit', () => {
     expect(mockStopOrderPolling).not.toHaveBeenCalled();
   });
 
+  it.each(['PRECREATED', 'UNKNOWN'])(
+    'stops polling on UI close for a %s stub that may never resolve',
+    async (status) => {
+      mockRampsController.state = { orders: [{ status }] };
+      const { api } = RampsControllerInit(getInitRequestMock());
+      await Promise.resolve();
+      await Promise.resolve();
+
+      api?.stopRampsLifecycle?.();
+
+      expect(mockStopOrderPolling).toHaveBeenCalled();
+    },
+  );
+
+  it('runs stale-stub cleanup again after a UI close/open cycle', async () => {
+    mockRampsController.state = { orders: [{ status: 'PRECREATED' }] };
+    const { api } = RampsControllerInit(getInitRequestMock());
+    await Promise.resolve();
+    await Promise.resolve();
+    const startCallsAfterBoot = mockStartOrderPolling.mock.calls.length;
+
+    // Close: the stub must not hold the lifecycle open, otherwise
+    // `lifecycleStarted` never clears and cleanup can never run again.
+    api?.stopRampsLifecycle?.();
+    expect(mockStopOrderPolling).toHaveBeenCalled();
+
+    // Reopen: lifecycle restarts, so cleanup gets another chance.
+    api?.startRampsLifecycle?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockStartOrderPolling.mock.calls.length).toBeGreaterThan(
+      startCallsAfterBoot,
+    );
+  });
+
   it('stops polling on UI close once every order is terminal', async () => {
     mockRampsController.state = {
       orders: [{ status: 'COMPLETED' }, { status: 'CANCELLED' }],

--- a/app/scripts/messenger-client-init/ramps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/ramps-controller-init.test.ts
@@ -16,6 +16,7 @@ import { RampsControllerInit } from './ramps-controller-init';
 import { RAMPS_NETWORK_ACCESS_DENIED_MESSAGE } from './ramps-network-gate';
 
 const mockRampsController = {
+  state: { orders: [] as { status: string }[] },
   init: jest.fn().mockResolvedValue(undefined),
   getCountries: jest.fn(),
   startOrderPolling: jest.fn(),
@@ -117,6 +118,7 @@ function getInitRequestMock(
 }
 
 function resetMockRampsController(): void {
+  mockRampsController.state = { orders: [] };
   mockInit = jest.fn().mockResolvedValue(undefined);
   mockStartOrderPolling = jest.fn();
   mockStopOrderPolling = jest.fn();
@@ -260,6 +262,50 @@ describe('RampsControllerInit', () => {
     await Promise.resolve();
     expect(mockStartOrderPolling).toHaveBeenCalled();
 
+    api?.stopRampsLifecycle?.();
+
+    expect(mockStopOrderPolling).toHaveBeenCalled();
+  });
+
+  it('keeps polling on UI close while an order is still pending', async () => {
+    mockRampsController.state = { orders: [{ status: 'PENDING' }] };
+    const { api } = RampsControllerInit(getInitRequestMock());
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockStartOrderPolling).toHaveBeenCalled();
+
+    api?.stopRampsLifecycle?.();
+
+    expect(mockStopOrderPolling).not.toHaveBeenCalled();
+  });
+
+  it('stops polling on UI close once every order is terminal', async () => {
+    mockRampsController.state = {
+      orders: [{ status: 'COMPLETED' }, { status: 'CANCELLED' }],
+    };
+    const { api } = RampsControllerInit(getInitRequestMock());
+    await Promise.resolve();
+    await Promise.resolve();
+
+    api?.stopRampsLifecycle?.();
+
+    expect(mockStopOrderPolling).toHaveBeenCalled();
+  });
+
+  it('stops polling on UI close with a pending order when network access is revoked', async () => {
+    mockRampsController.state = { orders: [{ status: 'PENDING' }] };
+    const { initMessenger, setUseExternalServices } = createInitMessenger();
+    const baseMessenger = getRootMessenger<never, never>();
+    const { api } = RampsControllerInit({
+      ...buildControllerInitRequestMock(),
+      controllerMessenger: getRampsControllerMessenger(baseMessenger),
+      initMessenger,
+      persistedState: {},
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    setUseExternalServices(false);
     api?.stopRampsLifecycle?.();
 
     expect(mockStopOrderPolling).toHaveBeenCalled();

--- a/app/scripts/messenger-client-init/ramps-controller-init.ts
+++ b/app/scripts/messenger-client-init/ramps-controller-init.ts
@@ -6,6 +6,7 @@ import {
 import type { OnboardingControllerState } from '../controllers/onboarding';
 import type { PreferencesControllerState } from '../controllers/preferences-controller';
 import { removeStalePrecreatedOrders } from '../lib/ramps-stale-order-cleanup';
+import { TERMINAL_ORDER_STATUSES } from '../lib/ramps/handleRampsOrderStatusChanged';
 import type { MessengerClientInitFunction } from './types';
 import { getRampsControllerApi } from './ramps-controller-api';
 import type { RampsControllerInitMessenger } from './messengers/ramps-controller-messenger';
@@ -22,6 +23,12 @@ function isRampsNetworkAllowed(
   );
 
   return completedOnboarding && Boolean(useExternalServices);
+}
+
+function hasUnsettledOrders(messengerClient: RampsController): boolean {
+  return (messengerClient.state?.orders ?? []).some(
+    (order) => !TERMINAL_ORDER_STATUSES.has(order.status),
+  );
 }
 
 function createRampsLifecycleManager(
@@ -62,7 +69,30 @@ function createRampsLifecycleManager(
     lifecycleStarted = false;
   };
 
-  return { startRampsLifecycle, stopRampsLifecycle };
+  /**
+   * Stop requested because the last UI window closed.
+   *
+   * Ramps checkout deliberately runs with no UI open — that is the whole reason
+   * the callback watcher lives in the background (see
+   * `app/scripts/lib/ramps/checkout-watch.ts`). Providers then take minutes to
+   * settle, so the PENDING -> COMPLETED transition lands squarely in the window
+   * where nothing would be polling, leaving the order showing its callback-time
+   * snapshot until the user next opens the wallet. Keep polling until every
+   * order is terminal, the same way pending transactions keep polling while the
+   * UI is closed. A revoked network gate still stops immediately.
+   */
+  const stopRampsLifecycleWhenSettled = (): void => {
+    if (isPollingAllowed() && hasUnsettledOrders(messengerClient)) {
+      return;
+    }
+    stopRampsLifecycle();
+  };
+
+  return {
+    startRampsLifecycle,
+    stopRampsLifecycle,
+    stopRampsLifecycleWhenSettled,
+  };
 }
 
 function registerRampsLifecycleSubscriptions(
@@ -120,8 +150,11 @@ export const RampsControllerInit: MessengerClientInitFunction<
   const isNetworkAllowed = () => isRampsNetworkAllowed(initMessenger);
   applyRampsNetworkGate(messengerClient, isNetworkAllowed);
 
-  const { startRampsLifecycle, stopRampsLifecycle } =
-    createRampsLifecycleManager(messengerClient, isNetworkAllowed);
+  const {
+    startRampsLifecycle,
+    stopRampsLifecycle,
+    stopRampsLifecycleWhenSettled,
+  } = createRampsLifecycleManager(messengerClient, isNetworkAllowed);
 
   const tryStartRampsLifecycle = (): void => {
     if (isNetworkAllowed()) {
@@ -147,7 +180,8 @@ export const RampsControllerInit: MessengerClientInitFunction<
     api: {
       ...getRampsControllerApi(messengerClient, platform),
       startRampsLifecycle: tryStartRampsLifecycle,
-      stopRampsLifecycle,
+      // Called by `stopNetworkRequests` when the last UI window closes.
+      stopRampsLifecycle: stopRampsLifecycleWhenSettled,
     },
   };
 };

--- a/app/scripts/messenger-client-init/ramps-controller-init.ts
+++ b/app/scripts/messenger-client-init/ramps-controller-init.ts
@@ -1,12 +1,12 @@
 import {
   RampsController,
+  RampsOrderStatus,
   getDefaultRampsControllerState,
   type RampsControllerMessenger,
 } from '@metamask/ramps-controller';
 import type { OnboardingControllerState } from '../controllers/onboarding';
 import type { PreferencesControllerState } from '../controllers/preferences-controller';
 import { removeStalePrecreatedOrders } from '../lib/ramps-stale-order-cleanup';
-import { TERMINAL_ORDER_STATUSES } from '../lib/ramps/handleRampsOrderStatusChanged';
 import type { MessengerClientInitFunction } from './types';
 import { getRampsControllerApi } from './ramps-controller-api';
 import type { RampsControllerInitMessenger } from './messengers/ramps-controller-messenger';
@@ -25,9 +25,26 @@ function isRampsNetworkAllowed(
   return completedOnboarding && Boolean(useExternalServices);
 }
 
-function hasUnsettledOrders(messengerClient: RampsController): boolean {
-  return (messengerClient.state?.orders ?? []).some(
-    (order) => !TERMINAL_ORDER_STATUSES.has(order.status),
+/**
+ * Statuses where the user has committed to a purchase and is waiting on the
+ * provider to settle.
+ *
+ * Deliberately narrower than "not terminal". `PRECREATED` and `UNKNOWN` stubs
+ * may never resolve — see `removeStalePrecreatedOrders`, where the API "can
+ * neither complete nor expire" them — so counting those as in-flight would keep
+ * the poll alive forever. Worse, it would be self-sustaining: `lifecycleStarted`
+ * would never clear, so `startRampsLifecycle` would short-circuit on every
+ * later call and the cleanup that prunes those very stubs would never run
+ * again. Leaving them out lets polling stop, which lets the cleanup run.
+ */
+const IN_FLIGHT_ORDER_STATUSES = new Set<string>([
+  RampsOrderStatus.Created,
+  RampsOrderStatus.Pending,
+]);
+
+function hasInFlightOrders(messengerClient: RampsController): boolean {
+  return (messengerClient.state?.orders ?? []).some((order) =>
+    IN_FLIGHT_ORDER_STATUSES.has(order.status),
   );
 }
 
@@ -77,12 +94,12 @@ function createRampsLifecycleManager(
    * `app/scripts/lib/ramps/checkout-watch.ts`). Providers then take minutes to
    * settle, so the PENDING -> COMPLETED transition lands squarely in the window
    * where nothing would be polling, leaving the order showing its callback-time
-   * snapshot until the user next opens the wallet. Keep polling until every
-   * order is terminal, the same way pending transactions keep polling while the
-   * UI is closed. A revoked network gate still stops immediately.
+   * snapshot until the user next opens the wallet. Keep polling while an order
+   * is still in flight, the same way pending transactions keep polling while
+   * the UI is closed. A revoked network gate still stops immediately.
    */
   const stopRampsLifecycleWhenSettled = (): void => {
-    if (isPollingAllowed() && hasUnsettledOrders(messengerClient)) {
+    if (isPollingAllowed() && hasInFlightOrders(messengerClient)) {
       return;
     }
     stopRampsLifecycle();


### PR DESCRIPTION
## **Description**

A ramps order could sit on `PENDING` in Activity indefinitely after the crypto had already been delivered.

**Reason for the change.** Order polling is tied to a MetaMask window being open. `controllerConnectionChanged` with zero active connections calls `stopNetworkRequests`, which stops the ramps lifecycle and with it `RampsController.stopOrderPolling`.

But ramps checkout deliberately runs with *no* UI open — that is the entire reason the callback watcher lives in the background (`app/scripts/lib/ramps/checkout-watch.ts`, "so popup-mode UI can close safely"). Providers then take minutes to settle after the callback fires, so the `PENDING -> COMPLETED` transition lands squarely in the window where nothing is polling. The order keeps showing its callback-time snapshot until the user next opens the wallet.

Observed with a Revolut Pay buy. The stored order was a stale snapshot (`status: PENDING`, `canBeUpdated: true`, `"Your order for ETH is processing"`) while a live `GET` of the exact URL the poller builds returned `status: COMPLETED`, `canBeUpdated: false`, `"Your ETH is now available in your account"`. The tx hash and the ETH were already there — only the order status was stale.


**Solution.** On UI close, keep polling until every order reaches a terminal status — the same treatment pending transactions already get (`stopNetworkRequests` does not stop those either). Once all orders are terminal, the next UI close stops polling as before.

A revoked network gate still stops polling immediately: `stopRampsLifecycleWhenSettled` is guarded on `isPollingAllowed()`, and the existing `OnboardingController` / `PreferencesController` subscriptions continue to call the unconditional stop when onboarding is incomplete or basic functionality is turned off.

### Known trade-off (reviewer input welcome)

`useRampsOrderEventToasts` is UI-side and transition-based, and seeds existing statuses on mount without toasting them. So in the exact case this PR fixes — the order settling while the UI is closed — the success toast no longer fires, because by the time the UI mounts the order is already `COMPLETED` and there is no transition left to observe. Previously the (late) transition happened while mounted, so the toast did fire.

Net: correct status immediately, no toast — versus wrong status until reopen, then a toast for something that happened minutes earlier. I think the former is better, but it is a real behaviour change and worth a follow-up if we want a terminal toast for transitions the UI never saw (e.g. persisting last-seen status per order).


## **Changelog**

CHANGELOG entry: Fixed a bug where a crypto purchase could stay stuck on "Pending" in Activity after the funds had already arrived.

## **Related issues**

Fixes:

## **Manual testing steps**

Needs a provider that settles a few minutes after the callback (Revolut Pay reproduces it reliably) and the extension in **popup** mode — in a pinned full-screen tab the UI never disconnects, so polling never stops and the bug does not reproduce.

1. Build with ramps enabled against the production ramps environment.
2. Open the extension popup and start a buy: pick a token, an amount, and Revolut Pay as the payment method. Continue.
3. The provider checkout opens in a new tab and the popup closes. Complete the payment.
4. On the callback, the extension opens `/activity` and the new order shows as **Pending** — correct at this point, the provider has not settled yet.
5. **Close every MetaMask window and tab.** This is the step that triggers the bug.
6. Wait for the provider to settle and the crypto to land on-chain (a few minutes).
7. Reopen MetaMask and look at the order row in Activity.

- **Before:** the row is still **Pending** on open, then flips to Completed a moment later once the reopened UI restarts polling.
- **After:** the row is already **Completed** on open, because polling continued while the UI was closed.

Regression checks worth covering:

8. With no orders in state, close all MetaMask windows and confirm order polling stops as before (no ongoing requests to the orders API).
9. With a pending order, turn **Settings → Security & privacy → Basic functionality** off and confirm polling stops immediately.

## **Screenshots/Recordings**

### **After**


<img width="1346" height="825" alt="revolut-order-completed" src="https://github.com/user-attachments/assets/a563964d-b82f-4c4f-b517-3fce9ce587bf" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes background lifecycle and polling when no UI is connected; logic is scoped but affects order status freshness and network usage until orders settle.
> 
> **Overview**
> When the last MetaMask window closes, ramps order polling no longer always stops. The background API’s `stopRampsLifecycle` (wired from `stopNetworkRequests`) now uses **settled-aware** shutdown: polling continues while network access is allowed and any order is **Created** or **Pending**, so provider settlement can update Activity after checkout closes the popup.
> 
> **PRECREATED** and **UNKNOWN** stubs are intentionally excluded from “in-flight” so they cannot keep the lifecycle open forever and block `removeStalePrecreatedOrders` on later opens. Unconditional `stopRampsLifecycle` remains for onboarding/preferences revocations.
> 
> Tests extend the ramps init mock with order state and cover pending vs terminal orders, stub statuses, UI close/open lifecycle, and revoked basic functionality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc9170ad9a59c82e8aab18e4077717ed5bc2e54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->