### PR TITLE
feat: enable deposits to money account

### DIFF
--- a/ui/components/app/money/money-account-balance/money-account-balance.test.tsx
+++ b/ui/components/app/money/money-account-balance/money-account-balance.test.tsx
@@ -228,7 +228,9 @@ describe('MoneyAccountBalance', () => {
 
     const { getByTestId } = render();
 
-    expect(getByTestId(MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID)).toBeDisabled();
+    expect(
+      getByTestId(MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID),
+    ).toBeDisabled();
   });
 
   it('prefers the last-known balance over the skeleton while loading', () => {

--- a/ui/components/app/money/money-account-balance/money-account-balance.test.tsx
+++ b/ui/components/app/money/money-account-balance/money-account-balance.test.tsx
@@ -210,7 +210,9 @@ describe('MoneyAccountBalance', () => {
     expect(getByText(tEn('moneyBalanceInfoWithdrawals'))).toBeInTheDocument();
   });
 
-  it('initiates a deposit with the addMusd intent when Add is clicked', () => {
+  it('initiates a generic deposit when Add is clicked', () => {
+    // No intent: consumers derive it from the transaction's actual payment
+    // method, exactly as mobile's MoneyBalanceCard does.
     arrange({ totalFiatFormatted: '$2,384.34' });
 
     const { getByTestId } = render();
@@ -218,7 +220,7 @@ describe('MoneyAccountBalance', () => {
     fireEvent.click(getByTestId(MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID));
 
     expect(mockInitiateDeposit).toHaveBeenCalledTimes(1);
-    expect(mockInitiateDeposit).toHaveBeenCalledWith({ intent: 'addMusd' });
+    expect(mockInitiateDeposit).toHaveBeenCalledWith();
   });
 
   it('disables the Add button while a deposit is being initiated', () => {

--- a/ui/components/app/money/money-account-balance/money-account-balance.test.tsx
+++ b/ui/components/app/money/money-account-balance/money-account-balance.test.tsx
@@ -6,10 +6,12 @@ import { tEn } from '../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import { useMoneyAccountBalance } from '../../../../hooks/money/useMoneyAccountBalance';
 import type { UseMoneyAccountBalanceResult } from '../../../../hooks/money/useMoneyAccountBalance';
+import { useMoneyAccountDeposit } from '../../../../hooks/money/useMoneyAccountDeposit';
 import { useMoneyAccountInfo } from '../../../../hooks/money/useMoneyAccountInfo';
 import type { UseMoneyAccountInfoResult } from '../../../../hooks/money/useMoneyAccountInfo';
 import {
   MoneyAccountBalance,
+  MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID,
   MONEY_ACCOUNT_BALANCE_INFO_TEST_ID,
   MONEY_ACCOUNT_BALANCE_LAST_KNOWN_TEST_ID,
   MONEY_ACCOUNT_BALANCE_SKELETON_TEST_ID,
@@ -25,8 +27,14 @@ jest.mock('../../../../hooks/money/useMoneyAccountInfo', () => ({
   useMoneyAccountInfo: jest.fn(),
 }));
 
+jest.mock('../../../../hooks/money/useMoneyAccountDeposit', () => ({
+  useMoneyAccountDeposit: jest.fn(),
+}));
+
 const mockUseMoneyAccountBalance = jest.mocked(useMoneyAccountBalance);
 const mockUseMoneyAccountInfo = jest.mocked(useMoneyAccountInfo);
+const mockUseMoneyAccountDeposit = jest.mocked(useMoneyAccountDeposit);
+const mockInitiateDeposit = jest.fn();
 
 const MONEY_ADDRESS = '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B' as const;
 
@@ -35,10 +43,11 @@ type ArrangeOptions = {
   totalFiatFormatted?: string;
   lastKnownTotalFiatFormatted?: string;
   isBalanceLoading?: boolean;
+  isDepositLoading?: boolean;
 };
 
 /**
- * Stubs the two hooks the component reads.
+ * Stubs the three hooks the component reads.
  *
  * Only the fields the component consumes are stated; the rest of the
  * 19-field balance result is irrelevant here and a partial cast keeps the test
@@ -49,13 +58,21 @@ type ArrangeOptions = {
  * @param options.totalFiatFormatted - The live formatted balance, if any.
  * @param options.lastKnownTotalFiatFormatted - The last-known balance, if any.
  * @param options.isBalanceLoading - Whether the balance fetch is in flight.
+ * @param options.isDepositLoading - Whether a deposit initiation is in flight.
  */
 const arrange = ({
   hasMoneyAccount = true,
   totalFiatFormatted,
   lastKnownTotalFiatFormatted,
   isBalanceLoading = false,
+  isDepositLoading = false,
 }: ArrangeOptions = {}) => {
+  mockInitiateDeposit.mockResolvedValue(undefined);
+  mockUseMoneyAccountDeposit.mockReturnValue({
+    initiateDeposit: mockInitiateDeposit,
+    isLoading: isDepositLoading,
+  });
+
   mockUseMoneyAccountInfo.mockReturnValue({
     isMoneyAccountFeatureEnabled: hasMoneyAccount,
     hasMoneyAccount,
@@ -191,6 +208,25 @@ describe('MoneyAccountBalance', () => {
 
     expect(getByText(tEn('moneyBalanceInfoBody'))).toBeInTheDocument();
     expect(getByText(tEn('moneyBalanceInfoWithdrawals'))).toBeInTheDocument();
+  });
+
+  it('initiates a deposit with the addMusd intent when Add is clicked', () => {
+    arrange({ totalFiatFormatted: '$2,384.34' });
+
+    const { getByTestId } = render();
+
+    fireEvent.click(getByTestId(MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID));
+
+    expect(mockInitiateDeposit).toHaveBeenCalledTimes(1);
+    expect(mockInitiateDeposit).toHaveBeenCalledWith({ intent: 'addMusd' });
+  });
+
+  it('disables the Add button while a deposit is being initiated', () => {
+    arrange({ totalFiatFormatted: '$2,384.34', isDepositLoading: true });
+
+    const { getByTestId } = render();
+
+    expect(getByTestId(MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID)).toBeDisabled();
   });
 
   it('prefers the last-known balance over the skeleton while loading', () => {

--- a/ui/components/app/money/money-account-balance/money-account-balance.tsx
+++ b/ui/components/app/money/money-account-balance/money-account-balance.tsx
@@ -22,6 +22,7 @@ import { InfoPopover } from '../../musd/info-popover';
 import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useMoneyAccountBalance } from '../../../../hooks/money/useMoneyAccountBalance';
+import { useMoneyAccountDeposit } from '../../../../hooks/money/useMoneyAccountDeposit';
 import { useMoneyAccountInfo } from '../../../../hooks/money/useMoneyAccountInfo';
 
 export const MONEY_ACCOUNT_BALANCE_TEST_ID = 'money-account-balance';
@@ -33,6 +34,8 @@ export const MONEY_ACCOUNT_BALANCE_APY_TEST_ID = 'money-account-balance-apy';
 export const MONEY_ACCOUNT_BALANCE_SKELETON_TEST_ID =
   'money-account-balance-skeleton';
 export const MONEY_ACCOUNT_BALANCE_INFO_TEST_ID = 'money-account-balance-info';
+export const MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID =
+  'money-account-balance-add-button';
 
 // The vault APY isn't wired up to a data source yet, so this is shown as a
 // fixed placeholder until a hook for it exists.
@@ -83,6 +86,8 @@ export const MoneyAccountBalance = () => {
   const { hasMoneyAccount } = useMoneyAccountInfo();
   const { totalFiatFormatted, lastKnownTotalFiatFormatted, isBalanceLoading } =
     useMoneyAccountBalance();
+  const { initiateDeposit, isLoading: isDepositLoading } =
+    useMoneyAccountDeposit();
 
   const balance = totalFiatFormatted ?? lastKnownTotalFiatFormatted;
   const isLoading = isBalanceLoading && balance === undefined;
@@ -195,6 +200,13 @@ export const MoneyAccountBalance = () => {
         size={ButtonSize.Md}
         variant={ButtonVariant.Primary}
         className="shrink-0 "
+        isLoading={isDepositLoading}
+        data-testid={MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID}
+        onClick={() =>
+          initiateDeposit({ intent: 'addMusd' }).catch((error) =>
+            console.error('Failed to initiate money account deposit', error),
+          )
+        }
       >
         {t('moneyAdd')}
       </Button>

--- a/ui/components/app/money/money-account-balance/money-account-balance.tsx
+++ b/ui/components/app/money/money-account-balance/money-account-balance.tsx
@@ -203,7 +203,7 @@ export const MoneyAccountBalance = () => {
         isLoading={isDepositLoading}
         data-testid={MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID}
         onClick={() =>
-          initiateDeposit({ intent: 'addMusd' }).catch((error) =>
+          initiateDeposit().catch((error) =>
             console.error('Failed to initiate money account deposit', error),
           )
         }

--- a/ui/components/app/toast-listener/transaction-event-toast-listener.tsx
+++ b/ui/components/app/toast-listener/transaction-event-toast-listener.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { RouteMessengerProvider } from '../../../contexts/route-messenger';
 import { useActivityCacheInvalidation } from '../../../hooks/activity/useActivityCacheInvalidation';
+import { useRefreshMoneyBalanceOnTxConfirm } from '../../../hooks/money/useRefreshMoneyBalanceOnTxConfirm';
 import {
   toastListenerCapabilities,
   useTransactionEventToasts,
@@ -9,6 +10,7 @@ import {
 const TransactionEventToastListenerInner = () => {
   useTransactionEventToasts();
   useActivityCacheInvalidation();
+  useRefreshMoneyBalanceOnTxConfirm();
   return null;
 };
 

--- a/ui/helpers/money/invalidate-balance-caches.test.ts
+++ b/ui/helpers/money/invalidate-balance-caches.test.ts
@@ -4,22 +4,36 @@ import { invalidateMoneyAccountBalanceCaches } from './invalidate-balance-caches
 
 jest.mock('../../store/background-connection', () => ({
   submitRequestToBackground: jest.fn(),
-}));
-
-jest.mock('../../contexts/query-client', () => ({
-  queryClient: { invalidateQueries: jest.fn() },
+  subscribeToMessengerEvent: jest.fn(),
 }));
 
 const submitRequestToBackgroundMock = jest.mocked(submitRequestToBackground);
-const invalidateQueriesMock = jest.mocked(queryClient.invalidateQueries);
 
 const ADDRESS = '0xAbC0000000000000000000000000000000000001';
 
+const FACADE_QUERY_KEY = [
+  'MoneyAccountBalanceService:fetchBalanceWithFallback',
+  ADDRESS,
+];
+
+const STALE_BALANCE = { totalBalance: '1000000' };
+const FRESH_BALANCE = { totalBalance: '2000000' };
+
+const messengerCalls = () =>
+  submitRequestToBackgroundMock.mock.calls
+    .filter(([method]) => method === 'messengerCall')
+    .map(([, args]) => args as [string, unknown[]]);
+
 describe('invalidateMoneyAccountBalanceCaches', () => {
   beforeEach(() => {
-    jest.resetAllMocks();
-    submitRequestToBackgroundMock.mockResolvedValue(undefined);
-    invalidateQueriesMock.mockResolvedValue(undefined);
+    jest.clearAllMocks();
+    queryClient.clear();
+    submitRequestToBackgroundMock.mockImplementation(async (_method, args) => {
+      const [action] = args as [string, unknown[]];
+      return action === 'MoneyAccountBalanceService:fetchBalanceWithFallback'
+        ? (FRESH_BALANCE as never)
+        : (undefined as never);
+    });
   });
 
   it('busts the RPC source cache in the balance service', async () => {
@@ -60,42 +74,57 @@ describe('invalidateMoneyAccountBalanceCaches', () => {
     );
   });
 
-  it('invalidates the UI facade query so mounted observers refetch', async () => {
-    await invalidateMoneyAccountBalanceCaches(ADDRESS);
-
-    expect(invalidateQueriesMock).toHaveBeenCalledWith({
-      queryKey: [
-        'MoneyAccountBalanceService:fetchBalanceWithFallback',
-        ADDRESS,
-      ],
-      refetchType: 'all',
-    });
-  });
-
-  it('busts both source caches before invalidating the facade', async () => {
-    const order: string[] = [];
-    submitRequestToBackgroundMock.mockImplementation(async (_method, args) => {
-      order.push(`source:${(args as [string, unknown[]])[0]}`);
-    });
-    invalidateQueriesMock.mockImplementation(async () => {
-      order.push('facade');
-    });
+  it('busts both source caches, then invalidates the cached facade query and refetches it through the background', async () => {
+    queryClient.setQueryData(FACADE_QUERY_KEY, STALE_BALANCE);
 
     await invalidateMoneyAccountBalanceCaches(ADDRESS);
 
-    expect(order).toStrictEqual([
-      'source:MoneyAccountBalanceService:invalidateQueries',
-      'source:MoneyAccountApiDataService:invalidateQueries',
-      'facade',
+    expect(messengerCalls().map(([action]) => action)).toStrictEqual([
+      'MoneyAccountBalanceService:invalidateQueries',
+      'MoneyAccountApiDataService:invalidateQueries',
+      'MoneyAccountBalanceService:invalidateQueries',
+      'MoneyAccountBalanceService:fetchBalanceWithFallback',
     ]);
+    expect(queryClient.getQueryData(FACADE_QUERY_KEY)).toStrictEqual(
+      FRESH_BALANCE,
+    );
   });
 
-  it('rejects when a source cache cannot be busted', async () => {
+  it('forwards the facade invalidation with arguments that survive JSON-RPC serialization', async () => {
+    queryClient.setQueryData(FACADE_QUERY_KEY, STALE_BALANCE);
+
+    await invalidateMoneyAccountBalanceCaches(ADDRESS);
+
+    const forwardedParams = messengerCalls().find(
+      ([action, params]) =>
+        action === 'MoneyAccountBalanceService:invalidateQueries' &&
+        params.length === 2,
+    )?.[1];
+
+    expect(forwardedParams).toStrictEqual([
+      { queryKey: FACADE_QUERY_KEY, refetchType: 'all' },
+      {},
+    ]);
+    // An `undefined` options argument would cross the UI→background boundary
+    // as `null` and crash the background's `options.cancelRefetch` read.
+    expect(JSON.parse(JSON.stringify(forwardedParams))).toStrictEqual(
+      forwardedParams,
+    );
+  });
+
+  it('rejects and leaves the facade query untouched when a source cache cannot be busted', async () => {
+    queryClient.setQueryData(FACADE_QUERY_KEY, STALE_BALANCE);
     submitRequestToBackgroundMock.mockRejectedValue(new Error('disconnected'));
 
     await expect(invalidateMoneyAccountBalanceCaches(ADDRESS)).rejects.toThrow(
       'disconnected',
     );
-    expect(invalidateQueriesMock).not.toHaveBeenCalled();
+    expect(
+      queryClient.getQueryCache().find({ queryKey: FACADE_QUERY_KEY })?.state
+        .isInvalidated,
+    ).toBe(false);
+    expect(queryClient.getQueryData(FACADE_QUERY_KEY)).toStrictEqual(
+      STALE_BALANCE,
+    );
   });
 });

--- a/ui/helpers/money/invalidate-balance-caches.ts
+++ b/ui/helpers/money/invalidate-balance-caches.ts
@@ -24,6 +24,31 @@ import { submitRequestToBackground } from '../../store/background-connection';
 export async function invalidateMoneyAccountBalanceCaches(
   address: string,
 ): Promise<void> {
+  await invalidateMoneyAccountBalanceSourceCaches(address);
+
+  await queryClient.invalidateQueries({
+    queryKey: [
+      MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+      address,
+    ],
+    refetchType: 'all',
+  });
+}
+
+/**
+ * Bust only the background source caches, without triggering a UI refetch.
+ *
+ * Every fetch through the facade re-caches whatever the sources return with a
+ * fresh `staleTime` — including a stale post-transaction read. Busting the
+ * source caches after such a read means the next poll fetches the sources
+ * anew instead of being served that re-cached stale value for another
+ * `staleTime` window.
+ *
+ * @param address - Money account address (same casing as used by the UI query).
+ */
+export async function invalidateMoneyAccountBalanceSourceCaches(
+  address: string,
+): Promise<void> {
   await Promise.all([
     submitRequestToBackground<void>('messengerCall', [
       'MoneyAccountBalanceService:invalidateQueries',
@@ -49,12 +74,4 @@ export async function invalidateMoneyAccountBalanceCaches(
       ],
     ]),
   ]);
-
-  await queryClient.invalidateQueries({
-    queryKey: [
-      MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
-      address,
-    ],
-    refetchType: 'all',
-  });
 }

--- a/ui/helpers/money/invalidate-balance-caches.ts
+++ b/ui/helpers/money/invalidate-balance-caches.ts
@@ -26,13 +26,20 @@ export async function invalidateMoneyAccountBalanceCaches(
 ): Promise<void> {
   await invalidateMoneyAccountBalanceSourceCaches(address);
 
-  await queryClient.invalidateQueries({
-    queryKey: [
-      MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
-      address,
-    ],
-    refetchType: 'all',
-  });
+  await queryClient.invalidateQueries(
+    {
+      queryKey: [
+        MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+        address,
+      ],
+      refetchType: 'all',
+    },
+    // The UI client forwards this argument to the background service over
+    // JSON-RPC, where an omitted argument arrives as `null` — bypassing
+    // tanstack's `options = {}` default and crashing its
+    // `options.cancelRefetch` read. Must stay an explicit object.
+    {},
+  );
 }
 
 /**

--- a/ui/helpers/money/money-transaction-guards.test.ts
+++ b/ui/helpers/money/money-transaction-guards.test.ts
@@ -14,9 +14,7 @@ import {
   nestedTxWithType,
 } from './money-transaction-guards';
 
-const makeTx = (
-  overrides: Partial<TransactionMeta> = {},
-): TransactionMeta =>
+const makeTx = (overrides: Partial<TransactionMeta> = {}): TransactionMeta =>
   ({
     id: 'tx-1',
     time: 0,

--- a/ui/helpers/money/money-transaction-guards.test.ts
+++ b/ui/helpers/money/money-transaction-guards.test.ts
@@ -1,0 +1,119 @@
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { MUSD_TOKEN_ADDRESS } from '@metamask/money-account-utils';
+import { CHAIN_IDS } from '../../../shared/constants/network';
+import {
+  isMoneyAccountTx,
+  isMoneyDepositTx,
+  isMoneyWithdrawTx,
+  isPerpsPredictMoneyActivity,
+  isPerpsPredictMoneyDeposit,
+  isPerpsPredictMoneyWithdraw,
+  nestedTxWithType,
+} from './money-transaction-guards';
+
+const makeTx = (
+  overrides: Partial<TransactionMeta> = {},
+): TransactionMeta =>
+  ({
+    id: 'tx-1',
+    time: 0,
+    txParams: {},
+    ...overrides,
+  }) as unknown as TransactionMeta;
+
+const MUSD_ON_MONAD = {
+  tokenAddress: MUSD_TOKEN_ADDRESS,
+  chainId: CHAIN_IDS.MONAD,
+};
+
+describe('nestedTxWithType', () => {
+  it('finds the first nested transaction of the given type', () => {
+    const nested = { type: TransactionType.moneyAccountDeposit };
+    const tx = makeTx({
+      nestedTransactions: [
+        { type: TransactionType.tokenMethodApprove },
+        nested,
+      ] as TransactionMeta['nestedTransactions'],
+    });
+
+    expect(nestedTxWithType(tx, TransactionType.moneyAccountDeposit)).toBe(
+      nested,
+    );
+  });
+
+  it('returns undefined when no nested transactions exist', () => {
+    expect(
+      nestedTxWithType(makeTx(), TransactionType.moneyAccountDeposit),
+    ).toBeUndefined();
+  });
+});
+
+describe('isMoneyDepositTx / isMoneyWithdrawTx / isMoneyAccountTx', () => {
+  it('matches a top-level deposit', () => {
+    const tx = makeTx({ type: TransactionType.moneyAccountDeposit });
+    expect(isMoneyDepositTx(tx)).toBe(true);
+    expect(isMoneyWithdrawTx(tx)).toBe(false);
+    expect(isMoneyAccountTx(tx)).toBe(true);
+  });
+
+  it('matches a nested withdraw inside a batch', () => {
+    const tx = makeTx({
+      type: TransactionType.batch,
+      nestedTransactions: [
+        { type: TransactionType.moneyAccountWithdraw },
+      ] as TransactionMeta['nestedTransactions'],
+    });
+    expect(isMoneyWithdrawTx(tx)).toBe(true);
+    expect(isMoneyDepositTx(tx)).toBe(false);
+    expect(isMoneyAccountTx(tx)).toBe(true);
+  });
+
+  it('rejects unrelated transactions', () => {
+    const tx = makeTx({ type: TransactionType.contractInteraction });
+    expect(isMoneyAccountTx(tx)).toBe(false);
+  });
+});
+
+describe('Perps/Predict money activity guards', () => {
+  it('matches a Perps deposit paid with mUSD on the money chain', () => {
+    const tx = makeTx({
+      type: TransactionType.perpsDeposit,
+      metamaskPay: MUSD_ON_MONAD,
+    });
+    expect(isPerpsPredictMoneyDeposit(tx)).toBe(true);
+    expect(isPerpsPredictMoneyWithdraw(tx)).toBe(false);
+    expect(isPerpsPredictMoneyActivity(tx)).toBe(true);
+  });
+
+  it('matches a nested Predict withdraw landing as mUSD on the money chain', () => {
+    const tx = makeTx({
+      type: TransactionType.batch,
+      nestedTransactions: [
+        { type: TransactionType.predictWithdraw },
+      ] as TransactionMeta['nestedTransactions'],
+      metamaskPay: MUSD_ON_MONAD,
+    });
+    expect(isPerpsPredictMoneyWithdraw(tx)).toBe(true);
+    expect(isPerpsPredictMoneyDeposit(tx)).toBe(false);
+    expect(isPerpsPredictMoneyActivity(tx)).toBe(true);
+  });
+
+  it('rejects a Perps deposit paid with a non-mUSD token', () => {
+    const tx = makeTx({
+      type: TransactionType.perpsDeposit,
+      metamaskPay: {
+        tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+        chainId: CHAIN_IDS.ARBITRUM,
+      },
+    });
+    expect(isPerpsPredictMoneyActivity(tx)).toBe(false);
+  });
+
+  it('rejects a Perps deposit with no pay metadata', () => {
+    const tx = makeTx({ type: TransactionType.perpsDeposit });
+    expect(isPerpsPredictMoneyActivity(tx)).toBe(false);
+  });
+});

--- a/ui/helpers/money/money-transaction-guards.ts
+++ b/ui/helpers/money/money-transaction-guards.ts
@@ -1,0 +1,138 @@
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { isMusdOnMoneyAccountChain } from '@metamask/money-account-utils';
+import type { Hex } from '@metamask/utils';
+
+/**
+ * The first nested transaction matching a given TransactionType, or undefined
+ * if none exists.
+ *
+ * @param transactionMeta - Transaction metadata.
+ * @param targetType - The nested transaction type to look for.
+ */
+export const nestedTxWithType = (
+  transactionMeta: TransactionMeta,
+  targetType: TransactionType,
+) =>
+  transactionMeta.nestedTransactions?.find(
+    (nested) => nested.type === targetType,
+  );
+
+export const isMoneyDepositTx = (transactionMeta: TransactionMeta) =>
+  transactionMeta.type === TransactionType.moneyAccountDeposit ||
+  Boolean(
+    nestedTxWithType(transactionMeta, TransactionType.moneyAccountDeposit),
+  );
+
+export const isMoneyWithdrawTx = (transactionMeta: TransactionMeta) =>
+  transactionMeta.type === TransactionType.moneyAccountWithdraw ||
+  Boolean(
+    nestedTxWithType(transactionMeta, TransactionType.moneyAccountWithdraw),
+  );
+
+export const isMoneyAccountTx = (transactionMeta: TransactionMeta) =>
+  isMoneyDepositTx(transactionMeta) || isMoneyWithdrawTx(transactionMeta);
+
+/**
+ * Perps/Predict deposit parent types (money → service). When funded from the
+ * Money account these are paid with mUSD via MetaMask Pay; the on-chain deposit
+ * is signed from the user's EOA on the service chain (Arbitrum/Polygon).
+ */
+export const PERPS_PREDICT_DEPOSIT_TYPES: TransactionType[] = [
+  TransactionType.perpsDeposit,
+  TransactionType.perpsDepositAndOrder,
+  TransactionType.predictDeposit,
+  TransactionType.predictDepositAndOrder,
+];
+
+/**
+ * Perps/Predict withdraw types (service → money). When the destination is the
+ * Money account these arrive as mUSD on Monad. The withdraw is wrapped in an
+ * EIP-7702 `batch`, so the type sits in `nestedTransactions`.
+ */
+export const PERPS_PREDICT_WITHDRAW_TYPES: TransactionType[] = [
+  TransactionType.perpsWithdraw,
+  TransactionType.predictWithdraw,
+];
+
+/**
+ * The Perps/Predict deposit or withdraw type for a tx, unwrapping an EIP-7702
+ * `batch` whose money-moving call sits in `nestedTransactions`.
+ *
+ * @param transactionMeta - Transaction metadata.
+ */
+const effectiveServiceType = (
+  transactionMeta: TransactionMeta,
+): TransactionType | undefined => {
+  const serviceTypes = [
+    ...PERPS_PREDICT_DEPOSIT_TYPES,
+    ...PERPS_PREDICT_WITHDRAW_TYPES,
+  ];
+  if (
+    transactionMeta.type &&
+    serviceTypes.includes(transactionMeta.type as TransactionType)
+  ) {
+    return transactionMeta.type as TransactionType;
+  }
+  return transactionMeta.nestedTransactions?.find(
+    (nested) => nested.type && serviceTypes.includes(nested.type),
+  )?.type;
+};
+
+/**
+ * True when the `metamaskPay` token is mUSD on the Money account chain (Monad).
+ * For a deposit this is the source the Money account paid; for a withdraw
+ * (`isPostQuote`) it's the destination — either way it links the tx to the
+ * Money account.
+ *
+ * @param transactionMeta - Transaction metadata.
+ */
+const isMusdMoneyPayToken = (transactionMeta: TransactionMeta): boolean =>
+  isMusdOnMoneyAccountChain(
+    transactionMeta.metamaskPay?.tokenAddress,
+    transactionMeta.metamaskPay?.chainId as Hex | undefined,
+  );
+
+/**
+ * Perps/Predict deposit funded from the Money account — from the perspective
+ * of the money account this is a 'Send'. The tx `from` is the user's EOA, not
+ * the Money account, so it's matched via the mUSD pay token rather than the
+ * address.
+ *
+ * @param transactionMeta - Transaction metadata.
+ */
+export const isPerpsPredictMoneyDeposit = (
+  transactionMeta: TransactionMeta,
+): boolean => {
+  const type = effectiveServiceType(transactionMeta);
+  return (
+    Boolean(type) &&
+    PERPS_PREDICT_DEPOSIT_TYPES.includes(type as TransactionType) &&
+    isMusdMoneyPayToken(transactionMeta)
+  );
+};
+
+/**
+ * Perps/Predict withdraw landing in the Money account — an inflow
+ * ("Deposited").
+ *
+ * @param transactionMeta - Transaction metadata.
+ */
+export const isPerpsPredictMoneyWithdraw = (
+  transactionMeta: TransactionMeta,
+): boolean => {
+  const type = effectiveServiceType(transactionMeta);
+  return (
+    Boolean(type) &&
+    PERPS_PREDICT_WITHDRAW_TYPES.includes(type as TransactionType) &&
+    isMusdMoneyPayToken(transactionMeta)
+  );
+};
+
+export const isPerpsPredictMoneyActivity = (
+  transactionMeta: TransactionMeta,
+): boolean =>
+  isPerpsPredictMoneyDeposit(transactionMeta) ||
+  isPerpsPredictMoneyWithdraw(transactionMeta);

--- a/ui/hooks/money/useMoneyAccountDeposit.test.ts
+++ b/ui/hooks/money/useMoneyAccountDeposit.test.ts
@@ -1,6 +1,7 @@
 import { act } from '@testing-library/react';
 import { EthAccountType, BtcAccountType } from '@metamask/keyring-api';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { MONEY_HOME_ROUTE } from '../../helpers/constants/routes';
 import { getMoneyAccountDepositIntent } from '../../helpers/money/deposit-intent';
 import {
   ConfirmationLoader,
@@ -77,6 +78,24 @@ describe('useMoneyAccountDeposit', () => {
     );
     expect(navigateToTransactionMock).toHaveBeenCalledWith(TRANSACTION_ID, {
       loader: ConfirmationLoader.CustomAmount,
+      goBackTo: '/',
+    });
+  });
+
+  it('passes the originating route as goBackTo so the confirmation returns there', async () => {
+    const { result } = renderHookWithProvider(
+      () => useMoneyAccountDeposit(),
+      EVM_ACCOUNT_STATE,
+      MONEY_HOME_ROUTE,
+    );
+
+    await act(async () => {
+      await result.current.initiateDeposit();
+    });
+
+    expect(navigateToTransactionMock).toHaveBeenCalledWith(TRANSACTION_ID, {
+      loader: ConfirmationLoader.CustomAmount,
+      goBackTo: MONEY_HOME_ROUTE,
     });
   });
 

--- a/ui/hooks/money/useMoneyAccountDeposit.ts
+++ b/ui/hooks/money/useMoneyAccountDeposit.ts
@@ -2,6 +2,7 @@ import { isEvmAccountType } from '@metamask/keyring-api';
 import { bytesToHex, type Hex } from '@metamask/utils';
 import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { parse as uuidParse, v4 as uuidv4 } from 'uuid';
 import { getMaybeSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import {
@@ -41,6 +42,10 @@ export type InitiateDepositOptions = {
  * the From row — and quotes — to that account instead of the money account
  * that executes the batch.
  *
+ * The current location is passed as `goBackTo` so closing the confirmation
+ * returns the user to the surface they started from (e.g. the Money home)
+ * rather than the global wallet home.
+ *
  * Two deliberate differences from mobile's hook, both consequences of the
  * extension navigating **after** creation rather than early with a skeleton:
  * there is no navigation to roll back on failure, and there is no
@@ -53,6 +58,7 @@ export type InitiateDepositOptions = {
  */
 export function useMoneyAccountDeposit() {
   const { navigateToTransaction } = useConfirmationNavigation();
+  const location = useLocation();
   const selectedAccount = useSelector(getMaybeSelectedInternalAccount);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -79,6 +85,7 @@ export function useMoneyAccountDeposit() {
 
         navigateToTransaction(transactionId, {
           loader: ConfirmationLoader.CustomAmount,
+          goBackTo: location.pathname + location.search,
         });
       } catch (error) {
         clearMoneyAccountDepositIntent(batchId);
@@ -93,7 +100,12 @@ export function useMoneyAccountDeposit() {
         setIsLoading(false);
       }
     },
-    [navigateToTransaction, selectedAccount],
+    [
+      location.pathname,
+      location.search,
+      navigateToTransaction,
+      selectedAccount,
+    ],
   );
 
   return { initiateDeposit, isLoading };

--- a/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.test.ts
+++ b/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.test.ts
@@ -1,0 +1,313 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  TransactionStatus,
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { MUSD_TOKEN_ADDRESS } from '@metamask/money-account-utils';
+import { CHAIN_IDS } from '../../../shared/constants/network';
+import { invalidateMoneyAccountBalanceCaches } from '../../helpers/money/invalidate-balance-caches';
+import { queryClient } from '../../contexts/query-client';
+import { selectPrimaryMoneyAccount } from '../../selectors/money-account';
+import { useRefreshMoneyBalanceOnTxConfirm } from './useRefreshMoneyBalanceOnTxConfirm';
+
+const mockSubscribe = jest.fn();
+const mockUnsubscribe = jest.fn();
+
+jest.mock('../useMessenger', () => ({
+  useMessenger: () => ({
+    subscribe: mockSubscribe,
+    unsubscribe: mockUnsubscribe,
+  }),
+}));
+
+jest.mock('react-redux', () => ({
+  useStore: () => ({ getState: jest.fn(() => ({})) }),
+}));
+
+jest.mock('../../selectors/money-account', () => ({
+  selectPrimaryMoneyAccount: jest.fn(),
+}));
+
+jest.mock('../../contexts/query-client', () => ({
+  queryClient: {
+    getQueryData: jest.fn(),
+  },
+}));
+
+jest.mock('../../helpers/money/invalidate-balance-caches', () => ({
+  invalidateMoneyAccountBalanceCaches: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetQueryData = jest.mocked(queryClient.getQueryData);
+const mockInvalidateMoneyAccountBalanceCaches = jest.mocked(
+  invalidateMoneyAccountBalanceCaches,
+);
+const mockSelectPrimaryMoneyAccount = jest.mocked(selectPrimaryMoneyAccount);
+
+const EVENT = 'TransactionController:transactionStatusUpdated';
+
+const MOCK_ADDRESS = '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B';
+
+const baseTx = {
+  id: 'tx-1',
+  time: 0,
+  txParams: {},
+} as unknown as TransactionMeta;
+
+const makeTx = (
+  type: TransactionType,
+  status: TransactionStatus = TransactionStatus.confirmed,
+  nested?: { type: TransactionType }[],
+): TransactionMeta =>
+  ({
+    ...baseTx,
+    type,
+    status,
+    nestedTransactions: nested,
+  }) as unknown as TransactionMeta;
+
+type StatusUpdatedHandler = (raw: {
+  transactionMeta: TransactionMeta;
+}) => void;
+
+const getStatusUpdatedHandler = (): StatusUpdatedHandler => {
+  const call = mockSubscribe.mock.calls.find(([event]) => event === EVENT);
+  if (!call) {
+    throw new Error('transactionStatusUpdated handler not subscribed');
+  }
+  return call[1];
+};
+
+const emit = (
+  handler: StatusUpdatedHandler,
+  transactionMeta: TransactionMeta,
+) => handler({ transactionMeta });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockInvalidateMoneyAccountBalanceCaches.mockResolvedValue(undefined);
+
+  let readCount = 0;
+  mockGetQueryData.mockImplementation(() => {
+    const phase = readCount < 1 ? 'baseline' : 'next';
+    readCount += 1;
+
+    return {
+      musdBalance: phase === 'baseline' ? '1000000' : '1100000',
+      vmusdValueInMusd: phase === 'baseline' ? '2000000' : '2100000',
+      totalBalance: phase === 'baseline' ? '3000000' : '3200000',
+    };
+  });
+
+  mockSelectPrimaryMoneyAccount.mockReturnValue({
+    address: MOCK_ADDRESS,
+  } as unknown as ReturnType<typeof selectPrimaryMoneyAccount>);
+});
+
+describe('useRefreshMoneyBalanceOnTxConfirm', () => {
+  it('subscribes to TransactionController:transactionStatusUpdated on mount', () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    expect(mockSubscribe).toHaveBeenCalledWith(EVENT, expect.any(Function));
+  });
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledWith(EVENT, expect.any(Function));
+  });
+
+  it('invalidates the balance query on confirmed deposit tx', async () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(handler, makeTx(TransactionType.moneyAccountDeposit));
+    await waitFor(() => {
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledWith(
+      MOCK_ADDRESS,
+    );
+  });
+
+  it('invalidates the balance query on confirmed withdraw tx', async () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(handler, makeTx(TransactionType.moneyAccountWithdraw));
+    await waitFor(() => {
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('invalidates on confirmed tx with nested deposit', async () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(
+      handler,
+      makeTx(TransactionType.contractInteraction, TransactionStatus.confirmed, [
+        { type: TransactionType.moneyAccountDeposit },
+      ]),
+    );
+    await waitFor(() => {
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('invalidates on confirmed tx with nested withdraw', async () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(
+      handler,
+      makeTx(TransactionType.contractInteraction, TransactionStatus.confirmed, [
+        { type: TransactionType.moneyAccountWithdraw },
+      ]),
+    );
+    await waitFor(() => {
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  const MUSD_ON_MONAD = {
+    tokenAddress: MUSD_TOKEN_ADDRESS,
+    chainId: CHAIN_IDS.MONAD,
+  };
+
+  it('invalidates on a confirmed Perps deposit funded from the Money account', async () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(handler, {
+      ...makeTx(TransactionType.perpsDeposit),
+      metamaskPay: MUSD_ON_MONAD,
+    } as unknown as TransactionMeta);
+    await waitFor(() => {
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('invalidates on a confirmed Predict withdraw landing in the Money account', async () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(handler, {
+      ...makeTx(TransactionType.batch, TransactionStatus.confirmed, [
+        { type: TransactionType.predictWithdraw },
+      ]),
+      metamaskPay: MUSD_ON_MONAD,
+    } as unknown as TransactionMeta);
+    await waitFor(() => {
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not invalidate for a Perps deposit NOT funded from the Money account', () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(handler, {
+      ...makeTx(TransactionType.perpsDeposit),
+      metamaskPay: {
+        tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+        chainId: CHAIN_IDS.ARBITRUM,
+      },
+    } as unknown as TransactionMeta);
+
+    expect(mockInvalidateMoneyAccountBalanceCaches).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate for non-confirmed status', () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(
+      handler,
+      makeTx(TransactionType.moneyAccountDeposit, TransactionStatus.failed),
+    );
+
+    expect(mockInvalidateMoneyAccountBalanceCaches).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate for unrelated tx type', () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(handler, makeTx(TransactionType.contractInteraction));
+
+    expect(mockInvalidateMoneyAccountBalanceCaches).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate when no primary money account address', () => {
+    mockSelectPrimaryMoneyAccount.mockReturnValue(undefined);
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(handler, makeTx(TransactionType.moneyAccountDeposit));
+
+    expect(mockInvalidateMoneyAccountBalanceCaches).not.toHaveBeenCalled();
+  });
+
+  it('reads store state at call time (not stale closure)', async () => {
+    mockSelectPrimaryMoneyAccount.mockReturnValue(undefined);
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    mockSelectPrimaryMoneyAccount.mockReturnValue({
+      address: MOCK_ADDRESS,
+    } as unknown as ReturnType<typeof selectPrimaryMoneyAccount>);
+
+    emit(handler, makeTx(TransactionType.moneyAccountDeposit));
+    await waitFor(() => {
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('refreshes once per transaction id when the confirmed status re-fires', async () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(handler, makeTx(TransactionType.moneyAccountDeposit));
+    emit(handler, makeTx(TransactionType.moneyAccountDeposit));
+    await waitFor(() => {
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the array-wrapped event payload', async () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler() as unknown as (
+      raw: [{ transactionMeta: TransactionMeta }],
+    ) => void;
+
+    handler([
+      { transactionMeta: makeTx(TransactionType.moneyAccountDeposit) },
+    ]);
+    await waitFor(() => {
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('retries the invalidation while the balance stays unchanged', async () => {
+    mockGetQueryData.mockReturnValue({
+      totalBalance: '3000000',
+    } as ReturnType<typeof queryClient.getQueryData>);
+
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getStatusUpdatedHandler();
+
+    emit(handler, makeTx(TransactionType.moneyAccountDeposit));
+    await waitFor(
+      () => {
+        expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(
+          4,
+        );
+      },
+      { timeout: 10000 },
+    );
+  });
+});

--- a/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.test.ts
+++ b/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.test.ts
@@ -6,7 +6,10 @@ import {
 } from '@metamask/transaction-controller';
 import { MUSD_TOKEN_ADDRESS } from '@metamask/money-account-utils';
 import { CHAIN_IDS } from '../../../shared/constants/network';
-import { invalidateMoneyAccountBalanceCaches } from '../../helpers/money/invalidate-balance-caches';
+import {
+  invalidateMoneyAccountBalanceCaches,
+  invalidateMoneyAccountBalanceSourceCaches,
+} from '../../helpers/money/invalidate-balance-caches';
 import { queryClient } from '../../contexts/query-client';
 import { selectPrimaryMoneyAccount } from '../../selectors/money-account';
 import { useRefreshMoneyBalanceOnTxConfirm } from './useRefreshMoneyBalanceOnTxConfirm';
@@ -37,11 +40,17 @@ jest.mock('../../contexts/query-client', () => ({
 
 jest.mock('../../helpers/money/invalidate-balance-caches', () => ({
   invalidateMoneyAccountBalanceCaches: jest.fn().mockResolvedValue(undefined),
+  invalidateMoneyAccountBalanceSourceCaches: jest
+    .fn()
+    .mockResolvedValue(undefined),
 }));
 
 const mockGetQueryData = jest.mocked(queryClient.getQueryData);
 const mockInvalidateMoneyAccountBalanceCaches = jest.mocked(
   invalidateMoneyAccountBalanceCaches,
+);
+const mockInvalidateMoneyAccountBalanceSourceCaches = jest.mocked(
+  invalidateMoneyAccountBalanceSourceCaches,
 );
 const mockSelectPrimaryMoneyAccount = jest.mocked(selectPrimaryMoneyAccount);
 
@@ -292,22 +301,43 @@ describe('useRefreshMoneyBalanceOnTxConfirm', () => {
     });
   });
 
-  it('retries the invalidation while the balance stays unchanged', async () => {
-    mockGetQueryData.mockReturnValue({
-      totalBalance: '3000000',
-    } as ReturnType<typeof queryClient.getQueryData>);
+  it('retries while the balance stays unchanged, then busts the source caches', async () => {
+    jest.useFakeTimers();
+    try {
+      mockGetQueryData.mockReturnValue({
+        totalBalance: '3000000',
+      } as ReturnType<typeof queryClient.getQueryData>);
 
+      renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+      const handler = getStatusUpdatedHandler();
+
+      emit(handler, makeTx(TransactionType.moneyAccountDeposit));
+      // Attempts back off at 500ms/1s/2s then 4s capped; ~20s covers all 8.
+      await jest.advanceTimersByTimeAsync(30_000);
+
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(8);
+      expect(
+        mockInvalidateMoneyAccountBalanceSourceCaches,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockInvalidateMoneyAccountBalanceSourceCaches,
+      ).toHaveBeenCalledWith(MOCK_ADDRESS);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not bust the source caches when a retry sees the balance change', async () => {
     renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
     const handler = getStatusUpdatedHandler();
 
     emit(handler, makeTx(TransactionType.moneyAccountDeposit));
-    await waitFor(
-      () => {
-        expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(
-          4,
-        );
-      },
-      { timeout: 10000 },
-    );
+    await waitFor(() => {
+      expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      mockInvalidateMoneyAccountBalanceSourceCaches,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.test.ts
+++ b/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.test.ts
@@ -76,9 +76,7 @@ const makeTx = (
     nestedTransactions: nested,
   }) as unknown as TransactionMeta;
 
-type StatusUpdatedHandler = (raw: {
-  transactionMeta: TransactionMeta;
-}) => void;
+type StatusUpdatedHandler = (raw: { transactionMeta: TransactionMeta }) => void;
 
 const getStatusUpdatedHandler = (): StatusUpdatedHandler => {
   const call = mockSubscribe.mock.calls.find(([event]) => event === EVENT);
@@ -293,9 +291,7 @@ describe('useRefreshMoneyBalanceOnTxConfirm', () => {
       raw: [{ transactionMeta: TransactionMeta }],
     ) => void;
 
-    handler([
-      { transactionMeta: makeTx(TransactionType.moneyAccountDeposit) },
-    ]);
+    handler([{ transactionMeta: makeTx(TransactionType.moneyAccountDeposit) }]);
     await waitFor(() => {
       expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledTimes(1);
     });

--- a/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.ts
+++ b/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.ts
@@ -1,0 +1,158 @@
+import { useEffect, useRef } from 'react';
+import { useStore } from 'react-redux';
+import {
+  TransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import type { CanonicalMoneyAccountBalanceResponse } from '@metamask/money-account-balance-service';
+import log from 'loglevel';
+import { MoneyAccountBalanceServiceQueryKeys } from '../../../shared/lib/money/query-keys';
+import { queryClient } from '../../contexts/query-client';
+import { defineAllowedRouteCapabilities } from '../../helpers/route-messenger-helpers';
+import { invalidateMoneyAccountBalanceCaches } from '../../helpers/money/invalidate-balance-caches';
+import {
+  isMoneyAccountTx,
+  isPerpsPredictMoneyActivity,
+} from '../../helpers/money/money-transaction-guards';
+import type { RouteMessengerFromCapabilities } from '../../messengers/route-messenger';
+import { selectPrimaryMoneyAccount } from '../../selectors/money-account';
+import type { MetaMaskReduxState } from '../../store/store';
+import { useMessenger } from '../useMessenger';
+
+const LOG_PREFIX = '[Money Balance Refresh]';
+
+const MAX_RETRIES = 4;
+const BASE_DELAY_MS = 500;
+const MAX_DELAY_MS = 4000;
+
+export const refreshMoneyBalanceCapabilities = defineAllowedRouteCapabilities({
+  actions: [],
+  events: ['TransactionController:transactionStatusUpdated'],
+});
+
+type RefreshMoneyBalanceMessenger = RouteMessengerFromCapabilities<
+  typeof refreshMoneyBalanceCapabilities
+>;
+
+type MoneyBalanceSnapshot = CanonicalMoneyAccountBalanceResponse | undefined;
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const readBalanceSnapshot = (address: string) =>
+  queryClient.getQueryData<MoneyBalanceSnapshot>([
+    MoneyAccountBalanceServiceQueryKeys.FETCH_BALANCE_WITH_FALLBACK,
+    address,
+  ]);
+
+const didBalanceChange = (
+  before: MoneyBalanceSnapshot,
+  after: MoneyBalanceSnapshot,
+) => before?.totalBalance !== after?.totalBalance;
+
+/**
+ * Capture the pre-invalidation cached snapshot as a baseline, then invalidate +
+ * refetch and compare. Retry up to MAX_RETRIES times if subsequent reads are
+ * byte-identical to baseline. Guards against RPC nodes / API indexes serving
+ * stale reads immediately after a transaction confirms. Fails visibly via
+ * log.error if the retry budget exhausts.
+ *
+ * @param address - Money account address.
+ */
+const refreshMoneyBalanceQueries = async (address: string) => {
+  const baseline = readBalanceSnapshot(address);
+
+  log.debug(`${LOG_PREFIX} Baseline snapshot established`, { baseline });
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await sleep(
+        Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS),
+      );
+    }
+
+    await invalidateMoneyAccountBalanceCaches(address);
+    const next = readBalanceSnapshot(address);
+    const changed = didBalanceChange(baseline, next);
+
+    log.debug(`${LOG_PREFIX} attempt ${attempt} result`, { changed, next });
+
+    if (changed) {
+      return;
+    }
+  }
+
+  log.error(
+    `${LOG_PREFIX} Balance unchanged after ${MAX_RETRIES} retries; awaiting 30s auto-poll`,
+  );
+};
+
+/**
+ * Refreshes the Money Account balance when a transaction that moves money
+ * balance confirms: direct Money txs (deposit/withdraw, including nested in a
+ * batch) plus Perps/Predict transfers to or from the Money account (paid with
+ * mUSD via MetaMask Pay).
+ *
+ * Extension adaptation of mobile's `useRefreshMoneyBalanceOnTxConfirm`: the
+ * confirmation signal is `TransactionController:transactionStatusUpdated`
+ * filtered to `confirmed` (the event the route messenger exposes) rather than
+ * `transactionConfirmed`, so refreshes are deduped by transaction id in case
+ * the status event re-fires.
+ */
+export function useRefreshMoneyBalanceOnTxConfirm(): void {
+  const messenger = useMessenger<RefreshMoneyBalanceMessenger>();
+  const store = useStore<MetaMaskReduxState>();
+  const refreshedIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const handleStatusUpdated = (
+      raw:
+        | { transactionMeta: TransactionMeta }
+        | [{ transactionMeta: TransactionMeta }],
+    ) => {
+      const payload = Array.isArray(raw) ? raw[0] : raw;
+      const transactionMeta = payload?.transactionMeta;
+
+      if (!transactionMeta) {
+        return;
+      }
+
+      if (transactionMeta.status !== TransactionStatus.confirmed) {
+        return;
+      }
+
+      const address = selectPrimaryMoneyAccount(store.getState())?.address;
+      if (!address) {
+        return;
+      }
+
+      const affectsMoneyBalance =
+        isMoneyAccountTx(transactionMeta) ||
+        isPerpsPredictMoneyActivity(transactionMeta);
+      if (!affectsMoneyBalance) {
+        return;
+      }
+
+      if (refreshedIdsRef.current.has(transactionMeta.id)) {
+        return;
+      }
+      refreshedIdsRef.current.add(transactionMeta.id);
+
+      refreshMoneyBalanceQueries(address).catch((error) => {
+        log.error(`${LOG_PREFIX} Balance refresh failed`, error);
+      });
+    };
+
+    messenger.subscribe(
+      'TransactionController:transactionStatusUpdated',
+      handleStatusUpdated,
+    );
+
+    return () => {
+      messenger.unsubscribe(
+        'TransactionController:transactionStatusUpdated',
+        handleStatusUpdated,
+      );
+    };
+  }, [messenger, store]);
+}

--- a/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.ts
+++ b/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.ts
@@ -78,9 +78,7 @@ const refreshMoneyBalanceQueries = async (address: string) => {
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     if (attempt > 0) {
-      await sleep(
-        Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS),
-      );
+      await sleep(Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS));
     }
 
     await invalidateMoneyAccountBalanceCaches(address);

--- a/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.ts
+++ b/ui/hooks/money/useRefreshMoneyBalanceOnTxConfirm.ts
@@ -9,7 +9,10 @@ import log from 'loglevel';
 import { MoneyAccountBalanceServiceQueryKeys } from '../../../shared/lib/money/query-keys';
 import { queryClient } from '../../contexts/query-client';
 import { defineAllowedRouteCapabilities } from '../../helpers/route-messenger-helpers';
-import { invalidateMoneyAccountBalanceCaches } from '../../helpers/money/invalidate-balance-caches';
+import {
+  invalidateMoneyAccountBalanceCaches,
+  invalidateMoneyAccountBalanceSourceCaches,
+} from '../../helpers/money/invalidate-balance-caches';
 import {
   isMoneyAccountTx,
   isPerpsPredictMoneyActivity,
@@ -21,7 +24,11 @@ import { useMessenger } from '../useMessenger';
 
 const LOG_PREFIX = '[Money Balance Refresh]';
 
-const MAX_RETRIES = 4;
+// Wider than mobile's 4-attempt budget: RPC nodes and the Money API indexer
+// can lag the on-chain state by tens of seconds after a confirmation, and an
+// exhausted budget costs a full staleTime + poll cycle before the next fresh
+// read. 8 attempts with capped backoff cover a ~20s window.
+const MAX_RETRIES = 8;
 const BASE_DELAY_MS = 500;
 const MAX_DELAY_MS = 4000;
 
@@ -57,6 +64,11 @@ const didBalanceChange = (
  * stale reads immediately after a transaction confirms. Fails visibly via
  * log.error if the retry budget exhausts.
  *
+ * On exhaustion the background source caches are busted one final time: the
+ * last (stale) refetch re-cached the stale figure with a fresh staleTime, so
+ * without this the 30s auto-poll would keep serving it for another staleTime
+ * window instead of reading the sources anew.
+ *
  * @param address - Money account address.
  */
 const refreshMoneyBalanceQueries = async (address: string) => {
@@ -81,6 +93,8 @@ const refreshMoneyBalanceQueries = async (address: string) => {
       return;
     }
   }
+
+  await invalidateMoneyAccountBalanceSourceCaches(address);
 
   log.error(
     `${LOG_PREFIX} Balance unchanged after ${MAX_RETRIES} retries; awaiting 30s auto-poll`,

--- a/ui/pages/money/money-home-page.test.tsx
+++ b/ui/pages/money/money-home-page.test.tsx
@@ -15,6 +15,8 @@ const mockUseMoneyAccountBalance = jest.fn();
 const mockUseMoneyAccountInterest = jest.fn();
 const mockUseMoneyDepositTokens = jest.fn();
 const mockUseMoneyActivityItems = jest.fn();
+const mockUseMoneyAccountDeposit = jest.fn();
+const mockInitiateDeposit = jest.fn();
 const mockNavigate = jest.fn();
 const mockSelectMoneyEarningSectionEnabled = jest.mocked(
   selectMoneyEarningSectionEnabled,
@@ -71,6 +73,9 @@ jest.mock('../../hooks/money/use-money-deposit-tokens', () => ({
 jest.mock('../../hooks/money/use-money-activity-items', () => ({
   useMoneyActivityItems: () => mockUseMoneyActivityItems(),
 }));
+jest.mock('../../hooks/money/useMoneyAccountDeposit', () => ({
+  useMoneyAccountDeposit: () => mockUseMoneyAccountDeposit(),
+}));
 
 describe('MoneyHomePage', () => {
   beforeEach(() => {
@@ -109,6 +114,11 @@ describe('MoneyHomePage', () => {
       isNoFeeToken: () => false,
     });
     mockUseMoneyActivityItems.mockReturnValue({ items: [] });
+    mockInitiateDeposit.mockResolvedValue(undefined);
+    mockUseMoneyAccountDeposit.mockReturnValue({
+      initiateDeposit: mockInitiateDeposit,
+      isLoading: false,
+    });
   });
 
   it('renders the full empty-state composition with a live zero balance', () => {
@@ -165,12 +175,55 @@ describe('MoneyHomePage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('keeps all groundwork actions inert', () => {
+  it('keeps groundwork actions other than the deposit entry points inert', () => {
     renderWithLocalization(<MoneyHomePage />);
 
+    const depositLabels = [
+      messages.moneyAdd.message,
+      messages.addFunds.message,
+    ];
     screen.getAllByRole('button').forEach((button) => {
-      expect(button).toBeDisabled();
+      if (depositLabels.includes(button.textContent ?? '')) {
+        expect(button).toBeEnabled();
+      } else {
+        expect(button).toBeDisabled();
+      }
     });
+  });
+
+  it('initiates a deposit from the Add action card', () => {
+    renderWithLocalization(<MoneyHomePage />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: messages.moneyAdd.message }),
+    );
+
+    expect(mockInitiateDeposit).toHaveBeenCalledTimes(1);
+    expect(mockInitiateDeposit).toHaveBeenCalledWith();
+  });
+
+  it('initiates a deposit from the unfunded Add funds CTA', () => {
+    renderWithLocalization(<MoneyHomePage />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: messages.addFunds.message }),
+    );
+
+    expect(mockInitiateDeposit).toHaveBeenCalledTimes(1);
+    expect(mockInitiateDeposit).toHaveBeenCalledWith();
+  });
+
+  it('disables the deposit entry points while a deposit is initiating', () => {
+    mockUseMoneyAccountDeposit.mockReturnValue({
+      initiateDeposit: mockInitiateDeposit,
+      isLoading: true,
+    });
+
+    renderWithLocalization(<MoneyHomePage />);
+
+    expect(
+      screen.getByRole('button', { name: messages.moneyAdd.message }),
+    ).toBeDisabled();
   });
 
   it('renders the filled-state composition for a funded Money account', () => {
@@ -230,7 +283,11 @@ describe('MoneyHomePage', () => {
       screen.queryByText(messages.moneyBenefits.message),
     ).not.toBeInTheDocument();
     screen.getAllByRole('button').forEach((button) => {
-      expect(button).toBeDisabled();
+      if (button.textContent === messages.moneyAdd.message) {
+        expect(button).toBeEnabled();
+      } else {
+        expect(button).toBeDisabled();
+      }
     });
   });
 

--- a/ui/pages/money/money-home-page.tsx
+++ b/ui/pages/money/money-home-page.tsx
@@ -24,6 +24,7 @@ import { useI18nContext } from '../../hooks/useI18nContext';
 import { useMoneyAccountAvailability } from '../../hooks/money/use-money-account-availability';
 import { useMoneyDepositTokens } from '../../hooks/money/use-money-deposit-tokens';
 import { useMoneyAccountBalance } from '../../hooks/money/useMoneyAccountBalance';
+import { useMoneyAccountDeposit } from '../../hooks/money/useMoneyAccountDeposit';
 import { useMoneyAccountInterest } from '../../hooks/money/useMoneyAccountInterest';
 import { useMoneyActivityItems } from '../../hooks/money/use-money-activity-items';
 import { moneyFormatUsd } from '../../helpers/money/format';
@@ -67,13 +68,21 @@ const formatInterestEarned = (value: string | undefined) => {
 type ActionCardProps = {
   icon: IconName;
   label: string;
+  onClick?: () => void;
+  disabled?: boolean;
 };
 
-const MoneyActionCard = ({ icon, label }: ActionCardProps) => {
+const MoneyActionCard = ({
+  icon,
+  label,
+  onClick,
+  disabled,
+}: ActionCardProps) => {
   return (
     <button
       type="button"
-      disabled
+      disabled={disabled}
+      onClick={onClick}
       className="flex h-[76px] flex-1 flex-col items-center justify-center gap-0.5 rounded-xl bg-background-muted disabled:cursor-default disabled:opacity-100"
     >
       <Icon name={icon} size={IconSize.Lg} color={IconColor.IconDefault} />
@@ -142,9 +151,16 @@ export function MoneyHomePage() {
   const { tokens: depositTokens, isNoFeeToken } = useMoneyDepositTokens();
   const privacyMode = useSelector(getPrivacyMode);
   const { items: activityItems } = useMoneyActivityItems();
+  const { initiateDeposit, isLoading: isDepositLoading } =
+    useMoneyAccountDeposit();
   const handleViewAllActivity = useCallback(() => {
     navigate(MONEY_ACTIVITY_ROUTE);
   }, [navigate]);
+  const handleAddFunds = useCallback(() => {
+    initiateDeposit().catch((error) =>
+      console.error('Failed to initiate money account deposit', error),
+    );
+  }, [initiateDeposit]);
 
   if (isAvailabilityLoading || (availability.isAvailable && isBalanceLoading)) {
     return (
@@ -233,10 +249,16 @@ export function MoneyHomePage() {
         </div>
 
         <div className="mt-2 flex w-full max-w-[389px] gap-2 py-2">
-          <MoneyActionCard icon={IconName.Add} label={t('moneyAdd')} />
+          <MoneyActionCard
+            icon={IconName.Add}
+            label={t('moneyAdd')}
+            onClick={handleAddFunds}
+            disabled={isDepositLoading}
+          />
           <MoneyActionCard
             icon={IconName.Arrow2UpRight}
             label={t('moneySend')}
+            disabled
           />
         </div>
 
@@ -266,7 +288,11 @@ export function MoneyHomePage() {
                   : t('moneyFundDescription')}
               </Text>
             </div>
-            <Button disabled className="w-full">
+            <Button
+              className="w-full"
+              isLoading={isDepositLoading}
+              onClick={handleAddFunds}
+            >
               {t('addFunds')}
             </Button>
           </section>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR wires up the money account add buttons to trigger a real deposit into the money account.
It also adds functionality to repeatedly try and update the money balance when a deposit is made, to ensure that the user gets rapid visual feedback that their deposit has succeeded.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: wire up money account deposit buttons

## **Related issues**

Fixes: MUSD-1310

## **Manual testing steps**

1. Enable the money account flags (they are turned on in dev!)
2. Use an upgraded account (this needs to be done on the mobile client at the moment) - otherwise deposited funds will be difficult to retrieve
3. Click add on the money home, or the extension home. Deposit some tokens. 
4. Observe that your balance updates.

Note that withdrawal is not implemented in this client yet. So to withdraw you'll need to go to mobile.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/46830796-1a38-48d8-aef5-5dae5e79fb5b


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches money deposit initiation, confirmation navigation, and balance cache invalidation across UI and background RPC—incorrect guards or cache ordering could show stale balances or miss refreshes after funded activity.
> 
> **Overview**
> Enables **real Money account deposits** from previously inert **Add** / **Add funds** entry points on the Money home page and the wallet **Money account balance** row. Clicks call `useMoneyAccountDeposit().initiateDeposit()` (generic, no preset intent), show loading on the buttons, and navigate to Pay confirmation with **`goBackTo`** set to the current route so dismiss returns to Money home instead of global wallet home.
> 
> Adds **post-confirmation balance refresh**: `useRefreshMoneyBalanceOnTxConfirm` listens on `TransactionController:transactionStatusUpdated` (confirmed only, deduped by tx id) and retriggers balance cache invalidation for Money deposits/withdraws (including nested batch txs) and Perps/Predict flows funded or settled via **mUSD on the Money chain** (`money-transaction-guards`). Refresh **retries up to ~20s** when `totalBalance` stays unchanged after invalidation, then busts **background source caches only** so stale reads are not re-cached for another `staleTime` window.
> 
> **Cache helpers** are split so full invalidation busts RPC/API source caches then invalidates the UI facade query (with an explicit `{}` options object to avoid a JSON-RPC `null` crash on `cancelRefetch`); source-only invalidation is used after exhausted retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b14463531f8a11ce52bf978d62506db9e94247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->