### PR TITLE
test: mitigate bug effect on the test side which navigates to Home instead of Send

### DIFF
--- a/test/e2e/tests/send/send-edit.spec.ts
+++ b/test/e2e/tests/send/send-edit.spec.ts
@@ -70,6 +70,9 @@ describe('Send - Edit Transaction', function () {
 
         await transactionConfirmation.checkGasFeeFiat('$0.07');
 
+        // Adding unrelated check for stability, to prevent issue where clicking Back navigates to Homepage instead of Sendpage(#CONF-1865)
+        await transactionConfirmation.checkSecurityProviderBannerAlertIsNotPresent();
+
         await transactionConfirmation.clickBackButton();
 
         await sendPage.editAmountByKeys([driver.Key.BACK_SPACE, '2', '.', '2']);
@@ -133,6 +136,9 @@ describe('Send - Edit Transaction', function () {
         await transactionConfirmation.checkSendAmount('1 ETH');
 
         await transactionConfirmation.checkGasFeeFiat('$0.75');
+
+        // Adding unrelated check for stability, to prevent issue where clicking Back navigates to Homepage instead of Sendpage(#CONF-1865)
+        await transactionConfirmation.checkSecurityProviderBannerAlertIsNotPresent();
 
         await transactionConfirmation.clickBackButton();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The flakiness seems to be in the app side. We click on the back button, and instead of landing into the previous send page, we land into the Home page (you can see the screenshot of the failure):



```
await transactionConfirmation.checkSendAmount('1 ETH');
await transactionConfirmation.checkGasFeeFiat('$0.07');
await transactionConfirmation.clickBackButton();
await sendPage.editAmountByKeys([driver.Key.BACK_SPACE, '2', '.', '2']);
await sendPage.pressContinueButton();
 ```

<img width="1366" height="682" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/9649d591-2ab2-4f3a-abb8-2abd02bd7b22" />

 

It seems the issue happens when we click the back button while ‘something’ is still in progress with the transaction, We can add a mitigation the test side (adding extra checks to ensure the transaction page is fully loaded) but this needs to be fixed on the wallet side eventually.



Bug: https://consensyssoftware.atlassian.net/browse/CONF-1865?xpis=eyJicmlkZ2UiOiJzbWFydExpbmtzIiwiaWQiOiIxNzg4MjQ5NjUxMDkwIiwic291cmNlIjoiamlyYS1KU1cifQ%3D%3D




## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization in E2E specs; no production wallet or navigation logic changes.
> 
> **Overview**
> Reduces flaky **Send – Edit Transaction** E2E failures linked to **CONF-1865**, where tapping **Back** on the confirm screen sometimes lands on **Home** instead of the send form.
> 
> In both the legacy-gas and EIP-1559 variants of `send-edit.spec.ts`, the flow now calls `checkSecurityProviderBannerAlertIsNotPresent()` immediately after the gas-fee assertions and **before** `clickBackButton()`. That helper waits for the security-provider banner to be absent (with a minimum guard delay), acting as an extra “page settled” gate so Back is not clicked while confirmation UI work is still in flight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69117d1d40b9bba16be09cdb3181c43db9c62b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->