### PR TITLE
feat(multichain-accounts): add AccountManagementList component

### DIFF
--- a/ui/components/multichain-accounts/account-management-list/account-management-list.stories.tsx
+++ b/ui/components/multichain-accounts/account-management-list/account-management-list.stories.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import {
+  AccountGroupType,
+  AccountWalletType,
+  toAccountGroupId,
+  toAccountWalletId,
+  toMultichainAccountGroupId,
+  toMultichainAccountWalletId,
+} from '@metamask/account-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import { AccountTreeWallets } from '../../../selectors/multichain-accounts/account-tree.types';
+import { AccountManagementList } from './account-management-list';
+
+const createMockWallets = (): AccountTreeWallets => {
+  const srpWalletId = toMultichainAccountWalletId('srp-1');
+  const srpGroup0Id = toMultichainAccountGroupId(srpWalletId, 0);
+  const srpGroup1Id = toMultichainAccountGroupId(srpWalletId, 1);
+  const srpGroup2Id = toMultichainAccountGroupId(srpWalletId, 2);
+
+  const ledgerWalletId = toAccountWalletId(
+    AccountWalletType.Keyring,
+    KeyringTypes.ledger,
+  );
+  const ledgerGroup0Id = toAccountGroupId(ledgerWalletId, '0');
+
+  const simpleKeyWalletId = toAccountWalletId(
+    AccountWalletType.Keyring,
+    KeyringTypes.simple,
+  );
+  const simpleKeyGroup0Id = toAccountGroupId(simpleKeyWalletId, '0');
+
+  return {
+    [srpWalletId]: {
+      id: srpWalletId,
+      type: AccountWalletType.Entropy,
+      status: 'ready',
+      metadata: {
+        name: 'Main Wallet',
+        entropy: { id: 'srp-1' },
+      },
+      groups: {
+        [srpGroup0Id]: {
+          id: srpGroup0Id,
+          type: AccountGroupType.MultichainAccount,
+          metadata: {
+            name: 'Account 1',
+            pinned: true,
+            hidden: false,
+            lastSelected: 0,
+            entropy: { groupIndex: 0 },
+          },
+          accounts: ['0x1'],
+        },
+        [srpGroup1Id]: {
+          id: srpGroup1Id,
+          type: AccountGroupType.MultichainAccount,
+          metadata: {
+            name: 'Account 2',
+            pinned: false,
+            hidden: false,
+            lastSelected: 0,
+            entropy: { groupIndex: 1 },
+          },
+          accounts: ['0x2'],
+        },
+        [srpGroup2Id]: {
+          id: srpGroup2Id,
+          type: AccountGroupType.MultichainAccount,
+          metadata: {
+            name: 'Hidden Account',
+            pinned: false,
+            hidden: true,
+            lastSelected: 0,
+            entropy: { groupIndex: 2 },
+          },
+          accounts: ['0x3'],
+        },
+      },
+    },
+    [ledgerWalletId]: {
+      id: ledgerWalletId,
+      type: AccountWalletType.Keyring,
+      status: 'ready',
+      metadata: {
+        name: 'Ledger Hardware',
+        keyring: { type: KeyringTypes.ledger },
+      },
+      groups: {
+        [ledgerGroup0Id]: {
+          id: ledgerGroup0Id,
+          type: AccountGroupType.SingleAccount,
+          metadata: {
+            name: 'Ledger 1',
+            pinned: false,
+            hidden: false,
+            lastSelected: 0,
+          },
+          accounts: ['0x4'],
+        },
+      },
+    },
+    [simpleKeyWalletId]: {
+      id: simpleKeyWalletId,
+      type: AccountWalletType.Keyring,
+      status: 'ready',
+      metadata: {
+        name: 'Simple Key Pair',
+        keyring: { type: KeyringTypes.simple },
+      },
+      groups: {
+        [simpleKeyGroup0Id]: {
+          id: simpleKeyGroup0Id,
+          type: AccountGroupType.SingleAccount,
+          metadata: {
+            name: 'Imported 1',
+            pinned: false,
+            hidden: false,
+            lastSelected: 0,
+          },
+          accounts: ['0x5'],
+        },
+      },
+    },
+  };
+};
+
+const meta: Meta<typeof AccountManagementList> = {
+  title: 'Components/MultichainAccounts/AccountManagementList',
+  component: AccountManagementList,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Full Account Management list projecting wallets into pinned, entropy, hardware, and imported sections.',
+      },
+    },
+  },
+  argTypes: {
+    isInSearchMode: { control: 'boolean' },
+    onAccountClick: { action: 'accountClicked' },
+    onRemoveWallet: { action: 'removeWallet' },
+    onRemoveAccount: { action: 'removeAccount' },
+  },
+  args: {
+    wallets: createMockWallets(),
+    primaryEntropySourceId: 'srp-1',
+    isInSearchMode: false,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '360px', margin: '0 auto' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AccountManagementList>;
+
+export const Default: Story = {};
+
+export const SearchMode: Story = {
+  args: {
+    isInSearchMode: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Search mode hides add-account rows within wallet sections.',
+      },
+    },
+  },
+};
+
+export const EntropyWalletOnly: Story = {
+  args: {
+    wallets: (() => {
+      const all = createMockWallets();
+      const srpWalletId = toAccountWalletId(AccountWalletType.Entropy, 'srp-1');
+      return {
+        [srpWalletId]: all[srpWalletId],
+      };
+    })(),
+  },
+};

