### PR TITLE
fix: treat non-zero native token addresses as native assets

### DIFF
--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -161,6 +161,64 @@ describe('asset-utils', () => {
       ]);
     });
 
+    it('returns native asset ID for Mantle non-zero native token address', () => {
+      const mantleNativeAddress = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000';
+      const zeroAddress = '0x0000000000000000000000000000000000000000';
+      const chainId = 'eip155:5000' as CaipChainId;
+
+      const result = toAssetId(mantleNativeAddress, chainId);
+      expect(result).toBe(toAssetId(zeroAddress, chainId));
+      expect(result).not.toBe(`eip155:5000/erc20:${mantleNativeAddress}`);
+      expect(CaipAssetTypeStruct.validate(result)).toStrictEqual([
+        undefined,
+        result,
+      ]);
+    });
+
+    it('returns native asset ID for Metis non-zero native token address', () => {
+      const metisNativeAddress = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000';
+      const zeroAddress = '0x0000000000000000000000000000000000000000';
+      const chainId = 'eip155:1088' as CaipChainId;
+
+      const result = toAssetId(metisNativeAddress, chainId);
+      expect(result).toBe(toAssetId(zeroAddress, chainId));
+      expect(result).not.toBe(`eip155:1088/erc20:${metisNativeAddress}`);
+      expect(CaipAssetTypeStruct.validate(result)).toStrictEqual([
+        undefined,
+        result,
+      ]);
+    });
+
+    it('returns native asset ID for Gnosis zero-address native token', () => {
+      const zeroAddress = '0x0000000000000000000000000000000000000000';
+      const chainId = 'eip155:100' as CaipChainId;
+
+      // Gnosis is not in the swaps native-asset map, so toAssetId falls back
+      // to the zero-address ERC-20 id rather than a distinct token contract.
+      const result = toAssetId(zeroAddress, chainId);
+      expect(result).toBe(
+        'eip155:100/erc20:0x0000000000000000000000000000000000000000',
+      );
+      expect(CaipAssetTypeStruct.validate(result)).toStrictEqual([
+        undefined,
+        result,
+      ]);
+    });
+
+    it('returns native asset ID for Stable zero-address native token', () => {
+      const zeroAddress = '0x0000000000000000000000000000000000000000';
+      const chainId = 'eip155:988' as CaipChainId;
+
+      const result = toAssetId(zeroAddress, chainId);
+      expect(result).toBe(
+        'eip155:988/erc20:0x0000000000000000000000000000000000000000',
+      );
+      expect(CaipAssetTypeStruct.validate(result)).toStrictEqual([
+        undefined,
+        result,
+      ]);
+    });
+
     it('should handle checksummed addresses', () => {
       const address = '0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984';
       const chainId = 'eip155:1' as CaipChainId;

--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -219,6 +219,20 @@ describe('asset-utils', () => {
       ]);
     });
 
