### PR TITLE
fix(settings): clean up post-onboarding back up SRP screen

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1849,6 +1849,9 @@
   "backToSafety": {
     "message": "Back to safety"
   },
+  "backToWallet": {
+    "message": "Back to wallet"
+  },
   "backUpIncomplete": {
     "message": "Back up incomplete"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1849,6 +1849,9 @@
   "backToSafety": {
     "message": "Back to safety"
   },
+  "backToWallet": {
+    "message": "Back to wallet"
+  },
   "backUpIncomplete": {
     "message": "Back up incomplete"
   },

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.test.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.test.tsx
@@ -208,9 +208,7 @@ describe('Wallet Ready Page', () => {
       expect(
         queryByText(messages.manageDefaultSettings.message),
       ).not.toBeInTheDocument();
-      expect(
-        queryByTestId('manage-default-settings'),
-      ).not.toBeInTheDocument();
+      expect(queryByTestId('manage-default-settings')).not.toBeInTheDocument();
     } finally {
       mockUseLocationSearch = previousSearch;
     }
@@ -218,8 +216,7 @@ describe('Wallet Ready Page', () => {
 
   it('shows "Back to wallet" and navigates home from settings SRP backup reminder', async () => {
     const previousSearch = mockUseLocationSearch;
-    mockUseLocationSearch =
-      '?isFromReminder=true&isFromSettingsSecurity=true';
+    mockUseLocationSearch = '?isFromReminder=true&isFromSettingsSecurity=true';
 
     try {
       const mockStore = configureMockStore([thunk])(mockState);

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.test.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.test.tsx
@@ -216,6 +216,28 @@ describe('Wallet Ready Page', () => {
     }
   });
 
+  it('shows "Back to wallet" and navigates home from settings SRP backup reminder', async () => {
+    const previousSearch = mockUseLocationSearch;
+    mockUseLocationSearch =
+      '?isFromReminder=true&isFromSettingsSecurity=true';
+
+    try {
+      const mockStore = configureMockStore([thunk])(mockState);
+      const { getByTestId, getByText } = renderWithProvider(
+        <CreationSuccessful />,
+        mockStore,
+      );
+
+      expect(getByText(messages.backToWallet.message)).toBeInTheDocument();
+      fireEvent.click(getByTestId('onboarding-complete-done'));
+      await waitFor(() => {
+        expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+      });
+    } finally {
+      mockUseLocationSearch = previousSearch;
+    }
+  });
+
   it('opens learn more link in new tab when "Learn how" is clicked (from SRP backup reminder)', () => {
     const openTabMock = jest.fn();
     const previousSearch = mockUseLocationSearch;

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.test.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.test.tsx
@@ -191,6 +191,31 @@ describe('Wallet Ready Page', () => {
     );
   });
 
+  it('does not render "Manage default settings" when opened from settings SRP backup reminder', () => {
+    const previousSearch = mockUseLocationSearch;
+    mockUseLocationSearch = '?isFromReminder=true';
+
+    try {
+      const mockStore = configureMockStore([thunk])(mockState);
+      const { queryByText, queryByTestId, getByText } = renderWithProvider(
+        <CreationSuccessful />,
+        mockStore,
+      );
+
+      expect(
+        getByText(messages.yourWalletIsReadyFromReminder.message),
+      ).toBeInTheDocument();
+      expect(
+        queryByText(messages.manageDefaultSettings.message),
+      ).not.toBeInTheDocument();
+      expect(
+        queryByTestId('manage-default-settings'),
+      ).not.toBeInTheDocument();
+    } finally {
+      mockUseLocationSearch = previousSearch;
+    }
+  });
+
   it('opens learn more link in new tab when "Learn how" is clicked (from SRP backup reminder)', () => {
     const openTabMock = jest.fn();
     const previousSearch = mockUseLocationSearch;

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -18,7 +18,6 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   ONBOARDING_PRIVACY_SETTINGS_ROUTE,
   DEFAULT_ROUTE,
-  SECURITY_AND_PASSWORD_ROUTE,
 } from '../../../helpers/constants/routes';
 import {
   getIsInitialized,
@@ -48,8 +47,7 @@ export default function CreationSuccessful() {
 
   const learnMoreLink = ZENDESK_URLS.BASIC_SAFETY_TIPS;
 
-  const { isFromReminder, isFromSettingsSecurity } =
-    useOnboardingSearchParams();
+  const { isFromReminder } = useOnboardingSearchParams();
   const isFromSettingsSRPBackup = isWalletReady && isFromReminder;
 
   // Guard: redirect if wallet is not properly set up.
@@ -125,9 +123,7 @@ export default function CreationSuccessful() {
 
   const onDone = useCallback(async () => {
     if (isFromReminder) {
-      navigate(
-        isFromSettingsSecurity ? SECURITY_AND_PASSWORD_ROUTE : DEFAULT_ROUTE,
-      );
+      navigate(DEFAULT_ROUTE);
       return;
     }
 
@@ -141,10 +137,16 @@ export default function CreationSuccessful() {
   }, [
     completeOnboardingFromCompletionPage,
     isFromReminder,
-    isFromSettingsSecurity,
     isResetWalletInProgress,
     navigate,
   ]);
+
+  let doneButtonLabel = t('done');
+  if (isFromSettingsSRPBackup) {
+    doneButtonLabel = t('backToWallet');
+  } else if (isSidePanelEnabled) {
+    doneButtonLabel = t('openWallet');
+  }
 
   const renderDoneButton = () => {
     return (
@@ -159,9 +161,11 @@ export default function CreationSuccessful() {
           size={ButtonSize.Lg}
           className="w-full"
           onClick={onDone}
-          disabled={isSidePanelEnabled && isSidePanelOpen}
+          disabled={
+            !isFromSettingsSRPBackup && isSidePanelEnabled && isSidePanelOpen
+          }
         >
-          {isSidePanelEnabled ? t('openWallet') : t('done')}
+          {doneButtonLabel}
         </Button>
       </Box>
     );

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -8,16 +8,11 @@ import {
   Text,
   TextVariant,
   TextColor,
-  IconColor,
   Box,
   BoxFlexDirection,
   BoxJustifyContent,
   BoxAlignItems,
-  FontWeight,
   TextButton,
-  Icon,
-  IconName,
-  IconSize,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -128,43 +123,6 @@ export default function CreationSuccessful() {
     );
   }, []);
 
-  const renderSettingsActions = useMemo(() => {
-    return (
-      <Box
-        flexDirection={BoxFlexDirection.Column}
-        alignItems={BoxAlignItems.Start}
-        justifyContent={BoxJustifyContent.Start}
-        className="creation-successful__settings-actions"
-        gap={4}
-      >
-        <Button
-          variant={ButtonVariant.Secondary}
-          data-testid="manage-default-settings"
-          className="rounded-lg w-full flex justify-between items-center"
-          onClick={() =>
-            navigate(`${ONBOARDING_PRIVACY_SETTINGS_ROUTE}?isFromReminder=true`)
-          }
-        >
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            justifyContent={BoxJustifyContent.Center}
-            alignItems={BoxAlignItems.Center}
-          >
-            <Icon name={IconName.Setting} size={IconSize.Md} className="mr-3" />
-            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-              {t('manageDefaultSettings')}
-            </Text>
-          </Box>
-          <Icon
-            name={IconName.ArrowRight}
-            color={IconColor.IconAlternative}
-            size={IconSize.Sm}
-          />
-        </Button>
-      </Box>
-    );
-  }, [navigate, t]);
-
   const onDone = useCallback(async () => {
     if (isFromReminder) {
       navigate(
@@ -262,7 +220,6 @@ export default function CreationSuccessful() {
               ])}
             </Text>
           </Box>
-          {renderSettingsActions}
         </Box>
       )}
       {!isFromSettingsSRPBackup && <WalletReadyAnimation />}

--- a/ui/pages/onboarding-flow/creation-successful/index.scss
+++ b/ui/pages/onboarding-flow/creation-successful/index.scss
@@ -15,27 +15,6 @@
     letter-spacing: -0.26px;
     margin-bottom: 48px;
   }
-
-  &__settings-actions {
-    .mm-box.mm-text {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      width: 100%;
-    }
-
-    &-text {
-      width: 100%;
-      text-align: center;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .mm-button-base {
-      height: 60px;
-    }
-  }
 }
 
 .riv-animation {

--- a/ui/pages/onboarding-flow/onboarding-flow.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.tsx
@@ -406,12 +406,13 @@ export default function OnboardingFlow() {
     if (
       pathname?.startsWith(ONBOARDING_REVEAL_SRP_ROUTE) ||
       pathname?.startsWith(ONBOARDING_REVIEW_SRP_ROUTE) ||
-      pathname?.startsWith(ONBOARDING_CONFIRM_SRP_ROUTE)
+      pathname?.startsWith(ONBOARDING_CONFIRM_SRP_ROUTE) ||
+      (pathname === ONBOARDING_COMPLETION_ROUTE && Boolean(isFromReminder))
     ) {
       return 'var(--color-background-default)';
     }
     return 'var(--color-background-muted)';
-  }, [pathname, isPopup]);
+  }, [pathname, isPopup, isFromReminder]);
 
   return (
     <Box


### PR DESCRIPTION
## **Description**

On the post-onboarding Manage wallet recovery SRP back up screen (“Keep your Secret Recovery Phrase safe!”):

- Remove **Manage default settings**
- Change the primary CTA to **Back to wallet** (goes to wallet home)
- Use the default (pure black) background like the other SRP backup screens

Onboarding is unchanged.

## **Changelog**

CHANGELOG entry: Updated the SRP reminder screen by removing Manage default settings, renaming the primary button to Back to wallet, and matching the default background

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open Settings > Security and password > Manage wallet recovery and reach “Keep your Secret Recovery Phrase safe!”
2. Confirm **Manage default settings** is gone.
3. Confirm the primary button says **Back to wallet** and opens wallet home.
4. Confirm the background matches the other SRP backup screens (default / pure black in dark theme).
5. In a fresh onboarding completion screen, confirm Manage default settings, Open wallet/Done, and muted background are unchanged.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/d8254204-e3f9-47fc-99cf-e5cf3822c949

### **After**

https://github.com/user-attachments/assets/96ef5da9-2758-437f-bf5f-507fa62ff7db

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX and navigation changes on the reminder-specific completion view, with tests added and no auth or data-handling impact.
> 
> **Overview**
> When users finish the **Settings → Manage wallet recovery** SRP reminder flow (`isFromReminder`), the onboarding completion screen is simplified: the **Manage default settings** block and its styles are removed, and the primary action is relabeled to **Back to wallet** via a new i18n string.
> 
> **Done** now always routes to wallet home (`DEFAULT_ROUTE`) from that reminder path instead of optionally returning to Security settings; the side-panel **Open wallet** disable rule no longer applies on this reminder variant.
> 
> The onboarding shell uses the default (SRP-style) background on the completion route when opened from the reminder, while standard onboarding completion behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c85fda4894fef2ad13811bf45809b4d48d38759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->