### PR TITLE
fix(swaps): update Robinhood default bridge token to USDG

### DIFF
--- a/shared/constants/bridge.ts
+++ b/shared/constants/bridge.ts
@@ -311,12 +311,12 @@ export const BRIDGE_CHAINID_COMMON_TOKEN_PAIR: BridgeChainTokenMap = {
     assetId: `${toEvmCaipChainId(CHAIN_IDS.ARC)}/erc20:${toChecksumHexAddress('0xbEf5f6d51CB62b58e6A8f77868681825C6fe21c1')}`,
   },
   [toEvmCaipChainId(CHAIN_IDS.ROBINHOOD_CHAIN)]: {
-    // ETH -> USDe on Robinhood
-    address: '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34',
-    symbol: 'USDe',
-    decimals: 18,
-    name: 'USDe',
-    assetId: `${toEvmCaipChainId(CHAIN_IDS.ROBINHOOD_CHAIN)}/erc20:${toChecksumHexAddress('0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34')}`,
+    // ETH -> USDG on Robinhood
+    address: '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168',
+    symbol: 'USDG',
+    decimals: 6,
+    name: 'Global Dollar',
+    assetId: `${toEvmCaipChainId(CHAIN_IDS.ROBINHOOD_CHAIN)}/erc20:${toChecksumHexAddress('0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168')}`,
   },
   [MultichainNetworks.SOLANA]: {
     // SOL -> USDC on Solana


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Update the default Robinhood Bridge destination token from USDe to USDG (Global Dollar). This changes the Robinhood entry in `shared/constants/bridge.ts` to use USDG’s address, symbol, six decimals, display name, and CAIP asset ID.

## **Changelog**

CHANGELOG entry: Updated the default Robinhood Bridge destination token to USDG

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4967

## **Manual testing steps**

1. Run MetaMask with Robinhood enabled in the Bridge configuration.
2. Open Swap & Bridge and select Robinhood as the destination network.
3. Verify USDG (Global Dollar) is preselected as the destination token and displays 6 decimals.

<!-- Screenshots/Recordings section omitted: no screenshots or recordings are applicable. -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable; no new tests are required for this constant-only change.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
