### PR TITLE
fix(perps): let unfavorable limit prices warn without blocking submit

### DIFF
--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -1456,11 +1456,23 @@ describe('PerpsOrderEntryPage', () => {
       );
     });
 
-    it('disables submit when long limit price is above current price', () => {
+    it('warns but still allows submit when long limit price is above current price', () => {
       mockSearchParams.set('orderType', 'limit');
       mockSearchParams.set('direction', 'long');
       const store = mockStore(createMockState());
       renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      // Near-liquidation stays blocking and an extreme limit price trips it, so
+      // it is held off to isolate the unfavorable-price guard under test.
+      mockIsNearLiquidationPrice.mockReturnValue(false);
+
+      // An amount is required so the assertion isolates the unfavorable-price
+      // guard rather than tripping the minimum-order-size one.
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const amountInput = amountContainer.querySelector('input');
+      fireEvent.change(amountInput as HTMLInputElement, {
+        target: { value: '100' },
+      });
 
       const limitContainer = screen.getByTestId('limit-price-input');
       const limitInput = limitContainer.querySelector('input');
@@ -1468,14 +1480,22 @@ describe('PerpsOrderEntryPage', () => {
         target: { value: '99999' },
       });
 
-      expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      expect(screen.getByTestId('limit-price-warning')).toBeInTheDocument();
+      expect(screen.getByTestId('submit-order-button')).not.toBeDisabled();
     });
 
-    it('disables submit when short limit price is below current price', () => {
+    it('warns but still allows submit when short limit price is below current price', () => {
       mockSearchParams.set('orderType', 'limit');
       mockSearchParams.set('direction', 'short');
+      mockIsNearLiquidationPrice.mockReturnValue(false);
       const store = mockStore(createMockState());
       renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const amountInput = amountContainer.querySelector('input');
+      fireEvent.change(amountInput as HTMLInputElement, {
+        target: { value: '100' },
+      });
 
       const limitContainer = screen.getByTestId('limit-price-input');
       const limitInput = limitContainer.querySelector('input');
@@ -1483,7 +1503,8 @@ describe('PerpsOrderEntryPage', () => {
         target: { value: '1' },
       });
 
-      expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      expect(screen.getByTestId('limit-price-warning')).toBeInTheDocument();
+      expect(screen.getByTestId('submit-order-button')).not.toBeDisabled();
     });
 
     it('does not disable submit for favorable long limit price', () => {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -115,10 +115,7 @@ import {
   formatPerpsFiatMinimal,
   formatPerpsFiatUniversal,
 } from '../../components/app/perps/utils/formatPerpsDisplayPrice';
-import {
-  isLimitPriceUnfavorable as checkLimitPriceUnfavorable,
-  isNearLiquidationPrice as checkNearLiquidationPrice,
-} from '../../components/app/perps/order-entry/limit-price-warnings';
+import { isNearLiquidationPrice as checkNearLiquidationPrice } from '../../components/app/perps/order-entry/limit-price-warnings';
 import {
   isValidTakeProfitPrice,
   isValidStopLossPrice,
@@ -880,17 +877,6 @@ const PerpsOrderEntryPage = () => {
     orderMode === 'new' && !isLoadingAccount && availableBalance <= 0;
   const isPrimaryTradeAction = orderMode !== 'new' || !hasNoAvailableBalance;
 
-  const isLimitPriceUnfavorable = useMemo(() => {
-    if (orderType !== 'limit' || !orderFormState) {
-      return false;
-    }
-    return checkLimitPriceUnfavorable(
-      orderFormState.limitPrice ?? '',
-      currentPrice,
-      orderDirection,
-    );
-  }, [orderType, orderFormState, orderDirection, currentPrice]);
-
   const isNearLiquidation = useMemo(() => {
     if (orderType !== 'limit' || !orderFormState) {
       return false;
@@ -1092,7 +1078,6 @@ const PerpsOrderEntryPage = () => {
       (isMaxSlippageLoading || !isEstimatedSlippageReady)) ||
     (isPrimaryTradeAction &&
       (isLimitPriceInvalid ||
-        isLimitPriceUnfavorable ||
         isNearLiquidation ||
         hasInvalidTPSL ||
         isInsufficientFunds ||


### PR DESCRIPTION
  ## **Description**

  In Pro mode's limit order flow, setting a limit buy price above the current market price (or a limit sell below it) means the order would fill immediately at market rather than resting on the book. That "unfavorable" condition was doing two things at once: showing an inline yellow warning in the limit price input, and disabling the submit button — so the user could not place the order at all.

The warning is the correct signal. The block was not. Traders intentionally cross the spread, and the UI should inform rather than prevent.

This decouples the two layers by removing `isLimitPriceUnfavorable` from `isSubmitDisabled` in `perps-order-entry-page.tsx`, along with its now-unused `useMemo` and import. The inline warning in `limit-price-input.tsx` is untouched, and `isLimitPriceUnfavorable()` in `limit-price-warnings.ts` is unchanged — it still drives the warning.

### Deliberately left in the guard:

- `isLimitPriceInvalid` (empty, NaN, or ≤ 0) — a genuine blocking condition
- `isNearLiquidation` — out of scope for this ticket, blocking behavior unchanged

## **Changelog**

CHANGELOG entry: Fixed a bug that prevented placing a Perps limit order when the limit price would fill immediately at market

  ## **Related issues**

  Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3797

  ## **Manual testing steps**

  1. Open a Perps market in Pro mode (e.g. BTC) and switch the order form to **Limit**
  2. Select **Long**, enter a limit price *above* the current market price, and enter a size
  3. Confirm the yellow "Limit price is above current price" warning appears **and** the "Open long BTC" button is enabled
  4. Select **Short**, enter a limit price *below* the current market price
  5. Confirm the "Limit price is below current price" warning appears **and** the "Open short BTC" button is enabled
  6. Clear the limit price, or set it to `0` — confirm the submit button is still disabled
  7. Confirm a favorable limit price shows no warning and submits normally

  ## **Screenshots/Recordings**

  ### **Before**

Loom Video: https://www.loom.com/share/6d575f614654429183c4042cbe623a36
<img width="782" height="996" alt="Screenshot 2026-08-28 at 1 21 32 PM" src="https://github.com/user-attachments/assets/1ba15106-1c09-4e5e-ae24-1f50dfb626c8" />
<img width="782" height="996" alt="Screenshot 2026-08-28 at 1 21 15 PM" src="https://github.com/user-attachments/assets/e1fe99e4-d606-4ab0-942f-296150821c7b" />



  ### **After**

Loom Video: Loom Video: https://www.loom.com/share/41ec35b9cf6745af947e825ec5f652e8
<img width="782" height="996" alt="Screenshot 2026-08-28 at 1 21 32 PM" src="https://github.com/user-attachments/assets/61df99f5-d1a0-463a-b140-5977f998a99f" />
<img width="782" height="996" alt="Screenshot 2026-08-28 at 1 21 15 PM" src="https://github.com/user-attachments/assets/cf100b8f-11db-4b30-927d-c95dcd84eba7" />



  ## **Pre-merge author checklist**

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I’ve included tests if applicable
  - [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX change in order-entry validation only; warnings remain and harder safety checks (invalid price, near liquidation) are unchanged.
> 
> **Overview**
> **Unfavorable limit prices no longer disable submit** on the Perps order entry page. Crossing the spread (long limit above market, short limit below) still shows the inline `limit-price-warning`, but traders can submit those orders.
> 
> In `perps-order-entry-page.tsx`, **`isLimitPriceUnfavorable` is removed from `isSubmitDisabled`** along with its `useMemo` and import. Invalid limit prices and near-liquidation checks **still block** submit.
> 
> Tests now expect the warning **and** an enabled submit button, with mocks for amount and near-liquidation so other guards do not interfere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98e165e788e95adee950348eda444cf499311d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->