### PR TITLE
ci: run e2e when privacy snapshot changes

### DIFF
--- a/.github/rules/filter-rules.yml
+++ b/.github/rules/filter-rules.yml
@@ -45,7 +45,6 @@ config_files: &config_files
   - 'crowdin.yml'
   - 'eslint.config.js'
   - 'oxfmt.config.mts'
-  - 'privacy-snapshot.json'
   - 'sonar-project.properties'
   - 'stylelint.config.js'
   - 'tailwind.config.js'
@@ -97,8 +96,9 @@ storybook_files:
   - '**/*.snap'
   - '.storybook/**'
 
-# E2E test files — changes require running E2E even when builds are reused
+# E2E test files and runtime inputs — changes require running E2E even when builds are reused
 e2e_test_files:
+  - 'privacy-snapshot.json'
   - 'test/e2e/**'
 
 # Build-affecting CI files — these live under .github/ (which is in ci_files


### PR DESCRIPTION
## **Description**

`privacy-snapshot.json` is read by every E2E suite to detect network hosts that are not in the approved privacy snapshot. However, the CI path filters classified the file as non-E2E configuration, so a pull request changing only the snapshot skipped E2E entirely.

This change removes the snapshot from the safe-to-skip configuration set and classifies it as an E2E runtime input. Privacy snapshot changes will therefore run E2E with both fresh and reused builds, without unnecessarily invalidating reusable build artifacts.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. On a test branch containing this change, modify only `privacy-snapshot.json`.
2. Open the branch's `Main` workflow run and inspect the `Get workflow and job requirements` output.
3. Verify `needs-e2e` is `true` and the E2E preparation, Chrome, and Firefox jobs run, including when build artifacts are reused from the base branch.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI path-filter configuration only; no application runtime or security logic changes.
> 
> **Overview**
> **Reclassifies `privacy-snapshot.json` in CI path filters** so pull requests that only update the privacy snapshot no longer skip E2E.
> 
> The file is removed from the `config_files` / `non_e2e_related_files` set and added under `e2e_test_files` (comment updated to include “runtime inputs”). That aligns filtering with E2E suites that read the snapshot for network-host checks: `needs-e2e` should be true for snapshot-only diffs, including when build artifacts are reused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab949eb97fa01069d256b8a0574df4a840e02507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->