--- a/ui/components/multichain-accounts/account-management-list/account-management-list.test.tsx
+++ b/ui/components/multichain-accounts/account-management-list/account-management-list.test.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import {
+  AccountGroupType,
+  AccountWalletType,
+  toAccountGroupId,
+  toAccountWalletId,
+  toMultichainAccountGroupId,
+  toMultichainAccountWalletId,
+} from '@metamask/account-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import configureStore from '../../../store/store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import mockState from '../../../../test/data/mock-state.json';
+import { setBackgroundConnection } from '../../../store/background-connection';
+import { AccountTreeWallets } from '../../../selectors/multichain-accounts/account-tree.types';
+import { AccountManagementList } from './account-management-list';
+
+const backgroundConnectionMock = new Proxy(
+  {},
+  {
+    get: () => jest.fn().mockResolvedValue(undefined),
+  },
+);
+
+const mockSetAccountGroupHidden = jest
+  .fn()
+  .mockImplementation(() => () => Promise.resolve());
+jest.mock('../../../store/actions', () => ({
+  ...jest.requireActual('../../../store/actions'),
+  setAccountGroupHidden: (...args: unknown[]) =>
+    mockSetAccountGroupHidden(...args),
+}));
+
+describe('AccountManagementList', () => {
+  const createMockWallets = (): AccountTreeWallets => {
+    const srp1WalletId = toMultichainAccountWalletId('srp-1');
+    const srp1Group0Id = toMultichainAccountGroupId(srp1WalletId, 0);
+    const srp1Group1Id = toMultichainAccountGroupId(srp1WalletId, 1);
+
+    const srp2WalletId = toMultichainAccountWalletId('srp-2');
+    const srp2Group0Id = toMultichainAccountGroupId(srp2WalletId, 0);
+
+    const simpleWalletId = toAccountWalletId(
+      AccountWalletType.Keyring,
+      KeyringTypes.simple,
+    );
+    const simpleGroup0Id = toAccountGroupId(simpleWalletId, '0');
+
+    return {
+      [srp1WalletId]: {
+        id: srp1WalletId,
+        type: AccountWalletType.Entropy,
+        status: 'ready',
+        metadata: {
+          name: 'Main Wallet',
+          entropy: { id: 'srp-1' },
+        },
+        groups: {
+          [srp1Group0Id]: {
+            id: srp1Group0Id,
+            type: AccountGroupType.MultichainAccount,
+            metadata: {
+              name: 'Account 1',
+              pinned: true,
+              hidden: false,
+              lastSelected: 0,
+              entropy: { groupIndex: 0 },
+            },
+            accounts: ['0x1'],
+          },
+          [srp1Group1Id]: {
+            id: srp1Group1Id,
+            type: AccountGroupType.MultichainAccount,
+            metadata: {
+              name: 'Account 2',
+              pinned: false,
+              hidden: false,
+              lastSelected: 0,
+              entropy: { groupIndex: 1 },
+            },
+            accounts: ['0x2'],
+          },
+        },
+      },
+      [srp2WalletId]: {
+        id: srp2WalletId,
+        type: AccountWalletType.Entropy,
+        status: 'ready',
+        metadata: {
+          name: 'Secondary Wallet',
+          entropy: { id: 'srp-2' },
+        },
+        groups: {
+          [srp2Group0Id]: {
+            id: srp2Group0Id,
+            type: AccountGroupType.MultichainAccount,
+            metadata: {
+              name: 'Account 3',
+              pinned: false,
+              hidden: false,
+              lastSelected: 0,
+              entropy: { groupIndex: 0 },
+            },
+            accounts: ['0x3'],
+          },
+        },
+      },
+      [simpleWalletId]: {
+        id: simpleWalletId,
+        type: AccountWalletType.Keyring,
+        status: 'ready',
+        metadata: {
+          name: 'Simple Key Pair',
+          keyring: { type: KeyringTypes.simple },
+        },
+        groups: {
+          [simpleGroup0Id]: {
+            id: simpleGroup0Id,
+            type: AccountGroupType.SingleAccount,
+            metadata: {
+              name: 'Imported 1',
+              pinned: false,
+              hidden: false,
+              lastSelected: 0,
+            },
+            accounts: ['0x4'],
+          },
+        },
+      },
+    };
+  };
+
+  const renderComponent = (
+    props: Partial<React.ComponentProps<typeof AccountManagementList>> = {},
+  ) => {
+    const store = configureStore(mockState);
+    const defaultProps = {
+      wallets: createMockWallets(),
+      primaryEntropySourceId: 'srp-1',
+      ...props,
+    };
+
+    return renderWithProvider(
+      <AccountManagementList {...defaultProps} />,
+      store,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setBackgroundConnection(backgroundConnectionMock as never);
+  });
+
+  it('renders all sections including Pinned and wallet sections', () => {
+    renderComponent();
+    expect(screen.getByTestId('account-management-list')).toBeInTheDocument();
+    expect(screen.getByText('Pinned')).toBeInTheDocument();
+    expect(screen.getByText('Main Wallet')).toBeInTheDocument();
+    expect(screen.getByText('Secondary Wallet')).toBeInTheDocument();
+    expect(screen.getByText('Imported')).toBeInTheDocument();
+  });
+
+  it('toggles section collapse when clicking header', () => {
+    renderComponent();
+    const pinnedHeader = screen.getByTestId('wallet-section-header-pinned');
+    expect(pinnedHeader).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(pinnedHeader);
+    expect(pinnedHeader).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('dispatches setAccountGroupHidden when clicking visibility toggle button', () => {
+    renderComponent();
+    const visibilityToggle = screen.getByTestId(
+      'account-management-row-visibility-toggle-entropy:srp-1/0',
+    );
+    fireEvent.click(visibilityToggle);
+    expect(mockSetAccountGroupHidden).toHaveBeenCalledWith(
+      'entropy:srp-1/0',
+      true,
+    );
+  });
+
+  it('triggers onAccountClick when clicking a visible account row', () => {
+    const handleAccountClick = jest.fn();
+    renderComponent({ onAccountClick: handleAccountClick });
+    const row = screen.getByTestId('account-management-row-entropy:srp-1/1');
+    const cell = row.querySelector('.multichain-account-cell');
+    if (cell) {
+      fireEvent.click(cell);
+    }
+    expect(handleAccountClick).toHaveBeenCalledWith('entropy:srp-1/1');
+  });
+
+  it('triggers onRemoveWallet when clicking remove on a removable wallet section header', () => {
+    const handleRemoveWallet = jest.fn();
+    renderComponent({ onRemoveWallet: handleRemoveWallet });
+
+    const removeButton = screen.getByTestId(
+      'wallet-section-header-wallet-entropy:srp-2-remove-button',
+    );
+    expect(removeButton).toBeInTheDocument();
+    fireEvent.click(removeButton);
+
+    expect(handleRemoveWallet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'wallet-entropy:srp-2',
+        title: 'Secondary Wallet',
+      }),
+    );
+  });
+
+  it('triggers onRenameWallet when editing a wallet header', async () => {
+    const handleRenameWallet = jest.fn();
+    renderComponent({ onRenameWallet: handleRenameWallet });
+
+    fireEvent.click(screen.getByText('Main Wallet'));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Renamed Main Wallet' } });
+    fireEvent.click(screen.getByTestId('wallet-section-header-title-save'));
+
+    await waitFor(() => {
+      expect(handleRenameWallet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'wallet-entropy:srp-1',
+        }),
+        'Renamed Main Wallet',
+      );
+    });
+  });
+
+  it('triggers onRemoveAccount when clicking remove on an imported account row', () => {
+    const handleRemoveAccount = jest.fn();
+    renderComponent({ onRemoveAccount: handleRemoveAccount });
+
+    const removeButton = screen.getByTestId(
+      'account-management-row-remove-keyring:Simple Key Pair/0',
+    );
+    expect(removeButton).toBeInTheDocument();
+    fireEvent.click(removeButton);
+
+    expect(handleRemoveAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        groupId: 'keyring:Simple Key Pair/0',
+      }),
+    );
+  });
+
+  it('triggers onRenameAccount when editing an account row', async () => {
+    const handleRenameAccount = jest.fn();
+    renderComponent({ onRenameAccount: handleRenameAccount });
+
+    fireEvent.click(screen.getByText('Account 2'));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'New Account 2' } });
+    fireEvent.click(
+      screen.getByTestId('account-management-row-name-entropy:srp-1/1-save'),
+    );
+
+    await waitFor(() => {
+      expect(handleRenameAccount).toHaveBeenCalledWith(
+        'entropy:srp-1/1',
+        'New Account 2',
+      );
+    });
+  });
+});

