### PR TITLE
fix(swaps): align asset picker network badge with send flow

### DIFF
--- a/ui/pages/bridge/asset-picker/__snapshots__/asset.test.tsx.snap
+++ b/ui/pages/bridge/asset-picker/__snapshots__/asset.test.tsx.snap
@@ -28,8 +28,8 @@ exports[`BridgeAsset should render ERC20 asset 1`] = `
       style="bottom: 0px; right: 0px;"
     >
       <div
-        class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-lg h-[34px] w-[34px] border-background-default border"
-        style="width: 20px; height: 20px; border-width: 2px; border-radius: 4px;"
+        class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative h-[34px] w-[34px] border-background-default border rounded-md"
+        style="width: 15px; height: 15px; border-width: 1px;"
       >
         <img
           alt="Ethereum"
@@ -123,8 +123,8 @@ exports[`BridgeAsset should render asset with accountType 1`] = `
       style="bottom: 0px; right: 0px;"
     >
       <div
-        class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-lg h-[34px] w-[34px] border-background-default border"
-        style="width: 20px; height: 20px; border-width: 2px; border-radius: 4px;"
+        class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative h-[34px] w-[34px] border-background-default border rounded-md"
+        style="width: 15px; height: 15px; border-width: 1px;"
       >
         <img
           alt="Bitcoin"
@@ -227,8 +227,8 @@ exports[`BridgeAsset should render asset with balance 1`] = `
       style="bottom: 0px; right: 0px;"
     >
       <div
-        class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-lg h-[34px] w-[34px] border-background-default border"
-        style="width: 20px; height: 20px; border-width: 2px; border-radius: 4px;"
+        class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative h-[34px] w-[34px] border-background-default border rounded-md"
+        style="width: 15px; height: 15px; border-width: 1px;"
       >
         <img
           alt="Ethereum"
@@ -330,8 +330,8 @@ exports[`BridgeAsset should render native asset 1`] = `
       style="bottom: 0px; right: 0px;"
     >
       <div
-        class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-lg h-[34px] w-[34px] border-background-default border"
-        style="width: 20px; height: 20px; border-width: 2px; border-radius: 4px;"
+        class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative h-[34px] w-[34px] border-background-default border rounded-md"
+        style="width: 15px; height: 15px; border-width: 1px;"
       >
         <img
           alt="Ethereum"

--- a/ui/pages/bridge/asset-picker/asset.tsx
+++ b/ui/pages/bridge/asset-picker/asset.tsx
@@ -105,7 +105,8 @@ export const BridgeAsset = React.forwardRef(
                   formatChainIdToCaip(asset.chainId)
                 ]
               }
-              style={{ width: 20, height: 20, borderWidth: 2, borderRadius: 4 }}
+              className="rounded-md"
+              style={{ width: 15, height: 15, borderWidth: 1 }}
               hasBorder
             />
           }


### PR DESCRIPTION
## **Description**

The Swaps asset picker network badge rendered larger and with a heavier border than the equivalent badge in the Send flow. This change aligns the badge's dimensions, corner radius, and border weight with the Send flow for consistent asset-picker visuals.

## **Changelog**

CHANGELOG entry: Fixed inconsistent network badge sizing and borders in the Swaps asset picker

## **Related issues**

Fixes: [SWAPS-4991](https://consensyssoftware.atlassian.net/browse/SWAPS-4991)

## **Manual testing steps**

1. Open the MetaMask extension and navigate to the Swaps flow.
2. Open the asset picker for a source or destination asset.
3. Verify the network badge is 15px, has a 1px border, and uses rounded corners.
4. Open the Send flow and compare the network badge styling.

## **Screenshots/Recordings**

### **Before**

The badge appeared more square and had a heavier border than the Send flow.

### **After**

Manually verified by the requester. No recording is attached.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[SWAPS-4991]: https://consensyssoftware.atlassian.net/browse/SWAPS-4991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic styling and snapshot updates only; no logic, data, or security impact.
> 
> **Overview**
> Updates the **network badge** on bridge/swaps asset picker rows so it matches the Send flow: **15×15px**, **1px** border, and **`rounded-md`** corners instead of the previous 20×20px, 2px border, and inline 4px radius.
> 
> The change is on the `AvatarNetwork` inside `BridgeAsset`’s `BadgeWrapper`; Jest snapshots for `asset.test.tsx` were refreshed to match the new markup and styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c859e1a2770831fb46590d195201524da3ca7667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->