+    it('returns the Rootstock native asset ID for its zero-address token', () => {
+      const zeroAddress = '0x0000000000000000000000000000000000000000';
+      const chainId = 'eip155:30' as CaipChainId;
+
+      const result = toAssetId(zeroAddress, chainId);
+      expect(result).toBe(
+        'eip155:30/erc20:0x0000000000000000000000000000000000000000',
+      );
+      expect(CaipAssetTypeStruct.validate(result)).toStrictEqual([
+        undefined,
+        result,
+      ]);
+    });
+
     it('should handle checksummed addresses', () => {
       const address = '0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984';
       const chainId = 'eip155:1' as CaipChainId;

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -19,20 +19,60 @@ import {
   isNativeAddress,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
-
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { MultichainNetworks } from '../constants/multichain/networks';
 import {
   TRON_SPECIAL_ASSET_CAIP_TYPES_SET,
   type TronSpecialAssetCaipType,
 } from '../constants/multichain/assets';
-import { POLYGON_NATIVE_TOKEN_ADDRESS } from '../constants/transaction';
+import { NATIVE_TOKEN_ADDRESS } from '../constants/transaction';
 import getFetchWithTimeout from './fetch-with-timeout';
 import { decimalToPrefixedHex } from './conversion.utils';
 import { TEN_SECONDS_IN_MILLISECONDS } from './transactions-controller-utils';
 
 const TOKEN_API_V3_BASE_URL = 'https://tokens.api.cx.metamask.io/v3';
 const STATIC_METAMASK_BASE_URL = 'https://static.cx.metamask.io';
-const polygonCaipChainId = 'eip155:137' as CaipChainId;
+
+/**
+ * Convert a CAIP-2 or hex chain id to hex for `getNativeTokenAddress`.
+ *
+ * @param chainId - Chain id in CAIP or hex form.
+ * @returns Hex chain id, or `undefined` when the input is not an EVM chain.
+ */
+function toHexChainId(chainId: CaipChainId | Hex | string): Hex | undefined {
+  if (isStrictHexString(chainId)) {
+    return chainId;
+  }
+  if (!isCaipChainId(chainId)) {
+    return undefined;
+  }
+  const { namespace, reference } = parseCaipChainId(chainId);
+  if (namespace !== KnownCaipNamespace.Eip155) {
+    return undefined;
+  }
+  return numberToHex(Number.parseInt(reference, 10));
+}
+
+/**
+ * True when `address` is this chain's native token, including non-zero natives
+ * such as Polygon (`0x…1010`) and Mantle/Metis (`0xdead…0000`).
+ *
+ * @param address - Token address or asset reference.
+ * @param chainId - Chain id in CAIP or hex form.
+ * @returns Whether the address is the native token for the chain.
+ */
+function isNativeTokenAddressForChain(
+  address: string,
+  chainId: CaipChainId | Hex | string,
+): boolean {
+  const hexChainId = toHexChainId(chainId);
+  if (!hexChainId) {
+    return false;
+  }
+  return (
+    address.toLowerCase() === getNativeTokenAddress(hexChainId).toLowerCase()
+  );
+}
 
 export const toAssetId = (
   address: Hex | CaipAssetType | string,
@@ -54,12 +94,16 @@ export const toAssetId = (
     return undefined;
   }
 
-  // TODO: Fix or replace `isNativeAddress` to support Polygon
-  const isPolygonNative =
-    chainIdToUse === polygonCaipChainId &&
-    addressToUse === POLYGON_NATIVE_TOKEN_ADDRESS;
+  // Non-zero native addresses (Polygon, Mantle, Metis, …) must share the same
+  // asset id as `0x0`, otherwise Send routes them as ERC-20 transfers.
+  if (
+    typeof addressToUse === 'string' &&
+    isNativeTokenAddressForChain(addressToUse, chainIdToUse)
+  ) {
+    addressToUse = NATIVE_TOKEN_ADDRESS;
+  }
 
-  if (isNativeAddress(addressToUse) || isPolygonNative) {
+  if (isNativeAddress(addressToUse)) {
     try {
       return getNativeAssetForChainId(chainIdToUse)?.assetId;
     } catch {

--- a/test/e2e/helpers/custom-network-harness.test.ts
+++ b/test/e2e/helpers/custom-network-harness.test.ts
@@ -2,8 +2,57 @@ import { DEFAULT_FIXTURE_ACCOUNT_ID } from '../constants';
 import {
   CONVERSION_RATE_NETWORKS,
   NON_ZERO_NATIVE_NETWORKS,
+  type CustomNetworkId,
   prepareCustomNetwork,
 } from './custom-network-harness';
+
+const NON_ZERO_NATIVE_NETWORK_CASES: {
+  id: CustomNetworkId;
+  chainIdHex: string;
+  clientId: string;
+  nativeAssetId: string;
+  nativeCurrency: string;
+}[] = [
+  {
+    id: 'rootstock',
+    chainIdHex: '0x1e',
+    clientId: 'rootstock-local',
+    nativeAssetId: 'eip155:30/slip44:60',
+    nativeCurrency: 'RBTC',
+  },
+  {
+    id: 'stable',
+    chainIdHex: '0x3dc',
+    clientId: 'stable-local',
+    nativeAssetId:
+      'eip155:988/erc20:0x0000000000000000000000000000000000000000',
+    nativeCurrency: 'USDT0',
+  },
+  {
+    id: 'mantle',
+    chainIdHex: '0x1388',
+    clientId: 'mantle-local',
+    nativeAssetId:
+      'eip155:5000/erc20:0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000',
+    nativeCurrency: 'MNT',
+  },
+  {
+    id: 'metis',
+    chainIdHex: '0x440',
+    clientId: 'metis-local',
+    nativeAssetId:
+      'eip155:1088/erc20:0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000',
+    nativeCurrency: 'METIS',
+  },
+  {
+    id: 'gnosis',
+    chainIdHex: '0x64',
+    clientId: 'gnosis-local',
+    nativeAssetId:
+      'eip155:100/erc20:0x0000000000000000000000000000000000000000',
+    nativeCurrency: 'XDAI',
+  },
+];
 
 function networkController(
   fixtures: ReturnType<typeof prepareCustomNetwork>['fixtures'],
@@ -93,49 +142,42 @@ describe('custom-network-harness', () => {
       );
     });
 
-    it('injects Mantle with the non-zero native asset id for native send', () => {
-      const { fixtures, network } = prepareCustomNetwork(
-        'mantle',
-        'nativeSend',
-      );
-      const assetsController = fixtures.data.AssetsController as {
-        assetsBalance: Record<string, Record<string, { amount: string }>>;
-      };
+    it.each(NON_ZERO_NATIVE_NETWORK_CASES)(
+      'injects $id with its native asset for native send',
+      ({ id, chainIdHex, clientId, nativeAssetId, nativeCurrency }) => {
+        const { fixtures, network } = prepareCustomNetwork(id, 'nativeSend');
+        const assetsController = fixtures.data.AssetsController as {
+          assetsBalance: Record<string, Record<string, { amount: string }>>;
+        };
+        const networkEnablementController = fixtures.data
+          .NetworkEnablementController as {
+          nativeAssetIdentifiers: Record<string, string>;
+        };
 
-      expect(networkController(fixtures).selectedNetworkClientId).toBe(
-        'mantle-local',
-      );
-      expect(
-        networkController(fixtures).networkConfigurationsByChainId['0x1388']
-          ?.nativeCurrency,
-      ).toBe('MNT');
-      expect(enabledEip155(fixtures)).toStrictEqual({ '0x1388': true });
-      expect(network.nativeSymbol).toBe('MNT');
-      expect(network.nativeAssetId).toBe(
-        'eip155:5000/erc20:0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000',
-      );
-      expect(
-        assetsController.assetsBalance[DEFAULT_FIXTURE_ACCOUNT_ID]?.[
-          network.uiNativeAssetId
-        ]?.amount,
-      ).toBe('25');
-    });
-
-    it('injects Metis with the non-zero native asset id for native send', () => {
-      const { fixtures, network } = prepareCustomNetwork('metis', 'nativeSend');
-
-      expect(networkController(fixtures).selectedNetworkClientId).toBe(
-        'metis-local',
-      );
-      expect(
-        networkController(fixtures).networkConfigurationsByChainId['0x440']
-          ?.nativeCurrency,
-      ).toBe('METIS');
-      expect(enabledEip155(fixtures)).toStrictEqual({ '0x440': true });
-      expect(network.uiNativeAssetId).toBe(
-        'eip155:1088/erc20:0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000',
-      );
-    });
+        expect(networkController(fixtures).selectedNetworkClientId).toBe(
+          clientId,
+        );
+        expect(
+          networkController(fixtures).networkConfigurationsByChainId[
+            chainIdHex
+          ]?.nativeCurrency,
+        ).toBe(nativeCurrency);
+        expect(enabledEip155(fixtures)).toStrictEqual({
+          [chainIdHex]: true,
+        });
+        expect(network.nativeAssetId).toBe(nativeAssetId);
+        expect(
+          networkEnablementController.nativeAssetIdentifiers[
+            network.caipChainId
+          ],
+        ).toBe(nativeAssetId);
+        expect(
+          assetsController.assetsBalance[DEFAULT_FIXTURE_ACCOUNT_ID]?.[
+            network.uiNativeAssetId
+          ]?.amount,
+        ).toBe('25');
+      },
+    );
   });
 
   describe('CONVERSION_RATE_NETWORKS', () => {

--- a/test/e2e/helpers/custom-network-harness.test.ts
+++ b/test/e2e/helpers/custom-network-harness.test.ts
@@ -158,9 +158,8 @@ describe('custom-network-harness', () => {
           clientId,
         );
         expect(
-          networkController(fixtures).networkConfigurationsByChainId[
-            chainIdHex
-          ]?.nativeCurrency,
+          networkController(fixtures).networkConfigurationsByChainId[chainIdHex]
+            ?.nativeCurrency,
         ).toBe(nativeCurrency);
         expect(enabledEip155(fixtures)).toStrictEqual({
           [chainIdHex]: true,

--- a/test/e2e/helpers/custom-network-harness.test.ts
+++ b/test/e2e/helpers/custom-network-harness.test.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_FIXTURE_ACCOUNT_ID } from '../constants';
 import {
   CONVERSION_RATE_NETWORKS,
+  NON_ZERO_NATIVE_NETWORKS,
   prepareCustomNetwork,
 } from './custom-network-harness';
 
@@ -91,6 +92,50 @@ describe('custom-network-harness', () => {
         'nativeAndErc20 is only defined for xdc, not injective',
       );
     });
+
+    it('injects Mantle with the non-zero native asset id for native send', () => {
+      const { fixtures, network } = prepareCustomNetwork(
+        'mantle',
+        'nativeSend',
+      );
+      const assetsController = fixtures.data.AssetsController as {
+        assetsBalance: Record<string, Record<string, { amount: string }>>;
+      };
+
+      expect(networkController(fixtures).selectedNetworkClientId).toBe(
+        'mantle-local',
+      );
+      expect(
+        networkController(fixtures).networkConfigurationsByChainId['0x1388']
+          ?.nativeCurrency,
+      ).toBe('MNT');
+      expect(enabledEip155(fixtures)).toStrictEqual({ '0x1388': true });
+      expect(network.nativeSymbol).toBe('MNT');
+      expect(network.nativeAssetId).toBe(
+        'eip155:5000/erc20:0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000',
+      );
+      expect(
+        assetsController.assetsBalance[DEFAULT_FIXTURE_ACCOUNT_ID]?.[
+          network.uiNativeAssetId
+        ]?.amount,
+      ).toBe('25');
+    });
+
+    it('injects Metis with the non-zero native asset id for native send', () => {
+      const { fixtures, network } = prepareCustomNetwork('metis', 'nativeSend');
+
+      expect(networkController(fixtures).selectedNetworkClientId).toBe(
+        'metis-local',
+      );
+      expect(
+        networkController(fixtures).networkConfigurationsByChainId['0x440']
+          ?.nativeCurrency,
+      ).toBe('METIS');
+      expect(enabledEip155(fixtures)).toStrictEqual({ '0x440': true });
+      expect(network.uiNativeAssetId).toBe(
+        'eip155:1088/erc20:0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000',
+      );
+    });
   });
 
   describe('CONVERSION_RATE_NETWORKS', () => {
@@ -101,6 +146,18 @@ describe('custom-network-harness', () => {
         'plasma',
         'rootstock',
         'hyperevm',
+      ]);
+    });
+  });
+
+  describe('NON_ZERO_NATIVE_NETWORKS', () => {
+    it('lists every non-zero-native regression network', () => {
+      expect(NON_ZERO_NATIVE_NETWORKS).toStrictEqual([
+        'rootstock',
+        'stable',
+        'mantle',
+        'metis',
+        'gnosis',
       ]);
     });
   });

--- a/test/e2e/helpers/custom-network-harness.ts
+++ b/test/e2e/helpers/custom-network-harness.ts
@@ -16,7 +16,11 @@ export type CustomNetworkId =
   | 'chiliz'
   | 'plasma'
   | 'rootstock'
-  | 'hyperevm';
+  | 'hyperevm'
+  | 'gnosis'
+  | 'stable'
+  | 'mantle'
+  | 'metis';
 
 export type CustomNetworkScenario =
   | 'nativeSend'
@@ -45,6 +49,9 @@ const SEEDED_ERC20_ADDRESS = '0x581c3c1a2a4ebde2a0df29b5cf4c116e42945947';
 const SEEDED_ERC20_ASSET_ID = `eip155:50/erc20:${SEEDED_ERC20_ADDRESS}`;
 const MAINNET_NATIVE_ASSET_ID = 'eip155:1/slip44:60';
 const MAINNET_CHAIN_ID_HEX = '0x1';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const DEAD_NATIVE_ADDRESS = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000';
+const METIS_CHAIN_ID_HEX = '0x440' as Hex;
 
 const CUSTOM_NETWORKS: Record<CustomNetworkId, CustomNetworkConfig> = {
   xdc: {
@@ -127,6 +134,58 @@ const CUSTOM_NETWORKS: Record<CustomNetworkId, CustomNetworkConfig> = {
     clientId: 'hyperevm-local',
     inDefaultFixture: false,
   },
+  gnosis: {
+    id: 'gnosis',
+    name: 'Gnosis',
+    chainIdHex: CHAIN_IDS.GNOSIS,
+    chainIdDecimal: 100,
+    nativeSymbol: 'XDAI',
+    nativeAssetId: `eip155:100/erc20:${ZERO_ADDRESS}`,
+    uiNativeAssetId: `eip155:100/erc20:${ZERO_ADDRESS}`,
+    caipChainId: 'eip155:100',
+    blockExplorerUrl: 'https://gnosisscan.io',
+    clientId: 'gnosis-local',
+    inDefaultFixture: false,
+  },
+  stable: {
+    id: 'stable',
+    name: 'Stable',
+    chainIdHex: CHAIN_IDS.STABLE_MAINNET,
+    chainIdDecimal: 988,
+    nativeSymbol: 'USDT0',
+    nativeAssetId: `eip155:988/erc20:${ZERO_ADDRESS}`,
+    uiNativeAssetId: `eip155:988/erc20:${ZERO_ADDRESS}`,
+    caipChainId: 'eip155:988',
+    blockExplorerUrl: 'https://stablescan.io',
+    clientId: 'stable-local',
+    inDefaultFixture: false,
+  },
+  mantle: {
+    id: 'mantle',
+    name: 'Mantle',
+    chainIdHex: CHAIN_IDS.MANTLE,
+    chainIdDecimal: 5000,
+    nativeSymbol: 'MNT',
+    nativeAssetId: `eip155:5000/erc20:${DEAD_NATIVE_ADDRESS}`,
+    uiNativeAssetId: `eip155:5000/erc20:${DEAD_NATIVE_ADDRESS}`,
+    caipChainId: 'eip155:5000',
+    blockExplorerUrl: 'https://mantlescan.xyz',
+    clientId: 'mantle-local',
+    inDefaultFixture: false,
+  },
+  metis: {
+    id: 'metis',
+    name: 'Metis Andromeda',
+    chainIdHex: METIS_CHAIN_ID_HEX,
+    chainIdDecimal: 1088,
+    nativeSymbol: 'METIS',
+    nativeAssetId: `eip155:1088/erc20:${DEAD_NATIVE_ADDRESS}`,
+    uiNativeAssetId: `eip155:1088/erc20:${DEAD_NATIVE_ADDRESS}`,
+    caipChainId: 'eip155:1088',
+    blockExplorerUrl: 'https://explorer.metis.io',
+    clientId: 'metis-local',
+    inDefaultFixture: false,
+  },
 };
 
 export const CONVERSION_RATE_NETWORKS: CustomNetworkId[] = [
@@ -135,6 +194,14 @@ export const CONVERSION_RATE_NETWORKS: CustomNetworkId[] = [
   'plasma',
   'rootstock',
   'hyperevm',
+];
+
+export const NON_ZERO_NATIVE_NETWORKS: CustomNetworkId[] = [
+  'rootstock',
+  'stable',
+  'mantle',
+  'metis',
+  'gnosis',
 ];
 
 export function getCustomNetwork(id: CustomNetworkId): CustomNetworkConfig {

--- a/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
@@ -125,6 +125,11 @@ class TransactionConfirmation extends Confirmation {
     testId: 'inline-alert',
   };
 
+  private readonly interactingWithLabel: RawLocator = {
+    css: 'p',
+    text: tEn('interactingWith'),
+  };
+
   private readonly networkName: RawLocator =
     '[data-testid="confirmation__details-network-name"]';
 
@@ -302,6 +307,26 @@ class TransactionConfirmation extends Confirmation {
   async checkInlineAlertIsDisplayed(): Promise<void> {
     console.log('Checking if inline alert is displayed');
     await this.driver.waitForSelector(this.inlineAlert);
+  }
+
+  /**
+   * Confirms a wallet-initiated native send (not an ERC-20 `transfer`).
+   * Native `simpleSend` confirmations show the native ticker in the heading
+   * and do not expose a token `transfer` function in advanced details.
+   *
+   * @param symbol - Native currency ticker expected in the send heading.
+   */
+  async checkNativeTransferPath(symbol: string): Promise<void> {
+    console.log(
+      `Checking confirmation is a native ${symbol} send, not ERC-20 transfer`,
+    );
+    await this.checkSendAmount(`1 ${symbol}`);
+    await this.clickAdvancedDetailsButton();
+    await this.driver.assertElementNotPresent(this.interactingWithLabel);
+    await this.driver.assertElementNotPresent({
+      css: this.advancedDetailsDataFunction,
+      text: 'transfer',
+    });
   }
 
   async checkNetworkIsDisplayed(network: string): Promise<void> {

--- a/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
@@ -38,6 +38,9 @@ class TransactionConfirmation extends Confirmation {
   private readonly advancedDetailsHexData: RawLocator =
     '[data-testid="advanced-details-transaction-hex"]';
 
+  private readonly advancedDetailsNonceSection: RawLocator =
+    '[data-testid="advanced-details-nonce-section"]';
+
   private readonly advancedDetailsSection: RawLocator =
     '[data-testid="advanced-details-data-section"]';
 
@@ -314,6 +317,10 @@ class TransactionConfirmation extends Confirmation {
    * Native `simpleSend` confirmations show the native ticker in the heading
    * and do not expose a token `transfer` function in advanced details.
    *
+   * Absence checks wait for the nonce section so they cannot pass during the
+   * render gap after toggling advanced details: wallet-initiated ERC-20
+   * transfers hide “Interacting with” until `showAdvancedDetails` is true.
+   *
    * @param symbol - Native currency ticker expected in the send heading.
    */
   async checkNativeTransferPath(symbol: string): Promise<void> {
@@ -322,11 +329,18 @@ class TransactionConfirmation extends Confirmation {
     );
     await this.checkSendAmount(`1 ${symbol}`);
     await this.clickAdvancedDetailsButton();
-    await this.driver.assertElementNotPresent(this.interactingWithLabel);
-    await this.driver.assertElementNotPresent({
-      css: this.advancedDetailsDataFunction,
-      text: 'transfer',
+    await this.driver.assertElementNotPresent(this.interactingWithLabel, {
+      findElementGuard: this.advancedDetailsNonceSection,
     });
+    await this.driver.assertElementNotPresent(
+      {
+        css: this.advancedDetailsDataFunction,
+        text: 'transfer',
+      },
+      {
+        findElementGuard: this.advancedDetailsNonceSection,
+      },
+    );
   }
 
   async checkNetworkIsDisplayed(network: string): Promise<void> {

--- a/test/e2e/tests/network/non-zero-native-address.spec.ts
+++ b/test/e2e/tests/network/non-zero-native-address.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Non-zero native currency address — Rootstock, Stable, Mantle, Metis, Gnosis.
+ *
+ * Monitors the regression where networks whose native token is not `0x0` (or
+ * is catalogued as `erc20:0x0`) show a duplicate/missing native row and route
+ * Send as an ERC-20 `transfer` instead of a native `simpleSend`.
+ *
+ * See `test/e2e/helpers/custom-network-harness.ts`.
+ */
+
+import { Driver } from '../../webdriver/driver';
+import { withFixtures } from '../../helpers';
+import {
+  NON_ZERO_NATIVE_NETWORKS,
+  getCustomNetwork,
+  prepareCustomNetwork,
+} from '../../helpers/custom-network-harness';
+import { login } from '../../page-objects/flows/login.flow';
+import ActivityTab from '../../page-objects/pages/home/activity-tab';
+import HomePage from '../../page-objects/pages/home/homepage';
+import TokensTab from '../../page-objects/pages/home/tokens-tab';
+import SendPage from '../../page-objects/pages/send/send-page';
+import TransactionConfirmation from '../../page-objects/pages/confirmations/transaction-confirmation';
+
+const DEFAULT_RECIPIENT = '0x2f318C334780961FB129D2a6c30D0763d9a5C970';
+const SEND_AMOUNT = '1';
+
+NON_ZERO_NATIVE_NETWORKS.forEach((id) => {
+  describe(`Non-zero native on ${getCustomNetwork(id).name}`, function () {
+    it('shows a single native row and sends via the native path', async function () {
+      const { fixtures, localNodeOptions, testSpecificMock, network } =
+        prepareCustomNetwork(id, 'nativeSend');
+
+      await withFixtures(
+        {
+          fixtures,
+          localNodeOptions,
+          testSpecificMock,
+          title: this.test?.fullTitle(),
+        },
+        async ({ driver }: { driver: Driver }) => {
+          // Homepage overview still shows an ETH-denominated default; the
+          // Tokens tab is the surface under test.
+          await login(driver, { validateBalance: false });
+
+          const tokensTab = new TokensTab(driver);
+          await tokensTab.checkTokenListIsDisplayed();
+          await tokensTab.checkTokenItemNumber(1);
+          await tokensTab.checkTokenExistsInList(network.nativeSymbol);
+          await tokensTab.checkExpectedTokenBalanceIsDisplayed(
+            '25',
+            network.nativeSymbol,
+          );
+
+          const homePage = new HomePage(driver);
+          await homePage.startSendFlow();
+
+          const sendPage = new SendPage(driver);
+          await sendPage.checkPageIsLoaded();
+          await sendPage.selectToken(network.chainIdHex, network.nativeSymbol);
+          await sendPage.fillRecipient({ recipientAddress: DEFAULT_RECIPIENT });
+          await sendPage.fillAmount(SEND_AMOUNT);
+          await sendPage.pressContinueButton();
+
+          const transactionConfirmation = new TransactionConfirmation(driver);
+          await transactionConfirmation.checkNativeTransferPath(
+            network.nativeSymbol,
+          );
+          await transactionConfirmation.clickFooterConfirmButtonAndWaitToDisappear();
+
+          await homePage.goToActivityList();
+          const activityTab = new ActivityTab(driver);
+          await activityTab.checkTransactionActivityByText('Sent');
+          await activityTab.checkCompletedTxNumberDisplayedInActivity(1);
+          await activityTab.checkTxAmountInActivity(
+            `-${SEND_AMOUNT} ${network.nativeSymbol}`,
+          );
+        },
+      );
+    });
+  });
+});

--- a/test/integration/tokens/non-zero-native-address.test.tsx
+++ b/test/integration/tokens/non-zero-native-address.test.tsx
@@ -1,0 +1,190 @@
+import type { Hex } from '@metamask/utils';
+import { act, screen, within } from '@testing-library/react';
+import nock from 'nock';
+import * as backgroundConnection from '../../../ui/store/background-connection';
+import { integrationTestRender } from '../../lib/render-helpers';
+import mockMetaMaskState from '../data/integration-init-state.json';
+import {
+  clickElementById,
+  createMockImplementation,
+  getSelectedAccountGroupAccounts,
+  getSelectedAccountGroupName,
+} from '../helpers';
+
+jest.setTimeout(20_000);
+
+jest.mock('../../../ui/store/background-connection', () => ({
+  ...jest.requireActual('../../../ui/store/background-connection'),
+  submitRequestToBackground: jest.fn(),
+}));
+
+type NonZeroNativeNetwork = {
+  chainId: Hex;
+  clientId: string;
+  name: string;
+  nativeAssetId: string;
+  symbol: string;
+};
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const DEAD_NATIVE_ADDRESS = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000';
+
+const NON_ZERO_NATIVE_NETWORKS: NonZeroNativeNetwork[] = [
+  {
+    chainId: '0x1e',
+    clientId: 'rootstock-local',
+    name: 'Rootstock Mainnet',
+    nativeAssetId: 'eip155:30/slip44:137',
+    symbol: 'RBTC',
+  },
+  {
+    chainId: '0x3dc',
+    clientId: 'stable-local',
+    name: 'Stable',
+    nativeAssetId: `eip155:988/erc20:${ZERO_ADDRESS}`,
+    symbol: 'USDT0',
+  },
+  {
+    chainId: '0x1388',
+    clientId: 'mantle-local',
+    name: 'Mantle',
+    nativeAssetId: `eip155:5000/erc20:${DEAD_NATIVE_ADDRESS}`,
+    symbol: 'MNT',
+  },
+  {
+    chainId: '0x440',
+    clientId: 'metis-local',
+    name: 'Metis Andromeda',
+    nativeAssetId: `eip155:1088/erc20:${DEAD_NATIVE_ADDRESS}`,
+    symbol: 'METIS',
+  },
+  {
+    chainId: '0x64',
+    clientId: 'gnosis-local',
+    name: 'Gnosis',
+    nativeAssetId: `eip155:100/erc20:${ZERO_ADDRESS}`,
+    symbol: 'XDAI',
+  },
+];
+
+const mockedBackgroundConnection = jest.mocked(backgroundConnection);
+const backgroundConnectionMocked = {
+  onNotification: jest.fn(),
+};
+const [selectedAccount] = getSelectedAccountGroupAccounts(mockMetaMaskState);
+const accountName = getSelectedAccountGroupName(mockMetaMaskState);
+
+function buildState(network: NonZeroNativeNetwork) {
+  return {
+    ...mockMetaMaskState,
+    consentDecisionMade: true,
+    selectedNetworkClientId: network.clientId,
+    enabledNetworkMap: {
+      eip155: {
+        [network.chainId]: true,
+      },
+    },
+    preferences: {
+      ...mockMetaMaskState.preferences,
+      tokenNetworkFilter: {
+        [network.chainId]: true,
+      },
+    },
+    networkConfigurationsByChainId: {
+      [network.chainId]: {
+        chainId: network.chainId,
+        rpcEndpoints: [
+          {
+            networkClientId: network.clientId,
+            url: 'http://localhost:8545',
+            type: 'custom',
+            name: network.name,
+          },
+        ],
+        defaultRpcEndpointIndex: 0,
+        blockExplorerUrls: [],
+        defaultBlockExplorerUrlIndex: 0,
+        name: network.name,
+        nativeCurrency: network.symbol,
+      },
+    },
+    networksMetadata: {
+      [network.clientId]: {
+        EIPS: {
+          1559: true,
+        },
+        status: 'available',
+      },
+    },
+    assetsBalance: {
+      [selectedAccount.id]: {
+        [network.nativeAssetId]: {
+          amount: '25',
+        },
+      },
+    },
+    assetsInfo: {
+      [network.nativeAssetId]: {
+        type: 'native',
+        decimals: 18,
+        symbol: network.symbol,
+        name: network.name,
+      },
+    },
+    assetsPrice: {
+      [network.nativeAssetId]: {
+        assetPriceType: 'fungible',
+        price: 1,
+        usdPrice: 1,
+        lastUpdated: Date.now(),
+      },
+    },
+    currencyRates: {
+      [network.symbol]: {
+        conversionRate: 1,
+      },
+    },
+  };
+}
+
+describe.each(NON_ZERO_NATIVE_NETWORKS)(
+  '$name non-zero native address',
+  (network) => {
+    beforeEach(() => {
+      process.env.PORTFOLIO_VIEW = 'true';
+      window.location.hash = '';
+      jest.resetAllMocks();
+      mockedBackgroundConnection.submitRequestToBackground.mockImplementation(
+        createMockImplementation({}),
+      );
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('displays one native token row with the expected balance', async () => {
+      await act(async () => {
+        await integrationTestRender({
+          preloadedState: buildState(network),
+          backgroundConnection: backgroundConnectionMocked,
+        });
+      });
+
+      await screen.findByText(accountName);
+      await clickElementById('account-overview__asset-tab');
+
+      const rows = await screen.findAllByTestId(
+        'multichain-token-list-button',
+      );
+      expect(rows).toHaveLength(1);
+
+      expect(
+        within(rows[0]).getByTestId('multichain-token-list-item-token-name'),
+      ).toHaveTextContent(network.symbol);
+      expect(
+        within(rows[0]).getByTestId('multichain-token-list-item-value'),
+      ).toHaveTextContent(`25 ${network.symbol}`);
+    });
+  },
+);

--- a/test/integration/tokens/non-zero-native-address.test.tsx
+++ b/test/integration/tokens/non-zero-native-address.test.tsx
@@ -174,9 +174,7 @@ describe.each(NON_ZERO_NATIVE_NETWORKS)(
       await screen.findByText(accountName);
       await clickElementById('account-overview__asset-tab');
 
-      const rows = await screen.findAllByTestId(
-        'multichain-token-list-button',
-      );
+      const rows = await screen.findAllByTestId('multichain-token-list-button');
       expect(rows).toHaveLength(1);
 
       expect(

--- a/test/jest/console-baseline-integration.json
+++ b/test/jest/console-baseline-integration.json
@@ -134,6 +134,12 @@
       "Reselect: Identity function warnings": 1,
       "Reselect: Input stability warnings": 5,
       "warn: ⚠️ React Router Future Flag": 1
+    },
+    "test/integration/tokens/non-zero-native-address.test.tsx": {
+      "Reselect: Identity function warnings": 1,
+      "Reselect: Input stability warnings": 5,
+      "error: Error: AggregateError": 5,
+      "warn: ⚠️ React Router Future Flag": 1
     }
   }
 }


### PR DESCRIPTION
## **Description**

On networks whose native currency uses a non-zero contract address (Mantle, Metis) or a zero-address sentinel (Gnosis, Stable), `toAssetId` could map that address as ERC-20. That could show a duplicate or missing native row on Tokens and route Send as a token `transfer`.

This generalizes the Polygon special case to `getNativeTokenAddress(chainId)` and covers WPN-1802 / EXT-10 with unit, integration, and E2E tests for Rootstock, Stable, Mantle, Metis, and Gnosis.

## **Changelog**

CHANGELOG entry: Fixed native token send on networks whose native currency uses a non-zero contract address

## **Related issues**

Fixes: [WPN-1802](https://consensyssoftware.atlassian.net/browse/WPN-1802)

## **Manual testing steps**

1. Run the extension and open the wallet home Tokens tab.
2. Switch to Mantle or Metis (non-zero native contract address).
3. Confirm a single native row is shown with the expected native symbol and balance.
4. Start Send, select the native token, enter a recipient and amount, and continue.
5. Confirm the confirmation is a native send (no ERC-20 `transfer` / "Interacting with").
6. Repeat on Gnosis or Stable (zero-address sentinel) and confirm the same Tokens and Send behavior.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[WPN-1802]: https://consensyssoftware.atlassian.net/browse/WPN-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core asset-id mapping used by Send and token lists; incorrect matching could still mis-route transfers, though scope is narrow and regression tests cover the affected networks.
> 
> **Overview**
> Fixes **Send** and **Tokens** misclassification on chains whose native currency is not the usual `0x0` sentinel (e.g. Mantle/Metis `0xdead…0000`, Polygon-style natives, or Gnosis/Stable-style `erc20:0x0` catalog entries).
> 
> **`toAssetId`** no longer special-cases Polygon alone. It compares the input address to **`getNativeTokenAddress(chainId)`** and, when they match, normalizes to **`NATIVE_TOKEN_ADDRESS`** before resolving the native CAIP asset id—so those tokens are not treated as ordinary ERC-20s.
> 
> Test coverage adds **unit** cases in `asset-utils.test.ts`, **integration** checks for a single native row on five networks, **E2E** send flows via an expanded custom-network harness (Rootstock, Stable, Mantle, Metis, Gnosis), and **`checkNativeTransferPath`** on the transaction confirmation page object to assert native `simpleSend` (no `transfer` / “Interacting with”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f1859668558cd7da66250a7b1427566fccc303. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->