### PR TITLE
fix(benchmarks): exit non-zero when a benchmark fails

### DIFF
--- a/test/e2e/benchmarks/run-benchmark.ts
+++ b/test/e2e/benchmarks/run-benchmark.ts
@@ -350,6 +350,7 @@ async function main(): Promise<void> {
 
   // Run benchmarks and collect results
   const allResults: Record<string, unknown> = {};
+  const failedBenchmarks: string[] = [];
 
   for (const filePath of filesToRun) {
     const fileName = path.basename(filePath, path.extname(filePath));
@@ -370,6 +371,7 @@ async function main(): Promise<void> {
     } catch (error) {
       console.error(`❌ Error running ${fileName}:`, error);
       allResults[resultKey] = { error: String(error) };
+      failedBenchmarks.push(resultKey);
     }
   }
 
@@ -393,6 +395,17 @@ async function main(): Promise<void> {
 
   console.log('\n📊 Benchmark Results:');
   console.log(outputStr);
+
+  // Throw only after the results file and the log are both out. A caller that
+  // reads the artifact -- the quality gate, and the `{ error: ... }` handling in
+  // particular -- still gets its input; what changes is that the process no
+  // longer exits 0 having produced a failure. `main().catch()` below routes this
+  // through `exitWithError`, which sets a non-zero exit code.
+  if (failedBenchmarks.length > 0) {
+    throw new Error(
+      `${failedBenchmarks.length} of ${filesToRun.length} benchmark(s) failed: ${failedBenchmarks.join(', ')}. Individual errors are logged above.`,
+    );
+  }
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Changelog

CHANGELOG entry: null

## Summary

- `run-benchmark.ts` catches a per-file error into `allResults[key] = { error: ... }` and continues; `main()` then resolves, so a run where every benchmark threw still exits **0** and CI reads it as a pass.
- This collects the failed keys and throws once at the end. `main().catch()` already routes to `exitWithError`, which sets a non-zero exit code — no new mechanism.
- The throw is placed **after** the results file is written and after the results are logged, so anything that reads the artifact still gets it. `compare-benchmarks.ts` and its `{ error: ... }` handling in particular are unaffected.

Observed instance this fixes the reporting for: a page-load run whose dapp server was not yet accepting connections threw, the throw was swallowed, the step went green in ~8s, and the first visible symptom was an `ENOENT` from the Sentry upload two steps later — pointing at the wrong subsystem.

This is the widest-reach change of the four in that thread, so it is deliberately last: it converts every currently-swallowed benchmark error across all 17 legs into a hard failure at once. The cause fix (#45873) should land first.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, confirm on `main` that a benchmark leg which produces no artifact fails its own step rather than surfacing downstream

### What was checked locally

Narrow single-file typecheck, three passes:

| arm | result |
|---|---|
| injected `const broken: number = 'x'` | `run-benchmark.ts(354,9): error TS2322` — instrument fires |
| this branch | 2 × `TS7016` on import lines 12 and 16 |
| `origin/main`, same flags | the same 2 `TS7016`, same lines |

Zero new diagnostics. Scope: those flags are ad-hoc (`--skipLibCheck --strict --target es2022 --module esnext --moduleResolution bundler`), not the project `tsconfig.json`, so this establishes *no new diagnostics under a check proven to fire* rather than a clean project typecheck — CI is the authority on that. `oxfmt -c oxfmt.config.mts` exits 0 with the file unchanged.

The runtime exit-code behaviour is **not** verified locally: `run-benchmark.ts` self-executes on import, so there is no unit-test seam without the refactor #45670 does.


## Related

Part of [MetaMask-planning#7181 (Benchmark Harness Reliability Improvements)](https://github.com/MetaMask/MetaMask-planning/issues/7181), under [#6944 (Performance Quality Gates)](https://github.com/MetaMask/MetaMask-planning/issues/6944).
