### PR TITLE
fix(ci): align CWS upload and rollout with 4-part crxVersion (INFRA-3646)

### DIFF
--- a/.github/workflows/adjust-cws-rollout.yml
+++ b/.github/workflows/adjust-cws-rollout.yml
@@ -102,8 +102,9 @@ jobs:
             echo "::error::CWS rollout must run from refs/heads/main (current: ${GITHUB_REF})"
             exit 1
           fi
-          # Sets GITHUB_ENV: WIF_*, EXTENSION_ID, PUBLISHER_ID, CRX_VERSION (see script header).
-          bash .github/scripts/cws-target-config.sh
+          # Sets GITHUB_ENV and same-step vars: WIF_*, EXTENSION_ID, PUBLISHER_ID, CRX_VERSION.
+          # shellcheck disable=SC1091
+          source .github/scripts/cws-target-config.sh
           {
             echo "target=${TARGET}"
             echo "extension_id=${EXTENSION_ID}"

--- a/.github/workflows/adjust-cws-rollout.yml
+++ b/.github/workflows/adjust-cws-rollout.yml
@@ -105,11 +105,6 @@ jobs:
           # Sets GITHUB_ENV and same-step vars: WIF_*, EXTENSION_ID, PUBLISHER_ID, CRX_VERSION.
           # shellcheck disable=SC1091
           source .github/scripts/cws-target-config.sh
-          {
-            echo "target=${TARGET}"
-            echo "extension_id=${EXTENSION_ID}"
-            echo "publisher_id=${PUBLISHER_ID}"
-          } >> "${GITHUB_OUTPUT}"
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.github/workflows/adjust-cws-rollout.yml
+++ b/.github/workflows/adjust-cws-rollout.yml
@@ -17,12 +17,14 @@ name: Adjust CWS rollout percentage
 # Listing vars (*_DEV, prod, EXTENSION_ID_FLASK) match upload; OIDC environment differs.
 #
 # CWS v2: :fetchStatus (current deployPercentage) → :setPublishedDeployPercentage
+# Version input is release semver X.Y.Z; crxVersion is derived per target via cws-target-config.sh
+# (prod/dev → X.Y.Z.0, flask → X.Y.Z.150 — same as upload and publish workflows).
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Published Chrome manifest version (e.g. 12.9.1) — must match live CWS crxVersion for the target listing'
+        description: 'Release semver X.Y.Z (e.g. 13.43.0) — crxVersion is derived per target (prod/dev → X.Y.Z.0, flask → X.Y.Z.150)'
         required: true
         type: string
       desired_percentage:
@@ -75,7 +77,9 @@ jobs:
       - name: Checkout scripts
         uses: actions/checkout@v6
         with:
-          sparse-checkout: .github/scripts/adjust-cws-rollout-guardrails.sh
+          sparse-checkout: |
+            .github/scripts/cws-target-config.sh
+            .github/scripts/adjust-cws-rollout-guardrails.sh
           sparse-checkout-cone-mode: false
 
       - name: Resolve target configuration
@@ -94,72 +98,12 @@ jobs:
         run: |
           set -euo pipefail
           GITHUB_REF="${{ github.ref }}"
-          # All targets require main. Originally each target had its own ref check to allow
-          # different branch policies; since all three targets are now aligned on refs/heads/main,
-          # the check is unified here before target resolution.
           if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
             echo "::error::CWS rollout must run from refs/heads/main (current: ${GITHUB_REF})"
             exit 1
           fi
-          if [[ "${TARGET}" == "dev" ]]; then
-            WIF_PROVIDER="${WIF_PROVIDER_DEV}"
-            WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_DEV}"
-            EXTENSION_ID="${EXTENSION_ID_DEV}"
-            PUBLISHER_ID="${PUBLISHER_ID_DEV}"
-          elif [[ "${TARGET}" == "production" ]]; then
-            WIF_PROVIDER="${WIF_PROVIDER_PROD}"
-            WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_PROD}"
-            EXTENSION_ID="${EXTENSION_ID_PROD}"
-            PUBLISHER_ID="${PUBLISHER_ID_PROD}"
-          elif [[ "${TARGET}" == "flask" ]]; then
-            WIF_PROVIDER="${WIF_PROVIDER_PROD}"
-            WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_PROD}"
-            EXTENSION_ID="${EXTENSION_ID_FLASK}"
-            PUBLISHER_ID="${PUBLISHER_ID_FLASK}"
-          else
-            echo "::error::Invalid target: ${TARGET}"
-            exit 1
-          fi
-          if [[ ! "${VERSION}" =~ ^[0-9]+(\.[0-9]+){0,3}$ ]]; then
-            echo "::error::Invalid version format: ${VERSION} — use 1–4 dot-separated integers (e.g. 12.9.1)"
-            exit 1
-          fi
-          IFS='.' read -r -a version_parts <<< "${VERSION}"
-          for part in "${version_parts[@]}"; do
-            if [[ ! "${part}" =~ ^(0|[1-9][0-9]*)$ ]]; then
-              echo "::error::Version segment must be a non-negative integer without leading zeros: ${part} in ${VERSION}"
-              exit 1
-            fi
-            if (( 10#${part} > 65535 )); then
-              echo "::error::Version segment out of range (0–65535): ${part} in ${VERSION}"
-              exit 1
-            fi
-          done
-          if [[ -z "${EXTENSION_ID:-}" ]]; then
-            case "${TARGET}" in
-              dev) EXTENSION_ID_VAR="EXTENSION_ID_DEV" ;;
-              production) EXTENSION_ID_VAR="EXTENSION_ID" ;;
-              flask) EXTENSION_ID_VAR="EXTENSION_ID_FLASK" ;;
-            esac
-            echo "::error::Missing ${EXTENSION_ID_VAR} repository variable for target '${TARGET}'"
-            exit 1
-          fi
-          missing=""
-          for name in WIF_PROVIDER WIF_SERVICE_ACCOUNT PUBLISHER_ID; do
-            if [[ -z "${!name:-}" ]]; then
-              missing="${missing} ${name}"
-            fi
-          done
-          if [[ -n "${missing}" ]]; then
-            echo "::error::Missing repository variables for target '${TARGET}':${missing}"
-            exit 1
-          fi
-          {
-            echo "WIF_PROVIDER=${WIF_PROVIDER}"
-            echo "WIF_SERVICE_ACCOUNT=${WIF_SERVICE_ACCOUNT}"
-            echo "EXTENSION_ID=${EXTENSION_ID}"
-            echo "PUBLISHER_ID=${PUBLISHER_ID}"
-          } >> "${GITHUB_ENV}"
+          # Sets GITHUB_ENV: WIF_*, EXTENSION_ID, PUBLISHER_ID, CRX_VERSION (see script header).
+          bash .github/scripts/cws-target-config.sh
           {
             echo "target=${TARGET}"
             echo "extension_id=${EXTENSION_ID}"
@@ -192,14 +136,8 @@ jobs:
             exit 1
           fi
           # setPublishedDeployPercentage only affects the live published revision.
-          # Read baseline exclusively from publishedItemRevisionStatus so a mistyped
-          # older version cannot supply a false current percentage.
-          # Flask CWS listing stores versions as "{version}-flask.0"; other targets use raw version.
-          if [[ "${TARGET}" == "flask" ]]; then
-            CRX_VERSION="${VERSION}-flask.0"
-          else
-            CRX_VERSION="${VERSION}"
-          fi
+          # Match publishedItemRevisionStatus.crxVersion against derived CRX_VERSION
+          # (4-part manifest version from cws-target-config.sh).
           published_channel=$(jq -c --arg ver "${CRX_VERSION}" '
             (.publishedItemRevisionStatus.distributionChannels // [])
             | map(select(.crxVersion == $ver))
@@ -220,7 +158,7 @@ jobs:
             exit 1
           fi
           echo "current_percentage=${current_pct}" >> "${GITHUB_OUTPUT}"
-          echo "Current rollout for version ${VERSION}: ${current_pct}%"
+          echo "Current rollout for crxVersion ${CRX_VERSION}: ${current_pct}%"
 
       - name: Validate rollout guardrails
         id: guardrails
@@ -277,7 +215,8 @@ jobs:
             echo "| GitHub Environment | \`${{ env.ROLLOUT_ENV }}\` (required reviewers — configure in repo Settings) |"
             echo "| Triggered by | \`${{ github.actor }}\` (sender: \`${{ github.event.sender.login }}\`, type=\`${{ github.event.sender.type }}\`) |"
             echo "| Target | \`${{ inputs.target }}\` |"
-            echo "| Version | \`${{ inputs.version }}\` |"
+            echo "| Version input | \`${{ inputs.version }}\` |"
+            echo "| crxVersion | \`${{ env.CRX_VERSION }}\` |"
             echo "| Branch | \`${{ github.ref }}\` |"
             echo "| Previous percentage | \`${CURRENT_PCT:-n/a}\` |"
             echo "| Requested percentage | \`${{ inputs.desired_percentage }}\` |"

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -7,14 +7,15 @@ name: Upload extension to Chrome Web Store
 # CWS API v2 upload (v1.1 sunsets 2026-10-15): chromewebstore.googleapis.com/upload/v2/...
 # INFRA-3649 — Runway sender verification (defense-in-depth; primary gate is WIF CEL on actor_id).
 # Idempotent re-run: after WIF auth, :fetchStatus skips upload when a draft for
-# CWS_EXPECTED_VERSION already exists (VERSION for production/dev; VERSION-flask.0 for flask)
-# or a prior async upload is still IN_PROGRESS (poll to terminal first).
+# CRX_VERSION already exists (4-part manifest version from cws-target-config.sh;
+# see development/webpack/utils/version.ts) or a prior async upload is still
+# IN_PROGRESS (poll to terminal first).
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Chrome manifest version (1–4 dot-separated integers, e.g. 13.0.0) — must match GitHub Release tag v{version}'
+        description: 'Release semver X.Y.Z (e.g. 13.43.0) — crxVersion is derived per target (prod/dev → X.Y.Z.0, flask → X.Y.Z.150)'
         required: true
         type: string
       target:
@@ -65,6 +66,12 @@ jobs:
       VERSION: ${{ inputs.version }}
       RELEASE_TAG: v${{ inputs.version }}
     steps:
+      - name: Checkout scripts
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts/cws-target-config.sh
+          sparse-checkout-cone-mode: false
+
       - name: Validate inputs and configuration
         env:
           TARGET: ${{ inputs.target }}
@@ -110,7 +117,6 @@ jobs:
               exit 1
             fi
           done
-          CWS_EXPECTED_VERSION="${VERSION}"
           if [[ "${TARGET}" == "dev" ]]; then
             WIF_PROVIDER="${WIF_PROVIDER_DEV}"
             WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_DEV}"
@@ -132,7 +138,6 @@ jobs:
             PUBLISHER_ID="${PUBLISHER_ID_FLASK}"
             PUBLISHER_EMAIL="${PUBLISHER_EMAIL_FLASK}"
             ZIP_NAME="metamask-chrome-${VERSION}-flask.0.zip"
-            CWS_EXPECTED_VERSION="${VERSION}-flask.0"
           else
             echo "::error::Invalid target: ${TARGET}"
             exit 1
@@ -181,14 +186,15 @@ jobs:
               exit 1
             fi
           fi
+          export TARGET="${TARGET}"
+          # shellcheck source=.github/scripts/cws-target-config.sh
+          # Source (not exec) so CRX_VERSION, EXTENSION_ID, PUBLISHER_ID, WIF_PROVIDER
+          # are available in this step's shell (as well as written to GITHUB_ENV).
+          # shellcheck disable=SC1091
+          source .github/scripts/cws-target-config.sh
           {
-            echo "WIF_PROVIDER=${WIF_PROVIDER}"
-            echo "WIF_SERVICE_ACCOUNT=${WIF_SERVICE_ACCOUNT}"
-            echo "EXTENSION_ID=${EXTENSION_ID}"
-            echo "PUBLISHER_ID=${PUBLISHER_ID}"
             echo "PUBLISHER_EMAIL=${PUBLISHER_EMAIL}"
             echo "ZIP_NAME=${ZIP_NAME}"
-            echo "CWS_EXPECTED_VERSION=${CWS_EXPECTED_VERSION}"
           } >> "${GITHUB_ENV}"
           {
             echo "## CWS upload"
@@ -196,7 +202,8 @@ jobs:
             echo "| Field | Value |"
             echo "|-------|-------|"
             echo "| Target | \`${TARGET}\` |"
-            echo "| Version | \`${VERSION}\` |"
+            echo "| Version input | \`${VERSION}\` |"
+            echo "| crxVersion | \`${CRX_VERSION}\` |"
             echo "| Release tag | \`${RELEASE_TAG}\` |"
             echo "| Asset | \`${ZIP_NAME}\` |"
             echo "| Extension ID | \`${EXTENSION_ID}\` |"
@@ -263,15 +270,17 @@ jobs:
           max_polls=6
           poll_interval_seconds=10
 
+          FETCH_STATUS_PREFLIGHT=/tmp/cws-fetch-status-preflight.json
+
           fetch_status() {
             local http_code
             http_code=$(curl -sS \
-              -o /tmp/fetch-status.json -w "%{http_code}" \
+              -o "${FETCH_STATUS_PREFLIGHT}" -w "%{http_code}" \
               -H "Authorization: Bearer ${ACCESS_TOKEN}" \
               "${FETCH_STATUS_URL}")
             if [[ "${http_code}" != "200" ]]; then
               echo "::error::fetchStatus failed with HTTP ${http_code}"
-              cat /tmp/fetch-status.json
+              cat "${FETCH_STATUS_PREFLIGHT}"
               exit 1
             fi
           }
@@ -281,24 +290,24 @@ jobs:
               [
                 .submittedItemRevisionStatus.distributionChannels[]?.crxVersion // empty
               ] | map(select(length > 0)) | first // empty
-            ' /tmp/fetch-status.json
+            ' "${FETCH_STATUS_PREFLIGHT}"
           }
 
           poll_async_upload() {
             local upload_state
-            upload_state=$(jq -r '.lastAsyncUploadState // empty' /tmp/fetch-status.json)
+            upload_state=$(jq -r '.lastAsyncUploadState // empty' "${FETCH_STATUS_PREFLIGHT}")
             local poll=0
             while [[ "${upload_state}" == "IN_PROGRESS" && $poll -lt ${max_polls} ]]; do
               poll=$((poll + 1))
               echo "Prior upload IN_PROGRESS; polling :fetchStatus (${poll}/${max_polls})..."
               sleep "${poll_interval_seconds}"
               fetch_status
-              upload_state=$(jq -r '.lastAsyncUploadState // empty' /tmp/fetch-status.json)
+              upload_state=$(jq -r '.lastAsyncUploadState // empty' "${FETCH_STATUS_PREFLIGHT}")
               echo "Poll ${poll}/${max_polls}: lastAsyncUploadState=${upload_state:-<unset>}"
             done
             if [[ "${upload_state}" == "IN_PROGRESS" ]]; then
               echo "::error::CWS upload still IN_PROGRESS after ${max_polls} polls (${poll_interval_seconds}s apart); check CWS console or re-run"
-              cat /tmp/fetch-status.json
+              cat "${FETCH_STATUS_PREFLIGHT}"
               exit 1
             fi
             echo "${upload_state}"
@@ -310,8 +319,8 @@ jobs:
           async_state=$(poll_async_upload)
           draft_version=$(draft_crx_version)
 
-          if [[ -n "${draft_version}" && "${draft_version}" == "${CWS_EXPECTED_VERSION}" ]]; then
-            echo "Draft for version ${CWS_EXPECTED_VERSION} already exists in CWS (crxVersion=${draft_version}). Skipping download and upload."
+          if [[ -n "${draft_version}" && "${draft_version}" == "${CRX_VERSION}" ]]; then
+            echo "Draft for crxVersion ${CRX_VERSION} already exists in CWS (crxVersion=${draft_version}). Skipping download and upload."
             {
               echo "skip_upload=true"
               echo "upload_state=SKIPPED_ALREADY_EXISTS"
@@ -320,7 +329,7 @@ jobs:
             exit 0
           fi
 
-          echo "No matching draft for version ${CWS_EXPECTED_VERSION} (draft=${draft_version:-<none>}, lastAsyncUploadState=${async_state:-<none>}). Proceeding with upload."
+          echo "No matching draft for crxVersion ${CRX_VERSION} (draft=${draft_version:-<none>}, lastAsyncUploadState=${async_state:-<none>}). Proceeding with upload."
           {
             echo "skip_upload=false"
             echo "upload_state="
@@ -381,11 +390,13 @@ jobs:
       # Dev listing rejects manifest.key tied to production extension ID (POC lesson).
       - name: Strip manifest key from zip (dev only)
         if: inputs.target == 'dev' && !inputs.dry-run && steps.cws-precheck.outputs.skip_upload != 'true'
+        env:
+          CRX_VERSION: ${{ env.CRX_VERSION }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/extension
           unzip -q "${ZIP_NAME}" -d /tmp/extension
-          jq 'del(.key) | .version = env.VERSION' /tmp/extension/manifest.json > /tmp/extension/manifest-tmp.json
+          jq 'del(.key) | .version = env.CRX_VERSION' /tmp/extension/manifest.json > /tmp/extension/manifest-tmp.json
           mv /tmp/extension/manifest-tmp.json /tmp/extension/manifest.json
           cd /tmp/extension
           zip -r -q "${GITHUB_WORKSPACE}/${ZIP_NAME}" .
@@ -409,8 +420,31 @@ jobs:
           UPLOAD_URL="https://chromewebstore.googleapis.com/upload/v2/publishers/${PUBLISHER_ID}/items/${EXTENSION_ID}:upload"
           FETCH_STATUS_URL="https://chromewebstore.googleapis.com/v2/publishers/${PUBLISHER_ID}/items/${EXTENSION_ID}:fetchStatus"
 
+          UPLOAD_RESPONSE=/tmp/cws-upload-response.json
+          FETCH_STATUS_POLL=/tmp/cws-fetch-status-poll.json
+
+          crx_from_fetch_status() {
+            jq -r '
+              (.submittedItemRevisionStatus.distributionChannels // [])[0].crxVersion // empty
+            ' "$1"
+          }
+
+          fetch_upload_crx_version() {
+            local http_code
+            http_code=$(curl -sS \
+              -o "${FETCH_STATUS_POLL}" -w "%{http_code}" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              "${FETCH_STATUS_URL}")
+            if [[ "${http_code}" != "200" ]]; then
+              echo "::error::fetchStatus failed with HTTP ${http_code} while resolving upload crxVersion"
+              cat "${FETCH_STATUS_POLL}"
+              exit 1
+            fi
+            crx_from_fetch_status "${FETCH_STATUS_POLL}"
+          }
+
           HTTP_CODE=$(curl -sS \
-            -o /tmp/response.json -w "%{http_code}" \
+            -o "${UPLOAD_RESPONSE}" -w "%{http_code}" \
             -X POST \
             -H "Authorization: Bearer ${ACCESS_TOKEN}" \
             -T "${ZIP_NAME}" \
@@ -419,52 +453,72 @@ jobs:
           echo "http_code=${HTTP_CODE}" >> "${GITHUB_OUTPUT}"
           echo "HTTP Status: ${HTTP_CODE}"
           echo ""
-          cat /tmp/response.json
+          cat "${UPLOAD_RESPONSE}"
           echo ""
 
           if [[ "${HTTP_CODE}" != "200" ]]; then
             echo "::error::Upload failed with HTTP ${HTTP_CODE}"
-            cat /tmp/response.json
+            cat "${UPLOAD_RESPONSE}"
             exit 1
           fi
 
-          UPLOAD_STATE=$(jq -r '.uploadState // empty' /tmp/response.json)
+          UPLOAD_STATE=$(jq -r '.uploadState // empty' "${UPLOAD_RESPONSE}")
+          UPLOAD_CRX=$(jq -r '.crxVersion // empty' "${UPLOAD_RESPONSE}")
+
           if [[ "${UPLOAD_STATE}" == "IN_PROGRESS" ]]; then
             max_polls=6
             poll_interval_seconds=10
-            echo "Upload in progress; polling :fetchStatus (up to ${max_polls}×${poll_interval_seconds}s)..."
+            echo "Upload in progress; polling :fetchStatus for lastAsyncUploadState (up to ${max_polls}×${poll_interval_seconds}s)..."
             poll=0
             while [[ "${UPLOAD_STATE}" == "IN_PROGRESS" && $poll -lt ${max_polls} ]]; do
               poll=$((poll + 1))
               sleep "${poll_interval_seconds}"
               FETCH_HTTP_CODE=$(curl -sS \
-                -o /tmp/fetch-status.json -w "%{http_code}" \
+                -o "${FETCH_STATUS_POLL}" -w "%{http_code}" \
                 -H "Authorization: Bearer ${ACCESS_TOKEN}" \
                 "${FETCH_STATUS_URL}")
               if [[ "${FETCH_HTTP_CODE}" != "200" ]]; then
                 echo "::error::fetchStatus failed with HTTP ${FETCH_HTTP_CODE} (poll ${poll}/${max_polls})"
-                cat /tmp/fetch-status.json
+                cat "${FETCH_STATUS_POLL}"
                 exit 1
               fi
-              UPLOAD_STATE=$(jq -r '.lastAsyncUploadState // empty' /tmp/fetch-status.json)
-              echo "Poll ${poll}/${max_polls}: uploadState=${UPLOAD_STATE:-<unset>}"
+              UPLOAD_STATE=$(jq -r '.lastAsyncUploadState // empty' "${FETCH_STATUS_POLL}")
+              echo "Poll ${poll}/${max_polls}: lastAsyncUploadState=${UPLOAD_STATE:-<unset>}"
             done
             if [[ "${UPLOAD_STATE}" == "IN_PROGRESS" ]]; then
               echo "::error::CWS upload still IN_PROGRESS after ${max_polls} polls (${poll_interval_seconds}s apart); check CWS console or re-run"
-              cat /tmp/fetch-status.json
+              cat "${FETCH_STATUS_POLL}"
               exit 1
-            fi
-            if [[ -f /tmp/fetch-status.json ]]; then
-              cp /tmp/fetch-status.json /tmp/response.json
             fi
           fi
 
           echo "upload_state=${UPLOAD_STATE}" >> "${GITHUB_OUTPUT}"
           if [[ "${UPLOAD_STATE}" != "SUCCEEDED" ]]; then
             echo "::error::CWS upload failed: uploadState=${UPLOAD_STATE:-<missing>}"
-            cat /tmp/response.json
+            cat "${UPLOAD_RESPONSE}"
             exit 1
           fi
+
+          # After SUCCEEDED, prefer :upload crxVersion (manifest of the package just uploaded).
+          # Do not read crxVersion during IN_PROGRESS polls — submittedItemRevisionStatus may
+          # still reflect a prior in-review revision. Fall back to :fetchStatus only when the
+          # upload response omitted crxVersion (async IN_PROGRESS path per CWS API docs).
+          UPLOAD_CRX=$(jq -r '.crxVersion // empty' "${UPLOAD_RESPONSE}")
+          if [[ -z "${UPLOAD_CRX}" ]]; then
+            UPLOAD_CRX="$(fetch_upload_crx_version)"
+          fi
+          if [[ -z "${UPLOAD_CRX}" ]]; then
+            echo "::error::CWS upload succeeded but crxVersion was not returned by :upload or :fetchStatus; cannot verify draft is ${CRX_VERSION}"
+            cat "${UPLOAD_RESPONSE}"
+            exit 1
+          fi
+          if [[ "${UPLOAD_CRX}" != "${CRX_VERSION}" ]]; then
+            echo "::error::CWS upload crxVersion ${UPLOAD_CRX} does not match expected ${CRX_VERSION}"
+            cat "${UPLOAD_RESPONSE}"
+            exit 1
+          fi
+          echo "upload_crx_version=${UPLOAD_CRX}" >> "${GITHUB_OUTPUT}"
+          echo "Verified CWS upload crxVersion=${UPLOAD_CRX}"
 
           echo "Package uploaded (draft/pending review). Not published to users."
 
@@ -476,6 +530,7 @@ jobs:
           DRAFT_VERSION: ${{ steps.cws-precheck.outputs.draft_version }}
           HTTP_CODE: ${{ steps.cws-upload.outputs.http_code }}
           UPLOAD_STATE: ${{ steps.cws-upload.outputs.upload_state }}
+          UPLOAD_CRX: ${{ steps.cws-upload.outputs.upload_crx_version }}
           ATTEST_OUTCOME: ${{ steps.verify-attestation.outcome }}
           SHA_OUTCOME: ${{ steps.verify-sha256sums.outcome }}
         run: |
@@ -500,6 +555,8 @@ jobs:
             echo "| CWS uploadState | \`${result_state}\` |"
             if [[ "${SKIP_UPLOAD}" == "true" && -n "${DRAFT_VERSION}" ]]; then
               echo "| Draft crxVersion | \`${DRAFT_VERSION}\` |"
+            elif [[ -n "${UPLOAD_CRX:-}" ]]; then
+              echo "| Upload crxVersion | \`${UPLOAD_CRX}\` |"
             fi
             echo "| Attestation verified | ${attest_display} |"
             echo "| SHA256SUMS verified | ${sha_display} |"

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -102,52 +102,26 @@ jobs:
               exit 1
             fi
           fi
-          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version: ${VERSION} — use release semver X.Y.Z (e.g. 13.43.0)"
-            exit 1
-          fi
-          if [[ "${TARGET}" == "dev" ]]; then
-            WIF_PROVIDER="${WIF_PROVIDER_DEV}"
-            WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_DEV}"
-            EXTENSION_ID="${EXTENSION_ID_DEV}"
-            PUBLISHER_ID="${PUBLISHER_ID_DEV}"
-            PUBLISHER_EMAIL="${PUBLISHER_EMAIL_DEV}"
-            ZIP_NAME="metamask-chrome-${VERSION}.zip"
-          elif [[ "${TARGET}" == "production" ]]; then
-            WIF_PROVIDER="${WIF_PROVIDER_PROD}"
-            WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_PROD}"
-            EXTENSION_ID="${EXTENSION_ID_PROD}"
-            PUBLISHER_ID="${PUBLISHER_ID_PROD}"
-            PUBLISHER_EMAIL="${PUBLISHER_EMAIL_PROD}"
-            ZIP_NAME="metamask-chrome-${VERSION}.zip"
-          elif [[ "${TARGET}" == "flask" ]]; then
-            WIF_PROVIDER="${WIF_PROVIDER_PROD}"
-            WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_PROD}"
-            EXTENSION_ID="${EXTENSION_ID_FLASK}"
-            PUBLISHER_ID="${PUBLISHER_ID_FLASK}"
-            PUBLISHER_EMAIL="${PUBLISHER_EMAIL_FLASK}"
-            ZIP_NAME="metamask-chrome-${VERSION}-flask.0.zip"
-          else
-            echo "::error::Invalid target: ${TARGET}"
-            exit 1
-          fi
-          if [[ -z "${EXTENSION_ID:-}" ]]; then
-            case "${TARGET}" in
-              dev) EXTENSION_ID_VAR="EXTENSION_ID_DEV" ;;
-              production) EXTENSION_ID_VAR="EXTENSION_ID" ;;
-              flask) EXTENSION_ID_VAR="EXTENSION_ID_FLASK" ;;
-            esac
-            echo "::error::Missing ${EXTENSION_ID_VAR} repository variable for target '${TARGET}'"
-            exit 1
-          fi
-          missing=""
-          for name in WIF_PROVIDER WIF_SERVICE_ACCOUNT PUBLISHER_ID PUBLISHER_EMAIL; do
-            if [[ -z "${!name:-}" ]]; then
-              missing="${missing} ${name}"
-            fi
-          done
-          if [[ -n "${missing}" ]]; then
-            echo "::error::Missing repository variables for target '${TARGET}':${missing}"
+          case "${TARGET}" in
+            dev)
+              PUBLISHER_EMAIL="${PUBLISHER_EMAIL_DEV}"
+              ZIP_NAME="metamask-chrome-${VERSION}.zip"
+              ;;
+            production)
+              PUBLISHER_EMAIL="${PUBLISHER_EMAIL_PROD}"
+              ZIP_NAME="metamask-chrome-${VERSION}.zip"
+              ;;
+            flask)
+              PUBLISHER_EMAIL="${PUBLISHER_EMAIL_FLASK}"
+              ZIP_NAME="metamask-chrome-${VERSION}-flask.0.zip"
+              ;;
+            *)
+              echo "::error::Invalid target: ${TARGET}"
+              exit 1
+              ;;
+          esac
+          if [[ -z "${PUBLISHER_EMAIL:-}" ]]; then
+            echo "::error::Missing publisher email repository variable for target '${TARGET}'"
             exit 1
           fi
           if [[ "${TARGET}" == "flask" ]]; then

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -389,7 +389,9 @@ jobs:
 
           crx_from_fetch_status() {
             jq -r '
-              (.submittedItemRevisionStatus.distributionChannels // [])[0].crxVersion // empty
+              [
+                .submittedItemRevisionStatus.distributionChannels[]?.crxVersion // empty
+              ] | map(select(length > 0)) | first // empty
             ' "$1"
           }
 
@@ -428,8 +430,10 @@ jobs:
 
           UPLOAD_STATE=$(jq -r '.uploadState // empty' "${UPLOAD_RESPONSE}")
           UPLOAD_CRX=$(jq -r '.crxVersion // empty' "${UPLOAD_RESPONSE}")
+          async_polled=false
 
           if [[ "${UPLOAD_STATE}" == "IN_PROGRESS" ]]; then
+            async_polled=true
             max_polls=6
             poll_interval_seconds=10
             echo "Upload in progress; polling :fetchStatus for lastAsyncUploadState (up to ${max_polls}×${poll_interval_seconds}s)..."
@@ -460,6 +464,11 @@ jobs:
           if [[ "${UPLOAD_STATE}" != "SUCCEEDED" ]]; then
             echo "::error::CWS upload failed: uploadState=${UPLOAD_STATE:-<missing>}"
             cat "${UPLOAD_RESPONSE}"
+            if [[ "${async_polled}" == "true" ]]; then
+              echo ""
+              echo "Last :fetchStatus response:"
+              cat "${FETCH_STATUS_POLL}"
+            fi
             exit 1
           fi
 

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -37,7 +37,7 @@ on:
       version:
         required: true
         type: string
-        description: 'Chrome manifest version — must match GitHub Release tag v{version}'
+        description: 'Release semver X.Y.Z (e.g. 13.43.0) — crxVersion is derived per target (prod/dev → X.Y.Z.0, flask → X.Y.Z.150)'
       target:
         required: true
         type: string

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -102,21 +102,10 @@ jobs:
               exit 1
             fi
           fi
-          if [[ ! "${VERSION}" =~ ^[0-9]+(\.[0-9]+){0,3}$ ]]; then
-            echo "::error::Invalid version format (Chrome manifest): ${VERSION} — use 1–4 dot-separated integers (e.g. 13.0.0), not semver pre-release/build metadata"
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version: ${VERSION} — use release semver X.Y.Z (e.g. 13.43.0)"
             exit 1
           fi
-          IFS='.' read -r -a version_parts <<< "${VERSION}"
-          for part in "${version_parts[@]}"; do
-            if [[ ! "${part}" =~ ^(0|[1-9][0-9]*)$ ]]; then
-              echo "::error::Version segment must be a non-negative integer without leading zeros: ${part} in ${VERSION}"
-              exit 1
-            fi
-            if (( 10#${part} > 65535 )); then
-              echo "::error::Version segment out of range (0–65535): ${part} in ${VERSION}"
-              exit 1
-            fi
-          done
           if [[ "${TARGET}" == "dev" ]]; then
             WIF_PROVIDER="${WIF_PROVIDER_DEV}"
             WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_DEV}"
@@ -241,7 +230,8 @@ jobs:
             echo "| Field | Value |"
             echo "|-------|-------|"
             echo "| Target | \`${{ inputs.target }}\` |"
-            echo "| Version | \`${{ inputs.version }}\` |"
+            echo "| Version input | \`${{ inputs.version }}\` |"
+            echo "| crxVersion | \`${{ env.CRX_VERSION }}\` |"
             echo "| Sender | \`${{ github.event.sender.login }}\` (id=\`${{ github.event.sender.id }}\`) |"
             echo "| Dry-run | \`true\` |"
             echo "| Result | Validation and sender verification passed. No download or upload performed. |"


### PR DESCRIPTION
## Description

CWS `crxVersion` is always the 4-part Chrome manifest `version` (`X.Y.Z.0` prod/dev, `X.Y.Z.150` flask per `development/webpack/utils/version.ts`), not `version_name` strings like `13.43.0-flask.0`.

**Prod evidence:** [release/13.45.1 upload run](https://github.com/MetaMask/metamask-extension/actions/runs/33087048519) — production `:upload` returned `13.45.1.0`; flask returned `13.45.1.150`.

Follow-up to #45765 (merged): `cws-publish.yml` already uses `cws-target-config.sh`. This PR aligns the other two CWS workflows.

### Workflow review

| Workflow | Change | crxVersion handling |
| --- | --- | --- |
| `upload-extension-to-cws.yml` | **Updated** | `cws-target-config.sh`; pre-flight skip + post-upload verify against `CRX_VERSION`; prefer `:upload` `crxVersion` after async `SUCCEEDED`, fall back to `:fetchStatus`; dev manifest set to 4-part; input `X.Y.Z` only |
| `cws-publish.yml` | **No change** (already on `main` via #45765) | `cws-target-config.sh`; post-`:publish` verify submitted/live `crxVersion` |
| `adjust-cws-rollout.yml` | **Updated** | `cws-target-config.sh`; match live `publishedItemRevisionStatus.crxVersion` (was `${VERSION}-flask.0` / raw 3-part — wrong) |

## Changelog

CHANGELOG entry: null

## Related issues

Related: INFRA-3646, INFRA-3881, INFRA-3651

## Manual testing steps

**Upload** (`upload-extension-to-cws.yml` on `release/*`):
1. Dispatch with `target=production`, `version=13.45.1` — expect upload summary `crxVersion` `13.45.1.0`.
2. Re-run same dispatch — pre-flight skips with "Draft for crxVersion 13.45.1.0 already exists".
3. Repeat flask with `version=13.45.1` — expect `13.45.1.150`.

**Rollout** (`adjust-cws-rollout.yml` on `main`, after a version is live):
4. Dispatch with `target=production`, `version=<live release X.Y.Z>`, `desired_percentage` ≥ current — confirm fetch finds published `crxVersion` `X.Y.Z.0` (not raw `X.Y.Z`).
5. Flask: same with live release — expect `X.Y.Z.150`.

**Publish** (no code change; sanity on `main`):
6. Confirm `cws-publish.yml` still derives `CRX_VERSION` via `cws-target-config.sh` and post-publish verify passes on next release.

<!--
## Screenshots/Recordings
### Before
### After
-->

## Pre-merge author checklist

- [x] Followed MetaMask Contributor Docs and Extension Coding Standards
- [x] Completed PR template
- [x] Tests N/A (workflow-only)
- [x] JSDoc N/A
- [ ] Labels per labeling guidelines

## Pre-merge reviewer checklist

- [ ] Manually tested or reviewed workflow dispatch paths above
- [ ] Confirms acceptance criteria for INFRA-3646

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production CWS upload, idempotent skip, and live rollout percentage targeting; incorrect version mapping could block releases or rollouts, though added post-upload verification and shared derivation reduce that risk.
> 
> **Overview**
> **Aligns CWS upload and rollout workflows with the real Chrome Web Store `crxVersion` (4-part manifest version), matching publish and webpack versioning.**
> 
> Operators now pass release semver **`X.Y.Z`** only; **`cws-target-config.sh`** derives **`CRX_VERSION`** per target (**prod/dev → `X.Y.Z.0`**, **flask → `X.Y.Z.150`**) and centralizes WIF/listing resolution. **`upload-extension-to-cws.yml`** and **`adjust-cws-rollout.yml`** drop duplicated inline target/version logic in favor of sourcing that script.
> 
> **Upload** idempotent pre-flight, dev manifest rewriting, and summaries use **`CRX_VERSION`** instead of 3-part input or the old flask **`VERSION-flask.0`** string. After a successful upload, the workflow verifies the returned **`crxVersion`** (preferring **`:upload`**, falling back to **`:fetchStatus`** after async completion).
> 
> **Rollout** matches live **`publishedItemRevisionStatus.crxVersion`** against the derived **`CRX_VERSION`** (fixing incorrect flask matching) and surfaces both version input and **`crxVersion`** in audit output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c29cb5ea06d0006cd90bdc4a7e5e3b452317c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->