### PR TITLE
fix(benchmarks): name the tier and CV widening on a ceiling violation

### DIFF
--- a/development/metamaskbot-build-announce/compare-benchmarks.test.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.test.ts
@@ -772,10 +772,78 @@ describe('buildMetricLines', () => {
     );
 
     const { details } = lines[0];
-    expect(details).toContain('absolute ceiling exceeded');
+    expect(details).toContain('fail ceiling exceeded');
     expect(details).toContain('11291ms');
     expect(details).toContain('11050ms');
     expect(details).not.toContain('-72.1%');
+    // No CV adjustment on this violation, so no widening clause is added.
+    expect(details).not.toContain('widened');
+  });
+
+  it('names the tier, so a warn ceiling is not read as a fail ceiling', () => {
+    const lines = buildMetricLines(
+      makeComparison({
+        relativeMetrics: [
+          {
+            metric: 'total',
+            percentile: 'p75',
+            current: 11291,
+            baseline: 11000,
+            delta: 291,
+            deltaPercent: 0.026,
+            severity: COMPARISON_SEVERITY.Pass.value,
+            indication: COMPARISON_SEVERITY.Pass.icon,
+          },
+        ],
+        absoluteViolations: [
+          {
+            metricId: 'total',
+            percentile: 'p75',
+            value: 11291,
+            threshold: 11050,
+            severity: THRESHOLD_SEVERITY.Warn,
+          },
+        ],
+      }),
+    );
+
+    const { details } = lines[0];
+    expect(details).toContain('warn ceiling exceeded');
+    expect(details).not.toContain('fail ceiling exceeded');
+  });
+
+  it('discloses CV widening and the pre-widening ceiling it came from', () => {
+    // 11050 effective = 8840 base x 1.250. Without this the reader sees only
+    // 11050 and cannot tell it was widened by this run's own variance.
+    const lines = buildMetricLines(
+      makeComparison({
+        relativeMetrics: [
+          {
+            metric: 'total',
+            percentile: 'p75',
+            current: 11291,
+            baseline: 11000,
+            delta: 291,
+            deltaPercent: 0.026,
+            severity: COMPARISON_SEVERITY.Pass.value,
+            indication: COMPARISON_SEVERITY.Pass.icon,
+          },
+        ],
+        absoluteViolations: [
+          {
+            metricId: 'total',
+            percentile: 'p75',
+            value: 11291,
+            threshold: 11050,
+            severity: THRESHOLD_SEVERITY.Fail,
+            cvAdjustment: 1.25,
+          },
+        ],
+      }),
+    );
+
+    const { details } = lines[0];
+    expect(details).toContain('widened x1.250 by CV from 8840ms');
   });
 
   it('overrides icon with 🟡 when absolute Warn violation matches the metric', () => {

--- a/development/metamaskbot-build-announce/compare-benchmarks.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.ts
@@ -24,6 +24,7 @@ import { parseArgs } from 'util';
 import { THRESHOLD_SEVERITY } from '../../shared/constants/benchmarks';
 import type {
   ThresholdSeverity,
+  ThresholdViolation,
   ComparisonKey,
   BenchmarkResults,
 } from '../../shared/constants/benchmarks';
@@ -75,6 +76,25 @@ async function loadBaseline(): Promise<HistoricalBaselineReference> {
   const result = await fetchHistoricalPerformanceDataFromMain();
   return result?.baseline ?? {};
 }
+
+/**
+ * Render the CV-adaptive widening that produced a violation's effective ceiling.
+ *
+ * `ThresholdViolation.threshold` is the fully-adjusted value, so a reader sees a
+ * limit without being told it was widened, by how much, or from what. Returns an
+ * empty string when no widening applied, leaving the existing line unchanged.
+ *
+ * @param violation - the violation whose ceiling is being reported
+ * @returns a parenthetical suffix, or '' when no CV adjustment was applied
+ */
+const describeCvAdjustment = (violation: ThresholdViolation): string => {
+  const { cvAdjustment } = violation;
+  if (cvAdjustment === undefined) {
+    return '';
+  }
+  const base = violation.threshold / cvAdjustment;
+  return `, widened x${cvAdjustment.toFixed(3)} by CV from ${Math.round(base)}ms`;
+};
 
 /**
  * Runs comparison for all loaded benchmarks.
@@ -259,9 +279,14 @@ export function buildMetricLines(
             const violation = comparison.absoluteViolations.find(
               (v) => v.metricId === metric && v.percentile === pKey,
             );
+            // Name the tier and the widening. `violation` already carries both
+            // `severity` and `cvAdjustment`; printing only the number left a
+            // reader unable to tell a warn ceiling from a fail ceiling, or a
+            // base ceiling from one this run's own variance widened -- which is
+            // the information needed to decide whether a red is about the PR.
             details.push(
               violation
-                ? `${pKey}: ${formatValue(violation.value)} (absolute ceiling exceeded, limit ${formatValue(violation.threshold)})`
+                ? `${pKey}: ${formatValue(violation.value)} (${violation.severity} ceiling exceeded, limit ${formatValue(violation.threshold)}${describeCvAdjustment(violation)})`
                 : `${pKey}: ${formatValue(rel.current)} (absolute ceiling exceeded)`,
             );
           } else {


### PR DESCRIPTION
## Changelog

CHANGELOG entry: null

## Summary

A gate line reads:

```
🟡 total | p75: 11098ms (absolute ceiling exceeded, limit 11050ms)
```

It does not say whether `11050` is the **warn** ceiling or the **fail** ceiling, nor whether this run's own variance widened it. A developer whose PR just went red cannot tell from the line whether the result is about their change — which is the information needed before deciding to reach for `skip-benchmark-gate`.

`ThresholdViolation` already carries `severity` and `cvAdjustment`. The printer used neither. This puts both in the line and derives the pre-widening base so the adjustment can be read rather than inferred:

```
🟡 total | p75: 11098ms (fail ceiling exceeded, limit 11050ms, widened x1.250 by CV from 8840ms)
```

No threshold, verdict, or gating behaviour changes — this is the report line only.

### Why this line specifically

Measured over the 87 completed `main`-branch push runs in the 7 days to 2026-09-01T12:07Z: **70 of 70 runs that printed `RESULT: PASS` also printed `absolute ceiling exceeded`**, and 9 benchmarks are amber in **85 of 85**. With the tier undisclosed, a saturated warn tier and a genuine fail render identically to a reader.

## Test plan

- [ ] CI green

### Executed locally

`npx jest development/metamaskbot-build-announce/compare-benchmarks.test.ts`

```
Tests:       37 passed, 37 total
```

Falsifier — the same suite against `origin/main`'s `compare-benchmarks.ts`, tests unchanged:

```
Tests:       3 failed, 34 passed, 37 total
```

The three that fail on base are the ones added or amended here, so they test the change rather than passing regardless of it.

Typecheck, narrow, three arms at ~8s each:

| arm | result |
|---|---|
| injected `const broken: number = 'x'` | `compare-benchmarks.ts(92,9): error TS2322` — instrument fires |
| this branch | 0 diagnostics |
| `origin/main`, same flags | 0 diagnostics |

Scope: those flags are ad-hoc (`--skipLibCheck --strict --target es2022 --module esnext --moduleResolution bundler`), not the project `tsconfig.json`, so this establishes *no new diagnostics under a check proven to fire* rather than a clean project typecheck — CI is the authority there. `oxfmt -c oxfmt.config.mts` exits 0 with the file unchanged.

## Related

Part of [MetaMask-planning#7182 (Quality Gates: Reliability)](https://github.com/MetaMask/MetaMask-planning/issues/7182), under [#6944 (Performance Quality Gates)](https://github.com/MetaMask/MetaMask-planning/issues/6944).

Adjacent but distinct: MetaMask/metamask-extension#45544 covers the `CV_ADAPTIVE_MAX` cliff — that widening is applied *wrongly* above CV 50; this covers the widening not being *disclosed* at all.
