### PR TITLE
feat(multichain-accounts): add account management projection and AccountManagementRow

### DIFF
--- a/ui/components/multichain-accounts/account-management-list/account-management-list.utils.test.ts
+++ b/ui/components/multichain-accounts/account-management-list/account-management-list.utils.test.ts
@@ -1,0 +1,293 @@
+import {
+  AccountGroupType,
+  AccountWalletType,
+  toAccountGroupId,
+  toAccountWalletId,
+  toMultichainAccountGroupId,
+  toMultichainAccountWalletId,
+} from '@metamask/account-api';
+import type {
+  AccountGroupObject,
+  AccountWalletObject,
+} from '@metamask/account-tree-controller';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import type { AccountTreeWallets } from '../../../selectors/multichain-accounts/account-tree.types';
+import {
+  isHardwareWallet,
+  isImportedWallet,
+  projectAccountManagementSections,
+} from './account-management-list.utils';
+
+describe('account-management-list.utils', () => {
+  type AccountWalletEntropy = Extract<
+    AccountWalletObject,
+    { type: AccountWalletType.Entropy }
+  >;
+  type AccountWalletKeyring = Extract<
+    AccountWalletObject,
+    { type: AccountWalletType.Keyring }
+  >;
+
+  const createMockEntropyWallet = (
+    id: string,
+    name: string,
+    groups: Record<string, { name: string; pinned?: boolean; hidden?: boolean }>,
+    status: AccountWalletEntropy['status'] = 'ready',
+  ): AccountWalletEntropy => {
+    const walletId = toMultichainAccountWalletId(id);
+    const walletGroups: AccountWalletEntropy['groups'] = {};
+
+    Object.entries(groups).forEach(([, groupMeta], index) => {
+      const groupId = toMultichainAccountGroupId(walletId, index);
+      const accounts: [string, ...string[]] = ['0x1'];
+      walletGroups[groupId] = {
+        id: groupId,
+        type: AccountGroupType.MultichainAccount,
+        metadata: {
+          name: groupMeta.name,
+          pinned: groupMeta.pinned ?? false,
+          hidden: groupMeta.hidden ?? false,
+          lastSelected: 0,
+          entropy: { groupIndex: index },
+        },
+        accounts,
+      };
+    });
+
+    return {
+      id: walletId,
+      type: AccountWalletType.Entropy,
+      status,
+      metadata: {
+        name,
+        entropy: {
+          id,
+        },
+      },
+      groups: walletGroups,
+    };
+  };
+
+  const createMockKeyringWallet = (
+    keyringType: KeyringTypes,
+    groups: Record<string, { name: string; pinned?: boolean; hidden?: boolean }>,
+  ): AccountWalletKeyring => {
+    const walletId = toAccountWalletId(AccountWalletType.Keyring, keyringType);
+    const walletGroups: AccountWalletKeyring['groups'] = {};
+
+    Object.entries(groups).forEach(([groupSuffix, groupMeta]) => {
+      const groupId = toAccountGroupId(walletId, groupSuffix);
+      const accounts: [string] = ['0x1'];
+      walletGroups[groupId] = {
+        id: groupId,
+        type: AccountGroupType.SingleAccount,
+        metadata: {
+          name: groupMeta.name,
+          pinned: groupMeta.pinned ?? false,
+          hidden: groupMeta.hidden ?? false,
+          lastSelected: 0,
+        },
+        accounts,
+      };
+    });
+
+    return {
+      id: walletId,
+      type: AccountWalletType.Keyring,
+      status: 'ready',
+      metadata: {
+        name: keyringType,
+        keyring: {
+          type: keyringType,
+        },
+      },
+      groups: walletGroups,
+    };
+  };
+
+  describe('isHardwareWallet', () => {
+    it('returns true for hardware keyrings', () => {
+      expect(
+        isHardwareWallet(createMockKeyringWallet(KeyringTypes.ledger, {})),
+      ).toBe(true);
+      expect(
+        isHardwareWallet(createMockKeyringWallet(KeyringTypes.trezor, {})),
+      ).toBe(true);
+      expect(
+        isHardwareWallet(createMockKeyringWallet(KeyringTypes.oneKey, {})),
+      ).toBe(true);
+      expect(
+        isHardwareWallet(createMockKeyringWallet(KeyringTypes.lattice, {})),
+      ).toBe(true);
+      expect(
+        isHardwareWallet(
+          createMockKeyringWallet(KeyringTypes.qr, {}),
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for non-hardware keyrings', () => {
+      expect(
+        isHardwareWallet(createMockKeyringWallet(KeyringTypes.simple, {})),
+      ).toBe(false);
+      expect(
+        isHardwareWallet(createMockEntropyWallet('srp-1', 'Wallet 1', {})),
+      ).toBe(false);
+    });
+  });
+
+  describe('isImportedWallet', () => {
+    it('returns true for simple key pair keyrings', () => {
+      expect(
+        isImportedWallet(createMockKeyringWallet(KeyringTypes.simple, {})),
+      ).toBe(true);
+    });
+
+    it('returns false for hardware or entropy wallets', () => {
+      expect(
+        isImportedWallet(createMockKeyringWallet(KeyringTypes.ledger, {})),
+      ).toBe(false);
+      expect(
+        isImportedWallet(createMockEntropyWallet('srp-1', 'Wallet 1', {})),
+      ).toBe(false);
+    });
+  });
+
+  describe('projectAccountManagementSections', () => {
+    it('returns empty array when wallets object is empty', () => {
+      expect(projectAccountManagementSections({ wallets: {} })).toEqual([]);
+    });
+
+    it('projects pinned accounts into virtual Pinned section while keeping them in their canonical section', () => {
+      const wallets: AccountTreeWallets = {
+        'entropy:srp-1': createMockEntropyWallet('srp-1', 'Main Wallet', {
+          'g-1': { name: 'Account 1', pinned: true },
+          'g-2': { name: 'Account 2', pinned: false },
+        }),
+      };
+
+      const sections = projectAccountManagementSections({
+        wallets,
+        primaryEntropySourceId: 'srp-1',
+      });
+
+      expect(sections).toHaveLength(2);
+      expect(sections[0].id).toBe('pinned');
+      expect(sections[0].type).toBe('pinned');
+      expect(sections[0].accounts).toHaveLength(1);
+      expect(sections[0].accounts[0].groupId).toBe('entropy:srp-1/0');
+      expect(sections[0].accounts[0].isPinned).toBe(true);
+
+      expect(sections[1].id).toBe('wallet-entropy:srp-1');
+      expect(sections[1].type).toBe('entropy-wallet');
+      expect(sections[1].accounts).toHaveLength(1);
+      expect(sections[1].accounts[0].groupId).toBe('entropy:srp-1/1');
+      expect(sections[1].isRemovable).toBe(false);
+      expect(sections[1].canAddAccount).toBe(true);
+    });
+
+    it('projects hardware accounts into Hardware section and imported into Imported section', () => {
+      const wallets: AccountTreeWallets = {
+        'entropy:srp-1': createMockEntropyWallet('srp-1', 'Main Wallet', {
+          'g-1': { name: 'Account 1' },
+        }),
+        'keyring:Ledger Hardware': createMockKeyringWallet(KeyringTypes.ledger, {
+          'g-hw-1': { name: 'Ledger 1' },
+        }),
+        'keyring:Simple Key Pair': createMockKeyringWallet(KeyringTypes.simple, {
+          'g-imp-1': { name: 'Imported 1' },
+        }),
+      };
+
+      const sections = projectAccountManagementSections({
+        wallets,
+        primaryEntropySourceId: 'srp-1',
+      });
+
+      expect(sections).toHaveLength(3);
+
+      // Entropy wallet
+      expect(sections[0].id).toBe('wallet-entropy:srp-1');
+      expect(sections[0].type).toBe('entropy-wallet');
+
+      // Hardware section
+      expect(sections[1].id).toBe('hardware-wallets');
+      expect(sections[1].type).toBe('hardware');
+      expect(sections[1].accounts).toHaveLength(1);
+      expect(sections[1].accounts[0].isHardware).toBe(true);
+
+      // Imported section
+      expect(sections[2].id).toBe('imported-accounts');
+      expect(sections[2].type).toBe('imported');
+      expect(sections[2].accounts).toHaveLength(1);
+      expect(sections[2].accounts[0].isImported).toBe(true);
+      expect(sections[2].accounts[0].isRemovable).toBe(true);
+    });
+
+    it('keeps hidden accounts in their canonical section with isHidden: true and excludes them from Pinned even if pinned: true', () => {
+      const wallets: AccountTreeWallets = {
+        'entropy:srp-1': createMockEntropyWallet('srp-1', 'Main Wallet', {
+          'g-1': { name: 'Account 1', pinned: true, hidden: true },
+          'g-2': { name: 'Account 2', hidden: true },
+        }),
+      };
+
+      const sections = projectAccountManagementSections({
+        wallets,
+        primaryEntropySourceId: 'srp-1',
+      });
+
+      // No pinned section because the pinned account is hidden (hidden takes precedence)
+      expect(sections).toHaveLength(1);
+      expect(sections[0].id).toBe('wallet-entropy:srp-1');
+      expect(sections[0].accounts).toHaveLength(2);
+      expect(sections[0].accounts[0].isHidden).toBe(true);
+      expect(sections[0].accounts[0].isPinned).toBe(false);
+      expect(sections[0].accounts[1].isHidden).toBe(true);
+    });
+
+    it('identifies removable secondary entropy wallets and marks primary wallet as non-removable', () => {
+      const wallets: AccountTreeWallets = {
+        'entropy:srp-1': createMockEntropyWallet('srp-1', 'Primary Wallet', {
+          'g-1': { name: 'Account 1' },
+        }),
+        'entropy:srp-2': createMockEntropyWallet('srp-2', 'Secondary Wallet', {
+          'g-2': { name: 'Account 2' },
+        }),
+      };
+
+      const sections = projectAccountManagementSections({
+        wallets,
+        primaryEntropySourceId: 'srp-1',
+      });
+
+      expect(sections).toHaveLength(2);
+      expect(sections[0].isRemovable).toBe(false);
+      expect(sections[1].isRemovable).toBe(true);
+    });
+
+    it('identifies locked wallets and disables add account / remove', () => {
+      const wallets: AccountTreeWallets = {
+        'entropy:srp-2': createMockEntropyWallet(
+          'srp-2',
+          'Locked Secondary Wallet',
+          {
+            'g-2': { name: 'Account 2' },
+          },
+          'uninitialized',
+        ),
+      };
+
+      const sections = projectAccountManagementSections({
+        wallets,
+        primaryEntropySourceId: 'srp-1',
+      });
+
+      expect(sections).toHaveLength(1);
+      expect(sections[0].isLocked).toBe(true);
+      expect(sections[0].canAddAccount).toBe(false);
+      expect(sections[0].isRemovable).toBe(false);
+      expect(sections[0].accounts[0].isLocked).toBe(true);
+    });
+  });
+});

--- a/ui/components/multichain-accounts/account-management-list/account-management-list.utils.ts
+++ b/ui/components/multichain-accounts/account-management-list/account-management-list.utils.ts
@@ -1,0 +1,281 @@
+import {
+  AccountGroupId,
+  AccountWalletId,
+  AccountWalletType,
+  isAccountWalletId,
+  stripAccountWalletType,
+} from '@metamask/account-api';
+import type {
+  AccountGroupObject,
+  AccountWalletObject,
+} from '@metamask/account-tree-controller';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import { AccountTreeWallets } from '../../../selectors/multichain-accounts/account-tree.types';
+
+export const HARDWARE_KEYRING_TYPES = new Set<string>([
+  KeyringTypes.ledger,
+  KeyringTypes.trezor,
+  KeyringTypes.oneKey,
+  KeyringTypes.lattice,
+  KeyringTypes.qr,
+  'Ledger Hardware',
+  'Trezor Hardware',
+  'OneKey Hardware',
+  'Lattice Hardware',
+  'QR Hardware Wallet Device',
+  'ledger',
+  'trezor',
+  'oneKey',
+  'lattice',
+  'qr',
+]);
+
+function getKeyringType(wallet: AccountWalletObject): string | undefined {
+  if (
+    wallet.type === AccountWalletType.Keyring &&
+    typeof wallet.metadata === 'object' &&
+    wallet.metadata !== null &&
+    'keyring' in wallet.metadata &&
+    typeof wallet.metadata.keyring === 'object' &&
+    wallet.metadata.keyring !== null &&
+    'type' in wallet.metadata.keyring &&
+    typeof wallet.metadata.keyring.type === 'string'
+  ) {
+    return wallet.metadata.keyring.type;
+  }
+  return undefined;
+}
+
+function extractRawEntropyId(id: string): string {
+  if (isAccountWalletId(id)) {
+    return stripAccountWalletType(id);
+  }
+  return id;
+}
+
+export function isHardwareWallet(wallet: AccountWalletObject): boolean {
+  const keyringType = getKeyringType(wallet);
+  return Boolean(keyringType && HARDWARE_KEYRING_TYPES.has(keyringType));
+}
+
+export function isImportedWallet(wallet: AccountWalletObject): boolean {
+  const keyringType = getKeyringType(wallet);
+  return (
+    keyringType === KeyringTypes.simple ||
+    keyringType === 'Simple Key Pair'
+  );
+}
+
+export type AccountManagementRowItem = {
+  id: string;
+  groupId: AccountGroupId;
+  groupData: AccountGroupObject;
+  walletId: AccountWalletId;
+  walletName?: string;
+  isPinned: boolean;
+  isHidden: boolean;
+  isLocked: boolean;
+  isHardware: boolean;
+  isImported: boolean;
+  isRemovable: boolean;
+};
+
+export type AccountManagementSectionType =
+  | 'pinned'
+  | 'entropy-wallet'
+  | 'hardware'
+  | 'imported'
+  | 'snap'
+  | 'other';
+
+export type AccountManagementSection = {
+  id: string;
+  title: string;
+  titleKey?: string;
+  type: AccountManagementSectionType;
+  walletId?: AccountWalletId;
+  isCollapsible?: boolean;
+  isLocked?: boolean;
+  isRemovable?: boolean;
+  canAddAccount?: boolean;
+  accounts: AccountManagementRowItem[];
+};
+
+export type ProjectAccountManagementSectionsOptions = {
+  wallets: AccountTreeWallets;
+  primaryEntropySourceId?: string;
+};
+
+/**
+ * Projects the raw AccountTreeWallets into ordered sections for Account Management:
+ * 1. Pinned section (virtual, always first if pinned accounts exist)
+ * 2. Entropy wallet sections (each entropy wallet in its canonical order)
+ * 3. Hardware wallets section (aggregated hardware accounts)
+ * 4. Imported accounts section (aggregated private-key imported accounts)
+ * 5. Other/Snap wallet sections (if any)
+ *
+ * Hidden accounts remain in their canonical source sections with isHidden: true.
+ * Hidden state takes precedence over pinned state.
+ * Empty sections are excluded.
+ * @param options0
+ * @param options0.wallets
+ * @param options0.primaryEntropySourceId
+ */
+export function projectAccountManagementSections({
+  wallets,
+  primaryEntropySourceId,
+}: ProjectAccountManagementSectionsOptions): AccountManagementSection[] {
+  if (!wallets || Object.keys(wallets).length === 0) {
+    return [];
+  }
+
+  const pinnedAccounts: AccountManagementRowItem[] = [];
+  const hardwareAccounts: AccountManagementRowItem[] = [];
+  const importedAccounts: AccountManagementRowItem[] = [];
+  const otherWalletSections: AccountManagementSection[] = [];
+  const entropyWalletSections: AccountManagementSection[] = [];
+
+  let isFirstEntropyWallet = true;
+
+  Object.values(wallets).forEach((walletData) => {
+    if (!walletData) {
+      return;
+    }
+
+    const walletId = walletData.id;
+    const isHardware = isHardwareWallet(walletData);
+    const isImported = isImportedWallet(walletData);
+    const isEntropy = walletData.type === AccountWalletType.Entropy;
+    const isSnap = walletData.type === AccountWalletType.Snap;
+    const isLocked = walletData.status === 'uninitialized';
+    const rawEntropyId = extractRawEntropyId(walletId);
+
+    const normalizedPrimaryEntropyId = primaryEntropySourceId
+      ? extractRawEntropyId(primaryEntropySourceId)
+      : undefined;
+
+    // Check if this entropy wallet is removable (not primary)
+    let isWalletRemovable = false;
+    if (isEntropy) {
+      if (normalizedPrimaryEntropyId && rawEntropyId) {
+        isWalletRemovable = rawEntropyId !== normalizedPrimaryEntropyId;
+      } else {
+        // If no explicit primary entropy source is passed, treat the first one as primary
+        isWalletRemovable = !isFirstEntropyWallet;
+      }
+      isFirstEntropyWallet = false;
+    }
+
+    const currentWalletAccounts: AccountManagementRowItem[] = [];
+
+    Object.values(walletData.groups || {}).forEach((groupData) => {
+      const groupId = groupData.id;
+      const isHidden = Boolean(groupData.metadata?.hidden);
+      // Hidden takes precedence over pinned
+      const isPinned = !isHidden && Boolean(groupData.metadata?.pinned);
+
+      const rowItem: AccountManagementRowItem = {
+        id: `account-${groupId}`,
+        groupId,
+        groupData,
+        walletId,
+        walletName: walletData.metadata?.name,
+        isPinned,
+        isHidden,
+        isLocked,
+        isHardware,
+        isImported,
+        isRemovable: isImported, // Imported private key accounts are individually removable
+      };
+
+      if (isPinned) {
+        pinnedAccounts.push(rowItem);
+      } else if (isHardware) {
+        hardwareAccounts.push(rowItem);
+      } else if (isImported) {
+        importedAccounts.push(rowItem);
+      } else if (isEntropy) {
+        currentWalletAccounts.push(rowItem);
+      } else {
+        currentWalletAccounts.push(rowItem);
+      }
+    });
+
+    if (isEntropy) {
+      if (currentWalletAccounts.length > 0 || !isLocked) {
+        entropyWalletSections.push({
+          id: `wallet-${walletId}`,
+          title: walletData.metadata?.name || '',
+          type: 'entropy-wallet',
+          walletId,
+          isCollapsible: true,
+          isLocked,
+          isRemovable: isWalletRemovable && !isLocked,
+          canAddAccount: !isLocked,
+          accounts: currentWalletAccounts,
+        });
+      }
+    } else if (!isHardware && !isImported) {
+      if (currentWalletAccounts.length > 0) {
+        otherWalletSections.push({
+          id: `wallet-${walletId}`,
+          title: walletData.metadata?.name || '',
+          type: isSnap ? 'snap' : 'other',
+          walletId,
+          isCollapsible: true,
+          isLocked,
+          isRemovable: false,
+          canAddAccount: false,
+          accounts: currentWalletAccounts,
+        });
+      }
+    }
+  });
+
+  const sections: AccountManagementSection[] = [];
+
+  // 1. Pinned section
+  if (pinnedAccounts.length > 0) {
+    sections.push({
+      id: 'pinned',
+      title: 'Pinned',
+      titleKey: 'pinned',
+      type: 'pinned',
+      isCollapsible: true,
+      accounts: pinnedAccounts,
+    });
+  }
+
+  // 2. Entropy wallet sections
+  sections.push(...entropyWalletSections);
+
+  // 3. Hardware wallets section
+  if (hardwareAccounts.length > 0) {
+    sections.push({
+      id: 'hardware-wallets',
+      title: 'Hardware',
+      titleKey: 'hardware',
+      type: 'hardware',
+      isCollapsible: true,
+      isRemovable: true,
+      accounts: hardwareAccounts,
+    });
+  }
+
+  // 4. Imported accounts section
+  if (importedAccounts.length > 0) {
+    sections.push({
+      id: 'imported-accounts',
+      title: 'Imported',
+      titleKey: 'imported',
+      type: 'imported',
+      isCollapsible: true,
+      accounts: importedAccounts,
+    });
+  }
+
+  // 5. Other / Snap wallets
+  sections.push(...otherWalletSections);
+
+  return sections;
+}

--- a/ui/components/multichain-accounts/account-management-list/account-management-row.stories.tsx
+++ b/ui/components/multichain-accounts/account-management-list/account-management-row.stories.tsx
@@ -1,0 +1,419 @@
+import React, { useState } from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import {
+  AccountGroupType,
+  AccountWalletType,
+  toAccountGroupId,
+  toAccountWalletId,
+  toMultichainAccountGroupId,
+  toMultichainAccountWalletId,
+} from '@metamask/account-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import {
+  Box,
+  BoxFlexDirection,
+  Text,
+  TextColor,
+  TextVariant,
+  FontWeight,
+} from '@metamask/design-system-react';
+import { AccountManagementRow } from './account-management-row';
+import { AccountManagementRowItem } from './account-management-list.utils';
+
+const defaultWalletId = toMultichainAccountWalletId('01');
+const defaultGroupId = toMultichainAccountGroupId(defaultWalletId, 0);
+
+const createMockRowItem = (
+  overrides?: Partial<AccountManagementRowItem>,
+): AccountManagementRowItem => {
+  const baseGroupId = overrides?.groupId ?? defaultGroupId;
+  const baseWalletId = overrides?.walletId ?? defaultWalletId;
+  const baseName = overrides?.groupData?.metadata?.name ?? 'Account 1';
+  const isHidden = overrides?.isHidden ?? false;
+
+  return {
+    id: `account-${baseGroupId}`,
+    groupId: baseGroupId,
+    groupData: {
+      id: baseGroupId,
+      type: AccountGroupType.MultichainAccount,
+      metadata: {
+        name: baseName,
+        pinned: false,
+        hidden: isHidden,
+        lastSelected: 0,
+        entropy: { groupIndex: 0 },
+      },
+      accounts: ['0x1'],
+      ...overrides?.groupData,
+    },
+    walletId: baseWalletId,
+    walletName: 'Wallet 1',
+    isPinned: false,
+    isHidden,
+    isLocked: false,
+    isHardware: false,
+    isImported: false,
+    isRemovable: false,
+    ...overrides,
+  };
+};
+
+const hideModeGroupId = toMultichainAccountGroupId(defaultWalletId, 0);
+/** Mode 1: Visible SRP / Entropy account — Eye hide action */
+const hideModeItem = createMockRowItem({
+  groupId: hideModeGroupId,
+  groupData: {
+    id: hideModeGroupId,
+    type: AccountGroupType.MultichainAccount,
+    metadata: {
+      name: 'Account 1',
+      pinned: false,
+      hidden: false,
+      lastSelected: 0,
+      entropy: { groupIndex: 0 },
+    },
+    accounts: ['0x1'],
+  },
+  isRemovable: false,
+  isImported: false,
+  isHardware: false,
+  isHidden: false,
+});
+
+const simpleKeyPairWalletId = toAccountWalletId(
+  AccountWalletType.Keyring,
+  KeyringTypes.simple,
+);
+const simpleKeyPairGroupId = toAccountGroupId(simpleKeyPairWalletId, '0');
+/** Mode 2: Imported private-key account — Remove action */
+const deleteModeImportedItem = createMockRowItem({
+  groupId: simpleKeyPairGroupId,
+  walletId: simpleKeyPairWalletId,
+  walletName: 'Imported',
+  groupData: {
+    id: simpleKeyPairGroupId,
+    type: AccountGroupType.SingleAccount,
+    metadata: {
+      name: 'Imported 1',
+      pinned: false,
+      hidden: false,
+      lastSelected: 0,
+    },
+    accounts: ['0x1'],
+  },
+  isRemovable: true,
+  isImported: true,
+  isHardware: false,
+  isHidden: false,
+});
+
+const ledgerWalletId = toAccountWalletId(
+  AccountWalletType.Keyring,
+  KeyringTypes.ledger,
+);
+const ledgerGroupId = toAccountGroupId(ledgerWalletId, '0');
+/** Mode 2 variant: Hardware account — Remove action */
+const deleteModeHardwareItem = createMockRowItem({
+  groupId: ledgerGroupId,
+  walletId: ledgerWalletId,
+  walletName: 'Ledger',
+  groupData: {
+    id: ledgerGroupId,
+    type: AccountGroupType.SingleAccount,
+    metadata: {
+      name: 'Ledger 1',
+      pinned: false,
+      hidden: false,
+      lastSelected: 0,
+    },
+    accounts: ['0x1'],
+  },
+  isRemovable: true,
+  isImported: false,
+  isHardware: true,
+  isLocked: true,
+  isHidden: false,
+});
+
+const hiddenGroupId = toMultichainAccountGroupId(defaultWalletId, 2);
+/** Mode 3: Already-hidden account — dimmed, EyeSlash unhide only */
+const hiddenStateItem = createMockRowItem({
+  groupId: hiddenGroupId,
+  groupData: {
+    id: hiddenGroupId,
+    type: AccountGroupType.MultichainAccount,
+    metadata: {
+      name: 'Account 3 (Hidden)',
+      pinned: false,
+      hidden: true,
+      lastSelected: 0,
+      entropy: { groupIndex: 2 },
+    },
+    accounts: ['0x1'],
+  },
+  isRemovable: false,
+  isHidden: true,
+});
+
+const InteractiveRow = (
+  args: React.ComponentProps<typeof AccountManagementRow>,
+) => {
+  const [item, setItem] = useState(args.item);
+
+  return (
+    <AccountManagementRow
+      {...args}
+      item={item}
+      onRenameAccount={(groupId, newName) => {
+        setItem((prev) => ({
+          ...prev,
+          groupData: {
+            ...prev.groupData,
+            metadata: {
+              ...prev.groupData.metadata,
+              name: newName,
+            },
+          },
+        }));
+        args.onRenameAccount?.(groupId, newName);
+      }}
+      onToggleVisibility={(groupId, currentHidden) => {
+        setItem((prev) => ({
+          ...prev,
+          isHidden: !currentHidden,
+          groupData: {
+            ...prev.groupData,
+            metadata: {
+              ...prev.groupData.metadata,
+              hidden: !currentHidden,
+            },
+          },
+        }));
+        args.onToggleVisibility?.(groupId, currentHidden);
+      }}
+    />
+  );
+};
+
+const StateLabel = ({ children }: { children: React.ReactNode }) => (
+  <Text
+    variant={TextVariant.BodyXs}
+    color={TextColor.TextAlternative}
+    fontWeight={FontWeight.Medium}
+    className="mb-1 px-4"
+  >
+    {children}
+  </Text>
+);
+
+const meta: Meta<typeof AccountManagementRow> = {
+  title: 'Components/MultichainAccounts/AccountManagementRow',
+  component: AccountManagementRow,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+Account Management rows have three mutually exclusive modes:
+
+1. **Hide mode** — Visible SRP/entropy accounts show an Eye action to hide.
+2. **Delete mode** — Imported and hardware accounts show a Remove action.
+3. **Hidden state** — Dimmed rows; only the EyeSlash unhide control is interactive.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    balance: { control: 'text' },
+    privacyMode: { control: 'boolean' },
+    showDefaultAddress: { control: 'boolean' },
+    pending: { control: 'boolean' },
+    onClick: { action: 'clicked' },
+    onToggleVisibility: { action: 'visibilityToggled' },
+    onRemoveAccount: { action: 'removeRequested' },
+    onRenameAccount: { action: 'renameRequested' },
+  },
+  args: {
+    item: hideModeItem,
+    balance: '$10,728.46',
+    privacyMode: false,
+    showDefaultAddress: false,
+    pending: false,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '360px', margin: '0 auto' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AccountManagementRow>;
+
+/**
+ * Mode 1 — Visible SRP / Entropy account with Eye hide action.
+ */
+export const HideMode: Story = {
+  name: '1. Hide Mode (SRP / Entropy)',
+  render: (args) => <InteractiveRow {...args} />,
+  args: {
+    item: hideModeItem,
+    balance: '$10,728.46',
+    showDefaultAddress: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Visible entropy/SRP account. Start accessory: Eye (hide). End accessory: balance + 6-dots drag handle. Row click navigates to account details.',
+      },
+    },
+  },
+};
+
+/**
+ * Mode 2 — Imported private-key account with Remove action.
+ */
+export const DeleteModeImported: Story = {
+  name: '2a. Delete Mode (Imported)',
+  render: (args) => <InteractiveRow {...args} />,
+  args: {
+    item: deleteModeImportedItem,
+    balance: '$3,412.00',
+    showDefaultAddress: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Imported private-key account. Start accessory: Remove. End accessory: balance + 6-dots drag handle. Triggers account removal confirmation.',
+      },
+    },
+  },
+};
+
+/**
+ * Mode 2 — Hardware account with Remove action.
+ */
+export const DeleteModeHardware: Story = {
+  name: '2b. Delete Mode (Hardware)',
+  render: (args) => <InteractiveRow {...args} />,
+  args: {
+    item: deleteModeHardwareItem,
+    balance: '$842.10',
+    showDefaultAddress: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Hardware wallet account. Start accessory: Remove. End accessory: balance + 6-dots drag handle.',
+      },
+    },
+  },
+};
+
+/**
+ * Mode 3 — Already-hidden account: dimmed, unhide only.
+ */
+export const HiddenState: Story = {
+  name: '3. Hidden State',
+  render: (args) => <InteractiveRow {...args} />,
+  args: {
+    item: hiddenStateItem,
+    balance: '$0.00',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Dimmed (50% opacity). Non-interactive except EyeSlash unhide. No remove button, no navigation on click.',
+      },
+    },
+  },
+};
+
+/**
+ * Side-by-side comparison of all three design modes.
+ */
+export const AllStates: Story = {
+  render: () => (
+    <Box flexDirection={BoxFlexDirection.Column} gap={4}>
+      <Box flexDirection={BoxFlexDirection.Column}>
+        <StateLabel>1. Hide mode — visible SRP / entropy</StateLabel>
+        <InteractiveRow
+          item={hideModeItem}
+          balance="$10,728.46"
+          showDefaultAddress
+          onClick={() => undefined}
+          onToggleVisibility={() => undefined}
+          onRenameAccount={() => undefined}
+        />
+      </Box>
+      <Box flexDirection={BoxFlexDirection.Column}>
+        <StateLabel>2. Delete mode — imported / hardware</StateLabel>
+        <InteractiveRow
+          item={deleteModeImportedItem}
+          balance="$3,412.00"
+          showDefaultAddress
+          onClick={() => undefined}
+          onRemoveAccount={() => undefined}
+          onRenameAccount={() => undefined}
+        />
+        <InteractiveRow
+          item={deleteModeHardwareItem}
+          balance="$842.10"
+          showDefaultAddress
+          onClick={() => undefined}
+          onRemoveAccount={() => undefined}
+          onRenameAccount={() => undefined}
+        />
+      </Box>
+      <Box flexDirection={BoxFlexDirection.Column}>
+        <StateLabel>3. Hidden state — dimmed, unhide only</StateLabel>
+        <InteractiveRow
+          item={hiddenStateItem}
+          balance="$0.00"
+          onToggleVisibility={() => undefined}
+        />
+      </Box>
+    </Box>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Visual comparison of the three Account Management row modes from the design spec.',
+      },
+    },
+  },
+};
+
+export const Pending: Story = {
+  render: (args) => <InteractiveRow {...args} />,
+  args: {
+    item: hideModeItem,
+    pending: true,
+    balance: '$10,728.46',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pending/creating account: reduced interactivity via MultichainAccountCell pending prop.',
+      },
+    },
+  },
+};
+
+export const PrivacyMode: Story = {
+  render: (args) => <InteractiveRow {...args} />,
+  args: {
+    item: hideModeItem,
+    privacyMode: true,
+    balance: '$10,728.46',
+    showDefaultAddress: true,
+  },
+};

