### PR TITLE
build(typescript): use bundler module resolution

### DIFF
--- a/app/scripts/constants/snaps.ts
+++ b/app/scripts/constants/snaps.ts
@@ -2,47 +2,38 @@
 export const PREINSTALLED_SNAPS_URLS = [
   new URL(
     '@metamask/bitcoin-wallet-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
   new URL(
     '@metamask/solana-wallet-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
   new URL(
     '@metamask/tron-wallet-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
   new URL(
     '@metamask/stellar-wallet-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
   new URL(
     '@metamask/permissions-kernel-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
   new URL(
     '@metamask/gator-permissions-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
   new URL(
     '@metamask/message-signing-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
   new URL(
     '@metamask/ens-resolver-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
   new URL(
     '@metamask/institutional-wallet-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
   // Add the following to the list only if the build is Flask or Experimental
@@ -52,7 +43,6 @@ export const PREINSTALLED_SNAPS_URLS = [
     ? [
         new URL(
           '@metamask/account-watcher/dist/preinstalled-snap.json',
-          // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
           import.meta.url,
         ),
       ]
@@ -63,7 +53,6 @@ export const PREINSTALLED_SNAPS_URLS = [
     ? [
         new URL(
           '@metamask/preinstalled-example-snap/dist/preinstalled-snap.json',
-          // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
           import.meta.url,
         ),
       ]

--- a/app/scripts/streams/phishing-stream.filter.test.ts
+++ b/app/scripts/streams/phishing-stream.filter.test.ts
@@ -99,7 +99,6 @@ describe('phishing-stream logging filter', () => {
   it('initPhishingStreams (page mux): logs unconditionally on both completion and error', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const callsBefore = (global as any).mockPipeline.mock.calls.length;
-    // @ts-expect-error - TypeScript requires .js extension for ESM but Jest cannot resolve it
     const { initPhishingStreams } = await import('./phishing-stream');
     initPhishingStreams();
     // The first pipeline call is the page mux pipeline (setupPhishingPageStreams)
@@ -121,7 +120,6 @@ describe('phishing-stream logging filter', () => {
   it('extension mux pipeline: logs unconditionally on both completion and error', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const before = (global as any).mockPipeline.mock.calls.length;
-    // @ts-expect-error - TypeScript requires .js extension for ESM but Jest cannot resolve it
     const { setupPhishingExtStreams } = await import('./phishing-stream');
     setupPhishingExtStreams();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -149,7 +147,6 @@ describe('phishing-stream runtime message listener', () => {
       message: unknown,
     ) => unknown)[];
     const listenerCountBefore = listeners.length;
-    // @ts-expect-error - TypeScript requires .js extension for ESM but Jest cannot resolve it
     const { initPhishingStreams } = await import('./phishing-stream');
     initPhishingStreams();
     const listener = listeners[listenerCountBefore];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,9 @@
     "tsBuildInfoFile": "node_modules/.cache/typescript/tsconfig.tsbuildinfo",
     "useUnknownInCatchVariables": true,
     // baseUrl is required for path mappings
-    "baseUrl": "."
+    "baseUrl": ".",
+    "module": "preserve",
+    "moduleResolution": "bundler"
   },
   "exclude": [
     // don't typecheck stories, as they don't yet pass the type checker.

--- a/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
+++ b/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
@@ -11,7 +11,6 @@ import {
   CandlestickSeries,
   HistogramSeries,
   ISeriesApi,
-  // @ts-expect-error suppress CommonJS vs ECMAScript error
 } from 'lightweight-charts';
 import { useSelector } from 'react-redux';
 import { brandColor } from '@metamask/design-tokens';

--- a/ui/contexts/rive-wasm/index.tsx
+++ b/ui/contexts/rive-wasm/index.tsx
@@ -12,11 +12,7 @@ import React, {
   useState,
 } from 'react';
 
-const RIVE_WASM_URL = new URL(
-  '@rive-app/canvas/rive.wasm',
-  // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
-  import.meta.url,
-);
+const RIVE_WASM_URL = new URL('@rive-app/canvas/rive.wasm', import.meta.url);
 
 /**
  * Module-level WASM init. Survives createRoot/StrictMode remounts of

--- a/ui/helpers/utils/web-vitals.test.ts
+++ b/ui/helpers/utils/web-vitals.test.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error suppress CommonJS vs ECMAScript error
 import { onINP, onFCP, onLCP, onCLS } from 'web-vitals/attribution';
 import {
   initINPObserver,

--- a/ui/helpers/utils/web-vitals.ts
+++ b/ui/helpers/utils/web-vitals.ts
@@ -33,9 +33,7 @@ import type {
   LCPMetricWithAttribution,
   CLSMetricWithAttribution,
   FCPMetricWithAttribution,
-  // @ts-expect-error suppress CommonJS vs ECMAScript error
 } from 'web-vitals/attribution';
-// @ts-expect-error suppress CommonJS vs ECMAScript error
 import { onINP, onLCP, onCLS, onFCP } from 'web-vitals/attribution';
 import type { WebVitalsMetrics } from '../../../shared/constants/benchmarks';
 

--- a/ui/pages/asset/components/chart/asset-chart.tsx
+++ b/ui/pages/asset/components/chart/asset-chart.tsx
@@ -8,9 +8,7 @@ import {
   ChartOptions,
   Decimation,
   Point,
-  // @ts-expect-error suppress CommonJS vs ECMAScript error
 } from 'chart.js';
-// @ts-expect-error suppress CommonJS vs ECMAScript error
 import { Line } from 'react-chartjs-2';
 import classnames from 'clsx';
 import { brandColor } from '@metamask/design-tokens';

--- a/ui/pages/asset/components/chart/chart-tooltip.tsx
+++ b/ui/pages/asset/components/chart/chart-tooltip.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// @ts-expect-error suppress CommonJS vs ECMAScript error
 import { Point } from 'chart.js';
 import { Box } from '@metamask/design-system-react';
 import { Text, TextDirection } from '../../../../components/component-library';

--- a/ui/pages/asset/components/chart/crosshair-plugin.ts
+++ b/ui/pages/asset/components/chart/crosshair-plugin.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error suppress CommonJS vs ECMAScript error
 import { Chart, Point, ChartEvent } from 'chart.js';
 
 type CrosshairChart = Chart & { crosshairX?: number };

--- a/ui/pages/asset/hooks/useHistoricalPrices.ts
+++ b/ui/pages/asset/hooks/useHistoricalPrices.ts
@@ -7,7 +7,6 @@ import {
   isStrictHexString,
   parseCaipAssetType,
 } from '@metamask/utils';
-// @ts-expect-error suppress CommonJS vs ECMAScript error
 import { Point } from 'chart.js';
 import { API_URLS, GC_TIMES, STALE_TIMES } from '@metamask/core-backend';
 import { fromIso8601DurationToPriceApiTimePeriod } from '../util';

--- a/ui/pages/onboarding-flow/welcome/welcome.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome.tsx
@@ -75,7 +75,6 @@ import LoginErrorModal from './login-error-modal';
 
 const MetaMaskWordMarkAnimation = lazy(
   () =>
-    // @ts-expect-error - TypeScript expects .js extension for ESM, but Jest needs the actual .tsx file
     import('./metamask-wordmark-animation') as unknown as Promise<{
       default: ComponentType<
         React.PropsWithChildren<{
@@ -89,7 +88,6 @@ const MetaMaskWordMarkAnimation = lazy(
 
 const FoxAppearAnimation = lazy(
   () =>
-    // @ts-expect-error - TypeScript expects .js extension for ESM, but Jest needs the actual .tsx file
     import('./fox-appear-animation') as unknown as Promise<{
       default: ComponentType<
         React.PropsWithChildren<{

--- a/ui/pages/unlock-page/unlock-page.component.tsx
+++ b/ui/pages/unlock-page/unlock-page.component.tsx
@@ -122,7 +122,6 @@ type LoginError = {
 
 const FoxAppearAnimation = lazy(
   () =>
-    // @ts-expect-error - Build system resolves without extension, but TS wants .js
     // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
     import('../onboarding-flow/welcome/fox-appear-animation') as Promise<{
       default: ComponentType<


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Switches `tsconfig.json` to `module: "preserve"` and `moduleResolution: "bundler"`, which lets TypeScript resolve ESM-only packages and correctly type `import.meta.url`. This makes a number of existing `@ts-expect-error` suppressions unnecessary, covering `import.meta.url` usages and `chart.js`/`lightweight-charts`/`web-vitals` imports, so they are removed.

`bundler` makes sense here given that we use Webpack.

This change is in preparation for `MetaMask/core` switching to ESM-only packages.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn lint:tsc` and confirm there are no type errors.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-check configuration and comment cleanup only; runtime bundling is unchanged and risk is mainly if `lint:tsc` surfaces new errors elsewhere.
> 
> **Overview**
> Updates root **`tsconfig.json`** with **`module: "preserve"`** and **`moduleResolution: "bundler"`** so `yarn lint:tsc` matches Webpack-style resolution and can type ESM-only packages and **`import.meta.url`** without workarounds.
> 
> With that in place, the PR **removes a large set of `@ts-expect-error` comments** that only existed for the old resolver—covering preinstalled snap URLs, Rive WASM URLs, **`chart.js`** / **`react-chartjs-2`** / **`lightweight-charts`** / **`web-vitals/attribution`**, dynamic lazy imports on onboarding/unlock, and phishing-stream test imports. No application behavior changes; this is type-checking alignment ahead of ESM-only **`@metamask/core`** packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d5eac33c35acad645981dd75c4acc04eda415f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->