### PR TITLE
feat(ui): add DragHandleIcon and InlineEditableLabel components

### DIFF
--- a/ui/components/multichain-accounts/drag-handle-icon/drag-handle-icon.test.tsx
+++ b/ui/components/multichain-accounts/drag-handle-icon/drag-handle-icon.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DragHandleIcon } from './drag-handle-icon';
+
+describe('DragHandleIcon', () => {
+  it('renders SVG with default props', () => {
+    render(<DragHandleIcon />);
+    const svg = screen.getByTestId('drag-handle-icon-svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '16');
+    expect(svg).toHaveAttribute('height', '16');
+    expect(svg).toHaveAttribute('fill', 'currentColor');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('supports custom size, class name, and color', () => {
+    render(<DragHandleIcon size={24} className="custom-drag-icon" color="#ff0000" />);
+    const svg = screen.getByTestId('drag-handle-icon-svg');
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('fill', '#ff0000');
+    expect(svg).toHaveClass('custom-drag-icon');
+  });
+});

--- a/ui/components/multichain-accounts/drag-handle-icon/drag-handle-icon.tsx
+++ b/ui/components/multichain-accounts/drag-handle-icon/drag-handle-icon.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export type DragHandleIconProps = {
+  size?: number;
+  className?: string;
+  color?: string;
+};
+
+/**
+ * 6-dots drag indicator icon (2 columns x 3 rows) matching Material Design / Figma drag_indicator.
+ * @param options0
+ * @param options0.size
+ * @param options0.className
+ * @param options0.color
+ */
+export const DragHandleIcon = ({
+  size = 16,
+  className = '',
+  color = 'currentColor',
+}: DragHandleIconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill={color}
+    className={className}
+    aria-hidden="true"
+    data-testid="drag-handle-icon-svg"
+  >
+    <path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+  </svg>
+);

--- a/ui/components/multichain-accounts/drag-handle-icon/index.ts
+++ b/ui/components/multichain-accounts/drag-handle-icon/index.ts
@@ -1,0 +1,1 @@
+export * from './drag-handle-icon';

--- a/ui/components/multichain-accounts/inline-editable-label/index.ts
+++ b/ui/components/multichain-accounts/inline-editable-label/index.ts
@@ -1,0 +1,2 @@
+export * from './inline-editable-label';
+export * from './inline-editable-label.types';

--- a/ui/components/multichain-accounts/inline-editable-label/inline-editable-label.stories.tsx
+++ b/ui/components/multichain-accounts/inline-editable-label/inline-editable-label.stories.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import {
+  FontWeight,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { InlineEditableLabel } from './inline-editable-label';
+import { InlineEditableLabelProps } from './inline-editable-label.types';
+
+const InteractiveLabel = (args: InlineEditableLabelProps) => {
+  const [value, setValue] = useState(args.value);
+
+  return (
+    <InlineEditableLabel
+      {...args}
+      value={value}
+      onSave={async (newValue) => {
+        setValue(newValue);
+        await args.onSave?.(newValue);
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof InlineEditableLabel> = {
+  title: 'Components/MultichainAccounts/InlineEditableLabel',
+  component: InlineEditableLabel,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Click-to-edit label used for renaming accounts and wallets inline.',
+      },
+    },
+  },
+  argTypes: {
+    value: {
+      control: 'text',
+      description: 'Current label text',
+    },
+    onSave: {
+      action: 'saved',
+      description: 'Called with the trimmed new value when the user saves',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder shown while editing',
+    },
+    maxLength: {
+      control: 'number',
+      description: 'Maximum input length',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disables entering edit mode',
+    },
+    ariaLabel: {
+      control: 'text',
+      description: 'Accessible label for the edit input',
+    },
+  },
+  args: {
+    value: 'Account 1',
+    placeholder: 'Account name',
+    maxLength: 50,
+    ariaLabel: 'Edit account name',
+    disabled: false,
+    variant: TextVariant.BodyMd,
+    color: TextColor.TextDefault,
+    fontWeight: FontWeight.Medium,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '360px', margin: '0 auto', padding: '16px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof InlineEditableLabel>;
+
+export const Default: Story = {
+  render: (args) => <InteractiveLabel {...args} />,
+};
+
+export const Disabled: Story = {
+  args: {
+    value: 'Locked Account Name',
+    disabled: true,
+  },
+};
+
+export const LongName: Story = {
+  render: (args) => <InteractiveLabel {...args} />,
+  args: {
+    value: 'This is a very long account name that may truncate',
+  },
+};

--- a/ui/components/multichain-accounts/inline-editable-label/inline-editable-label.test.tsx
+++ b/ui/components/multichain-accounts/inline-editable-label/inline-editable-label.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { InlineEditableLabel } from './inline-editable-label';
+
+describe('InlineEditableLabel', () => {
+  const defaultProps = {
+    value: 'Account 1',
+    onSave: jest.fn(),
+    ariaLabel: 'Edit account name',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders read-only text initially', () => {
+    renderWithProvider(<InlineEditableLabel {...defaultProps} />);
+    expect(screen.getByText('Account 1')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('enters edit mode on click and shows input and checkmark button', () => {
+    renderWithProvider(<InlineEditableLabel {...defaultProps} />);
+    fireEvent.click(screen.getByText('Account 1'));
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('Account 1');
+    expect(screen.getByTestId('inline-editable-label-save')).toBeInTheDocument();
+  });
+
+  it('saves new value on checkmark button click', async () => {
+    renderWithProvider(<InlineEditableLabel {...defaultProps} />);
+    fireEvent.click(screen.getByText('Account 1'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'New Account Name' } });
+    fireEvent.click(screen.getByTestId('inline-editable-label-save'));
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith('New Account Name');
+    });
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('saves new value on Enter key press', async () => {
+    renderWithProvider(<InlineEditableLabel {...defaultProps} />);
+    fireEvent.click(screen.getByText('Account 1'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'New Account Name' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith('New Account Name');
+    });
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('cancels edit mode on Escape key press without saving', () => {
+    renderWithProvider(<InlineEditableLabel {...defaultProps} />);
+    fireEvent.click(screen.getByText('Account 1'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Changed Name' } });
+    fireEvent.keyDown(input, { key: 'Escape', code: 'Escape' });
+
+    expect(defaultProps.onSave).not.toHaveBeenCalled();
+    expect(screen.getByText('Account 1')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('cancels edit mode on blur without saving', () => {
+    renderWithProvider(<InlineEditableLabel {...defaultProps} />);
+    fireEvent.click(screen.getByText('Account 1'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Changed Name' } });
+    fireEvent.blur(input);
+
+    expect(defaultProps.onSave).not.toHaveBeenCalled();
+    expect(screen.getByText('Account 1')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('does not enter edit mode when disabled is true', () => {
+    renderWithProvider(<InlineEditableLabel {...defaultProps} disabled />);
+    fireEvent.click(screen.getByText('Account 1'));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('does not trigger onSave when value is unchanged or empty', () => {
+    renderWithProvider(<InlineEditableLabel {...defaultProps} />);
+    fireEvent.click(screen.getByText('Account 1'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    expect(defaultProps.onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('does not trigger onSave when value is identical to original', () => {
+    renderWithProvider(<InlineEditableLabel {...defaultProps} />);
+    fireEvent.click(screen.getByText('Account 1'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    expect(defaultProps.onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('stops propagation when clicked to start editing or when editing container is clicked', () => {
+    const parentClick = jest.fn();
+    renderWithProvider(
+      <div onClick={parentClick}>
+        <InlineEditableLabel {...defaultProps} />
+      </div>,
+    );
+
+    fireEvent.click(screen.getByText('Account 1'));
+    expect(parentClick).not.toHaveBeenCalled();
+
+    const editingContainer = screen.getByTestId(
+      'inline-editable-label-editing',
+    );
+    fireEvent.click(editingContainer);
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it('supports custom testId, placeholder, maxLength, and ariaLabel', () => {
+    renderWithProvider(
+      <InlineEditableLabel
+        {...defaultProps}
+        testId="custom-label"
+        placeholder="Enter name"
+        maxLength={30}
+        ariaLabel="Custom aria label"
+      />,
+    );
+
+    expect(screen.getByTestId('custom-label')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('custom-label'));
+
+    const input = screen.getByTestId('custom-label-input');
+    expect(input).toHaveAttribute('placeholder', 'Enter name');
+    expect(input).toHaveAttribute('maxLength', '30');
+    expect(input).toHaveAttribute('aria-label', 'Custom aria label');
+    expect(screen.getByTestId('custom-label-save')).toBeInTheDocument();
+  });
+
+  it('updates input value when value prop changes', () => {
+    const { rerender } = renderWithProvider(
+      <InlineEditableLabel {...defaultProps} value="Old Name" />,
+    );
+
+    expect(screen.getByText('Old Name')).toBeInTheDocument();
+
+    rerender(<InlineEditableLabel {...defaultProps} value="Updated Name" />);
+    expect(screen.getByText('Updated Name')).toBeInTheDocument();
+  });
+});

--- a/ui/components/multichain-accounts/inline-editable-label/inline-editable-label.tsx
+++ b/ui/components/multichain-accounts/inline-editable-label/inline-editable-label.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  ButtonIcon,
+  ButtonIconSize,
+  FontWeight,
+  IconName,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { InlineEditableLabelProps } from './inline-editable-label.types';
+
+export const InlineEditableLabel = ({
+  value,
+  onSave,
+  placeholder,
+  maxLength = 50,
+  ariaLabel,
+  variant = TextVariant.BodyMd,
+  color = TextColor.TextDefault,
+  fontWeight = FontWeight.Medium,
+  className,
+  testId = 'inline-editable-label',
+  disabled = false,
+}: InlineEditableLabelProps) => {
+  const t = useI18nContext();
+  const [isEditing, setIsEditing] = useState(false);
+  const [prevValue, setPrevValue] = useState(value);
+  const [currentValue, setCurrentValue] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  if (value !== prevValue) {
+    setPrevValue(value);
+    setCurrentValue(value);
+  }
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const handleStartEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (disabled) {
+      return;
+    }
+    setCurrentValue(value);
+    setIsEditing(true);
+  };
+
+  const handleCancel = useCallback(() => {
+    setCurrentValue(value);
+    setIsEditing(false);
+  }, [value]);
+
+  const handleSave = useCallback(async () => {
+    const trimmed = currentValue.trim();
+    if (!trimmed || trimmed === value) {
+      handleCancel();
+      return;
+    }
+    await onSave(trimmed);
+    setIsEditing(false);
+  }, [currentValue, value, onSave, handleCancel]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      handleSave();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      handleCancel();
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={1}
+        className="inline-editable-label__editing"
+        data-testid={`${testId}-editing`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={currentValue}
+          maxLength={maxLength}
+          placeholder={placeholder}
+          aria-label={ariaLabel || t('accountName')}
+          onChange={(e) => setCurrentValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleCancel}
+          className="px-2 py-1 text-sm rounded border border-primary-default bg-background-default text-text-default outline-none"
+          data-testid={`${testId}-input`}
+        />
+        <ButtonIcon
+          size={ButtonIconSize.Sm}
+          iconName={IconName.Check}
+          ariaLabel={t('save')}
+          onMouseDown={(e) => {
+            // Prevent onBlur from canceling before save click fires
+            e.preventDefault();
+          }}
+          onClick={handleSave}
+          data-testid={`${testId}-save`}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      className={`inline-editable-label ${disabled ? '' : 'cursor-pointer'} ${className || ''}`.trim()}
+      onClick={handleStartEdit}
+      data-testid={testId}
+    >
+      <Text
+        variant={variant}
+        color={color}
+        fontWeight={fontWeight}
+        ellipsis
+      >
+        {value}
+      </Text>
+    </Box>
+  );
+};

--- a/ui/components/multichain-accounts/inline-editable-label/inline-editable-label.types.ts
+++ b/ui/components/multichain-accounts/inline-editable-label/inline-editable-label.types.ts
@@ -1,0 +1,15 @@
+import { FontWeight, TextColor, TextVariant } from '@metamask/design-system-react';
+
+export type InlineEditableLabelProps = {
+  value: string;
+  onSave: (newValue: string) => Promise<void> | void;
+  placeholder?: string;
+  maxLength?: number;
+  ariaLabel?: string;
+  variant?: TextVariant;
+  color?: TextColor;
+  fontWeight?: FontWeight;
+  className?: string;
+  testId?: string;
+  disabled?: boolean;
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request introduces two reusable UI primitives for multichain account management:
1. `DragHandleIcon`: Renders a 6-dots drag indicator icon (2 columns x 3 rows) matching Material Design / Figma specifications.
2. `InlineEditableLabel`: A reusable click-to-edit label component that allows users to edit names inline with keyboard accessibility (Enter/checkmark save, Escape/blur cancel), custom design tokens, and guard mechanisms.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

1. Run `yarn storybook`
2. Navigate to `Components/MultichainAccounts/InlineEditableLabel`
3. Click on the label to enter edit mode, type new text, and click the checkmark or press Enter to save.
4. Verify pressing Escape or clicking outside reverts changes.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)