### PR TITLE
test: flaky test `Send Tron it should be possible to send TRX`

### DIFF
--- a/test/e2e/tests/send/send-tron.spec.ts
+++ b/test/e2e/tests/send/send-tron.spec.ts
@@ -10,7 +10,7 @@ import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/
 import ActivityTab from '../../page-objects/pages/home/activity-tab';
 import { TxToastNotification } from '../../page-objects/components/tx-toast-notification';
 import {
-  mockTronApis,
+  mockTronSendApis,
   TRON_RECIPIENT_ADDRESS,
 } from '../tron/mocks/common-tron';
 
@@ -20,7 +20,7 @@ describe('Send Tron', function () {
       {
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
-        testSpecificMock: mockTronApis,
+        testSpecificMock: mockTronSendApis,
       },
       async ({ driver }: { driver: Driver }) => {
         await login(driver);
@@ -39,7 +39,6 @@ describe('Send Tron', function () {
         const sendPage = new SendPage(driver);
         await sendPage.selectToken('tron:728126428', 'TRX');
 
-        // Wait for the send page to load
         await sendPage.fillRecipient({
           recipientAddress: TRON_RECIPIENT_ADDRESS,
         });
@@ -54,7 +53,7 @@ describe('Send Tron', function () {
         const activityTab = new ActivityTab(driver);
         await activityTab.goToActivityList();
         await activityTab.checkTxAmountInActivity('-1 TRX', 1);
-        await activityTab.checkNoFailedTransactions();
+        await activityTab.checkConfirmedTxNumberDisplayedInActivity(1);
       },
     );
   });

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -22,6 +22,16 @@ export const TRX_BALANCE = 106072392; // ~106.07 TRX
 export const TRX_TO_USD_RATE = 0.29469;
 export const SUN_PER_TRX = 1_000_000;
 
+export const BROADCAST_TXID =
+  '6db783c4142b3749a4b598db4644155455c9206e2eca4b31efbd48e46773d9d5';
+
+// Hex-encoded version of TRON_ACCOUNT_ADDRESS (TJ3QZbBREK1Xybe1jf4nR9Attb8i54vGS3).
+export const TRON_ACCOUNT_ADDRESS_HEX =
+  '41588c5216750cceaad16cf5a757e3f7b32835a5e1';
+
+export const TRON_RECIPIENT_ADDRESS_HEX =
+  '41639f09ebb2021f11ab768b639859ea6f66a9ea50';
+
 const TRON_BLOCK_RESPONSE = {
   blockID: '0000000004b6f733ff89d72ddc1ce1eabd6045d84cbc4eb0a7e88d9223c12c5e',
   block_header: {
@@ -216,7 +226,7 @@ export async function mockBroadTransaction(
       statusCode: 200,
       json: {
         result: true,
-        txid: '6db783c4142b3749a4b598db4644155455c9206e2eca4b31efbd48e46773d9d5',
+        txid: BROADCAST_TXID,
       },
     }));
 }
@@ -476,7 +486,7 @@ export async function createStatefulTronAccountMock(
         statusCode: 200,
         json: {
           result: true,
-          txid: '6db783c4142b3749a4b598db4644155455c9206e2eca4b31efbd48e46773d9d5',
+          txid: BROADCAST_TXID,
         },
       };
     });
@@ -1626,6 +1636,217 @@ export async function mockAccountsApiV5WithTron(
         balances,
       },
     }));