--- a/ui/components/multichain-accounts/account-management-list/account-management-list.tsx
+++ b/ui/components/multichain-accounts/account-management-list/account-management-list.tsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { AccountGroupId } from '@metamask/account-api';
+import { Box, BoxFlexDirection } from '@metamask/design-system-react';
+import { useDispatch } from '../../../store/hooks';
+import { setAccountGroupHidden } from '../../../store/actions';
+import { selectBalanceForAllWallets } from '../../../selectors/assets';
+import { getPreferences } from '../../../../shared/lib/selectors/preferences';
+import {
+  getIsDefaultAddressEnabled,
+  getShowDefaultAddressPreference,
+  getMetaMaskHdKeyrings,
+} from '../../../selectors';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
+import { useFormatters } from '../../../hooks/useFormatters';
+import { getAccountGroupDisplayBalance } from '../../../helpers/utils/account-group-balance';
+import { AccountTreeWallets } from '../../../selectors/multichain-accounts/account-tree.types';
+import { AddMultichainAccount } from '../add-multichain-account';
+import { WalletSectionHeader } from '../wallet-section-header';
+import { AccountManagementRow } from './account-management-row';
+import {
+  AccountManagementRowItem,
+  AccountManagementSection,
+  projectAccountManagementSections,
+} from './account-management-list.utils';
+
+export type AccountManagementListProps = {
+  wallets: AccountTreeWallets;
+  isInSearchMode?: boolean;
+  onAccountClick?: (accountGroupId: AccountGroupId) => void;
+  onRemoveWallet?: (section: AccountManagementSection) => void;
+  onRemoveAccount?: (item: AccountManagementRowItem) => void;
+  onRenameAccount?: (groupId: AccountGroupId, newName: string) => void;
+  onRenameWallet?: (section: AccountManagementSection, newTitle: string) => void;
+  primaryEntropySourceId?: string;
+};
+
+export const AccountManagementList = ({
+  wallets,
+  isInSearchMode = false,
+  onAccountClick,
+  onRemoveWallet,
+  onRemoveAccount,
+  onRenameAccount,
+  onRenameWallet,
+  primaryEntropySourceId,
+}: AccountManagementListProps) => {
+  const dispatch = useDispatch();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const { formatCurrencyWithMinThreshold } = useFormatters();
+  const allBalances = useSelector(selectBalanceForAllWallets);
+  const { privacyMode } = useSelector(getPreferences);
+  const isDefaultAddressEnabled = useSelector(getIsDefaultAddressEnabled);
+  const showDefaultAddressPreference = useSelector(
+    getShowDefaultAddressPreference,
+  );
+  const showDefaultAddress =
+    isDefaultAddressEnabled && showDefaultAddressPreference;
+
+  const hdKeyrings = useSelector(getMetaMaskHdKeyrings);
+
+  const effectivePrimaryEntropySourceId = useMemo(() => {
+    if (primaryEntropySourceId) {
+      return primaryEntropySourceId;
+    }
+    return hdKeyrings?.[0]?.metadata?.id;
+  }, [primaryEntropySourceId, hdKeyrings]);
+
+  const [collapsedSectionKeys, setCollapsedSectionKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const toggleSectionExpanded = useCallback((sectionKey: string) => {
+    setCollapsedSectionKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(sectionKey)) {
+        next.delete(sectionKey);
+      } else {
+        next.add(sectionKey);
+      }
+      return next;
+    });
+  }, []);
+
+  const sections = useMemo(
+    () =>
+      projectAccountManagementSections({
+        wallets,
+        primaryEntropySourceId: effectivePrimaryEntropySourceId,
+      }),
+    [wallets, effectivePrimaryEntropySourceId],
+  );
+
+  const handleToggleAccountVisibility = useCallback(
+    async (accountGroupId: AccountGroupId, currentHidden: boolean) => {
+      const newHiddenState = !currentHidden;
+      await dispatch(setAccountGroupHidden(accountGroupId, newHiddenState));
+
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.AccountHidden)
+          .addCategory(MetaMetricsEventCategory.Accounts)
+          .addProperties({
+            hidden: newHiddenState,
+          })
+          .build(),
+      );
+    },
+    [dispatch, trackEvent, createEventBuilder],
+  );
+
+  return (
+    <Box
+      className="account-management-list flex flex-col w-full"
+      flexDirection={BoxFlexDirection.Column}
+      data-testid="account-management-list"
+    >
+      {sections.map((section) => {
+        const isExpanded = !collapsedSectionKeys.has(section.id);
+        const handleRenameWallet = onRenameWallet
+          ? (newTitle: string) => onRenameWallet(section, newTitle)
+          : undefined;
+
+        return (
+          <Box
+            key={section.id}
+            className="wallet-section flex flex-col w-full"
+            flexDirection={BoxFlexDirection.Column}
+            data-testid={`wallet-section-${section.id}`}
+          >
+            <WalletSectionHeader
+              title={section.title}
+              testId={`wallet-section-header-${section.id}`}
+              isCollapsible={section.isCollapsible}
+              isExpanded={isExpanded}
+              onToggleExpand={() => toggleSectionExpanded(section.id)}
+              isLocked={section.isLocked}
+              isRemovable={section.isRemovable}
+              showDragHandle
+              onRemove={
+                onRemoveWallet ? () => onRemoveWallet(section) : undefined
+              }
+              onRename={handleRenameWallet}
+            />
+            {isExpanded && (
+              <Box
+                className="wallet-section__accounts flex flex-col w-full"
+                flexDirection={BoxFlexDirection.Column}
+              >
+                {section.accounts.map((item) => {
+                  const groupBalance = getAccountGroupDisplayBalance(
+                    allBalances?.wallets?.[item.walletId]?.groups?.[
+                      item.groupId
+                    ],
+                  );
+                  const balance =
+                    groupBalance &&
+                    formatCurrencyWithMinThreshold(
+                      groupBalance.amount,
+                      groupBalance.currency,
+                    );
+
+                  return (
+                    <AccountManagementRow
+                      key={item.id}
+                      item={item}
+                      balance={balance}
+                      privacyMode={privacyMode}
+                      showDefaultAddress={showDefaultAddress}
+                      onClick={onAccountClick}
+                      onToggleVisibility={handleToggleAccountVisibility}
+                      onRemoveAccount={onRemoveAccount}
+                      onRenameAccount={onRenameAccount}
+                    />
+                  );
+                })}
+                {!isInSearchMode &&
+                  section.canAddAccount &&
+                  section.walletId && (
+                    <AddMultichainAccount
+                      walletId={section.walletId}
+                      data-testid={`add-account-to-${section.walletId}`}
+                    />
+                  )}
+              </Box>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};

--- a/ui/components/multichain-accounts/account-management-list/index.ts
+++ b/ui/components/multichain-accounts/account-management-list/index.ts
@@ -1,0 +1,3 @@
+export * from './account-management-list';
+export * from './account-management-list.utils';
+export * from './account-management-row';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request introduces the `AccountManagementList` component:
1. Composes sections directly from `WalletSectionHeader` and `AccountManagementRow` list items.
2. Manages collapsible section expansion state, balance display formatting, and add-account rows per eligible entropy wallet.
3. Forwards wallet removal, account removal, inline renaming, and visibility toggling.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

1. Run Storybook (`yarn storybook`).
2. Navigate to `Components/MultichainAccounts/AccountManagementList`.
3. Test section collapsing, add-account visibility in default vs search mode, and wallet/account actions.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)