### PR TITLE
feat(money): send from money account to perps via transfer sheet

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5760,6 +5760,24 @@
   "moneyToastWithdrawFailedTitle": {
     "message": "Transfer failed"
   },
+  "moneyTransferBetweenAccounts": {
+    "message": "Another account"
+  },
+  "moneyTransferComingSoon": {
+    "message": "Coming soon"
+  },
+  "moneyTransferPerpsAccount": {
+    "message": "Perps account"
+  },
+  "moneyTransferSendExternal": {
+    "message": "External address"
+  },
+  "moneyTransferTitle": {
+    "message": "Send funds to"
+  },
+  "moneyTransferWithdrawToBank": {
+    "message": "Bank account"
+  },
   "month": {
     "message": "month"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5760,6 +5760,24 @@
   "moneyToastWithdrawFailedTitle": {
     "message": "Transfer failed"
   },
+  "moneyTransferBetweenAccounts": {
+    "message": "Another account"
+  },
+  "moneyTransferComingSoon": {
+    "message": "Coming soon"
+  },
+  "moneyTransferPerpsAccount": {
+    "message": "Perps account"
+  },
+  "moneyTransferSendExternal": {
+    "message": "External address"
+  },
+  "moneyTransferTitle": {
+    "message": "Send funds to"
+  },
+  "moneyTransferWithdrawToBank": {
+    "message": "Bank account"
+  },
   "month": {
     "message": "month"
   },

--- a/ui/hooks/money/useMoneyPerpsDeposit.test.ts
+++ b/ui/hooks/money/useMoneyPerpsDeposit.test.ts
@@ -1,0 +1,96 @@
+import { act } from '@testing-library/react';
+import { TransactionType } from '@metamask/transaction-controller';
+import mockState from '../../../test/data/mock-state.json';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { usePerpsDepositConfirmation } from '../../components/app/perps/hooks/usePerpsDepositConfirmation';
+import { usePerpsEligibility } from '../perps/usePerpsEligibility';
+import { selectIsMoneyAccountTransactionEnabled } from '../../pages/confirmations/selectors/feature-flags';
+import { PayWithOption } from '../../pages/confirmations/hooks/useConfirmationNavigation';
+import { useMoneyPerpsDeposit } from './useMoneyPerpsDeposit';
+
+jest.mock('../../components/app/perps/hooks/usePerpsDepositConfirmation');
+jest.mock('../perps/usePerpsEligibility');
+jest.mock('../../pages/confirmations/selectors/feature-flags', () => ({
+  ...jest.requireActual('../../pages/confirmations/selectors/feature-flags'),
+  selectIsMoneyAccountTransactionEnabled: jest.fn(),
+}));
+
+const usePerpsDepositConfirmationMock = jest.mocked(
+  usePerpsDepositConfirmation,
+);
+const usePerpsEligibilityMock = jest.mocked(usePerpsEligibility);
+const selectIsMoneyAccountTransactionEnabledMock = jest.mocked(
+  selectIsMoneyAccountTransactionEnabled,
+);
+
+describe('useMoneyPerpsDeposit', () => {
+  const triggerMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    triggerMock.mockResolvedValue({ transactionId: 'tx-1' });
+    usePerpsDepositConfirmationMock.mockReturnValue({
+      trigger: triggerMock,
+      isLoading: false,
+    });
+    usePerpsEligibilityMock.mockReturnValue({ isEligible: true });
+    selectIsMoneyAccountTransactionEnabledMock.mockReturnValue(true);
+  });
+
+  it('locks payWithOption to MoneyAccount when creating the deposit', () => {
+    renderHookWithProvider(() => useMoneyPerpsDeposit(), mockState);
+
+    expect(usePerpsDepositConfirmationMock).toHaveBeenCalledWith({
+      payWithOption: PayWithOption.MoneyAccount,
+    });
+  });
+
+  it('is enabled when eligible and the perpsDeposit money flag is on', () => {
+    const { result } = renderHookWithProvider(
+      () => useMoneyPerpsDeposit(),
+      mockState,
+    );
+
+    expect(result.current.isEnabled).toBe(true);
+    expect(selectIsMoneyAccountTransactionEnabledMock).toHaveBeenCalledWith(
+      expect.anything(),
+      TransactionType.perpsDeposit,
+    );
+  });
+
+  it('is disabled when the user is not perps-eligible', () => {
+    usePerpsEligibilityMock.mockReturnValue({ isEligible: false });
+
+    const { result } = renderHookWithProvider(
+      () => useMoneyPerpsDeposit(),
+      mockState,
+    );
+
+    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.isEligible).toBe(false);
+  });
+
+  it('is disabled when the money-account perpsDeposit flag is off', () => {
+    selectIsMoneyAccountTransactionEnabledMock.mockReturnValue(false);
+
+    const { result } = renderHookWithProvider(
+      () => useMoneyPerpsDeposit(),
+      mockState,
+    );
+
+    expect(result.current.isEnabled).toBe(false);
+  });
+
+  it('initiates the money-funded perps deposit', async () => {
+    const { result } = renderHookWithProvider(
+      () => useMoneyPerpsDeposit(),
+      mockState,
+    );
+
+    await act(async () => {
+      await result.current.initiatePerpsDeposit();
+    });
+
+    expect(triggerMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/hooks/money/useMoneyPerpsDeposit.ts
+++ b/ui/hooks/money/useMoneyPerpsDeposit.ts
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { TransactionType } from '@metamask/transaction-controller';
+import { usePerpsDepositConfirmation } from '../../components/app/perps/hooks/usePerpsDepositConfirmation';
+import { usePerpsEligibility } from '../perps/usePerpsEligibility';
+import { selectIsMoneyAccountTransactionEnabled } from '../../pages/confirmations/selectors/feature-flags';
+import { PayWithOption } from '../../pages/confirmations/hooks/useConfirmationNavigation';
+
+/**
+ * Money home entry for sending funds to a Perps account: opens the Perps
+ * deposit confirmation with Money Account locked as the funding source
+ * (`payWithOption=money_account`), matching mobile `useMoneyPerpsDeposit`.
+ *
+ * Destination account selection on the confirmation updates `txParams.from`
+ * via {@link PerpsAccountPickerRow}.
+ *
+ * @returns Whether the entry is enabled, the initiator, and loading state.
+ */
+export function useMoneyPerpsDeposit() {
+  const { isEligible } = usePerpsEligibility();
+  const isFlagEnabled = useSelector((state) =>
+    selectIsMoneyAccountTransactionEnabled(state, TransactionType.perpsDeposit),
+  );
+  const { trigger, isLoading } = usePerpsDepositConfirmation({
+    payWithOption: PayWithOption.MoneyAccount,
+  });
+
+  const initiatePerpsDeposit = useCallback(async () => {
+    try {
+      await trigger();
+    } catch (error) {
+      console.error(
+        '[MoneyPerpsDeposit] Perps deposit initiation failed',
+        error,
+      );
+    }
+  }, [trigger]);
+
+  return {
+    isEnabled: Boolean(isEligible && isFlagEnabled),
+    isEligible,
+    initiatePerpsDeposit,
+    isLoading,
+  };
+}

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -131,10 +131,12 @@ const MOCK_AVAILABLE_TOKEN = {
 
 const DEFAULT_ALERTS_HOOK_RETURN: {
   alertMessage?: string;
+  hasAlert: boolean;
   hideResults: boolean;
   disableUpdate: boolean;
 } = {
   alertMessage: undefined,
+  hasAlert: false,
   hideResults: false,
   disableUpdate: false,
 };
@@ -907,6 +909,7 @@ describe('CustomAmountInfo', () => {
     const { queryByText } = render({
       alertsHookReturn: {
         alertMessage: undefined,
+        hasAlert: true,
         hideResults: true,
         disableUpdate: false,
       },
@@ -921,6 +924,7 @@ describe('CustomAmountInfo', () => {
     const { getByText } = render({
       alertsHookReturn: {
         alertMessage: messages.alertNoPayTokenQuotesMessage.message,
+        hasAlert: true,
         hideResults: true,
         disableUpdate: false,
       },

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -161,6 +161,8 @@ export const CustomAmountInfo = React.memo(
     const isAwaitingRequiredToken =
       !disablePay && !primaryRequiredToken && !isWithdraw;
 
+    // disableUpdate only depends on account/hardware/signing alerts, not the
+    // typed amount — evaluate without pending fiat so amount state can load.
     const { disableUpdate } = useTransactionCustomAmountAlerts();
 
     const {
@@ -177,6 +179,11 @@ export const CustomAmountInfo = React.memo(
       disableUpdate,
       prefillMaxOnLoad,
     });
+
+    const { alertMessage, hasAlert, hideResults } =
+      useTransactionCustomAmountAlerts({
+        pendingFiatAmount: amountFiat,
+      });
 
     const { isNative: isNativePayToken, payToken } = useTransactionPayToken();
     const { isNoFeeToken } = usePayWithNoFeeToken();
@@ -221,6 +228,7 @@ export const CustomAmountInfo = React.memo(
           amountHuman={amountHuman}
           currency={currency}
           disablePay={disablePay}
+          hasAlert={hasAlert}
           hasInput={hasInput}
           hasTokens={hasTokens}
           hidePayTokenAmount={hidePayTokenAmount}
@@ -230,7 +238,7 @@ export const CustomAmountInfo = React.memo(
         >
           {children}
         </CenterContainer>
-        <AlertMessage />
+        <AlertMessage alertMessage={alertMessage} />
         {displayPercentageButtons && (
           <PercentageButtons
             disabled={!hasTokens || Boolean(disablePercentageButtons)}
@@ -244,6 +252,7 @@ export const CustomAmountInfo = React.memo(
             disablePay={disablePay}
             displayAccountRow={displayAccountRow}
             hasAmount={hasAmount}
+            hideResults={hideResults}
           />
         )}
       </Box>
@@ -278,6 +287,7 @@ type CenterContainerProps = {
   children?: ReactNode;
   currency?: string;
   disablePay?: boolean;
+  hasAlert?: boolean;
   hasInput: boolean;
   hasTokens: boolean;
   hidePayTokenAmount?: boolean;
@@ -294,6 +304,7 @@ function CenterContainer({
   children,
   currency,
   disablePay,
+  hasAlert = false,
   hasInput,
   hasTokens,
   hidePayTokenAmount,
@@ -315,6 +326,7 @@ function CenterContainer({
         autoFocus={autoFocusAmount}
         currency={currency}
         disabled={!hasTokens}
+        hasAlert={hasAlert}
         isLoading={isAmountLoading}
         onChange={onAmountChange}
       />
@@ -366,15 +378,16 @@ function BottomContainer({
   disablePay,
   displayAccountRow,
   hasAmount,
+  hideResults,
 }: {
   amountFiat: string;
   disablePay?: boolean;
   displayAccountRow?: boolean;
   hasAmount: boolean;
+  hideResults: boolean;
 }) {
   const t = useI18nContext();
   const isResultReady = useIsResultReady(hasAmount, disablePay);
-  const { hideResults } = useTransactionCustomAmountAlerts();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
@@ -460,9 +473,7 @@ function useIsResultReady(hasAmount: boolean, disablePay?: boolean) {
   return Boolean(disablePay) || isQuotePending || Boolean(quotes?.length);
 }
 
-function AlertMessage() {
-  const { alertMessage } = useTransactionCustomAmountAlerts();
-
+function AlertMessage({ alertMessage }: { alertMessage?: string }) {
   if (!alertMessage) {
     return null;
   }

--- a/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
+++ b/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
@@ -156,6 +156,7 @@ function setupDefaultMocks({
       useTransactionCustomAmountAlertsModule.useTransactionCustomAmountAlerts,
     )
     .mockReturnValue({
+      hasAlert: false,
       hideResults,
       disableUpdate: false,
     });

--- a/ui/pages/confirmations/components/rows/perps-account-picker-row/perps-account-picker-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/perps-account-picker-row/perps-account-picker-row.test.tsx
@@ -4,7 +4,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { TransactionType } from '@metamask/transaction-controller';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
-import { useConfirmContext } from '../../../context/confirm';
+import { useTransactionMetadataRequestOptional } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import {
   PayWithOption,
   useConfirmationNavigationOptions,
@@ -20,7 +20,7 @@ import {
   PerpsAccountPickerRow,
 } from './perps-account-picker-row';
 
-jest.mock('../../../context/confirm');
+jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
 jest.mock('../../../hooks/useConfirmationNavigation', () => ({
   PayWithOption: { MoneyAccount: 'money_account' },
   useConfirmationNavigationOptions: jest.fn(),
@@ -64,7 +64,9 @@ const MOCK_ACCOUNTS: SubAccountInfo[] = [
 const mockStore = configureStore([thunk]);
 
 describe('PerpsAccountPickerRow', () => {
-  const useConfirmContextMock = jest.mocked(useConfirmContext);
+  const useTransactionMetadataRequestOptionalMock = jest.mocked(
+    useTransactionMetadataRequestOptional,
+  );
   const useConfirmationNavigationOptionsMock = jest.mocked(
     useConfirmationNavigationOptions,
   );
@@ -78,13 +80,11 @@ describe('PerpsAccountPickerRow', () => {
       payWithOption: PayWithOption.MoneyAccount,
     } as ReturnType<typeof useConfirmationNavigationOptions>);
 
-    useConfirmContextMock.mockReturnValue({
-      currentConfirmation: {
-        id: TX_ID_MOCK,
-        chainId: CHAIN_ID_MOCK,
-        type: TransactionType.perpsDeposit,
-        txParams: { from: FROM_ADDRESS_MOCK },
-      },
+    useTransactionMetadataRequestOptionalMock.mockReturnValue({
+      id: TX_ID_MOCK,
+      chainId: CHAIN_ID_MOCK,
+      type: TransactionType.perpsDeposit,
+      txParams: { from: FROM_ADDRESS_MOCK },
     } as never);
 
     usePerpsSubAccountsMock.mockReturnValue({
@@ -117,12 +117,10 @@ describe('PerpsAccountPickerRow', () => {
   });
 
   it('renders nothing when the confirmation is not a perps deposit', () => {
-    useConfirmContextMock.mockReturnValue({
-      currentConfirmation: {
-        id: TX_ID_MOCK,
-        type: TransactionType.simpleSend,
-        txParams: { from: FROM_ADDRESS_MOCK },
-      },
+    useTransactionMetadataRequestOptionalMock.mockReturnValue({
+      id: TX_ID_MOCK,
+      type: TransactionType.simpleSend,
+      txParams: { from: FROM_ADDRESS_MOCK },
     } as never);
 
     renderWithProvider(<PerpsAccountPickerRow />, mockStore({}));
@@ -259,11 +257,9 @@ describe('PerpsAccountPickerRow', () => {
   });
 
   it('does not update the transaction when it has no id', () => {
-    useConfirmContextMock.mockReturnValue({
-      currentConfirmation: {
-        type: TransactionType.perpsDeposit,
-        txParams: { from: FROM_ADDRESS_MOCK },
-      },
+    useTransactionMetadataRequestOptionalMock.mockReturnValue({
+      type: TransactionType.perpsDeposit,
+      txParams: { from: FROM_ADDRESS_MOCK },
     } as never);
 
     renderWithProvider(<PerpsAccountPickerRow />, mockStore({}));

--- a/ui/pages/confirmations/components/rows/perps-account-picker-row/perps-account-picker-row.tsx
+++ b/ui/pages/confirmations/components/rows/perps-account-picker-row/perps-account-picker-row.tsx
@@ -1,8 +1,5 @@
 import React, { useCallback } from 'react';
-import {
-  TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import {
   Skeleton,
@@ -17,7 +14,7 @@ import { updateEditableParams } from '../../../../../store/actions';
 import { useDispatch } from '../../../../../store/hooks';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { parsePerpsTotalBalance } from '../../../../../hooks/perps/perpsBalance';
-import { useConfirmContext } from '../../../context/confirm';
+import { useTransactionMetadataRequestOptional } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import {
   PayWithOption,
   useConfirmationNavigationOptions,
@@ -76,17 +73,17 @@ const formatBalance = (account: SubAccountInfo): React.ReactNode => {
 const PerpsAccountPickerRowContent = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const transactionMeta = useTransactionMetadataRequestOptional();
   const { subAccounts, selectedSubAccount } = usePerpsSubAccounts();
 
   const handleSelect = useCallback(
     (id: string) => {
-      const transactionId = currentConfirmation?.id;
+      const transactionId = transactionMeta?.id;
       if (!transactionId) {
         return;
       }
 
-      const from = currentConfirmation?.txParams?.from ?? '';
+      const from = transactionMeta?.txParams?.from ?? '';
       if (id.toLowerCase() === from.toLowerCase()) {
         return;
       }
@@ -99,7 +96,7 @@ const PerpsAccountPickerRowContent = () => {
         console.error('Failed to update perps deposit destination', error);
       });
     },
-    [currentConfirmation, dispatch],
+    [transactionMeta, dispatch],
   );
 
   return (
@@ -123,11 +120,11 @@ const PerpsAccountPickerRowContent = () => {
  */
 export function PerpsAccountPickerRow() {
   const { payWithOption } = useConfirmationNavigationOptions();
-  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const transactionMeta = useTransactionMetadataRequestOptional();
 
   const isMoneyAccountPerpsDeposit =
     payWithOption === PayWithOption.MoneyAccount &&
-    hasTransactionType(currentConfirmation, [TransactionType.perpsDeposit]);
+    hasTransactionType(transactionMeta, [TransactionType.perpsDeposit]);
 
   if (!isMoneyAccountPerpsDeposit) {
     return null;

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts
@@ -669,6 +669,34 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     ]);
   });
 
+  it('returns alert when pending amount exceeds money-account balance without a pay token', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+      isNative: false,
+      setPayToken: jest.fn(),
+    });
+    useMoneyAccountWithdrawableFiatMock.mockReturnValue({
+      withdrawableFiatRaw: '10',
+      withdrawableFiatFormatted: '$10.00',
+    });
+
+    const { result } = runHook(
+      { pendingAmountUsd: '25.00' },
+      { paymentOverride: PaymentOverride.MoneyAccount },
+    );
+
+    expect(result.current).toStrictEqual([
+      {
+        key: AlertsName.InsufficientPayTokenBalance,
+        field: RowAlertKey.EstimatedFee,
+        isBlocking: true,
+        reason: expect.stringContaining('Insufficient funds'),
+        message: expect.stringContaining('Insufficient funds'),
+        severity: Severity.Danger,
+      },
+    ]);
+  });
+
   // For Perps Withdraw (and other post-quote flows), `payToken` is the
   // *destination* token — its balance has nothing to do with whether the
   // user can fund the withdraw. Only the source-network gas check on the

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.ts
@@ -157,13 +157,16 @@ export function useInsufficientPayTokenBalanceAlert({
     new BigNumber(balanceRaw ?? '0').gt(0) &&
     new BigNumber(totals?.sourceAmount.raw ?? '0').eq(balanceRaw ?? '0');
 
+  // Money Account → Perps (and other Money payment overrides) may not have a
+  // wallet payToken selected yet while the amount is being typed; balance still
+  // comes from withdrawable money-account fiat, so allow the input check.
   const isInsufficientForInput = useMemo(
     () =>
       !isPostQuote &&
-      payToken &&
+      (Boolean(payToken) || isMoneyPaymentOverride) &&
       balanceUsd !== undefined &&
       totalAmountUsd.gt(balanceUsd),
-    [balanceUsd, isPostQuote, payToken, totalAmountUsd],
+    [balanceUsd, isMoneyPaymentOverride, isPostQuote, payToken, totalAmountUsd],
   );
 
   const isInsufficientForFees = useMemo(() => {

--- a/ui/pages/confirmations/hooks/alerts/usePendingAmountAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/usePendingAmountAlerts.test.ts
@@ -1,0 +1,60 @@
+import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
+import { getMockConfirmState } from '../../../../../test/data/confirmations/helper';
+import { useInsufficientMoneyAccountBalanceAlert } from './transactions/useInsufficientMoneyAccountBalanceAlert';
+import { useInsufficientPayTokenBalanceAlert } from './transactions/useInsufficientPayTokenBalanceAlert';
+import { useTransactionDepositLimitAlert } from './transactions/useTransactionDepositLimitAlert';
+import { usePendingAmountAlerts } from './usePendingAmountAlerts';
+
+jest.mock('./transactions/useInsufficientPayTokenBalanceAlert');
+jest.mock('./transactions/useInsufficientMoneyAccountBalanceAlert');
+jest.mock('./transactions/useTransactionDepositLimitAlert');
+
+const useInsufficientPayTokenBalanceAlertMock = jest.mocked(
+  useInsufficientPayTokenBalanceAlert,
+);
+const useInsufficientMoneyAccountBalanceAlertMock = jest.mocked(
+  useInsufficientMoneyAccountBalanceAlert,
+);
+const useTransactionDepositLimitAlertMock = jest.mocked(
+  useTransactionDepositLimitAlert,
+);
+
+describe('usePendingAmountAlerts', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useInsufficientPayTokenBalanceAlertMock.mockReturnValue([]);
+    useInsufficientMoneyAccountBalanceAlertMock.mockReturnValue([]);
+    useTransactionDepositLimitAlertMock.mockReturnValue([]);
+  });
+
+  it('passes pendingFiatAmount as pendingAmountUsd when available', () => {
+    renderHookWithConfirmContextProvider(
+      () =>
+        usePendingAmountAlerts({
+          pendingFiatAmount: '0.34',
+        }),
+      getMockConfirmState(),
+    );
+
+    expect(useInsufficientPayTokenBalanceAlertMock).toHaveBeenCalledWith({
+      pendingAmountUsd: '0.34',
+    });
+    expect(useInsufficientMoneyAccountBalanceAlertMock).toHaveBeenCalledWith({
+      pendingAmount: '0.34',
+    });
+    expect(useTransactionDepositLimitAlertMock).toHaveBeenCalledWith({
+      pendingAmount: '0.34',
+    });
+  });
+
+  it('defaults pendingAmountUsd to 0 when pendingFiatAmount is omitted', () => {
+    renderHookWithConfirmContextProvider(
+      () => usePendingAmountAlerts({}),
+      getMockConfirmState(),
+    );
+
+    expect(useInsufficientPayTokenBalanceAlertMock).toHaveBeenCalledWith({
+      pendingAmountUsd: '0',
+    });
+  });
+});

--- a/ui/pages/confirmations/hooks/alerts/usePendingAmountAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/usePendingAmountAlerts.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+import type { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
+import { useInsufficientMoneyAccountBalanceAlert } from './transactions/useInsufficientMoneyAccountBalanceAlert';
+import { useInsufficientPayTokenBalanceAlert } from './transactions/useInsufficientPayTokenBalanceAlert';
+import { useTransactionDepositLimitAlert } from './transactions/useTransactionDepositLimitAlert';
+
+/**
+ * Amount-entry alerts evaluated against the in-progress fiat value (before the
+ * debounced quote refresh). Mirrors mobile `usePendingAmountAlerts` so Money →
+ * Perps and other Pay amount screens block when the typed amount exceeds the
+ * available Money Account / pay-token balance.
+ *
+ * @param options
+ * @param options.pendingFiatAmount - Current amount-field fiat string.
+ */
+export function usePendingAmountAlerts({
+  pendingFiatAmount,
+}: {
+  pendingFiatAmount?: string;
+} = {}): Alert[] {
+  const insufficientTokenFundsAlert = useInsufficientPayTokenBalanceAlert({
+    pendingAmountUsd: pendingFiatAmount ?? '0',
+  });
+
+  const insufficientMoneyAccountBalanceAlert =
+    useInsufficientMoneyAccountBalanceAlert({
+      pendingAmount: pendingFiatAmount,
+    });
+
+  const depositLimitAlert = useTransactionDepositLimitAlert({
+    pendingAmount: pendingFiatAmount,
+  });
+
+  return useMemo(
+    () => [
+      ...insufficientTokenFundsAlert,
+      ...insufficientMoneyAccountBalanceAlert,
+      ...depositLimitAlert,
+    ],
+    [
+      depositLimitAlert,
+      insufficientMoneyAccountBalanceAlert,
+      insufficientTokenFundsAlert,
+    ],
+  );
+}

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.test.ts
@@ -3,10 +3,12 @@ import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/co
 import useAlerts from '../../../../hooks/useAlerts';
 import { Severity } from '../../../../helpers/constants/design-system';
 import { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
+import { usePendingAmountAlerts } from '../alerts/usePendingAmountAlerts';
 import { AlertsName } from '../alerts/constants';
 import { useTransactionCustomAmountAlerts } from './useTransactionCustomAmountAlerts';
 
 jest.mock('../../../../hooks/useAlerts');
+jest.mock('../alerts/usePendingAmountAlerts');
 
 const createMockAlert = (overrides: Partial<Alert> = {}): Alert =>
   ({
@@ -39,21 +41,23 @@ const createMockUseAlertsReturnValue = (
     ...overrides,
   }) as unknown as ReturnType<typeof useAlerts>;
 
-function runHook() {
+function runHook(pendingFiatAmount?: string) {
   const state = getMockConfirmState();
 
   return renderHookWithConfirmContextProvider(
-    () => useTransactionCustomAmountAlerts(),
+    () => useTransactionCustomAmountAlerts({ pendingFiatAmount }),
     state,
   );
 }
 
 describe('useTransactionCustomAmountAlerts', () => {
   const useAlertsMock = jest.mocked(useAlerts);
+  const usePendingAmountAlertsMock = jest.mocked(usePendingAmountAlerts);
 
   beforeEach(() => {
     jest.resetAllMocks();
     useAlertsMock.mockReturnValue(createMockUseAlertsReturnValue());
+    usePendingAmountAlertsMock.mockReturnValue([]);
   });
 
   it('returns base state when no alerts', () => {
@@ -61,6 +65,7 @@ describe('useTransactionCustomAmountAlerts', () => {
 
     expect(result.current).toStrictEqual({
       disableUpdate: false,
+      hasAlert: false,
       hideResults: false,
     });
   });
@@ -84,6 +89,7 @@ describe('useTransactionCustomAmountAlerts', () => {
 
     expect(result.current).toStrictEqual({
       disableUpdate: false,
+      hasAlert: false,
       hideResults: false,
     });
   });
@@ -108,35 +114,9 @@ describe('useTransactionCustomAmountAlerts', () => {
 
     const { result } = runHook();
 
-    expect(result.current).toStrictEqual({
-      disableUpdate: false,
-      hideResults: true,
-    });
-  });
-
-  it('sets hideResults to true when InsufficientMoneyAccountBalance alert exists', () => {
-    useAlertsMock.mockReturnValue(
-      createMockUseAlertsReturnValue({
-        alerts: [
-          createMockAlert({
-            key: AlertsName.InsufficientMoneyAccountBalance,
-            message: 'Insufficient funds',
-            isBlocking: true,
-            severity: Severity.Danger,
-          }),
-        ],
-        hasDangerAlerts: true,
-        hasAlerts: true,
-        hasUnconfirmedDangerAlerts: true,
-      }),
-    );
-
-    const { result } = runHook();
-
-    expect(result.current).toStrictEqual({
-      disableUpdate: false,
-      hideResults: true,
-    });
+    expect(result.current.hideResults).toBe(true);
+    expect(result.current.hasAlert).toBe(true);
+    expect(result.current.alertMessage).toBe('Max deposit: $100,000');
   });
 
   it('sets hideResults to true when InsufficientPayTokenBalance alert exists', () => {
@@ -145,6 +125,7 @@ describe('useTransactionCustomAmountAlerts', () => {
         alerts: [
           createMockAlert({
             key: AlertsName.InsufficientPayTokenBalance,
+            reason: 'Insufficient funds',
             message: 'Insufficient funds',
             isBlocking: true,
             severity: Severity.Danger,
@@ -159,18 +140,44 @@ describe('useTransactionCustomAmountAlerts', () => {
     const { result } = runHook();
 
     expect(result.current).toStrictEqual({
+      alertMessage: 'Insufficient funds',
       disableUpdate: false,
+      hasAlert: true,
       hideResults: true,
     });
   });
 
-  it('sets hideResults and disableUpdate when AccountNoFunds alert exists', () => {
+  it('prefers pending amount insufficient-funds alerts while typing', () => {
+    usePendingAmountAlertsMock.mockReturnValue([
+      createMockAlert({
+        key: AlertsName.InsufficientPayTokenBalance,
+        reason: 'Insufficient funds',
+        message: 'Insufficient funds',
+        isBlocking: true,
+        severity: Severity.Danger,
+      }),
+    ]);
+
+    const { result } = runHook('25.00');
+
+    expect(usePendingAmountAlertsMock).toHaveBeenCalledWith({
+      pendingFiatAmount: '25.00',
+    });
+    expect(result.current).toStrictEqual({
+      alertMessage: 'Insufficient funds',
+      disableUpdate: false,
+      hasAlert: true,
+      hideResults: true,
+    });
+  });
+
+  it('sets hideResults to true when AccountNoFunds alert exists', () => {
     useAlertsMock.mockReturnValue(
       createMockUseAlertsReturnValue({
         alerts: [
           createMockAlert({
             key: AlertsName.AccountNoFunds,
-            reason: 'Insufficient funds',
+            reason: 'No funds available',
             message: 'No funds available. Use a different account.',
             isBlocking: true,
             severity: Severity.Danger,
@@ -187,6 +194,7 @@ describe('useTransactionCustomAmountAlerts', () => {
     expect(result.current).toStrictEqual({
       alertMessage: 'No funds available. Use a different account.',
       disableUpdate: true,
+      hasAlert: true,
       hideResults: true,
     });
   });
@@ -197,8 +205,8 @@ describe('useTransactionCustomAmountAlerts', () => {
         alerts: [
           createMockAlert({
             key: AlertsName.PerpsWithdrawBalanceUnavailable,
+            reason: "Couldn't check your Perps balance",
             message: "Couldn't check your Perps balance. Try again.",
-            reason: 'Balance unavailable',
             isBlocking: true,
             severity: Severity.Danger,
           }),
@@ -214,6 +222,7 @@ describe('useTransactionCustomAmountAlerts', () => {
     expect(result.current).toStrictEqual({
       alertMessage: "Couldn't check your Perps balance. Try again.",
       disableUpdate: false,
+      hasAlert: true,
       hideResults: true,
     });
   });
@@ -237,10 +246,9 @@ describe('useTransactionCustomAmountAlerts', () => {
 
     const { result } = runHook();
 
-    expect(result.current).toStrictEqual({
-      disableUpdate: true,
-      hideResults: true,
-    });
+    expect(result.current.hideResults).toBe(true);
+    expect(result.current.disableUpdate).toBe(true);
+    expect(result.current.hasAlert).toBe(true);
   });
 
   it('returns alertMessage when alert has both reason and different message', () => {
@@ -248,7 +256,7 @@ describe('useTransactionCustomAmountAlerts', () => {
       createMockUseAlertsReturnValue({
         alerts: [
           createMockAlert({
-            key: 'test-alert',
+            key: 'no-quotes',
             reason: 'No quotes',
             message: 'This payment route is not available right now.',
             isBlocking: true,
@@ -266,18 +274,19 @@ describe('useTransactionCustomAmountAlerts', () => {
     expect(result.current).toStrictEqual({
       alertMessage: 'This payment route is not available right now.',
       disableUpdate: false,
+      hasAlert: true,
       hideResults: false,
     });
   });
 
-  it('does not return alertMessage when reason and message are the same', () => {
+  it('does not return alertMessage when reason and message are the same for other alerts', () => {
     useAlertsMock.mockReturnValue(
       createMockUseAlertsReturnValue({
         alerts: [
           createMockAlert({
             key: 'test-alert',
-            reason: 'Insufficient funds',
-            message: 'Insufficient funds',
+            reason: 'Something went wrong',
+            message: 'Something went wrong',
             isBlocking: true,
             severity: Severity.Danger,
           }),
@@ -292,6 +301,7 @@ describe('useTransactionCustomAmountAlerts', () => {
 
     expect(result.current).toStrictEqual({
       disableUpdate: false,
+      hasAlert: true,
       hideResults: false,
     });
   });
@@ -315,9 +325,8 @@ describe('useTransactionCustomAmountAlerts', () => {
 
     const { result } = runHook();
 
-    expect(result.current).toStrictEqual({
-      disableUpdate: true,
-      hideResults: true,
-    });
+    expect(result.current.disableUpdate).toBe(true);
+    expect(result.current.hasAlert).toBe(true);
+    expect(result.current.hideResults).toBe(true);
   });
 });

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import useAlerts from '../../../../hooks/useAlerts';
 import { useConfirmContext } from '../../context/confirm';
+import { usePendingAmountAlerts } from '../alerts/usePendingAmountAlerts';
 import { AlertsName } from '../alerts/constants';
 
 const ALERTS_HIDE_RESULTS: string[] = [
@@ -20,19 +21,36 @@ const ALERTS_DISABLE_UPDATE: string[] = [
   AlertsName.SigningOrSubmitting,
 ];
 
-export function useTransactionCustomAmountAlerts(): {
+/** Amount-field alerts that should surface their message even when it matches reason. */
+const ALERTS_SHOW_INLINE_MESSAGE: string[] = [
+  AlertsName.InsufficientPayTokenBalance,
+  AlertsName.InsufficientMoneyAccountBalance,
+  AlertsName.DepositLimit,
+];
+
+export function useTransactionCustomAmountAlerts({
+  pendingFiatAmount,
+}: {
+  pendingFiatAmount?: string;
+} = {}): {
   alertMessage?: string;
+  hasAlert: boolean;
   hideResults: boolean;
   disableUpdate: boolean;
 } {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const transactionId = currentConfirmation?.id ?? '';
   const { alerts: confirmationAlerts } = useAlerts(transactionId);
+  const pendingAmountAlerts = usePendingAmountAlerts({
+    pendingFiatAmount,
+  });
 
-  const blockingAlerts = useMemo(
-    () => confirmationAlerts.filter((a) => a.isBlocking),
-    [confirmationAlerts],
-  );
+  const blockingAlerts = useMemo(() => {
+    const confirmationBlocking = confirmationAlerts.filter((a) => a.isBlocking);
+    // Prefer live typed-amount alerts so Money → Perps shows insufficient
+    // funds before the debounced quote refreshes required tokens.
+    return [...pendingAmountAlerts, ...confirmationBlocking];
+  }, [confirmationAlerts, pendingAmountAlerts]);
 
   const hideResults = useMemo(
     () => blockingAlerts.some((a) => ALERTS_HIDE_RESULTS.includes(a.key)),
@@ -48,18 +66,23 @@ export function useTransactionCustomAmountAlerts(): {
 
   if (!firstAlert) {
     return {
-      hideResults,
       disableUpdate,
+      hasAlert: false,
+      hideResults,
     };
   }
 
-  const { reason, message } = firstAlert;
+  const { reason, message, key } = firstAlert;
+  const showInlineEvenIfSame = ALERTS_SHOW_INLINE_MESSAGE.includes(key);
   const alertMessage =
-    reason && message && reason !== message ? message : undefined;
+    reason && message && (reason !== message || showInlineEvenIfSame)
+      ? (message as string)
+      : undefined;
 
   return {
     ...(alertMessage ? { alertMessage } : {}),
-    hideResults,
     disableUpdate,
+    hasAlert: true,
+    hideResults,
   };
 }

--- a/ui/pages/money/components/money-transfer-sheet/index.ts
+++ b/ui/pages/money/components/money-transfer-sheet/index.ts
@@ -1,0 +1,5 @@
+export {
+  MoneyTransferSheet,
+  MONEY_TRANSFER_SHEET_TEST_IDS,
+} from './money-transfer-sheet';
+export type { MoneyTransferSheetProps } from './money-transfer-sheet';

--- a/ui/pages/money/components/money-transfer-sheet/money-transfer-sheet.test.tsx
+++ b/ui/pages/money/components/money-transfer-sheet/money-transfer-sheet.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithLocalization } from '../../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
+import { useMoneyAccountWithdrawal } from '../../../../hooks/money/useMoneyAccountWithdrawal';
+import { useMoneyPerpsDeposit } from '../../../../hooks/money/useMoneyPerpsDeposit';
+import {
+  MoneyTransferSheet,
+  MONEY_TRANSFER_SHEET_TEST_IDS,
+} from './money-transfer-sheet';
+
+jest.mock('../../../../hooks/money/useMoneyAccountWithdrawal');
+jest.mock('../../../../hooks/money/useMoneyPerpsDeposit');
+
+const useMoneyAccountWithdrawalMock = jest.mocked(useMoneyAccountWithdrawal);
+const useMoneyPerpsDepositMock = jest.mocked(useMoneyPerpsDeposit);
+
+describe('MoneyTransferSheet', () => {
+  const onClose = jest.fn();
+  const initiateWithdrawal = jest.fn().mockResolvedValue(undefined);
+  const initiatePerpsDeposit = jest.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useMoneyAccountWithdrawalMock.mockReturnValue({
+      initiateWithdrawal,
+      isLoading: false,
+    });
+    useMoneyPerpsDepositMock.mockReturnValue({
+      isEnabled: true,
+      isEligible: true,
+      initiatePerpsDeposit,
+      isLoading: false,
+    });
+  });
+
+  it('renders send destinations including Perps account', () => {
+    renderWithLocalization(<MoneyTransferSheet isOpen onClose={onClose} />);
+
+    expect(
+      screen.getByText(messages.moneyTransferTitle.message),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(MONEY_TRANSFER_SHEET_TEST_IDS.betweenAccounts),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(MONEY_TRANSFER_SHEET_TEST_IDS.perpsAccount),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(MONEY_TRANSFER_SHEET_TEST_IDS.sendExternal),
+    ).toBeDisabled();
+    expect(
+      screen.getByTestId(MONEY_TRANSFER_SHEET_TEST_IDS.withdrawToBank),
+    ).toBeDisabled();
+  });
+
+  it('hides Perps when the user is not eligible', () => {
+    useMoneyPerpsDepositMock.mockReturnValue({
+      isEnabled: false,
+      isEligible: false,
+      initiatePerpsDeposit,
+      isLoading: false,
+    });
+
+    renderWithLocalization(<MoneyTransferSheet isOpen onClose={onClose} />);
+
+    expect(
+      screen.queryByTestId(MONEY_TRANSFER_SHEET_TEST_IDS.perpsAccount),
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables Perps when the money-account flag is off', () => {
+    useMoneyPerpsDepositMock.mockReturnValue({
+      isEnabled: false,
+      isEligible: true,
+      initiatePerpsDeposit,
+      isLoading: false,
+    });
+
+    renderWithLocalization(<MoneyTransferSheet isOpen onClose={onClose} />);
+
+    expect(
+      screen.getByTestId(MONEY_TRANSFER_SHEET_TEST_IDS.perpsAccount),
+    ).toBeDisabled();
+  });
+
+  it('closes and initiates a money-funded Perps deposit', () => {
+    renderWithLocalization(<MoneyTransferSheet isOpen onClose={onClose} />);
+
+    fireEvent.click(
+      screen.getByTestId(MONEY_TRANSFER_SHEET_TEST_IDS.perpsAccount),
+    );
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(initiatePerpsDeposit).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes and initiates a between-accounts withdrawal', () => {
+    renderWithLocalization(<MoneyTransferSheet isOpen onClose={onClose} />);
+
+    fireEvent.click(
+      screen.getByTestId(MONEY_TRANSFER_SHEET_TEST_IDS.betweenAccounts),
+    );
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(initiateWithdrawal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/pages/money/components/money-transfer-sheet/money-transfer-sheet.tsx
+++ b/ui/pages/money/components/money-transfer-sheet/money-transfer-sheet.tsx
@@ -1,0 +1,205 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Tag,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+} from '../../../../components/component-library';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useMoneyAccountWithdrawal } from '../../../../hooks/money/useMoneyAccountWithdrawal';
+import { useMoneyPerpsDeposit } from '../../../../hooks/money/useMoneyPerpsDeposit';
+
+export const MONEY_TRANSFER_SHEET_TEST_IDS = {
+  container: 'money-transfer-sheet',
+  betweenAccounts: 'money-transfer-between-accounts',
+  perpsAccount: 'money-transfer-perps-account',
+  sendExternal: 'money-transfer-send-external',
+  withdrawToBank: 'money-transfer-withdraw-to-bank',
+} as const;
+
+type MoneyTransferOption = {
+  label: string;
+  icon: IconName;
+  testId: string;
+  onPress?: () => void;
+  disabled?: boolean;
+  comingSoon?: boolean;
+};
+
+export type MoneyTransferSheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+/**
+ * Money home “Send funds to” sheet — mirrors mobile `MoneyTransferSheet`.
+ * “Perps account” opens the Perps deposit confirmation funded from the money
+ * account; destination is chosen on the confirmation via the perps picker.
+ * @param options0
+ * @param options0.isOpen
+ * @param options0.onClose
+ */
+export function MoneyTransferSheet({
+  isOpen,
+  onClose,
+}: MoneyTransferSheetProps) {
+  const t = useI18nContext();
+  const { initiateWithdrawal, isLoading: isWithdrawLoading } =
+    useMoneyAccountWithdrawal();
+  const {
+    isEnabled: isPerpsEnabled,
+    isEligible: isPerpsEligible,
+    initiatePerpsDeposit,
+    isLoading: isPerpsLoading,
+  } = useMoneyPerpsDeposit();
+
+  const isBusy = isWithdrawLoading || isPerpsLoading;
+
+  const handleBetweenAccounts = useCallback(() => {
+    onClose();
+    initiateWithdrawal().catch((error: unknown) => {
+      console.error(
+        '[MoneyTransferSheet] Between-accounts initiation failed',
+        error,
+      );
+    });
+  }, [initiateWithdrawal, onClose]);
+
+  const handlePerpsAccount = useCallback(() => {
+    onClose();
+    initiatePerpsDeposit().catch((error: unknown) => {
+      console.error(
+        '[MoneyTransferSheet] Perps deposit initiation failed',
+        error,
+      );
+    });
+  }, [initiatePerpsDeposit, onClose]);
+
+  const options = useMemo((): MoneyTransferOption[] => {
+    const rows: MoneyTransferOption[] = [
+      {
+        label: t('moneyTransferBetweenAccounts'),
+        icon: IconName.Arrow2UpRight,
+        onPress: handleBetweenAccounts,
+        testId: MONEY_TRANSFER_SHEET_TEST_IDS.betweenAccounts,
+        disabled: isBusy,
+      },
+    ];
+
+    if (isPerpsEligible) {
+      rows.push({
+        label: t('moneyTransferPerpsAccount'),
+        icon: IconName.Candlestick,
+        onPress: handlePerpsAccount,
+        testId: MONEY_TRANSFER_SHEET_TEST_IDS.perpsAccount,
+        disabled: !isPerpsEnabled || isBusy,
+      });
+    }
+
+    rows.push(
+      {
+        label: t('moneyTransferSendExternal'),
+        icon: IconName.Arrow2Up,
+        testId: MONEY_TRANSFER_SHEET_TEST_IDS.sendExternal,
+        disabled: true,
+        comingSoon: true,
+      },
+      {
+        label: t('moneyTransferWithdrawToBank'),
+        icon: IconName.Bank,
+        testId: MONEY_TRANSFER_SHEET_TEST_IDS.withdrawToBank,
+        disabled: true,
+        comingSoon: true,
+      },
+    );
+
+    return [
+      ...rows.filter((option) => !option.disabled),
+      ...rows.filter((option) => option.disabled),
+    ];
+  }, [
+    handleBetweenAccounts,
+    handlePerpsAccount,
+    isBusy,
+    isPerpsEligible,
+    isPerpsEnabled,
+    t,
+  ]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      isClosedOnEscapeKey
+      isClosedOnOutsideClick
+      onClose={onClose}
+      data-testid={MONEY_TRANSFER_SHEET_TEST_IDS.container}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader onClose={onClose}>
+          <Text variant={TextVariant.HeadingSm}>{t('moneyTransferTitle')}</Text>
+        </ModalHeader>
+        <ModalBody>
+          <div className="flex flex-col">
+            {options.map((option) => (
+              <button
+                key={option.testId}
+                type="button"
+                data-testid={option.testId}
+                disabled={option.disabled}
+                onClick={option.disabled ? undefined : option.onPress}
+                className="flex w-full items-center gap-3 rounded-lg px-1 py-3 text-left disabled:cursor-default"
+              >
+                <Icon
+                  name={option.icon}
+                  size={IconSize.Lg}
+                  color={
+                    option.disabled
+                      ? IconColor.IconMuted
+                      : IconColor.IconDefault
+                  }
+                />
+                {option.comingSoon ? (
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      fontWeight={FontWeight.Medium}
+                      color={TextColor.TextAlternative}
+                    >
+                      {option.label}
+                    </Text>
+                    <Tag>{t('moneyTransferComingSoon')}</Tag>
+                  </div>
+                ) : (
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                    color={
+                      option.disabled
+                        ? TextColor.TextAlternative
+                        : TextColor.TextDefault
+                    }
+                  >
+                    {option.label}
+                  </Text>
+                )}
+              </button>
+            ))}
+          </div>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/ui/pages/money/money-home-page.test.tsx
+++ b/ui/pages/money/money-home-page.test.tsx
@@ -18,8 +18,6 @@ const mockUseMoneyActivityItems = jest.fn();
 const mockUseMoneyActivityItemClick = jest.fn();
 const mockUseMoneyAccountDeposit = jest.fn();
 const mockInitiateDeposit = jest.fn();
-const mockUseMoneyAccountWithdrawal = jest.fn();
-const mockInitiateWithdrawal = jest.fn();
 const mockNavigate = jest.fn();
 const mockSelectMoneyEarningSectionEnabled = jest.mocked(
   selectMoneyEarningSectionEnabled,
@@ -91,12 +89,25 @@ jest.mock('../../hooks/money/use-money-activity-items', () => ({
 jest.mock('../../hooks/money/useMoneyAccountDeposit', () => ({
   useMoneyAccountDeposit: () => mockUseMoneyAccountDeposit(),
 }));
-jest.mock('../../hooks/money/useMoneyAccountWithdrawal', () => ({
-  useMoneyAccountWithdrawal: () => mockUseMoneyAccountWithdrawal(),
-}));
 
 jest.mock('../../hooks/money/use-money-activity-item-click', () => ({
   useMoneyActivityItemClick: () => mockUseMoneyActivityItemClick(),
+}));
+jest.mock('./components/money-transfer-sheet', () => ({
+  MoneyTransferSheet: ({
+    isOpen,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="money-transfer-sheet">
+        <button type="button" onClick={onClose}>
+          Close transfer sheet
+        </button>
+      </div>
+    ) : null,
 }));
 
 jest.mock('../../helpers/money/report-money-error', () => ({
@@ -146,11 +157,6 @@ describe('MoneyHomePage', () => {
     mockInitiateDeposit.mockResolvedValue(undefined);
     mockUseMoneyAccountDeposit.mockReturnValue({
       initiateDeposit: mockInitiateDeposit,
-      isLoading: false,
-    });
-    mockInitiateWithdrawal.mockResolvedValue(undefined);
-    mockUseMoneyAccountWithdrawal.mockReturnValue({
-      initiateWithdrawal: mockInitiateWithdrawal,
       isLoading: false,
     });
   });
@@ -244,6 +250,18 @@ describe('MoneyHomePage', () => {
     });
   });
 
+  it('opens the money transfer sheet from Send', () => {
+    renderWithLocalization(<MoneyHomePage />);
+
+    expect(
+      screen.queryByTestId('money-transfer-sheet'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('money-send-button'));
+
+    expect(screen.getByTestId('money-transfer-sheet')).toBeInTheDocument();
+  });
+
   it('initiates a deposit from the Add action card', () => {
     renderWithLocalization(<MoneyHomePage />);
 
@@ -277,34 +295,6 @@ describe('MoneyHomePage', () => {
     expect(
       screen.getByRole('button', { name: messages.moneyAdd.message }),
     ).toBeDisabled();
-  });
-
-  it('initiates a withdrawal from the Send action card', () => {
-    renderWithLocalization(<MoneyHomePage />);
-
-    fireEvent.click(
-      screen.getByRole('button', { name: messages.moneySend.message }),
-    );
-
-    expect(mockInitiateWithdrawal).toHaveBeenCalledTimes(1);
-    expect(mockInitiateWithdrawal).toHaveBeenCalledWith();
-    expect(mockInitiateDeposit).not.toHaveBeenCalled();
-  });
-
-  it('disables the Send action card while a withdrawal is initiating', () => {
-    mockUseMoneyAccountWithdrawal.mockReturnValue({
-      initiateWithdrawal: mockInitiateWithdrawal,
-      isLoading: true,
-    });
-
-    renderWithLocalization(<MoneyHomePage />);
-
-    expect(
-      screen.getByRole('button', { name: messages.moneySend.message }),
-    ).toBeDisabled();
-    expect(
-      screen.getByRole('button', { name: messages.moneyAdd.message }),
-    ).toBeEnabled();
   });
 
   it('renders the filled-state composition for a funded Money account', () => {
@@ -358,6 +348,8 @@ describe('MoneyHomePage', () => {
     expect(
       screen.queryByText(messages.moneyBenefits.message),
     ).not.toBeInTheDocument();
+    expect(screen.getByTestId('money-send-button')).toBeEnabled();
+    expect(screen.getByTestId('money-add-button')).toBeEnabled();
     screen.getAllByRole('button').forEach((button) => {
       if (
         [messages.moneyAdd.message, messages.moneySend.message].includes(

--- a/ui/pages/money/money-home-page.tsx
+++ b/ui/pages/money/money-home-page.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
@@ -28,7 +28,6 @@ import { useMoneyDepositTokens } from '../../hooks/money/use-money-deposit-token
 import { useMoneyAccountBalance } from '../../hooks/money/useMoneyAccountBalance';
 import { useMoneyAccountDeposit } from '../../hooks/money/useMoneyAccountDeposit';
 import { useMoneyAccountInterest } from '../../hooks/money/useMoneyAccountInterest';
-import { useMoneyAccountWithdrawal } from '../../hooks/money/useMoneyAccountWithdrawal';
 import { useMoneyActivityItems } from '../../hooks/money/use-money-activity-items';
 import { useMoneyActivityItemClick } from '../../hooks/money/use-money-activity-item-click';
 import { moneyFormatUsd } from '../../helpers/money/format';
@@ -44,6 +43,7 @@ import { MoneyCondensedInfoCards } from './components/money-condensed-info-cards
 import { MoneyPotentialEarnings } from './components/money-potential-earnings';
 import { MoneyPositionPlaceholder } from './components/money-position-placeholder';
 import { MoneyActivityFilter } from './utils/money-activity-filters';
+import { MoneyTransferSheet } from './components/money-transfer-sheet';
 
 const MONEY_FUNDED_BALANCE_THRESHOLD = 0.01;
 const MONEY_ONBOARDING_ARTWORK = './images/money-onboarding-stepper-step-1.png';
@@ -80,6 +80,7 @@ type ActionCardProps = {
   label: string;
   onClick?: () => void;
   disabled?: boolean;
+  testId?: string;
 };
 
 const MoneyActionCard = ({
@@ -87,12 +88,14 @@ const MoneyActionCard = ({
   label,
   onClick,
   disabled,
+  testId,
 }: ActionCardProps) => {
   return (
     <button
       type="button"
       disabled={disabled}
       onClick={onClick}
+      data-testid={testId}
       className="flex h-[76px] flex-1 flex-col items-center justify-center gap-0.5 rounded-xl bg-background-muted disabled:cursor-default disabled:opacity-100"
     >
       <Icon name={icon} size={IconSize.Lg} color={IconColor.IconDefault} />
@@ -110,6 +113,7 @@ const MoneySectionDivider = () => {
 export function MoneyHomePage() {
   const t = useI18nContext();
   const navigate = useNavigate();
+  const [isTransferSheetOpen, setIsTransferSheetOpen] = useState(false);
   const { availability, isLoading: isAvailabilityLoading } =
     useMoneyAccountAvailability();
   const {
@@ -178,14 +182,15 @@ export function MoneyHomePage() {
   const handleAddFunds = useCallback(() => {
     initiateDeposit();
   }, [initiateDeposit]);
-  const { initiateWithdrawal, isLoading: isWithdrawalLoading } =
-    useMoneyAccountWithdrawal();
   const handleLearnMore = useCallback(() => {
     global.platform.openTab({ url: MONEY_LANDING_URL });
   }, []);
-  const handleSend = useCallback(() => {
-    initiateWithdrawal();
-  }, [initiateWithdrawal]);
+  const handleOpenTransferSheet = useCallback(() => {
+    setIsTransferSheetOpen(true);
+  }, []);
+  const handleCloseTransferSheet = useCallback(() => {
+    setIsTransferSheetOpen(false);
+  }, []);
 
   if (isAvailabilityLoading || (availability.isAvailable && isBalanceLoading)) {
     return (
@@ -229,254 +234,263 @@ export function MoneyHomePage() {
     ) : null;
 
   return (
-    <main
-      className="min-h-full bg-background-default pb-5"
-      data-testid="money-home-page"
-    >
-      <header className="flex h-14 items-center justify-between px-4">
-        <Text variant={TextVariant.HeadingLg} fontWeight={FontWeight.Bold}>
-          {t('money')}
-        </Text>
-        <ButtonIcon
-          iconName={IconName.MoreVertical}
-          ariaLabel={t('moneyMoreOptions')}
-          disabled
-        />
-      </header>
-
-      {isBalanceFetchError ? (
-        <div className="px-4 pt-2">
-          <BannerAlert
-            severity={BannerAlertSeverity.Warning}
-            title={t('moneyBalanceUnavailable')}
-            description={t('moneyBalanceUnavailableBannerDescription')}
-            actionButtonLabel={t('moneyBalanceRetry')}
-            actionButtonOnClick={() => {
-              refetchBalance().catch((error) => {
-                reportMoneyError(
-                  '[Money Account] Balance retry failed',
-                  error,
-                  { query: 'fetchBalanceWithFallback' },
-                );
-              });
-            }}
-            data-testid="money-balance-unavailable-banner"
-          />
-        </div>
-      ) : null}
-
-      <div className="flex flex-col items-center gap-2 px-4 pt-2">
-        <div className="flex w-full max-w-[784px] flex-col gap-1 sm:items-center">
-          <Text
-            variant={TextVariant.DisplayLg}
-            fontWeight={FontWeight.Medium}
-            data-testid="money-balance"
-          >
-            {balanceDisplay}
+    <>
+      <main
+        className="min-h-full bg-background-default pb-5"
+        data-testid="money-home-page"
+      >
+        <header className="flex h-14 items-center justify-between px-4">
+          <Text variant={TextVariant.HeadingLg} fontWeight={FontWeight.Bold}>
+            {t('money')}
           </Text>
-          {isLastKnownBalance ? (
+          <ButtonIcon
+            iconName={IconName.MoreVertical}
+            ariaLabel={t('moneyMoreOptions')}
+            disabled
+          />
+        </header>
+
+        {isBalanceFetchError ? (
+          <div className="px-4 pt-2">
+            <BannerAlert
+              severity={BannerAlertSeverity.Warning}
+              title={t('moneyBalanceUnavailable')}
+              description={t('moneyBalanceUnavailableBannerDescription')}
+              actionButtonLabel={t('moneyBalanceRetry')}
+              actionButtonOnClick={() => {
+                refetchBalance().catch((error) => {
+                  reportMoneyError(
+                    '[Money Account] Balance retry failed',
+                    error,
+                    { query: 'fetchBalanceWithFallback' },
+                  );
+                });
+              }}
+              data-testid="money-balance-unavailable-banner"
+            />
+          </div>
+        ) : null}
+
+        <div className="flex flex-col items-center gap-2 px-4 pt-2">
+          <div className="flex w-full max-w-[784px] flex-col gap-1 sm:items-center">
             <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextAlternative}
-              data-testid="money-home-last-known"
+              variant={TextVariant.DisplayLg}
+              fontWeight={FontWeight.Medium}
+              data-testid="money-balance"
             >
-              {t('moneyBalanceLastKnown')}
+              {balanceDisplay}
             </Text>
-          ) : null}
-          <div className="flex h-6 items-center gap-1">
-            {vaultApyQuery.isLoading && !apyDisplay ? (
-              <Skeleton className="h-4 w-24" />
-            ) : (
-              <>
-                {apyDisplay ? (
+            {isLastKnownBalance ? (
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextAlternative}
+                data-testid="money-home-last-known"
+              >
+                {t('moneyBalanceLastKnown')}
+              </Text>
+            ) : null}
+            <div className="flex h-6 items-center gap-1">
+              {vaultApyQuery.isLoading && !apyDisplay ? (
+                <Skeleton className="h-4 w-24" />
+              ) : (
+                <>
+                  {apyDisplay ? (
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      className="text-success-default"
+                    >
+                      {t('moneyApy', [apyDisplay])}
+                    </Text>
+                  ) : null}
                   <Text
                     variant={TextVariant.BodyMd}
-                    className="text-success-default"
+                    color={TextColor.TextAlternative}
                   >
-                    {t('moneyApy', [apyDisplay])}
+                    {apyDisplay ? `• ${t('moneyMusd')}` : t('moneyMusd')}
                   </Text>
-                ) : null}
+                  <Icon
+                    name={IconName.Info}
+                    size={IconSize.Sm}
+                    color={IconColor.IconAlternative}
+                  />
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-2 flex w-full max-w-[389px] gap-2 py-2">
+            <MoneyActionCard
+              icon={IconName.Add}
+              label={t('moneyAdd')}
+              onClick={handleAddFunds}
+              disabled={isDepositLoading}
+              testId="money-add-button"
+            />
+            <MoneyActionCard
+              icon={IconName.Arrow2UpRight}
+              label={t('moneySend')}
+              onClick={handleOpenTransferSheet}
+              testId="money-send-button"
+            />
+          </div>
+
+          {showFundedLayout ? null : (
+            <section className="mt-1 flex w-full max-w-[389px] flex-col gap-4 overflow-hidden rounded-2xl bg-background-muted p-4">
+              <img
+                src={MONEY_ONBOARDING_ARTWORK}
+                alt=""
+                className="h-[185px] w-full rounded-[14px] object-cover"
+              />
+              <div>
+                <Text
+                  variant={TextVariant.HeadingLg}
+                  fontWeight={FontWeight.Bold}
+                >
+                  {apyDisplay
+                    ? t('moneyEarnApyTitle', [apyDisplay])
+                    : t('moneyEarnTitle')}
+                </Text>
                 <Text
                   variant={TextVariant.BodyMd}
                   color={TextColor.TextAlternative}
+                  className="mt-1"
                 >
-                  {apyDisplay ? `• ${t('moneyMusd')}` : t('moneyMusd')}
+                  {apyDisplay
+                    ? t('moneyFundDescriptionWithApy', [apyDisplay])
+                    : t('moneyFundDescription')}
                 </Text>
-                <Icon
-                  name={IconName.Info}
-                  size={IconSize.Sm}
-                  color={IconColor.IconAlternative}
-                />
-              </>
-            )}
-          </div>
+              </div>
+              <Button
+                className="w-full"
+                isLoading={isDepositLoading}
+                onClick={handleAddFunds}
+              >
+                {t('addFunds')}
+              </Button>
+            </section>
+          )}
         </div>
 
-        <div className="mt-2 flex w-full max-w-[389px] gap-2 py-2">
-          <MoneyActionCard
-            icon={IconName.Add}
-            label={t('moneyAdd')}
-            onClick={handleAddFunds}
-            disabled={isDepositLoading}
-          />
-          <MoneyActionCard
-            icon={IconName.Arrow2UpRight}
-            label={t('moneySend')}
-            onClick={handleSend}
-            disabled={isWithdrawalLoading}
-          />
-        </div>
+        <div
+          className={`mx-auto w-full max-w-[816px] ${showFundedLayout ? '' : 'mt-3'}`}
+        >
+          {showFundedLayout ? (
+            <>
+              {isMoneyEarningSectionEnabled ? (
+                <>
+                  <MoneyPositionPlaceholder
+                    monthlyEarnings={monthlyEarnings}
+                    lifetimeEarnings={lifetimeEarnings}
+                    isMonthlyLoading={isMonthlyEarningsLoading}
+                    isLifetimeLoading={isLifetimeEarningsLoading}
+                  />
+                  <MoneySectionDivider />
+                </>
+              ) : null}
+              <MoneyActivityList
+                items={activityItems}
+                privacyMode={privacyMode}
+                onViewAll={handleViewAllActivity}
+                onItemClick={handleActivityItemClick}
+                hasMore={hasMoreActivity}
+                isSettling={isActivitySettling}
+              />
+              <MoneySectionDivider />
+              {earnOnYourCryptoSection}
+              <MoneyCondensedInfoCards />
+            </>
+          ) : (
+            <>
+              <section className="px-4 py-3">
+                <div className="flex items-center gap-1">
+                  <Text
+                    variant={TextVariant.HeadingMd}
+                    fontWeight={FontWeight.Bold}
+                  >
+                    {t('moneyHowItWorks')}
+                  </Text>
+                  <Icon
+                    name={IconName.ArrowRight}
+                    size={IconSize.Md}
+                    color={IconColor.IconAlternative}
+                  />
+                </div>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
+                  className="mt-2"
+                  data-testid="money-how-it-works-description"
+                >
+                  {apyDisplay
+                    ? t('moneyHowItWorksDescriptionWithApy', [
+                        <span key="apy" className="text-success-default">
+                          {t('moneyApy', [apyDisplay])}
+                        </span>,
+                      ])
+                    : t('moneyHowItWorksDescription')}
+                </Text>
+              </section>
 
-        {showFundedLayout ? null : (
-          <section className="mt-1 flex w-full max-w-[389px] flex-col gap-4 overflow-hidden rounded-2xl bg-background-muted p-4">
-            <img
-              src={MONEY_ONBOARDING_ARTWORK}
-              alt=""
-              className="h-[185px] w-full rounded-[14px] object-cover"
-            />
-            <div>
-              <Text
-                variant={TextVariant.HeadingLg}
-                fontWeight={FontWeight.Bold}
-              >
-                {apyDisplay
-                  ? t('moneyEarnApyTitle', [apyDisplay])
-                  : t('moneyEarnTitle')}
-              </Text>
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
-                className="mt-1"
-              >
-                {apyDisplay
-                  ? t('moneyFundDescriptionWithApy', [apyDisplay])
-                  : t('moneyFundDescription')}
-              </Text>
-            </div>
-            <Button
-              className="w-full"
-              isLoading={isDepositLoading}
-              onClick={handleAddFunds}
-            >
-              {t('addFunds')}
-            </Button>
-          </section>
-        )}
-      </div>
+              <MoneySectionDivider />
+              <MoneyActivityList
+                items={activityItems}
+                privacyMode={privacyMode}
+                onViewAll={handleViewAllActivity}
+                onItemClick={handleActivityItemClick}
+                hasMore={hasMoreActivity}
+                isSettling={isActivitySettling}
+              />
 
-      <div
-        className={`mx-auto w-full max-w-[816px] ${showFundedLayout ? '' : 'mt-3'}`}
-      >
-        {showFundedLayout ? (
-          <>
-            {isMoneyEarningSectionEnabled ? (
-              <>
-                <MoneyPositionPlaceholder
-                  monthlyEarnings={monthlyEarnings}
-                  lifetimeEarnings={lifetimeEarnings}
-                  isMonthlyLoading={isMonthlyEarningsLoading}
-                  isLifetimeLoading={isLifetimeEarningsLoading}
-                />
-                <MoneySectionDivider />
-              </>
-            ) : null}
-            <MoneyActivityList
-              items={activityItems}
-              privacyMode={privacyMode}
-              onViewAll={handleViewAllActivity}
-              onItemClick={handleActivityItemClick}
-              hasMore={hasMoreActivity}
-              isSettling={isActivitySettling}
-            />
-            <MoneySectionDivider />
-            {earnOnYourCryptoSection}
-            <MoneyCondensedInfoCards />
-          </>
-        ) : (
-          <>
-            <section className="px-4 py-3">
-              <div className="flex items-center gap-1">
+              <MoneySectionDivider />
+              {earnOnYourCryptoSection}
+
+              <section className="px-4 py-3">
                 <Text
                   variant={TextVariant.HeadingMd}
                   fontWeight={FontWeight.Bold}
                 >
-                  {t('moneyHowItWorks')}
+                  {t('moneyBenefits')}
                 </Text>
-                <Icon
-                  name={IconName.ArrowRight}
-                  size={IconSize.Md}
-                  color={IconColor.IconAlternative}
-                />
-              </div>
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
-                className="mt-2"
-                data-testid="money-how-it-works-description"
-              >
-                {apyDisplay
-                  ? t('moneyHowItWorksDescriptionWithApy', [
-                      <span key="apy" className="text-success-default">
-                        {t('moneyApy', [apyDisplay])}
-                      </span>,
-                    ])
-                  : t('moneyHowItWorksDescription')}
-              </Text>
-            </section>
-
-            <MoneySectionDivider />
-            <MoneyActivityList
-              items={activityItems}
-              privacyMode={privacyMode}
-              onViewAll={handleViewAllActivity}
-              onItemClick={handleActivityItemClick}
-              hasMore={hasMoreActivity}
-              isSettling={isActivitySettling}
-            />
-
-            <MoneySectionDivider />
-            {earnOnYourCryptoSection}
-
-            <section className="px-4 py-3">
-              <Text
-                variant={TextVariant.HeadingMd}
-                fontWeight={FontWeight.Bold}
-              >
-                {t('moneyBenefits')}
-              </Text>
-              <ul className="mt-3 flex flex-col gap-3">
-                {[
-                  apyDisplay
-                    ? t('moneyBenefitAutoEarnWithApy', [apyDisplay])
-                    : t('moneyBenefitAutoEarn'),
-                  t('moneyBenefitStablecoin'),
-                  t('moneyBenefitLiquidity'),
-                  t('moneyBenefitSend'),
-                ].map((benefit) => (
-                  <li key={benefit} className="flex items-start gap-3">
-                    <Icon
-                      name={IconName.Check}
-                      size={IconSize.Md}
-                      color={IconColor.SuccessDefault}
-                      className="mt-0.5 shrink-0"
-                    />
-                    <Text variant={TextVariant.BodyMd}>{benefit}</Text>
-                  </li>
-                ))}
-              </ul>
-              <Button
-                variant={ButtonVariant.Secondary}
-                className="mt-4 w-full"
-                onClick={handleLearnMore}
-                data-testid="money-learn-more"
-              >
-                {t('moneyLearnMore')}
-              </Button>
-            </section>
-          </>
-        )}
-      </div>
-    </main>
+                <ul className="mt-3 flex flex-col gap-3">
+                  {[
+                    apyDisplay
+                      ? t('moneyBenefitAutoEarnWithApy', [apyDisplay])
+                      : t('moneyBenefitAutoEarn'),
+                    t('moneyBenefitStablecoin'),
+                    t('moneyBenefitLiquidity'),
+                    t('moneyBenefitSend'),
+                  ].map((benefit) => (
+                    <li key={benefit} className="flex items-start gap-3">
+                      <Icon
+                        name={IconName.Check}
+                        size={IconSize.Md}
+                        color={IconColor.SuccessDefault}
+                        className="mt-0.5 shrink-0"
+                      />
+                      <Text variant={TextVariant.BodyMd}>{benefit}</Text>
+                    </li>
+                  ))}
+                </ul>
+                <Button
+                  variant={ButtonVariant.Secondary}
+                  className="mt-4 w-full"
+                  onClick={handleLearnMore}
+                  data-testid="money-learn-more"
+                >
+                  {t('moneyLearnMore')}
+                </Button>
+              </section>
+            </>
+          )}
+        </div>
+      </main>
+      {isTransferSheetOpen ? (
+        <MoneyTransferSheet
+          isOpen={isTransferSheetOpen}
+          onClose={handleCloseTransferSheet}
+        />
+      ) : null}
+    </>
   );
 }
 


### PR DESCRIPTION
## **Description**

Adds the production Money home entry point for sending funds from the Money account to a selected Perps account, matching mobile.

**Reason:** Users could only reach the Money → Perps deposit flow via developer options; Money home Send was disabled.

**Solution:**
- Enable Money home **Send** and open a **Send funds to** transfer sheet.
- **Perps account** starts a `perpsDeposit` confirmation with `payWithOption=money_account` (money account locked as funding source).
- Destination Perps account selection continues on the confirmation screen (from the base branch) via `txParams.from`.
- Show **Insufficient funds** while typing when the amount exceeds the withdrawable Money account balance (before quote debounce).

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1825

## **Manual testing steps**

1. Enable `confirmations_pay_extended.enableMoneyAccountTransactions.perpsDeposit` and ensure the wallet has a funded Money account and Perps eligibility.
2. Open the extension and go to **Money** home.
3. Tap **Send** and confirm the **Send funds to** sheet opens.
4. Tap **Perps account** and confirm the **Send to Perps** confirmation opens with the Money account as the funding source.
5. Use the Perps destination picker to select a different account and confirm the **To** row updates.
6. Enter an amount greater than the available Money account balance and confirm **Insufficient funds** appears and confirm stays disabled.
7. Enter a valid amount and complete the deposit.

## **Screenshots/Recordings**
https://github.com/user-attachments/assets/62c1b2fc-c37c-4424-b1a5-a144dd5953fc

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real money and Perps transfer entry points and confirmation-time balance validation, though flows remain gated by Perps eligibility and money-account transaction feature flags.
> 
> **Overview**
> Enables **Money home Send** to open a **Send funds to** sheet (aligned with mobile) instead of jumping straight into a between-accounts withdrawal. **Perps account** starts a money-funded `perpsDeposit` confirmation with `payWithOption=money_account`; **Another account** still triggers the existing withdrawal flow. External address and bank rows are shown as coming soon/disabled.
> 
> Confirmation amount UX is updated so **insufficient funds** can appear while the user types: pending fiat alerts (`usePendingAmountAlerts`) are merged ahead of debounced quote alerts, money-account flows can validate balance without a selected pay token, and `CustomAmountInfo` loads amount state before applying pending-amount blocking. **PerpsAccountPickerRow** reads transaction metadata via `useTransactionMetadataRequestOptional` instead of confirm context.
> 
> New copy in `en` / `en_GB` and tests cover the hook, sheet, home Send behavior, and alert wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 292739f8245b717b135b91e8424b9a317a1b9b9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->