### PR TITLE
feat: add watchlist navigation and auto select filter

### DIFF
--- a/shared/constants/perps.ts
+++ b/shared/constants/perps.ts
@@ -29,11 +29,22 @@ export const PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS = 5;
 // Market categories are owned by the controller (v8 `MARKET_CATEGORIES`); the UI
 // only adds the `all` and `new` pseudo-filters, so a new core category does not
 // require a change here.
-export const VALID_MARKET_FILTERS = [
+export const MARKET_CATEGORY_FILTERS = [
   'all',
   ...MARKET_CATEGORIES,
   'new',
 ] as const satisfies readonly MarketTypeFilter[];
+
+// User state, not a market category, so it stays out of the controller's
+// `MarketTypeFilter` union.
+export const WATCHLIST_MARKET_FILTER = 'watchlist';
+
+export const VALID_MARKET_FILTERS = [
+  ...MARKET_CATEGORY_FILTERS,
+  WATCHLIST_MARKET_FILTER,
+] as const;
+
+export type MarketCategoryFilter = (typeof MARKET_CATEGORY_FILTERS)[number];
 
 export type MarketFilter = (typeof VALID_MARKET_FILTERS)[number];
 

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -70,6 +70,10 @@ export class PerpsTab extends PerpsPositionsBase {
 
   private readonly perpsWatchlist = { testId: 'perps-watchlist' };
 
+  private readonly perpsWatchlistHeader = {
+    testId: 'perps-watchlist-header',
+  };
+
   private readonly perpsWatchlistMarket = (symbol: string) => {
     return {
       testId: `perps-watchlist-${symbol}`,
@@ -126,6 +130,14 @@ export class PerpsTab extends PerpsPositionsBase {
    */
   async clickRecentActivitySeeAll(): Promise<void> {
     await this.driver.clickElement(this.perpsRecentActivitySeeAll);
+  }
+
+  /**
+   * Clicks the Watchlist section header, which opens the market list with the
+   * watchlist filter pre-selected.
+   */
+  async clickWatchlistHeader(): Promise<void> {
+    await this.driver.clickElement(this.perpsWatchlistHeader);
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -177,4 +177,13 @@ export class PerpsMarketListPage {
   async waitForFilterSortRow(): Promise<void> {
     await this.driver.waitForSelector(this.filterSortRow);
   }
+
+  /**
+   * Waits for a specific market row to be visible in the list.
+   *
+   * @param symbol - Market symbol, e.g. 'BTC'.
+   */
+  async waitForMarketRow(symbol: string): Promise<void> {
+    await this.driver.waitForSelector({ testId: `market-row-${symbol}` });
+  }
 }

--- a/test/e2e/tests/perps/perps-watchlist.spec.ts
+++ b/test/e2e/tests/perps/perps-watchlist.spec.ts
@@ -129,4 +129,36 @@ describe('Perps Watchlist', function (this: Suite) {
       },
     );
   });
+
+  it('opens the market list filtered to the watchlist from the section header', async function () {
+    await withFixtures(
+      {
+        ...getPerpsConfigEligible(this.test?.fullTitle()),
+        ignoredConsoleErrors: ['Value is null'],
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+
+        const perpsTab = new PerpsTab(driver);
+        await perpsTab.navigateToPerpsHome();
+        await perpsTab.waitForBalanceSection();
+
+        const marketListPage = new PerpsMarketListPage(driver);
+        const marketDetailPage = new PerpsMarketDetailPage(driver);
+
+        await marketListPage.navigateToMarketList();
+        await marketDetailPage.navigateToMarket('BTC');
+        await marketDetailPage.clickFavoriteButton();
+        await marketDetailPage.clickBack();
+        await marketListPage.clickBack();
+        await perpsTab.waitForWatchlistMarket('BTC');
+
+        await perpsTab.clickWatchlistHeader();
+
+        await marketListPage.checkPageIsLoaded();
+        await marketListPage.waitForFilterLabel('Watchlist');
+        await marketListPage.waitForMarketRow('BTC');
+      },
+    );
+  });
 });

--- a/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
+++ b/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
@@ -1,15 +1,5 @@
 import React, { useCallback } from 'react';
-import {
-  Box,
-  BoxFlexDirection,
-  ButtonBase,
-  Text,
-  FontWeight,
-  Icon,
-  IconName,
-  IconSize,
-  IconColor,
-} from '@metamask/design-system-react';
+import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import { useNavigate } from 'react-router-dom';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
@@ -17,6 +7,7 @@ import {
   PERPS_MARKET_LIST_ROUTE,
 } from '../../../../helpers/constants/routes';
 import { MarketRow } from '../market-row';
+import { PerpsSectionHeader } from '../perps-section-header';
 import { PERPS_CONSTANTS } from '../constants';
 import type { PerpsMarketData } from '../types';
 
@@ -47,18 +38,11 @@ export const PerpsExploreMarkets = ({ markets }: PerpsExploreMarketsProps) => {
       gap={2}
       data-testid="perps-explore-section"
     >
-      <ButtonBase
-        className="w-full flex flex-row justify-between items-center px-4 py-3 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
+      <PerpsSectionHeader
+        label={t('perpsExploreMarkets')}
         onClick={handleSeeAllPerps}
         data-testid="perps-explore-markets-row"
-      >
-        <Text fontWeight={FontWeight.Medium}>{t('perpsExploreMarkets')}</Text>
-        <Icon
-          name={IconName.ArrowRight}
-          size={IconSize.Sm}
-          color={IconColor.IconAlternative}
-        />
-      </ButtonBase>
+      />
       <Box flexDirection={BoxFlexDirection.Column}>
         {markets
           .slice(0, PERPS_CONSTANTS.EXPLORE_MARKETS_LIMIT)

--- a/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
+++ b/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
@@ -8,11 +8,6 @@ import {
   TextVariant,
   TextColor,
   FontWeight,
-  ButtonBase,
-  Icon,
-  IconName,
-  IconSize,
-  IconColor,
   Skeleton,
 } from '@metamask/design-system-react';
 import { useNavigate } from 'react-router-dom';
@@ -22,6 +17,7 @@ import { PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS } from '../../../../../shared/co
 import { PERPS_EVENT_VALUE } from '../../../../../shared/constants/perps-events';
 import { PERPS_ACTIVITY_ROUTE } from '../../../../helpers/constants/routes';
 import { PerpsCardSkeleton } from '../perps-skeletons/perps-card-skeleton';
+import { PerpsSectionHeader } from '../perps-section-header';
 import type { PerpsTransaction } from '../types';
 
 export type PerpsRecentActivityProps = {
@@ -132,19 +128,12 @@ export const PerpsRecentActivity = ({
       data-testid="perps-recent-activity"
     >
       {/* Section Header */}
-      <ButtonBase
-        className="w-full flex flex-row justify-between items-center px-4 py-3 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
+      <PerpsSectionHeader
+        label={t('perpsRecentActivity')}
         onClick={handleSeeAll}
         data-testid="perps-recent-activity-see-all"
         aria-label={`${t('perpsRecentActivity')}, ${t('perpsSeeAll')}`}
-      >
-        <Text fontWeight={FontWeight.Medium}>{t('perpsRecentActivity')}</Text>
-        <Icon
-          name={IconName.ArrowRight}
-          size={IconSize.Sm}
-          color={IconColor.IconAlternative}
-        />
-      </ButtonBase>
+      />
 
       {/* Transaction List */}
       <Box flexDirection={BoxFlexDirection.Column}>

--- a/ui/components/app/perps/perps-section-header/index.ts
+++ b/ui/components/app/perps/perps-section-header/index.ts
@@ -1,0 +1,2 @@
+export { PerpsSectionHeader } from './perps-section-header';
+export type { PerpsSectionHeaderProps } from './perps-section-header';

--- a/ui/components/app/perps/perps-section-header/perps-section-header.tsx
+++ b/ui/components/app/perps/perps-section-header/perps-section-header.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {
+  ButtonBase,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+} from '@metamask/design-system-react';
+
+export type PerpsSectionHeaderProps = {
+  label: string;
+  onClick: () => void;
+  'data-testid'?: string;
+  'aria-label'?: string;
+};
+
+/**
+ * Clickable section header on the Perps tab: label, right-pointing arrow,
+ * hover and pressed states.
+ *
+ * `ButtonBase` stands in for the SectionHeader primitive the design system
+ * lacks, and supplies the button role and keyboard activation.
+ *
+ * @param options0 - Component props
+ * @param options0.label - Section title shown on the left
+ * @param options0.onClick - Invoked on click and on keyboard activation
+ * @param options0.'data-testid' - Test id forwarded to the button
+ * @param options0.'aria-label' - Overrides the accessible name
+ */
+export const PerpsSectionHeader = ({
+  label,
+  onClick,
+  'data-testid': dataTestId,
+  'aria-label': ariaLabel,
+}: PerpsSectionHeaderProps) => (
+  <ButtonBase
+    className="w-full flex flex-row justify-between items-center px-4 py-3 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
+    onClick={onClick}
+    data-testid={dataTestId}
+    aria-label={ariaLabel}
+  >
+    <Text fontWeight={FontWeight.Medium}>{label}</Text>
+    <Icon
+      name={IconName.ArrowRight}
+      size={IconSize.Sm}
+      color={IconColor.IconAlternative}
+    />
+  </ButtonBase>
+);
+
+export default PerpsSectionHeader;

--- a/ui/components/app/perps/perps-watchlist/perps-watchlist.test.tsx
+++ b/ui/components/app/perps/perps-watchlist/perps-watchlist.test.tsx
@@ -5,7 +5,10 @@ import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import { mockCryptoMarkets } from '../mocks';
-import { PERPS_MARKET_DETAIL_ROUTE } from '../../../../helpers/constants/routes';
+import {
+  PERPS_MARKET_DETAIL_ROUTE,
+  PERPS_MARKET_LIST_ROUTE,
+} from '../../../../helpers/constants/routes';
 import { PerpsWatchlist } from './perps-watchlist';
 
 const mockNavigate = jest.fn();
@@ -28,6 +31,40 @@ const mockStore = configureStore({
 describe('PerpsWatchlist', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
+  });
+
+  describe('header navigation', () => {
+    const renderWatchlist = () =>
+      renderWithProvider(
+        <PerpsWatchlist markets={mockCryptoMarkets.slice(0, 2)} />,
+        mockStore,
+      );
+
+    it('navigates to the market list with the watchlist filter pre-selected', () => {
+      renderWatchlist();
+
+      fireEvent.click(screen.getByTestId('perps-watchlist-header'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${PERPS_MARKET_LIST_ROUTE}?filter=watchlist`,
+      );
+    });
+
+    it('renders the header as a button', () => {
+      renderWatchlist();
+
+      expect(screen.getByTestId('perps-watchlist-header').tagName).toBe(
+        'BUTTON',
+      );
+    });
+
+    it('matches the other Perps section headers', () => {
+      renderWatchlist();
+
+      expect(
+        screen.getByRole('button', { name: messages.perpsWatchlist.message }),
+      ).toBeInTheDocument();
+    });
   });
 
   it('renders the watchlist section', () => {

--- a/ui/components/app/perps/perps-watchlist/perps-watchlist.tsx
+++ b/ui/components/app/perps/perps-watchlist/perps-watchlist.tsx
@@ -1,17 +1,15 @@
 import React, { useCallback } from 'react';
-import {
-  Box,
-  BoxFlexDirection,
-  BoxAlignItems,
-  BoxJustifyContent,
-  Text,
-  FontWeight,
-} from '@metamask/design-system-react';
+import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import { useNavigate } from 'react-router-dom';
 import type { PerpsMarketData } from '@metamask/perps-controller';
+import { WATCHLIST_MARKET_FILTER } from '../../../../../shared/constants/perps';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { PERPS_MARKET_DETAIL_ROUTE } from '../../../../helpers/constants/routes';
+import {
+  PERPS_MARKET_DETAIL_ROUTE,
+  PERPS_MARKET_LIST_ROUTE,
+} from '../../../../helpers/constants/routes';
 import { MarketRow } from '../market-row';
+import { PerpsSectionHeader } from '../perps-section-header';
 
 /**
  * PerpsWatchlist displays a list of watched markets.
@@ -34,6 +32,10 @@ export const PerpsWatchlist = ({ markets }: PerpsWatchlistProps) => {
     [navigate],
   );
 
+  const handleHeaderClick = useCallback(() => {
+    navigate(`${PERPS_MARKET_LIST_ROUTE}?filter=${WATCHLIST_MARKET_FILTER}`);
+  }, [navigate]);
+
   if (markets.length === 0) {
     return null;
   }
@@ -44,17 +46,11 @@ export const PerpsWatchlist = ({ markets }: PerpsWatchlistProps) => {
       gap={2}
       data-testid="perps-watchlist"
     >
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        justifyContent={BoxJustifyContent.Between}
-        alignItems={BoxAlignItems.Center}
-        paddingLeft={4}
-        paddingRight={4}
-        paddingTop={4}
-        marginBottom={2}
-      >
-        <Text fontWeight={FontWeight.Medium}>{t('perpsWatchlist')}</Text>
-      </Box>
+      <PerpsSectionHeader
+        label={t('perpsWatchlist')}
+        onClick={handleHeaderClick}
+        data-testid="perps-watchlist-header"
+      />
       <Box flexDirection={BoxFlexDirection.Column}>
         {markets.map((market) => (
           <MarketRow

--- a/ui/pages/perps/market-list/components/filter-select/filter-select.tsx
+++ b/ui/pages/perps/market-list/components/filter-select/filter-select.tsx
@@ -33,6 +33,8 @@ export type FilterSelectProps = {
   onChange: (filter: MarketFilter) => void;
   /** Whether to show the "New" filter option (only shown if there are uncategorized assets) */
   showNewFilter?: boolean;
+  /** Whether to show the "Watchlist" option (only shown if the watchlist has markets) */
+  showWatchlistFilter?: boolean;
 };
 
 /**
@@ -42,25 +44,31 @@ export type FilterSelectProps = {
  * @param props.value - Currently selected filter
  * @param props.onChange - Callback when filter changes
  * @param props.showNewFilter - Whether to show the "New" filter option
+ * @param props.showWatchlistFilter - Whether to show the "Watchlist" option
  */
 export const FilterSelect = ({
   value,
   onChange,
   showNewFilter = false,
+  showWatchlistFilter = false,
 }: FilterSelectProps) => {
   const t = useI18nContext();
 
   const options: DropdownOption<MarketFilter>[] = useMemo(() => {
-    const baseOptions: DropdownOption<MarketFilter>[] = (
-      ['all', WATCHLIST_MARKET_FILTER, ...MARKET_CATEGORIES] as const
-    ).map((id) => ({ id, label: t(FILTER_LABEL_KEYS[id]) }));
+    const categoryIds = showWatchlistFilter
+      ? (['all', WATCHLIST_MARKET_FILTER, ...MARKET_CATEGORIES] as const)
+      : (['all', ...MARKET_CATEGORIES] as const);
+
+    const baseOptions: DropdownOption<MarketFilter>[] = categoryIds.map(
+      (id) => ({ id, label: t(FILTER_LABEL_KEYS[id]) }),
+    );
 
     if (showNewFilter) {
       baseOptions.push({ id: 'new', label: t(FILTER_LABEL_KEYS.new) });
     }
 
     return baseOptions;
-  }, [t, showNewFilter]);
+  }, [t, showNewFilter, showWatchlistFilter]);
 
   return (
     <Dropdown

--- a/ui/pages/perps/market-list/components/filter-select/filter-select.tsx
+++ b/ui/pages/perps/market-list/components/filter-select/filter-select.tsx
@@ -1,6 +1,9 @@
 import React, { useMemo } from 'react';
 import { MARKET_CATEGORIES } from '@metamask/perps-controller';
-import type { MarketFilter } from '../../../../../../shared/constants/perps';
+import {
+  WATCHLIST_MARKET_FILTER,
+  type MarketFilter,
+} from '../../../../../../shared/constants/perps';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { Dropdown, type DropdownOption } from '../dropdown';
 
@@ -11,6 +14,8 @@ import { Dropdown, type DropdownOption } from '../dropdown';
  */
 const FILTER_LABEL_KEYS: Record<MarketFilter, string> = {
   all: 'perpsFilterAll',
+  // Reuses the Perps tab section heading rather than adding a duplicate string.
+  watchlist: 'perpsWatchlist',
   crypto: 'perpsFilterCrypto',
   stock: 'perpsFilterStocks',
   'pre-ipo': 'perpsFilterPreIpo',
@@ -47,7 +52,7 @@ export const FilterSelect = ({
 
   const options: DropdownOption<MarketFilter>[] = useMemo(() => {
     const baseOptions: DropdownOption<MarketFilter>[] = (
-      ['all', ...MARKET_CATEGORIES] as const
+      ['all', WATCHLIST_MARKET_FILTER, ...MARKET_CATEGORIES] as const
     ).map((id) => ({ id, label: t(FILTER_LABEL_KEYS[id]) }));
 
     if (showNewFilter) {

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -396,7 +396,9 @@ describe('MarketListView', () => {
         fireEvent.click(screen.getByTestId('filter-select-option-watchlist'));
 
         await waitFor(() => {
-          expect(screen.queryByTestId('market-row-ETH')).not.toBeInTheDocument();
+          expect(
+            screen.queryByTestId('market-row-ETH'),
+          ).not.toBeInTheDocument();
         });
         expect(screen.getByTestId('market-row-BTC')).toBeInTheDocument();
       });

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -280,6 +280,100 @@ describe('MarketListView', () => {
       });
     });
 
+    describe('watchlist filter', () => {
+      // Needs watchlist state, which the shared store does not carry.
+      const watchlistStore = configureStore({
+        metamask: {
+          ...mockState.metamask,
+          remoteFeatureFlags: {
+            perpsEnabledVersion: { enabled: true, minimumVersion: '0.0.0' },
+          },
+          isTestnet: false,
+          watchlistMarkets: { testnet: [], mainnet: ['BTC', 'SOL'] },
+        },
+      });
+
+      it('shows only watchlisted markets for the watchlist query param', async () => {
+        renderWithProvider(
+          <MarketListView />,
+          watchlistStore,
+          '/perps/market-list?filter=watchlist',
+        );
+
+        await waitFor(() => {
+          expect(screen.getByTestId('filter-select-button')).toHaveTextContent(
+            messages.perpsWatchlist.message,
+          );
+        });
+        expect(screen.getByTestId('market-row-BTC')).toBeInTheDocument();
+        expect(screen.getByTestId('market-row-SOL')).toBeInTheDocument();
+        // ETH is a market the user has not watchlisted.
+        expect(screen.queryByTestId('market-row-ETH')).not.toBeInTheDocument();
+      });
+
+      it('reads the watchlist for the active network', async () => {
+        const testnetStore = configureStore({
+          metamask: {
+            ...mockState.metamask,
+            remoteFeatureFlags: {
+              perpsEnabledVersion: { enabled: true, minimumVersion: '0.0.0' },
+            },
+            isTestnet: true,
+            watchlistMarkets: { testnet: ['ETH'], mainnet: ['BTC', 'SOL'] },
+          },
+        });
+
+        renderWithProvider(
+          <MarketListView />,
+          testnetStore,
+          '/perps/market-list?filter=watchlist',
+        );
+
+        await waitFor(() => {
+          expect(screen.getByTestId('market-row-ETH')).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId('market-row-BTC')).not.toBeInTheDocument();
+      });
+
+      it('clears the watchlist filter when a category is chosen', async () => {
+        renderWithProvider(
+          <MarketListView />,
+          watchlistStore,
+          '/perps/market-list?filter=watchlist',
+        );
+
+        await waitFor(() => screen.getByTestId('market-row-BTC'));
+
+        fireEvent.click(screen.getByTestId('filter-select-button'));
+        await waitFor(() => screen.getByTestId('filter-select-menu'));
+        fireEvent.click(screen.getByTestId('filter-select-option-crypto'));
+
+        await waitFor(() => {
+          // ETH is crypto but not watchlisted: proves replace, not combine.
+          expect(screen.getByTestId('market-row-ETH')).toBeInTheDocument();
+        });
+      });
+
+      it('clears a category when the watchlist option is chosen', async () => {
+        renderWithProvider(
+          <MarketListView />,
+          watchlistStore,
+          '/perps/market-list?filter=crypto',
+        );
+
+        await waitFor(() => screen.getByTestId('market-row-ETH'));
+
+        fireEvent.click(screen.getByTestId('filter-select-button'));
+        await waitFor(() => screen.getByTestId('filter-select-menu'));
+        fireEvent.click(screen.getByTestId('filter-select-option-watchlist'));
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('market-row-ETH')).not.toBeInTheDocument();
+        });
+        expect(screen.getByTestId('market-row-BTC')).toBeInTheDocument();
+      });
+    });
+
     it('shows stock markets on Stocks tab even when perpsHip3AllowlistMarkets flag is absent', async () => {
       // mockStore has no perpsHip3AllowlistMarkets flag → allowedHip3Sources defaults to Set()
       renderWithProvider(<MarketListView />, mockStore);

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -354,6 +354,34 @@ describe('MarketListView', () => {
         });
       });
 
+      it('hides the watchlist option while the watchlist is empty', async () => {
+        renderWithProvider(<MarketListView />, mockStore);
+
+        fireEvent.click(screen.getByTestId('filter-select-button'));
+        await waitFor(() => screen.getByTestId('filter-select-menu'));
+
+        expect(
+          screen.queryByTestId('filter-select-option-watchlist'),
+        ).not.toBeInTheDocument();
+      });
+
+      it('falls back to all markets for a stale watchlist link', async () => {
+        renderWithProvider(
+          <MarketListView />,
+          mockStore,
+          '/perps/market-list?filter=watchlist',
+        );
+
+        // Without the fallback the trigger renders a blank label, because the
+        // selected id is no longer among the options.
+        await waitFor(() => {
+          expect(screen.getByTestId('filter-select-button')).toHaveTextContent(
+            messages.perpsFilterAll.message,
+          );
+        });
+        expect(screen.getByTestId('market-row-ETH')).toBeInTheDocument();
+      });
+
       it('clears a category when the watchlist option is chosen', async () => {
         renderWithProvider(
           <MarketListView />,

--- a/ui/pages/perps/market-list/index.tsx
+++ b/ui/pages/perps/market-list/index.tsx
@@ -50,12 +50,17 @@ import {
   getHip3AllowedSourcesSet,
 } from '../../../selectors/perps/feature-flags';
 import {
+  selectPerpsIsTestnet,
+  selectPerpsWatchlistMarkets,
+} from '../../../selectors/perps-controller';
+import {
   sortMarkets,
   type SortField,
   type SortDirection,
 } from '../utils/sortMarkets';
 import {
   normalizeMarketFilter,
+  WATCHLIST_MARKET_FILTER,
   type MarketFilter,
 } from '../../../../shared/constants/perps';
 import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
@@ -141,16 +146,23 @@ const isUncategorizedHip3Market = (
  * @param markets - Array of markets to filter
  * @param filter - Market type filter
  * @param allowedHip3Sources - Set of allowed HIP-3 market sources (used for "new" tab only)
+ * @param watchlistSymbols - Upper-cased watchlisted symbols (used for the "watchlist" filter only)
  * @returns Filtered array of markets
  */
 const filterByType = (
   markets: PerpsMarketData[],
   filter: MarketFilter,
   allowedHip3Sources: Set<string>,
+  watchlistSymbols: Set<string>,
 ): PerpsMarketData[] => {
   switch (filter) {
     case 'all': {
       return markets;
+    }
+    case WATCHLIST_MARKET_FILTER: {
+      return markets.filter((m) =>
+        watchlistSymbols.has(m.symbol.toUpperCase()),
+      );
     }
     case 'crypto': {
       return markets.filter(isCryptoMarket);
@@ -178,6 +190,8 @@ export const MarketListView = () => {
   const [searchParams] = useSearchParams();
   const isPerpsExperienceAvailable = useSelector(getIsPerpsExperienceAvailable);
   const allowedHip3Sources = useSelector(getHip3AllowedSourcesSet);
+  const watchlistMarketsState = useSelector(selectPerpsWatchlistMarkets);
+  const isTestnet = useSelector(selectPerpsIsTestnet);
   const { track } = usePerpsEventTracking();
   const { setFlowAttribution } = usePerpsAttribution();
 
@@ -226,6 +240,17 @@ export const MarketListView = () => {
     },
   });
 
+  const watchlistSymbols = useMemo(
+    () =>
+      new Set(
+        (isTestnet
+          ? watchlistMarketsState.testnet
+          : watchlistMarketsState.mainnet
+        ).map((symbol) => symbol.toUpperCase()),
+      ),
+    [isTestnet, watchlistMarketsState],
+  );
+
   // Check if there are any uncategorized HIP-3 markets (for showing "New" filter)
   const hasUncategorizedMarkets = useMemo(() => {
     return allMarkets.some((m) =>
@@ -244,7 +269,12 @@ export const MarketListView = () => {
       markets = filterMarketsByQuery(allMarkets, searchQuery);
     } else {
       // Not searching: apply filters
-      markets = filterByType(allMarkets, selectedFilter, allowedHip3Sources);
+      markets = filterByType(
+        allMarkets,
+        selectedFilter,
+        allowedHip3Sources,
+        watchlistSymbols,
+      );
     }
 
     markets = sortMarkets({
@@ -257,6 +287,7 @@ export const MarketListView = () => {
     allMarkets,
     selectedFilter,
     allowedHip3Sources,
+    watchlistSymbols,
     searchQuery,
     sortField,
     sortDirection,

--- a/ui/pages/perps/market-list/index.tsx
+++ b/ui/pages/perps/market-list/index.tsx
@@ -200,6 +200,20 @@ export const MarketListView = () => {
     usePerpsLiveMarketListData();
   const { account } = usePerpsLiveAccount();
 
+  // Upper-cased so lookups match `PerpsMarketData.symbol` casing.
+  const watchlistSymbols = useMemo(
+    () =>
+      new Set(
+        (isTestnet
+          ? watchlistMarketsState.testnet
+          : watchlistMarketsState.mainnet
+        ).map((symbol) => symbol.toUpperCase()),
+      ),
+    [isTestnet, watchlistMarketsState],
+  );
+
+  const hasWatchlistMarkets = watchlistSymbols.size > 0;
+
   // Read initial filter from URL params (set by deeplink)
   const initialFilter = useMemo<MarketFilter>(() => {
     const filterParam = searchParams.get('filter');
@@ -207,12 +221,20 @@ export const MarketListView = () => {
       // normalizeMarketFilter resolves legacy aliases (e.g. `stocks`) and returns
       // null for unknown values, so no extra validation is needed here.
       const normalizedFilter = normalizeMarketFilter(filterParam);
+      // The watchlist option is hidden while the watchlist is empty, so a stale
+      // link to it would otherwise select an option that is not in the list.
+      if (
+        normalizedFilter === WATCHLIST_MARKET_FILTER &&
+        !hasWatchlistMarkets
+      ) {
+        return 'all';
+      }
       if (normalizedFilter) {
         return normalizedFilter;
       }
     }
     return 'all';
-  }, [searchParams]);
+  }, [searchParams, hasWatchlistMarkets]);
 
   // State
   const [searchQuery, setSearchQuery] = useState('');
@@ -239,17 +261,6 @@ export const MarketListView = () => {
       [PERPS_EVENT_PROPERTY.MARKET_CATEGORY_FILTER]: selectedFilter,
     },
   });
-
-  const watchlistSymbols = useMemo(
-    () =>
-      new Set(
-        (isTestnet
-          ? watchlistMarketsState.testnet
-          : watchlistMarketsState.mainnet
-        ).map((symbol) => symbol.toUpperCase()),
-      ),
-    [isTestnet, watchlistMarketsState],
-  );
 
   // Check if there are any uncategorized HIP-3 markets (for showing "New" filter)
   const hasUncategorizedMarkets = useMemo(() => {
@@ -685,6 +696,7 @@ export const MarketListView = () => {
             value={selectedFilter}
             onChange={handleFilterChange}
             showNewFilter={hasUncategorizedMarkets}
+            showWatchlistFilter={hasWatchlistMarkets}
           />
           <SortDropdown
             selectedField={sortField}


### PR DESCRIPTION
## **Description**

  The Watchlist section on the Perps tab was a dead header — no click target, and no way to see more than the preview rows. Clicking it now opens the market list already filtered to the user's watchlisted markets, rather than the full unfiltered list.

  Three parts:

  **A Watchlist option in the category select.** Added to the existing `FilterSelect` dropdown (not a pill — the Dropdown→pill conversion is TAT-3854's scope), positioned directly after "All". It reuses the existing `perpsWatchlist` string rather than adding a duplicate for translators. Mutual exclusivity with the categories comes free, since `selectedFilter` is single-valued state.

  **Filtering.** A new `filterByType` case. It's the only filter answered by user state rather than by the market object, so the view derives an upper-cased symbol set from `selectPerpsWatchlistMarkets` + `selectPerpsIsTestnet` and passes it in — matching how `usePerpsTabExploreData` resolves the same thing.

  **A clickable header** navigating to `?filter=watchlist`. No route work was needed; `market-list/index.tsx` already read that param through `normalizeMarketFilter`.

  **Extracted `PerpsSectionHeader`.** Explore Markets and Recent Activity each had this header inline with a byte-identical className string; the Watchlist header would have been a third copy, so all three now share one component. It's built on `ButtonBase`, which renders a real `<button>` — that supplies the button role and Enter/Space activation, so no hand-rolled `role`/`tabIndex`/`onKeyDown`. The ticket's note that the design system has no `SectionHeader` primitive is correct, but hand-rolling the semantics turned out to be unnecessary.

  ## **Changelog**

  CHANGELOG entry: Added a Watchlist filter to the Perps market list, and made the Perps tab Watchlist header open it

  ## **Related issues**

  Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3850

  ## **Manual testing steps**

  1. Open the Perps tab (requires `PERPS_ENABLED=true` in `.metamaskrc`)
  2. Open the market list, pick a market, and click the star to watchlist it — repeat for a second market
  3. Return to the Perps tab and confirm the Watchlist section header now shows a right-pointing arrow and a hover state matching Explore Markets and Recent Activity
  4. Click the Watchlist header — the market list opens with the filter reading "Watchlist" and only the watchlisted markets listed
  5. Tab to the header and press Enter, then Space — both should navigate the same way
  6. In the market list, open the filter dropdown and pick a category — the watchlist filter clears and category results show
  7. Pick Watchlist again — the category clears
  8. Click an individual watchlist row on the Perps tab and confirm it still opens market detail

  ## **Screenshots/Recordings**

  ### **Before**

<img width="481" height="997" alt="Screenshot 2026-08-31 at 3 52 46 PM" src="https://github.com/user-attachments/assets/87fe760b-609c-4711-87eb-2fa7503da477" />


  ### **After**

Loom video:  https://www.loom.com/share/6eaf829dbed940d8a328e60eea391736
<img width="481" height="997" alt="Screenshot 2026-08-31 at 3 47 40 PM" src="https://github.com/user-attachments/assets/a212c6a1-6150-4464-a8f8-b8aeb4f8e21d" />
<img width="481" height="997" alt="Screenshot 2026-08-31 at 3 47 32 PM" src="https://github.com/user-attachments/assets/35950a5d-40ea-4c5f-9c00-b2f49f0ef0cc" />



  ## **Pre-merge author checklist**

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I’ve included tests if applicable
  - [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Perps UI and client-side filter/navigation only; watchlist data already lives in the controller with no auth or payment changes.
> 
> **Overview**
> Makes the Perps tab **Watchlist** header behave like Explore Markets and Recent Activity: it is now a full-width button with arrow and hover state, and opens the market list with **`?filter=watchlist`** so users see all favorited markets, not just the home preview rows.
> 
> Adds a **Watchlist** entry to the market list category dropdown (after **All**, only when the user has favorites), wired through shared **`WATCHLIST_MARKET_FILTER`** and a split between **`MARKET_CATEGORY_FILTERS`** and the UI-only watchlist value. **`filterByType`** filters by Redux watchlist symbols for the active network; stale deep links with an empty watchlist fall back to **All**. Explore Markets and Recent Activity headers are refactored to shared **`PerpsSectionHeader`**.
> 
> Unit, component, and e2e coverage exercises header navigation, filter mutual exclusivity, and network-specific watchlist state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a500497e2ec15a50a2f1f52bb5ab11beb27e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->