+}
+
+/**
+ * Minimal Tron mocks for a native TRX send flow.
+ *
+ * - TRX-only account (no TRC20/TRC10 tokens)
+ * - Stateful broadcast: after the tx is broadcast, both
+ *   `gettransactioninfobyid` and the `/transactions` history endpoint
+ *   return the confirmed tx so the snap's polling loop can flip the
+ *   activity row from pending → confirmed.
+ * - TRX-only spot prices (no HTX/SEED/USDT/USDD data)
+ * - No pre-existing transaction history
+ */
+export async function mockTronSendApis(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint[]> {
+  let broadcasted = false;
+
+  // --- stateful broadcast + confirmation mocks ---
+
+  const broadcastEndpoint = await mockServer
+    .forPost(tronInfuraUrl('/wallet/broadcasttransaction'))
+    .thenCallback(() => {
+      broadcasted = true;
+      return {
+        statusCode: 200,
+        json: { result: true, txid: BROADCAST_TXID },
+      };
+    });
+
+  // The snap polls this endpoint every 3 s after broadcast (up to 5 attempts).
+  // Once it sees `id` + `blockNumber` it triggers a history sync.
+  const txInfoEndpoint = await mockServer
+    .forPost(tronInfuraUrl('/wallet/gettransactioninfobyid'))
+    .always()
+    .thenCallback(() => {
+      if (!broadcasted) {
+        return { statusCode: 200, json: {} };
+      }
+      return {
+        statusCode: 200,
+        json: {
+          id: BROADCAST_TXID,
+          blockNumber: 79099700,
+          blockTimeStamp: Date.now(),
+          receipt: { result: 'SUCCESS', net_usage: 265 },
+        },
+      };
+    });
+
+  // Native tx history: returns the confirmed send after broadcast.
+  const txHistoryEndpoint = await mockServer
+    .forGet(tronInfuraUrl(`/v1/accounts/${TRON_ACCOUNT_ADDRESS}/transactions`))
+    .always()
+    .thenCallback(() => {
+      if (!broadcasted) {
+        return {
+          statusCode: 200,
+          json: {
+            data: [],
+            success: true,
+            meta: { at: Date.now(), page_size: 0 },
+          },
+        };
+      }
+      return {
+        statusCode: 200,
+        json: {
+          data: [
+            {
+              ret: [{ contractRet: 'SUCCESS', fee: 0 }],
+              txID: BROADCAST_TXID,
+              net_usage: 265,
+              blockNumber: 79099700,
+              block_timestamp: Date.now(),
+              raw_data: {
+                contract: [
+                  {
+                    parameter: {
+                      value: {
+                        amount: 1_000_000,
+                        owner_address: TRON_ACCOUNT_ADDRESS_HEX,
+                        to_address: TRON_RECIPIENT_ADDRESS_HEX,
+                      },
+                      type_url: 'type.googleapis.com/protocol.TransferContract',
+                    },
+                    type: 'TransferContract',
+                  },
+                ],
+                ref_block_bytes: 'f733',
+                ref_block_hash: 'ff89d72ddc1ce1ea',
+                expiration: Date.now() + 60_000,
+                timestamp: Date.now(),
+              },
+              internal_transactions: [],
+            },
+          ],
+          success: true,
+          meta: { at: Date.now(), page_size: 1 },
+        },
+      };
+    });
+
+  // TRC20 history: always empty (native TRX send, not a token transfer)
+  const trc20HistoryEndpoint = await mockServer
+    .forGet(
+      tronInfuraUrl(`/v1/accounts/${TRON_ACCOUNT_ADDRESS}/transactions/trc20`),
+    )
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        data: [],
+        success: true,
+        meta: { at: Date.now(), page_size: 0 },
+      },
+    }));
+
+  // --- TRX-only account (no TRC20/TRC10 balances) ---
+
+  const accountEndpoint = await mockServer
+    .forGet(
+      new RegExp(
+        `^${TRON_INFURA_BASE_URL}/v1/accounts/${TRON_ACCOUNT_ADDRESS}($|\\?)`,
+        'u',
+      ),
+    )
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        data: [
+          {
+            address: TRON_ACCOUNT_ADDRESS_HEX,
+            balance: TRX_BALANCE,
+            owner_permission: {
+              keys: [{ address: TRON_ACCOUNT_ADDRESS, weight: 1 }],
+              threshold: 1,
+              permission_name: 'owner',
+            },
+            active_permission: [
+              {
+                operations:
+                  '7fff1fc0033ec30f000000000000000000000000000000000000000000000000',
+                keys: [{ address: TRON_ACCOUNT_ADDRESS, weight: 1 }],
+                threshold: 1,
+                id: 2,
+                type: 'Active',
+                permission_name: 'active',
+              },
+            ],
+            account_resource: { energy_window_optimized: true },
+            frozenV2: [
+              {},
+              { amount: 20000000, type: 'ENERGY' },
+              { type: 'TRON_POWER' },
+            ],
+            trc20: [],
+            assetV2: [],
+          },
+        ],
+        success: true,
+        meta: { at: Date.now(), page_size: 1 },
+      },
+    }));
+
+  // --- TRX-only spot prices ---
+
+  const spotPricesEndpoint = await mockServer
+    .forGet('https://price.api.cx.metamask.io/v3/spot-prices')
+    .always()
+    .thenCallback((request) => {
+      const url = new URL(request.url);
+      const ids = url.searchParams.get('assetIds')?.split(',') ?? [];
+      const withMarket = url.searchParams.get('includeMarketData') === 'true';
+      const vs = url.searchParams.get('vsCurrency') ?? 'usd';
+
+      const trxMarketData = { id: 'tron', price: TRX_TO_USD_RATE };
+      const json = Object.fromEntries(
+        ids.map((id) => [
+          id,
+          id.includes('slip44:195')
+            ? withMarket
+              ? trxMarketData
+              : { [vs]: TRX_TO_USD_RATE }
+            : null,
+        ]),
+      );
+      return { statusCode: 200, json };
+    });
+
+  return [
+    await mockTokensV2SupportedNetworks(mockServer),
+    await mockTokensV3Assets(mockServer),
+    await mockAccountsApiV2WithTron(mockServer),
+    await mockAccountsApiV5WithTron(mockServer),
+    await mockTronFeatureFlags(mockServer),
+    await mockTronGetReward(mockServer),
+    await mockTronGetBlock(mockServer),
+    await mockTronGetNowBlock(mockServer),
+    await mockTronGetBlockByNum(mockServer),
+    await mockTronGetAccountResource(mockServer),
+    await mockExchangeRates(mockServer),
+    await mockFiatExchangeRates(mockServer),
+    broadcastEndpoint,
+    txInfoEndpoint,
+    txHistoryEndpoint,
+    trc20HistoryEndpoint,
+    accountEndpoint,
+    spotPricesEndpoint,
+  ];
 }
 
 export async function mockTronApis(

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -1641,13 +1641,11 @@ export async function mockAccountsApiV5WithTron(
 /**
  * Minimal Tron mocks for a native TRX send flow.
  *
- * - TRX-only account (no TRC20/TRC10 tokens)
- * - Stateful broadcast: after the tx is broadcast, both
- *   `gettransactioninfobyid` and the `/transactions` history endpoint
- *   return the confirmed tx so the snap's polling loop can flip the
- *   activity row from pending → confirmed.
- * - TRX-only spot prices (no HTX/SEED/USDT/USDD data)
- * - No pre-existing transaction history
+ * TRX-only account (no TRC20/TRC10 tokens), stateful broadcast that flips
+ * `gettransactioninfobyid` and `/transactions` to confirmed after broadcast,
+ * TRX-only spot prices, and no pre-existing transaction history.
+ *
+ * @param mockServer - The Mockttp server instance.
  */
 export async function mockTronSendApis(
   mockServer: Mockttp,
@@ -1815,14 +1813,13 @@ export async function mockTronSendApis(
 
       const trxMarketData = { id: 'tron', price: TRX_TO_USD_RATE };
       const json = Object.fromEntries(
-        ids.map((id) => [
-          id,
-          id.includes('slip44:195')
-            ? withMarket
-              ? trxMarketData
-              : { [vs]: TRX_TO_USD_RATE }
-            : null,
-        ]),
+        ids.map((id) => {
+          if (!id.includes('slip44:195')) {
+            return [id, null];
+          }
+          const price = withMarket ? trxMarketData : { [vs]: TRX_TO_USD_RATE };
+          return [id, price];
+        }),
       );
       return { statusCode: 200, json };
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The test is flaky as sometimes we find another transaction in the activity list instead of the Send Tron 1TRX.
There are 2 problems, both related with the mocks:
- We were utilizing a long list of generic mocks for Tron, which populate the activity list with several unrelated transactions, as well as add multiple unrelated TRC20 tokens etc. This causes thatWhen the history loaded first, the HTX transfer landed at position 1 and checkTxAmountInActivity('-1 TRX', 1) saw -50,000 HTX instead.
- We were using a wrong hex address in the confirmed transaction mock, so the snap classified it as unknown, which the UI maps to "Contract Interaction".

A problem with the final assertion:
- We were not checking for the actual confirmed transaction state, which allowrf all these convoluted situation to pass the test sometimes (as we checked for no failed transactions, and the test could pass while the send TRX appear the first in the list, while in Pending state)


This has now been fixed:
- We are using a simplified version of the mocks (without unrelated activity, or tokens etc)
- The fix was using the correct hex (41588c5216750cceaad16cf5a757e3f7b32835a5e1) that actually decodes to TJ3QZbBREK1Xybe1jf4nR9Attb8i54vGS3. Now the snap sees from === account and classifies it as type: "send" → the activity row shows "Send".
- We look for the confirmed transaction

<img width="845" height="212" alt="image" src="https://github.com/user-attachments/assets/6a23ec4b-a268-4e01-a23b-bf1f410a796e" />

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See how an unrelated tx appears on top causing the test to fail as it doesnt find the Send TRX

<img width="1366" height="682" alt="image" src="https://github.com/user-attachments/assets/0d3c744c-d001-4210-8ee6-5d3a7c640b41" />



### **After**

<img width="1262" height="859" alt="image" src="https://github.com/user-attachments/assets/a20c8854-e155-45a1-ab9f-84a9e509518b" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and mock-only changes; no production wallet or snap behavior modified.
> 
> **Overview**
> Addresses flakiness in the **Send Tron** e2e by replacing the broad `mockTronApis` fixture with a new **`mockTronSendApis`** tailored to native TRX sends.
> 
> The new mock set uses a **TRX-only account** (no TRC20/TRC10), **empty history until broadcast**, then flips **`gettransactioninfobyid`** and **`/transactions`** to return a confirmed 1 TRX transfer after `broadcasttransaction`—matching snap polling and history sync. Shared **`BROADCAST_TXID`** and hex address constants dedupe broadcast responses.
> 
> The spec assertion moves from **`checkNoFailedTransactions`** to **`checkConfirmedTxNumberDisplayedInActivity(1)`** so activity reflects the mocked confirmed send.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd875a9677988211705d2169ad6ba3da719600f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->