--- a/ui/components/multichain-accounts/account-management-list/account-management-row.test.tsx
+++ b/ui/components/multichain-accounts/account-management-list/account-management-row.test.tsx
@@ -1,0 +1,450 @@
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import {
+  AccountGroupType,
+  AccountWalletType,
+  toAccountGroupId,
+  toAccountWalletId,
+  toMultichainAccountGroupId,
+  toMultichainAccountWalletId,
+} from '@metamask/account-api';
+import type { AccountGroupObject } from '@metamask/account-tree-controller';
+import configureStore from '../../../store/store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import mockState from '../../../../test/data/mock-state.json';
+import { AccountManagementRow } from './account-management-row';
+import { AccountManagementRowItem } from './account-management-list.utils';
+
+describe('AccountManagementRow', () => {
+  const defaultWalletId = toMultichainAccountWalletId('01');
+  const defaultGroupId = toMultichainAccountGroupId(defaultWalletId, 0);
+  const importedWalletId = toAccountWalletId(
+    AccountWalletType.Keyring,
+    'imported',
+  );
+  const importedGroupId = toAccountGroupId(importedWalletId, '0');
+  const hiddenGroupId = toMultichainAccountGroupId(defaultWalletId, 1);
+
+  const createMockRowItem = (
+    overrides?: Partial<AccountManagementRowItem>,
+  ): AccountManagementRowItem => {
+    const isSingleAccount = overrides?.isImported || overrides?.isHardware;
+    const defaultItemGroupId = isSingleAccount
+      ? importedGroupId
+      : defaultGroupId;
+    const defaultItemWalletId = isSingleAccount
+      ? importedWalletId
+      : defaultWalletId;
+
+    const groupId = overrides?.groupId || defaultItemGroupId;
+    const walletId = overrides?.walletId || defaultItemWalletId;
+    const accounts: [string, ...string[]] = [`${groupId}/0`];
+
+    const groupData: AccountGroupObject = isSingleAccount
+      ? {
+          id: groupId,
+          type: AccountGroupType.SingleAccount,
+          metadata: {
+            name: 'Account 1',
+            pinned: false,
+            hidden: false,
+            lastSelected: 0,
+          },
+          accounts: [accounts[0]],
+          ...overrides?.groupData,
+        }
+      : {
+          id: defaultGroupId,
+          type: AccountGroupType.MultichainAccount,
+          metadata: {
+            name: 'Account 1',
+            pinned: false,
+            hidden: false,
+            lastSelected: 0,
+            entropy: { groupIndex: 0 },
+          },
+          accounts,
+          ...overrides?.groupData,
+        };
+
+    return {
+      id: `account-${groupId}`,
+      groupId,
+      groupData,
+      walletId,
+      walletName: 'Wallet 1',
+      isPinned: false,
+      isHidden: false,
+      isLocked: false,
+      isHardware: false,
+      isImported: false,
+      isRemovable: false,
+      ...overrides,
+    };
+  };
+
+  const renderComponent = (
+    props: Partial<React.ComponentProps<typeof AccountManagementRow>> = {},
+  ) => {
+    const store = configureStore(mockState);
+
+    const defaultProps = {
+      item: createMockRowItem(),
+      balance: '$100.00',
+      ...props,
+    };
+
+    return renderWithProvider(<AccountManagementRow {...defaultProps} />, store);
+  };
+
+  it('renders account name and balance', () => {
+    renderComponent();
+    expect(screen.getByText('Account 1')).toBeInTheDocument();
+    expect(screen.getByText('$100.00')).toBeInTheDocument();
+  });
+
+  describe('Mode 1: Hide Mode (Visible SRP / Entropy Account)', () => {
+    it('renders Eye toggle, drag handle with cursor-grab class, and no remove button', () => {
+      renderComponent({
+        item: createMockRowItem({ isHidden: false, isRemovable: false }),
+      });
+
+      const hideButton = screen.getByTestId(
+        `account-management-row-visibility-toggle-${defaultGroupId}`,
+      );
+      expect(hideButton).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(messages.hideAccount.message),
+      ).toBeInTheDocument();
+
+      const dragHandle = screen.getByTestId(
+        `account-management-row-drag-handle-${defaultGroupId}`,
+      );
+      expect(dragHandle).toBeInTheDocument();
+      expect(dragHandle).toHaveClass('cursor-grab');
+      expect(dragHandle).not.toHaveClass('opacity-30');
+
+      expect(
+        screen.queryByTestId(
+          `account-management-row-remove-${defaultGroupId}`,
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onToggleVisibility with (groupId, false) when clicking Eye toggle', () => {
+      const handleToggle = jest.fn();
+      renderComponent({
+        item: createMockRowItem({ isHidden: false, isRemovable: false }),
+        onToggleVisibility: handleToggle,
+      });
+
+      const hideButton = screen.getByTestId(
+        `account-management-row-visibility-toggle-${defaultGroupId}`,
+      );
+      fireEvent.click(hideButton);
+      expect(handleToggle).toHaveBeenCalledWith(defaultGroupId, false);
+    });
+  });
+
+  describe('Mode 2: Delete Mode (Visible Removable Imported / Hardware Account)', () => {
+    it('renders RemoveMinus button, drag handle with cursor-grab class, and no eye toggle', () => {
+      const item = createMockRowItem({
+        groupId: importedGroupId,
+        walletId: importedWalletId,
+        isRemovable: true,
+        isImported: true,
+        isHidden: false,
+      });
+      renderComponent({ item });
+
+      const removeButton = screen.getByTestId(
+        `account-management-row-remove-${importedGroupId}`,
+      );
+      expect(removeButton).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(messages.removeAccount.message),
+      ).toBeInTheDocument();
+      expect(removeButton).toHaveClass('text-error-default');
+
+      const dragHandle = screen.getByTestId(
+        `account-management-row-drag-handle-${importedGroupId}`,
+      );
+      expect(dragHandle).toBeInTheDocument();
+      expect(dragHandle).toHaveClass('cursor-grab');
+
+      expect(
+        screen.queryByTestId(
+          `account-management-row-visibility-toggle-${importedGroupId}`,
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onRemoveAccount with item when clicking remove button', () => {
+      const handleRemove = jest.fn();
+      const item = createMockRowItem({
+        groupId: importedGroupId,
+        walletId: importedWalletId,
+        isRemovable: true,
+        isImported: true,
+        isHidden: false,
+      });
+      renderComponent({
+        item,
+        onRemoveAccount: handleRemove,
+      });
+
+      const removeButton = screen.getByTestId(
+        `account-management-row-remove-${importedGroupId}`,
+      );
+      fireEvent.click(removeButton);
+      expect(handleRemove).toHaveBeenCalledWith(item);
+    });
+  });
+
+  describe('Mode 3: Hidden State', () => {
+    it('renders EyeSlash unhide button, disabled drag handle with opacity-30 and cursor-not-allowed, and has hidden class', () => {
+      renderComponent({
+        item: createMockRowItem({
+          groupId: hiddenGroupId,
+          isHidden: true,
+          isRemovable: true, // Even if removable, hidden state takes precedence
+        }),
+      });
+
+      const row = screen.getByTestId(
+        `account-management-row-${hiddenGroupId}`,
+      );
+      expect(row).toHaveClass('account-management-row--hidden');
+      expect(row).toHaveClass('opacity-50');
+
+      const showButton = screen.getByTestId(
+        `account-management-row-visibility-toggle-${hiddenGroupId}`,
+      );
+      expect(showButton).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(messages.showAccount.message),
+      ).toBeInTheDocument();
+
+      const dragHandle = screen.getByTestId(
+        `account-management-row-drag-handle-${hiddenGroupId}`,
+      );
+      expect(dragHandle).toBeInTheDocument();
+      expect(dragHandle).toHaveClass('opacity-30');
+      expect(dragHandle).toHaveClass('cursor-not-allowed');
+
+      expect(
+        screen.queryByTestId(
+          `account-management-row-remove-${hiddenGroupId}`,
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onToggleVisibility with (groupId, true) when clicking EyeSlash button', () => {
+      const handleToggle = jest.fn();
+      renderComponent({
+        item: createMockRowItem({
+          groupId: hiddenGroupId,
+          isHidden: true,
+        }),
+        onToggleVisibility: handleToggle,
+      });
+
+      const showButton = screen.getByTestId(
+        `account-management-row-visibility-toggle-${hiddenGroupId}`,
+      );
+      fireEvent.click(showButton);
+      expect(handleToggle).toHaveBeenCalledWith(hiddenGroupId, true);
+    });
+
+    it('does not trigger onClick when clicking a hidden row', () => {
+      const handleClick = jest.fn();
+      renderComponent({
+        item: createMockRowItem({
+          groupId: hiddenGroupId,
+          isHidden: true,
+        }),
+        onClick: handleClick,
+      });
+
+      const row = screen.getByTestId(
+        `account-management-row-${hiddenGroupId}`,
+      );
+      fireEvent.click(row);
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Inline Rename', () => {
+    it('renders InlineEditableLabel and invokes onRenameAccount when saving new name via save button', async () => {
+      const handleRename = jest.fn();
+      renderComponent({
+        item: createMockRowItem({
+          groupId: defaultGroupId,
+          isHidden: false,
+        }),
+        onRenameAccount: handleRename,
+      });
+
+      const editableLabel = screen.getByTestId(
+        `account-management-row-name-${defaultGroupId}`,
+      );
+      expect(editableLabel).toBeInTheDocument();
+      fireEvent.click(editableLabel);
+
+      const input = screen.getByTestId(
+        `account-management-row-name-${defaultGroupId}-input`,
+      );
+      expect(input).toBeInTheDocument();
+      fireEvent.change(input, { target: { value: 'Renamed Account' } });
+
+      const saveButton = screen.getByTestId(
+        `account-management-row-name-${defaultGroupId}-save`,
+      );
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(handleRename).toHaveBeenCalledWith(
+          defaultGroupId,
+          'Renamed Account',
+        );
+      });
+      expect(
+        screen.queryByTestId(
+          `account-management-row-name-${defaultGroupId}-input`,
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('invokes onRenameAccount when pressing Enter key in input', async () => {
+      const handleRename = jest.fn();
+      renderComponent({
+        item: createMockRowItem({
+          groupId: defaultGroupId,
+          isHidden: false,
+        }),
+        onRenameAccount: handleRename,
+      });
+
+      const editableLabel = screen.getByTestId(
+        `account-management-row-name-${defaultGroupId}`,
+      );
+      fireEvent.click(editableLabel);
+
+      const input = screen.getByTestId(
+        `account-management-row-name-${defaultGroupId}-input`,
+      );
+      fireEvent.change(input, { target: { value: 'Enter Account Name' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleRename).toHaveBeenCalledWith(
+          defaultGroupId,
+          'Enter Account Name',
+        );
+      });
+    });
+
+    it('cancels rename without invoking onRenameAccount when pressing Escape key', () => {
+      const handleRename = jest.fn();
+      renderComponent({
+        item: createMockRowItem({
+          groupId: defaultGroupId,
+          isHidden: false,
+        }),
+        onRenameAccount: handleRename,
+      });
+
+      const editableLabel = screen.getByTestId(
+        `account-management-row-name-${defaultGroupId}`,
+      );
+      fireEvent.click(editableLabel);
+
+      const input = screen.getByTestId(
+        `account-management-row-name-${defaultGroupId}-input`,
+      );
+      fireEvent.change(input, { target: { value: 'Cancelled Name' } });
+      fireEvent.keyDown(input, { key: 'Escape', code: 'Escape' });
+
+      expect(handleRename).not.toHaveBeenCalled();
+      expect(
+        screen.queryByTestId(
+          `account-management-row-name-${defaultGroupId}-input`,
+        ),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('Account 1')).toBeInTheDocument();
+    });
+
+    it('renders static name string when onRenameAccount is not provided', () => {
+      renderComponent({
+        item: createMockRowItem({
+          groupId: defaultGroupId,
+          isHidden: false,
+        }),
+        onRenameAccount: undefined,
+      });
+
+      expect(
+        screen.queryByTestId(
+          `account-management-row-name-${defaultGroupId}`,
+        ),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('Account 1')).toBeInTheDocument();
+    });
+
+    it('renders static name string and does not allow editing when account is hidden even if onRenameAccount is provided', () => {
+      const handleRename = jest.fn();
+      renderComponent({
+        item: createMockRowItem({
+          groupId: hiddenGroupId,
+          isHidden: true,
+        }),
+        onRenameAccount: handleRename,
+      });
+
+      expect(
+        screen.queryByTestId(
+          `account-management-row-name-${hiddenGroupId}`,
+        ),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('Account 1')).toBeInTheDocument();
+    });
+  });
+
+  describe('Row Interactivity', () => {
+    it('triggers onClick when clicking a visible row', () => {
+      const handleClick = jest.fn();
+      renderComponent({
+        item: createMockRowItem({ isHidden: false }),
+        onClick: handleClick,
+      });
+
+      const row = screen.getByTestId(
+        `account-management-row-${defaultGroupId}`,
+      );
+      const cell = row.querySelector('.multichain-account-cell');
+      if (cell) {
+        fireEvent.click(cell);
+      }
+      expect(handleClick).toHaveBeenCalledWith(defaultGroupId);
+    });
+
+    it('does not trigger onClick when pending is true', () => {
+      const handleClick = jest.fn();
+      renderComponent({
+        item: createMockRowItem({ isHidden: false }),
+        pending: true,
+        onClick: handleClick,
+      });
+
+      const row = screen.getByTestId(
+        `account-management-row-${defaultGroupId}`,
+      );
+      const cell = row.querySelector('.multichain-account-cell');
+      if (cell) {
+        fireEvent.click(cell);
+      }
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/components/multichain-accounts/account-management-list/account-management-row.tsx
+++ b/ui/components/multichain-accounts/account-management-list/account-management-row.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { AccountGroupId } from '@metamask/account-api';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  ButtonIcon,
+  ButtonIconSize,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { MultichainAccountCell } from '../multichain-account-cell';
+import { InlineEditableLabel } from '../inline-editable-label';
+import { DragHandleIcon } from '../drag-handle-icon';
+import { AccountManagementRowItem } from './account-management-list.utils';
+
+export type AccountManagementRowProps = {
+  item: AccountManagementRowItem;
+  balance?: string;
+  privacyMode?: boolean;
+  showDefaultAddress?: boolean;
+  onClick?: (groupId: AccountGroupId) => void;
+  onToggleVisibility?: (groupId: AccountGroupId, currentHidden: boolean) => void;
+  onRemoveAccount?: (item: AccountManagementRowItem) => void;
+  onRenameAccount?: (groupId: AccountGroupId, newName: string) => void;
+  pending?: boolean;
+};
+
+export const AccountManagementRow = ({
+  item,
+  balance,
+  privacyMode = false,
+  showDefaultAddress = false,
+  onClick,
+  onToggleVisibility,
+  onRemoveAccount,
+  onRenameAccount,
+  pending = false,
+}: AccountManagementRowProps) => {
+  const t = useI18nContext();
+  const { groupId, groupData, isHidden, isRemovable } = item;
+
+  const handleRowClick = () => {
+    if (isHidden || pending) {
+      return;
+    }
+    onClick?.(groupId);
+  };
+
+  const handleToggleVisibility = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggleVisibility?.(groupId, isHidden);
+  };
+
+  const handleRemoveClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRemoveAccount?.(item);
+  };
+
+  let actionButton: React.ReactNode;
+  if (isHidden) {
+    actionButton = (
+      <ButtonIcon
+        size={ButtonIconSize.Sm}
+        iconName={IconName.EyeSlash}
+        ariaLabel={t('showAccount')}
+        onClick={handleToggleVisibility}
+        data-testid={`account-management-row-visibility-toggle-${groupId}`}
+      />
+    );
+  } else if (isRemovable) {
+    actionButton = (
+      <ButtonIcon
+        size={ButtonIconSize.Sm}
+        iconName={IconName.RemoveMinus}
+        ariaLabel={t('removeAccount')}
+        onClick={handleRemoveClick}
+        data-testid={`account-management-row-remove-${groupId}`}
+        className="text-error-default"
+      />
+    );
+  } else {
+    actionButton = (
+      <ButtonIcon
+        size={ButtonIconSize.Sm}
+        iconName={IconName.Eye}
+        ariaLabel={t('hideAccount')}
+        onClick={handleToggleVisibility}
+        data-testid={`account-management-row-visibility-toggle-${groupId}`}
+      />
+    );
+  }
+
+  const startAccessory = actionButton;
+
+  const endAccessory = (
+    <Box
+      className={`account-management-row__drag-handle flex items-center justify-center text-icon-muted ${
+        isHidden ? 'opacity-30 cursor-not-allowed' : 'cursor-grab'
+      }`}
+      data-testid={`account-management-row-drag-handle-${groupId}`}
+      aria-hidden="true"
+    >
+      <DragHandleIcon size={16} />
+    </Box>
+  );
+
+  const accountNameContent =
+    !isHidden && onRenameAccount ? (
+      <InlineEditableLabel
+        value={groupData.metadata?.name || ''}
+        onSave={(newName) => onRenameAccount(groupId, newName)}
+        testId={`account-management-row-name-${groupId}`}
+        ariaLabel={t('accountName')}
+      />
+    ) : (
+      groupData.metadata?.name || ''
+    );
+
+  return (
+    <Box
+      className={`account-management-row${isHidden ? ' account-management-row--hidden opacity-50 pointer-events-auto' : ''}`}
+      style={isHidden ? { opacity: 0.5 } : undefined}
+      data-testid={`account-management-row-${groupId}`}
+    >
+      <MultichainAccountCell
+        accountId={groupId}
+        accountName={accountNameContent}
+        accountNameString={groupData.metadata?.name || ''}
+        balance={balance}
+        privacyMode={privacyMode}
+        showDefaultAddress={!isHidden && showDefaultAddress}
+        onClick={isHidden ? undefined : handleRowClick}
+        disableHoverEffect={isHidden}
+        pending={pending}
+        startAccessory={startAccessory}
+        endAccessory={endAccessory}
+      />
+    </Box>
+  );
+};

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -191,15 +191,24 @@ export const MultichainAccountCell = ({
         />
         <Box marginLeft={3} style={{ overflow: 'hidden' }}>
           {/* Prevent overflow of account name by long account names */}
-          <Text
-            className="multichain-account-cell__account-name"
-            variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
-            ellipsis
-            data-testid={`multichain-account-cell-name-${ariaLabelName}`}
-          >
-            {accountName}
-          </Text>
+          {typeof accountName === 'string' ? (
+            <Text
+              className="multichain-account-cell__account-name"
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              ellipsis
+              data-testid={`multichain-account-cell-name-${ariaLabelName}`}
+            >
+              {accountName}
+            </Text>
+          ) : (
+            <Box
+              className="multichain-account-cell__account-name"
+              data-testid={`multichain-account-cell-name-${ariaLabelName}`}
+            >
+              {accountName}
+            </Box>
+          )}
           {balancePosition === 'subtitle' && (
             <BalanceDisplay
               balance={balance}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request introduces the projection layer and account row component for the Account Management screen:
1. `projectAccountManagementSections`: A pure projection utility that transforms `AccountTreeWallets` into canonical sections (Pinned, Entropy Wallets, Hardware Wallets, Imported Accounts).
2. `AccountManagementRow`: Wraps `MultichainAccountCell` and manages three mutually exclusive modes:
   - **Mode 1 (Hide Mode — Visible SRP Accounts):** Left Eye hide action, right balance + 6-dots drag handle (`DragHandleIcon`).
   - **Mode 2 (Delete Mode — Visible Imported & Hardware Accounts):** Left red circle minus action (`IconName.RemoveMinus`), right balance + 6-dots drag handle.
   - **Mode 3 (Hidden State):** 50% opacity, non-unhide interactions disabled, left EyeSlash unhide action, right disabled 6-dots drag handle.
   - Supports inline account name renaming via `InlineEditableLabel`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

1. Run Storybook (`yarn storybook`).
2. Navigate to `Components/MultichainAccounts/AccountManagementRow` and inspect all three modes:
   - `1. Hide Mode (SRP / Entropy)`
   - `2a. Delete Mode (Imported)`
   - `2b. Delete Mode (Hardware)`
   - `3. Hidden State`
   - `All States` (side-by-side comparison).
3. Test inline renaming, eye toggling, and delete triggers.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)