### PR TITLE
feat(perps): add a "Top movers" section to the Perps tab

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -8071,6 +8071,18 @@
     "message": "TP/SL updated successfully",
     "description": "Success toast text shown when TP/SL settings are updated"
   },
+  "perpsTopMovers": {
+    "message": "Top movers",
+    "description": "Heading of the Perps tab section ranking markets by 24h price change"
+  },
+  "perpsTopMoversGainers": {
+    "message": "Gainers",
+    "description": "Toggle option showing the markets that rose the most over 24h in the Top movers section"
+  },
+  "perpsTopMoversLosers": {
+    "message": "Losers",
+    "description": "Toggle option showing the markets that fell the most over 24h in the Top movers section"
+  },
   "perpsTrades": {
     "message": "Trades"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -8071,6 +8071,18 @@
     "message": "TP/SL updated successfully",
     "description": "Success toast text shown when TP/SL settings are updated"
   },
+  "perpsTopMovers": {
+    "message": "Top movers",
+    "description": "Heading of the Perps tab section ranking markets by 24h price change"
+  },
+  "perpsTopMoversGainers": {
+    "message": "Gainers",
+    "description": "Toggle option showing the markets that rose the most over 24h in the Top movers section"
+  },
+  "perpsTopMoversLosers": {
+    "message": "Losers",
+    "description": "Toggle option showing the markets that fell the most over 24h in the Top movers section"
+  },
   "perpsTrades": {
     "message": "Trades"
   },

--- a/test/mocks/metamask-perps-controller.js
+++ b/test/mocks/metamask-perps-controller.js
@@ -54,6 +54,7 @@ const mockPerpsEventPropertyKeys = {
   ORDER_TIMESTAMP: 'order_timestamp',
   ENTRY_POINT: 'entry_point',
   DISCOVERY_SOURCE: 'discovery_source',
+  SOURCE_SECTION: 'source_section',
   PERP_DISCOVERY_SOURCE: 'perp_discovery_source',
   HL_FEE_RATE: 'hl_fee_rate',
   BULK_ACTION_ID: 'bulk_action_id',
@@ -175,6 +176,7 @@ const mockPerpsEventValueLiterals = {
     SUPPORT: 'support',
     FEEDBACK: 'give_feedback',
     GIVE_FEEDBACK: 'give_feedback',
+    TOP_MOVERS: 'top_movers',
   },
   MAX_SLIPPAGE_SOURCE: {
     DEFAULT: 'default',
@@ -216,6 +218,10 @@ const mockPerpsEventValueLiterals = {
     ASSET_DETAIL_SCREEN: 'asset_detail_screen',
     PERPS_MARKET_LIST_ALL: 'perps_market_list_all',
     PERP_MARKET_SEARCH: 'perp_market_search',
+  },
+  SOURCE_SECTION: {
+    TOP_GAINERS: 'top_gainers',
+    TOP_LOSERS: 'top_losers',
   },
   ACTION: {
     CREATE_POSITION: 'create_position',

--- a/ui/components/app/perps/constants.ts
+++ b/ui/components/app/perps/constants.ts
@@ -50,6 +50,13 @@ export const PERPS_CONSTANTS = {
 
   /** Max markets shown in the explore section (aligned with mobile). */
   EXPLORE_MARKETS_LIMIT: 8,
+
+  /**
+   * Max markets ranked in the Top movers section. Matches mobile's
+   * `TOP_MOVERS_LIMIT` and fills the design's 2-column x 4-row grid exactly,
+   * so the pills stack without scrolling.
+   */
+  TOP_MOVERS_LIMIT: 8,
 } as const;
 
 /**

--- a/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
@@ -23,6 +23,20 @@ describe('usePerpsTabExploreData', () => {
     });
   });
 
+  it('returns every live market unsliced so other sections can rank the same data', () => {
+    const { result } = renderHookWithProvider(() => usePerpsTabExploreData(), {
+      metamask: { ...mockState.metamask },
+    });
+
+    expect(result.current.allMarkets).toStrictEqual([
+      ...mockCryptoMarkets,
+      ...mockHip3Markets,
+    ]);
+    expect(result.current.allMarkets.length).toBeGreaterThan(
+      PERPS_CONSTANTS.EXPLORE_MARKETS_LIMIT,
+    );
+  });
+
   it('returns explore preview markets and watchlist markets from the same live source', () => {
     const { result } = renderHookWithProvider(() => usePerpsTabExploreData(), {
       metamask: {

--- a/ui/components/app/perps/hooks/usePerpsTabExploreData.ts
+++ b/ui/components/app/perps/hooks/usePerpsTabExploreData.ts
@@ -13,6 +13,13 @@ export type UsePerpsTabExploreDataOptions = {
 };
 
 export type UsePerpsTabExploreDataReturn = {
+  /**
+   * Every live market, unsliced. The Perps tab owns the single market-list
+   * stream subscription, so sections that need a different view of the same
+   * data (e.g. Top movers ranking by price change) read it from here rather
+   * than opening a second subscription.
+   */
+  allMarkets: PerpsMarketData[];
   exploreMarkets: PerpsMarketData[];
   watchlistMarkets: PerpsMarketData[];
   isInitialLoading: boolean;
@@ -53,6 +60,7 @@ export function usePerpsTabExploreData(
   );
 
   return {
+    allMarkets: liveMarkets,
     exploreMarkets,
     watchlistMarkets: filteredWatchlistMarkets,
     isInitialLoading,

--- a/ui/components/app/perps/hooks/usePerpsTopMovers.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsTopMovers.test.ts
@@ -1,0 +1,129 @@
+import { renderHookWithProviderTyped } from '../../../../../test/lib/render-helpers-navigate';
+import mockState from '../../../../../test/data/mock-state.json';
+import { usePerpsLiveMarketListData } from '../../../../hooks/perps/stream';
+import type { SortDirection } from '../../../../pages/perps/utils/sortMarkets';
+import { PERPS_CONSTANTS } from '../constants';
+import type { PerpsMarketData } from '../types';
+import { usePerpsTopMovers } from './usePerpsTopMovers';
+
+jest.mock('../../../../hooks/perps/stream', () => ({
+  usePerpsLiveMarketListData: jest.fn(),
+}));
+
+const mockUsePerpsLiveMarketListData = jest.mocked(usePerpsLiveMarketListData);
+
+const createMarket = (
+  symbol: string,
+  change24hPercent: string,
+): PerpsMarketData =>
+  ({
+    symbol,
+    name: symbol,
+    maxLeverage: '20x',
+    price: '$1.00',
+    change24h: '+$0.00',
+    change24hPercent,
+    volume: '$1M',
+  }) as PerpsMarketData;
+
+const setLiveMarkets = (
+  markets: PerpsMarketData[],
+  isInitialLoading = false,
+) => {
+  mockUsePerpsLiveMarketListData.mockReturnValue({
+    markets,
+    isInitialLoading,
+  } as ReturnType<typeof usePerpsLiveMarketListData>);
+};
+
+const renderTopMovers = (direction: SortDirection) =>
+  renderHookWithProviderTyped(
+    () => usePerpsTopMovers({ direction }),
+    mockState,
+  );
+
+describe('usePerpsTopMovers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ranks the biggest risers first when direction is desc', () => {
+    setLiveMarkets([
+      createMarket('BTC', '+1.00%'),
+      createMarket('ETH', '+9.00%'),
+      createMarket('SOL', '-4.00%'),
+    ]);
+
+    const { result } = renderTopMovers('desc');
+
+    expect(result.current.markets.map((market) => market.symbol)).toStrictEqual(
+      ['ETH', 'BTC', 'SOL'],
+    );
+  });
+
+  it('ranks the biggest fallers first when direction is asc', () => {
+    setLiveMarkets([
+      createMarket('BTC', '+1.00%'),
+      createMarket('ETH', '+9.00%'),
+      createMarket('SOL', '-4.00%'),
+    ]);
+
+    const { result } = renderTopMovers('asc');
+
+    expect(result.current.markets.map((market) => market.symbol)).toStrictEqual(
+      ['SOL', 'BTC', 'ETH'],
+    );
+  });
+
+  it('caps the ranking at the top movers limit', () => {
+    const markets = Array.from(
+      { length: PERPS_CONSTANTS.TOP_MOVERS_LIMIT + 5 },
+      (_, index) => createMarket(`SYM${index}`, `+${index}.00%`),
+    );
+    setLiveMarkets(markets);
+
+    const { result } = renderTopMovers('desc');
+
+    expect(result.current.markets).toHaveLength(
+      PERPS_CONSTANTS.TOP_MOVERS_LIMIT,
+    );
+  });
+
+  it('leaves the source market list untouched', () => {
+    const markets = [
+      createMarket('BTC', '+1.00%'),
+      createMarket('ETH', '+9.00%'),
+    ];
+    setLiveMarkets(markets);
+
+    renderTopMovers('desc');
+
+    expect(markets.map((market) => market.symbol)).toStrictEqual([
+      'BTC',
+      'ETH',
+    ]);
+  });
+
+  it('reports the stream initial loading state', () => {
+    setLiveMarkets([], true);
+
+    const { result } = renderTopMovers('desc');
+
+    expect(result.current.isInitialLoading).toBe(true);
+    expect(result.current.markets).toStrictEqual([]);
+  });
+
+  it('treats markets with no usable change value as zero change', () => {
+    setLiveMarkets([
+      createMarket('BTC', '--'),
+      createMarket('ETH', '+9.00%'),
+      createMarket('SOL', '-4.00%'),
+    ]);
+
+    const { result } = renderTopMovers('desc');
+
+    expect(result.current.markets.map((market) => market.symbol)).toStrictEqual(
+      ['ETH', 'BTC', 'SOL'],
+    );
+  });
+});

--- a/ui/components/app/perps/hooks/usePerpsTopMovers.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsTopMovers.test.ts
@@ -35,25 +35,19 @@ const renderTopMovers = (
   );
 
 describe('usePerpsTopMovers', () => {
-  it('ranks the biggest risers first when direction is desc', () => {
-    const { result } = renderTopMovers(MARKETS, 'desc');
+  it.each([
+    ['desc', ['ETH', 'BTC', 'SOL']],
+    ['asc', ['SOL', 'BTC', 'ETH']],
+  ] as [SortDirection, string[]][])(
+    'ranks markets by 24h change when direction is %s',
+    (direction, expectedOrder) => {
+      const { result } = renderTopMovers(MARKETS, direction);
 
-    expect(result.current.map((market) => market.symbol)).toStrictEqual([
-      'ETH',
-      'BTC',
-      'SOL',
-    ]);
-  });
-
-  it('ranks the biggest fallers first when direction is asc', () => {
-    const { result } = renderTopMovers(MARKETS, 'asc');
-
-    expect(result.current.map((market) => market.symbol)).toStrictEqual([
-      'SOL',
-      'BTC',
-      'ETH',
-    ]);
-  });
+      expect(result.current.map((market) => market.symbol)).toStrictEqual(
+        expectedOrder,
+      );
+    },
+  );
 
   it('caps the ranking at the top movers limit', () => {
     const markets = Array.from(

--- a/ui/components/app/perps/hooks/usePerpsTopMovers.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsTopMovers.test.ts
@@ -1,16 +1,9 @@
 import { renderHookWithProviderTyped } from '../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../test/data/mock-state.json';
-import { usePerpsLiveMarketListData } from '../../../../hooks/perps/stream';
 import type { SortDirection } from '../../../../pages/perps/utils/sortMarkets';
 import { PERPS_CONSTANTS } from '../constants';
 import type { PerpsMarketData } from '../types';
 import { usePerpsTopMovers } from './usePerpsTopMovers';
-
-jest.mock('../../../../hooks/perps/stream', () => ({
-  usePerpsLiveMarketListData: jest.fn(),
-}));
-
-const mockUsePerpsLiveMarketListData = jest.mocked(usePerpsLiveMarketListData);
 
 const createMarket = (
   symbol: string,
@@ -26,53 +19,40 @@ const createMarket = (
     volume: '$1M',
   }) as PerpsMarketData;
 
-const setLiveMarkets = (
-  markets: PerpsMarketData[],
-  isInitialLoading = false,
-) => {
-  mockUsePerpsLiveMarketListData.mockReturnValue({
-    markets,
-    isInitialLoading,
-  } as ReturnType<typeof usePerpsLiveMarketListData>);
-};
+const MARKETS = [
+  createMarket('BTC', '+1.00%'),
+  createMarket('ETH', '+9.00%'),
+  createMarket('SOL', '-4.00%'),
+];
 
-const renderTopMovers = (direction: SortDirection) =>
+const renderTopMovers = (
+  markets: PerpsMarketData[],
+  direction: SortDirection,
+) =>
   renderHookWithProviderTyped(
-    () => usePerpsTopMovers({ direction }),
+    () => usePerpsTopMovers({ markets, direction }),
     mockState,
   );
 
 describe('usePerpsTopMovers', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('ranks the biggest risers first when direction is desc', () => {
-    setLiveMarkets([
-      createMarket('BTC', '+1.00%'),
-      createMarket('ETH', '+9.00%'),
-      createMarket('SOL', '-4.00%'),
+    const { result } = renderTopMovers(MARKETS, 'desc');
+
+    expect(result.current.map((market) => market.symbol)).toStrictEqual([
+      'ETH',
+      'BTC',
+      'SOL',
     ]);
-
-    const { result } = renderTopMovers('desc');
-
-    expect(result.current.markets.map((market) => market.symbol)).toStrictEqual(
-      ['ETH', 'BTC', 'SOL'],
-    );
   });
 
   it('ranks the biggest fallers first when direction is asc', () => {
-    setLiveMarkets([
-      createMarket('BTC', '+1.00%'),
-      createMarket('ETH', '+9.00%'),
-      createMarket('SOL', '-4.00%'),
+    const { result } = renderTopMovers(MARKETS, 'asc');
+
+    expect(result.current.map((market) => market.symbol)).toStrictEqual([
+      'SOL',
+      'BTC',
+      'ETH',
     ]);
-
-    const { result } = renderTopMovers('asc');
-
-    expect(result.current.markets.map((market) => market.symbol)).toStrictEqual(
-      ['SOL', 'BTC', 'ETH'],
-    );
   });
 
   it('caps the ranking at the top movers limit', () => {
@@ -80,13 +60,10 @@ describe('usePerpsTopMovers', () => {
       { length: PERPS_CONSTANTS.TOP_MOVERS_LIMIT + 5 },
       (_, index) => createMarket(`SYM${index}`, `+${index}.00%`),
     );
-    setLiveMarkets(markets);
 
-    const { result } = renderTopMovers('desc');
+    const { result } = renderTopMovers(markets, 'desc');
 
-    expect(result.current.markets).toHaveLength(
-      PERPS_CONSTANTS.TOP_MOVERS_LIMIT,
-    );
+    expect(result.current).toHaveLength(PERPS_CONSTANTS.TOP_MOVERS_LIMIT);
   });
 
   it('leaves the source market list untouched', () => {
@@ -94,9 +71,8 @@ describe('usePerpsTopMovers', () => {
       createMarket('BTC', '+1.00%'),
       createMarket('ETH', '+9.00%'),
     ];
-    setLiveMarkets(markets);
 
-    renderTopMovers('desc');
+    renderTopMovers(markets, 'desc');
 
     expect(markets.map((market) => market.symbol)).toStrictEqual([
       'BTC',
@@ -104,26 +80,25 @@ describe('usePerpsTopMovers', () => {
     ]);
   });
 
-  it('reports the stream initial loading state', () => {
-    setLiveMarkets([], true);
+  it('returns an empty ranking when no markets are supplied', () => {
+    const { result } = renderTopMovers([], 'desc');
 
-    const { result } = renderTopMovers('desc');
-
-    expect(result.current.isInitialLoading).toBe(true);
-    expect(result.current.markets).toStrictEqual([]);
+    expect(result.current).toStrictEqual([]);
   });
 
   it('treats markets with no usable change value as zero change', () => {
-    setLiveMarkets([
+    const markets = [
       createMarket('BTC', '--'),
       createMarket('ETH', '+9.00%'),
       createMarket('SOL', '-4.00%'),
+    ];
+
+    const { result } = renderTopMovers(markets, 'desc');
+
+    expect(result.current.map((market) => market.symbol)).toStrictEqual([
+      'ETH',
+      'BTC',
+      'SOL',
     ]);
-
-    const { result } = renderTopMovers('desc');
-
-    expect(result.current.markets.map((market) => market.symbol)).toStrictEqual(
-      ['ETH', 'BTC', 'SOL'],
-    );
   });
 });

--- a/ui/components/app/perps/hooks/usePerpsTopMovers.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsTopMovers.test.ts
@@ -35,19 +35,20 @@ const renderTopMovers = (
   );
 
 describe('usePerpsTopMovers', () => {
-  it.each([
+  const rankingCases: [direction: SortDirection, expectedOrder: string[]][] = [
     ['desc', ['ETH', 'BTC', 'SOL']],
     ['asc', ['SOL', 'BTC', 'ETH']],
-  ] as [SortDirection, string[]][])(
-    'ranks markets by 24h change when direction is %s',
-    (direction, expectedOrder) => {
+  ];
+
+  rankingCases.forEach(([direction, expectedOrder]) => {
+    it(`ranks markets by 24h change when direction is ${direction}`, () => {
       const { result } = renderTopMovers(MARKETS, direction);
 
       expect(result.current.map((market) => market.symbol)).toStrictEqual(
         expectedOrder,
       );
-    },
-  );
+    });
+  });
 
   it('caps the ranking at the top movers limit', () => {
     const markets = Array.from(

--- a/ui/components/app/perps/hooks/usePerpsTopMovers.ts
+++ b/ui/components/app/perps/hooks/usePerpsTopMovers.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { usePerpsLiveMarketListData } from '../../../../hooks/perps/stream';
 import {
   sortMarkets,
   type SortDirection,
@@ -8,45 +7,40 @@ import { MARKET_SORTING_CONFIG, PERPS_CONSTANTS } from '../constants';
 import type { PerpsMarketData } from '../types';
 
 export type UsePerpsTopMoversOptions = {
+  /** Live markets to rank, supplied by the Perps tab's market-list stream owner. */
+  markets: PerpsMarketData[];
   /** `desc` ranks the biggest risers (gainers), `asc` the biggest fallers (losers). */
   direction: SortDirection;
 };
 
-export type UsePerpsTopMoversReturn = {
-  markets: PerpsMarketData[];
-  isInitialLoading: boolean;
-};
-
 /**
- * Ranks the live perps markets by 24h price change and returns the top
+ * Ranks the supplied perps markets by 24h price change and returns the top
  * `PERPS_CONSTANTS.TOP_MOVERS_LIMIT` in the requested direction.
  *
- * Reads the same market-list stream channel the Perps tab's Explore section
- * uses, so switching direction only re-derives an existing snapshot — no
- * refetch, and no extra subscription. Mobile's `usePerpsTopMovers` additionally
- * merges `usePerpsLivePrices` ticks because its base markets come from a REST
- * snapshot; the extension's stream already pushes updated `change24hPercent`,
- * so that merge would add an all-symbol subscription for no gain.
+ * Deliberately takes markets as an argument rather than reading the stream
+ * itself. The background `prices` channel is a single shared stream whose
+ * `perpsDeactivatePriceStream` teardown is global and not ref-counted, so it
+ * assumes one active owner; on the Perps tab that owner is
+ * `usePerpsTabExploreData`. Subscribing again here would add a second 30s
+ * refresh interval and let either consumer's unmount tear the stream down for
+ * the whole tab.
  *
  * @param options - Hook options.
+ * @param options.markets - Live markets to rank.
  * @param options.direction - Ranking direction: `desc` for gainers, `asc` for losers.
- * @returns The ranked markets and whether the first market snapshot is still loading.
+ * @returns The ranked markets, capped at the Top movers limit.
  */
 export function usePerpsTopMovers({
+  markets,
   direction,
-}: UsePerpsTopMoversOptions): UsePerpsTopMoversReturn {
-  const { markets: liveMarkets, isInitialLoading } =
-    usePerpsLiveMarketListData();
-
-  const markets = useMemo(
+}: UsePerpsTopMoversOptions): PerpsMarketData[] {
+  return useMemo(
     () =>
       sortMarkets({
-        markets: liveMarkets,
+        markets,
         sortBy: MARKET_SORTING_CONFIG.SORT_FIELDS.PRICE_CHANGE,
         direction,
       }).slice(0, PERPS_CONSTANTS.TOP_MOVERS_LIMIT),
-    [liveMarkets, direction],
+    [markets, direction],
   );
-
-  return { markets, isInitialLoading };
 }

--- a/ui/components/app/perps/hooks/usePerpsTopMovers.ts
+++ b/ui/components/app/perps/hooks/usePerpsTopMovers.ts
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { usePerpsLiveMarketListData } from '../../../../hooks/perps/stream';
+import {
+  sortMarkets,
+  type SortDirection,
+} from '../../../../pages/perps/utils/sortMarkets';
+import { MARKET_SORTING_CONFIG, PERPS_CONSTANTS } from '../constants';
+import type { PerpsMarketData } from '../types';
+
+export type UsePerpsTopMoversOptions = {
+  /** `desc` ranks the biggest risers (gainers), `asc` the biggest fallers (losers). */
+  direction: SortDirection;
+};
+
+export type UsePerpsTopMoversReturn = {
+  markets: PerpsMarketData[];
+  isInitialLoading: boolean;
+};
+
+/**
+ * Ranks the live perps markets by 24h price change and returns the top
+ * `PERPS_CONSTANTS.TOP_MOVERS_LIMIT` in the requested direction.
+ *
+ * Reads the same market-list stream channel the Perps tab's Explore section
+ * uses, so switching direction only re-derives an existing snapshot — no
+ * refetch, and no extra subscription. Mobile's `usePerpsTopMovers` additionally
+ * merges `usePerpsLivePrices` ticks because its base markets come from a REST
+ * snapshot; the extension's stream already pushes updated `change24hPercent`,
+ * so that merge would add an all-symbol subscription for no gain.
+ *
+ * @param options - Hook options.
+ * @param options.direction - Ranking direction: `desc` for gainers, `asc` for losers.
+ * @returns The ranked markets and whether the first market snapshot is still loading.
+ */
+export function usePerpsTopMovers({
+  direction,
+}: UsePerpsTopMoversOptions): UsePerpsTopMoversReturn {
+  const { markets: liveMarkets, isInitialLoading } =
+    usePerpsLiveMarketListData();
+
+  const markets = useMemo(
+    () =>
+      sortMarkets({
+        markets: liveMarkets,
+        sortBy: MARKET_SORTING_CONFIG.SORT_FIELDS.PRICE_CHANGE,
+        direction,
+      }).slice(0, PERPS_CONSTANTS.TOP_MOVERS_LIMIT),
+    [liveMarkets, direction],
+  );
+
+  return { markets, isInitialLoading };
+}

--- a/ui/components/app/perps/perps-top-movers/index.ts
+++ b/ui/components/app/perps/perps-top-movers/index.ts
@@ -1,0 +1,2 @@
+export { PerpsTopMovers } from './perps-top-movers';
+export { PerpsTopMoverPill } from './perps-top-mover-pill';

--- a/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import configureStore from '../../../../store/store';
+import mockState from '../../../../../test/data/mock-state.json';
+import type { PerpsMarketData } from '../types';
+import { PerpsTopMoverPill } from './perps-top-mover-pill';
+
+const mockStore = configureStore({ metamask: { ...mockState.metamask } });
+
+const createMarket = (
+  overrides: Partial<PerpsMarketData> = {},
+): PerpsMarketData =>
+  ({
+    symbol: 'BTC',
+    name: 'Bitcoin',
+    maxLeverage: '20x',
+    price: '$45,250.00',
+    change24h: '+$1,250.00',
+    change24hPercent: '+2.84%',
+    volume: '$1.2B',
+    ...overrides,
+  }) as PerpsMarketData;
+
+describe('PerpsTopMoverPill', () => {
+  const onPress = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the pill for the market', () => {
+    renderWithProvider(
+      <PerpsTopMoverPill market={createMarket()} onPress={onPress} />,
+      mockStore,
+    );
+
+    expect(screen.getByTestId('perps-top-movers-pill-BTC')).toBeInTheDocument();
+  });
+
+  it('displays the ticker', () => {
+    renderWithProvider(
+      <PerpsTopMoverPill market={createMarket()} onPress={onPress} />,
+      mockStore,
+    );
+
+    expect(screen.getByText('BTC')).toBeInTheDocument();
+  });
+
+  it('displays the signed 24h change', () => {
+    renderWithProvider(
+      <PerpsTopMoverPill market={createMarket()} onPress={onPress} />,
+      mockStore,
+    );
+
+    expect(screen.getByText('+2.84%')).toBeInTheDocument();
+  });
+
+  it('signs a positive change that arrives without a sign', () => {
+    renderWithProvider(
+      <PerpsTopMoverPill
+        market={createMarket({ change24hPercent: '2.84%' })}
+        onPress={onPress}
+      />,
+      mockStore,
+    );
+
+    expect(screen.getByText('+2.84%')).toBeInTheDocument();
+  });
+
+  it('displays a negative change unchanged', () => {
+    renderWithProvider(
+      <PerpsTopMoverPill
+        market={createMarket({ change24hPercent: '-4.10%' })}
+        onPress={onPress}
+      />,
+      mockStore,
+    );
+
+    expect(screen.getByText('-4.10%')).toBeInTheDocument();
+  });
+
+  it('strips the provider prefix from a HIP-3 ticker', () => {
+    renderWithProvider(
+      <PerpsTopMoverPill
+        market={createMarket({ symbol: 'xyz:TSLA', name: 'Tesla' })}
+        onPress={onPress}
+      />,
+      mockStore,
+    );
+
+    expect(
+      screen.getByTestId('perps-top-movers-pill-xyz-TSLA'),
+    ).toHaveTextContent('TSLA');
+  });
+
+  it('calls onPress with the market when the pill is clicked', () => {
+    const market = createMarket();
+    renderWithProvider(
+      <PerpsTopMoverPill market={market} onPress={onPress} />,
+      mockStore,
+    );
+
+    fireEvent.click(screen.getByTestId('perps-top-movers-pill-BTC'));
+
+    expect(onPress).toHaveBeenCalledWith(market);
+  });
+});

--- a/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.test.tsx
@@ -22,72 +22,51 @@ const createMarket = (
     ...overrides,
   }) as PerpsMarketData;
 
-describe('PerpsTopMoverPill', () => {
-  const onPress = jest.fn();
+const onPress = jest.fn();
 
+const renderPill = (overrides: Partial<PerpsMarketData> = {}) =>
+  renderWithProvider(
+    <PerpsTopMoverPill market={createMarket(overrides)} onPress={onPress} />,
+    mockStore,
+  );
+
+describe('PerpsTopMoverPill', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('renders the pill for the market', () => {
-    renderWithProvider(
-      <PerpsTopMoverPill market={createMarket()} onPress={onPress} />,
-      mockStore,
-    );
+    renderPill();
 
     expect(screen.getByTestId('perps-top-movers-pill-BTC')).toBeInTheDocument();
   });
 
   it('displays the ticker', () => {
-    renderWithProvider(
-      <PerpsTopMoverPill market={createMarket()} onPress={onPress} />,
-      mockStore,
-    );
+    renderPill();
 
     expect(screen.getByText('BTC')).toBeInTheDocument();
   });
 
   it('displays the signed 24h change', () => {
-    renderWithProvider(
-      <PerpsTopMoverPill market={createMarket()} onPress={onPress} />,
-      mockStore,
-    );
+    renderPill();
 
     expect(screen.getByText('+2.84%')).toBeInTheDocument();
   });
 
   it('signs a positive change that arrives without a sign', () => {
-    renderWithProvider(
-      <PerpsTopMoverPill
-        market={createMarket({ change24hPercent: '2.84%' })}
-        onPress={onPress}
-      />,
-      mockStore,
-    );
+    renderPill({ change24hPercent: '2.84%' });
 
     expect(screen.getByText('+2.84%')).toBeInTheDocument();
   });
 
   it('displays a negative change unchanged', () => {
-    renderWithProvider(
-      <PerpsTopMoverPill
-        market={createMarket({ change24hPercent: '-4.10%' })}
-        onPress={onPress}
-      />,
-      mockStore,
-    );
+    renderPill({ change24hPercent: '-4.10%' });
 
     expect(screen.getByText('-4.10%')).toBeInTheDocument();
   });
 
   it('strips the provider prefix from a HIP-3 ticker', () => {
-    renderWithProvider(
-      <PerpsTopMoverPill
-        market={createMarket({ symbol: 'xyz:TSLA', name: 'Tesla' })}
-        onPress={onPress}
-      />,
-      mockStore,
-    );
+    renderPill({ symbol: 'xyz:TSLA', name: 'Tesla' });
 
     expect(
       screen.getByTestId('perps-top-movers-pill-xyz-TSLA'),

--- a/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.test.tsx
@@ -41,6 +41,16 @@ describe('PerpsTopMoverPill', () => {
     expect(screen.getByTestId('perps-top-movers-pill-BTC')).toBeInTheDocument();
   });
 
+  it('sizes to its label instead of stretching or shrinking in a row', () => {
+    renderPill();
+
+    const pill = screen.getByTestId('perps-top-movers-pill-BTC');
+
+    expect(pill).toHaveClass('w-auto', 'shrink-0');
+    expect(pill).not.toHaveClass('flex-1');
+    expect(pill).not.toHaveClass('min-w-0');
+  });
+
   it('displays the ticker', () => {
     renderPill();
 

--- a/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.tsx
@@ -27,7 +27,7 @@ export type PerpsTopMoverPillProps = {
 // hugs its label the way mobile's do; `h-auto` prevents the fixed `h-12` from
 // stretching the capsule.
 const PILL_STYLES =
-  'flex-1 h-auto min-w-0 justify-center gap-1.5 rounded-full bg-muted px-2 py-1.5 cursor-pointer hover:bg-hover active:bg-pressed';
+  'w-auto shrink-0 h-auto justify-center gap-1.5 rounded-full bg-muted px-2 py-1.5 cursor-pointer hover:bg-hover active:bg-pressed';
 
 /**
  * PerpsTopMoverPill renders one ranked market as a horizontal pill: token

--- a/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import {
   ButtonBase,
   Text,
@@ -41,18 +41,10 @@ export const PerpsTopMoverPill = ({
   market,
   onPress,
 }: PerpsTopMoverPillProps) => {
-  const displaySymbol = useMemo(
-    () => getDisplaySymbol(market.symbol),
-    [market.symbol],
-  );
-  const changeLabel = useMemo(
-    () => formatSignedChangePercent(market.change24hPercent),
-    [market.change24hPercent],
-  );
-  const changeColor = useMemo(
-    () => getChangeColor(market.change24hPercent),
-    [market.change24hPercent],
-  );
+  // Plain string derivations over primitives — cheaper to recompute than to memoize.
+  const displaySymbol = getDisplaySymbol(market.symbol);
+  const changeLabel = formatSignedChangePercent(market.change24hPercent);
+  const changeColor = getChangeColor(market.change24hPercent);
 
   const handleClick = useCallback(() => {
     onPress(market);

--- a/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.tsx
@@ -27,7 +27,7 @@ export type PerpsTopMoverPillProps = {
 // hugs its label the way mobile's do; `h-auto` prevents the fixed `h-12` from
 // stretching the capsule.
 const PILL_STYLES =
-  'w-auto shrink-0 h-auto min-w-0 gap-2 rounded-full bg-muted px-2 py-2 cursor-pointer hover:bg-hover active:bg-pressed';
+  'flex-1 h-auto min-w-0 justify-center gap-1.5 rounded-full bg-muted px-2 py-1.5 cursor-pointer hover:bg-hover active:bg-pressed';
 
 /**
  * PerpsTopMoverPill renders one ranked market as a horizontal pill: token

--- a/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.tsx
@@ -1,8 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
 import {
-  Box,
-  BoxFlexDirection,
-  BoxAlignItems,
   ButtonBase,
   Text,
   TextVariant,
@@ -24,14 +21,16 @@ export type PerpsTopMoverPillProps = {
   onPress: (market: PerpsMarketData) => void;
 };
 
-// A pill is one grid cell: logo, ticker, and signed 24h change on a muted
-// rounded surface. `h-auto`/`min-h-[48px]` overrides ButtonBase's fixed `h-12`
-// so the label never clips when a long ticker wraps the row taller.
+// A content-width lozenge: logo, ticker and change sit inline on one row,
+// matching mobile's `ExplorePill` (`rounded-full`, muted background, p-2).
+// `w-auto`/`shrink-0` override ButtonBase's full-width default so each pill
+// hugs its label the way mobile's do; `h-auto` prevents the fixed `h-12` from
+// stretching the capsule.
 const PILL_STYLES =
-  'w-full min-w-0 h-auto min-h-[48px] justify-start gap-2 rounded-xl bg-muted px-3 py-2 text-left cursor-pointer hover:bg-hover active:bg-pressed';
+  'w-auto shrink-0 h-auto min-w-0 gap-2 rounded-full bg-muted px-2 py-2 cursor-pointer hover:bg-hover active:bg-pressed';
 
 /**
- * PerpsTopMoverPill renders one ranked market in the Top movers grid: token
+ * PerpsTopMoverPill renders one ranked market as a horizontal pill: token
  * logo, display ticker, and its signed 24h price change coloured by direction.
  *
  * @param options0 - Component props.
@@ -62,7 +61,6 @@ export const PerpsTopMoverPill = ({
   return (
     <ButtonBase
       className={PILL_STYLES}
-      isFullWidth
       onClick={handleClick}
       data-testid={`perps-top-movers-pill-${market.symbol.replace(/:/gu, '-')}`}
     >
@@ -71,27 +69,21 @@ export const PerpsTopMoverPill = ({
         size={AvatarTokenSize.Sm}
         className="shrink-0"
       />
-      <Box
-        className="min-w-0 flex-1 overflow-hidden"
-        flexDirection={BoxFlexDirection.Column}
-        alignItems={BoxAlignItems.Start}
-        gap={0}
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        className="whitespace-nowrap"
       >
-        <Text
-          variant={TextVariant.BodySm}
-          fontWeight={FontWeight.Medium}
-          className="block max-w-full truncate"
-        >
-          {displaySymbol}
-        </Text>
-        <Text
-          variant={TextVariant.BodyXs}
-          color={changeColor}
-          className="block max-w-full truncate"
-        >
-          {changeLabel}
-        </Text>
-      </Box>
+        {displaySymbol}
+      </Text>
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        color={changeColor}
+        className="whitespace-nowrap"
+      >
+        {changeLabel}
+      </Text>
     </ButtonBase>
   );
 };

--- a/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-mover-pill.tsx
@@ -1,0 +1,99 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  ButtonBase,
+  Text,
+  TextVariant,
+  FontWeight,
+  AvatarTokenSize,
+} from '@metamask/design-system-react';
+import { PerpsTokenLogo } from '../perps-token-logo';
+import {
+  getChangeColor,
+  getDisplaySymbol,
+  formatSignedChangePercent,
+} from '../utils';
+import type { PerpsMarketData } from '../types';
+
+export type PerpsTopMoverPillProps = {
+  /** Market to render in the pill */
+  market: PerpsMarketData;
+  /** Callback when the pill is pressed */
+  onPress: (market: PerpsMarketData) => void;
+};
+
+// A pill is one grid cell: logo, ticker, and signed 24h change on a muted
+// rounded surface. `h-auto`/`min-h-[48px]` overrides ButtonBase's fixed `h-12`
+// so the label never clips when a long ticker wraps the row taller.
+const PILL_STYLES =
+  'w-full min-w-0 h-auto min-h-[48px] justify-start gap-2 rounded-xl bg-muted px-3 py-2 text-left cursor-pointer hover:bg-hover active:bg-pressed';
+
+/**
+ * PerpsTopMoverPill renders one ranked market in the Top movers grid: token
+ * logo, display ticker, and its signed 24h price change coloured by direction.
+ *
+ * @param options0 - Component props.
+ * @param options0.market - The market to render.
+ * @param options0.onPress - Called with the market when the pill is pressed.
+ */
+export const PerpsTopMoverPill = ({
+  market,
+  onPress,
+}: PerpsTopMoverPillProps) => {
+  const displaySymbol = useMemo(
+    () => getDisplaySymbol(market.symbol),
+    [market.symbol],
+  );
+  const changeLabel = useMemo(
+    () => formatSignedChangePercent(market.change24hPercent),
+    [market.change24hPercent],
+  );
+  const changeColor = useMemo(
+    () => getChangeColor(market.change24hPercent),
+    [market.change24hPercent],
+  );
+
+  const handleClick = useCallback(() => {
+    onPress(market);
+  }, [onPress, market]);
+
+  return (
+    <ButtonBase
+      className={PILL_STYLES}
+      isFullWidth
+      onClick={handleClick}
+      data-testid={`perps-top-movers-pill-${market.symbol.replace(/:/gu, '-')}`}
+    >
+      <PerpsTokenLogo
+        symbol={market.symbol}
+        size={AvatarTokenSize.Sm}
+        className="shrink-0"
+      />
+      <Box
+        className="min-w-0 flex-1 overflow-hidden"
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Start}
+        gap={0}
+      >
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          className="block max-w-full truncate"
+        >
+          {displaySymbol}
+        </Text>
+        <Text
+          variant={TextVariant.BodyXs}
+          color={changeColor}
+          className="block max-w-full truncate"
+        >
+          {changeLabel}
+        </Text>
+      </Box>
+    </ButtonBase>
+  );
+};
+
+export default PerpsTopMoverPill;

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
@@ -108,6 +108,17 @@ describe('PerpsTopMovers', () => {
       );
     });
 
+    it('keeps the bordered toggle track inset from the screen edges', () => {
+      renderSection();
+
+      const track = screen.getByTestId('perps-top-movers-toggle');
+
+      expect(track).toHaveClass('p-1');
+      expect(track).not.toHaveClass('pl-4');
+      expect(track).not.toHaveClass('pr-4');
+      expect(track.parentElement).toHaveClass('pl-4', 'pr-4');
+    });
+
     it('splits the ranked pills evenly across two rows', () => {
       renderSection(
         Array.from({ length: PERPS_CONSTANTS.TOP_MOVERS_LIMIT }, (_, index) =>

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
@@ -4,7 +4,6 @@ import { renderWithProvider } from '../../../../../test/lib/render-helpers-navig
 import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
-import { usePerpsLiveMarketListData } from '../../../../hooks/perps/stream';
 import {
   PERPS_MARKET_DETAIL_ROUTE,
   PERPS_MARKET_LIST_ROUTE,
@@ -25,18 +24,12 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock('../../../../hooks/perps/stream', () => ({
-  usePerpsLiveMarketListData: jest.fn(),
-}));
-
 const mockTrack = jest.fn();
 
 jest.mock('../../../../hooks/perps', () => ({
   ...jest.requireActual('../../../../hooks/perps'),
   usePerpsEventTracking: () => ({ track: mockTrack }),
 }));
-
-const mockUsePerpsLiveMarketListData = jest.mocked(usePerpsLiveMarketListData);
 
 const mockStore = configureStore({ metamask: { ...mockState.metamask } });
 
@@ -60,17 +53,11 @@ const MARKETS = [
   createMarket('SOL', '-4.00%'),
 ];
 
-const setLiveMarkets = (
-  markets: PerpsMarketData[],
-  isInitialLoading = false,
-) => {
-  mockUsePerpsLiveMarketListData.mockReturnValue({
-    markets,
-    isInitialLoading,
-  } as ReturnType<typeof usePerpsLiveMarketListData>);
-};
-
-const renderSection = () => renderWithProvider(<PerpsTopMovers />, mockStore);
+const renderSection = (markets = MARKETS, isLoading = false) =>
+  renderWithProvider(
+    <PerpsTopMovers markets={markets} isLoading={isLoading} />,
+    mockStore,
+  );
 
 const getPillSymbols = () =>
   screen
@@ -80,7 +67,6 @@ const getPillSymbols = () =>
 describe('PerpsTopMovers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    setLiveMarkets(MARKETS);
   });
 
   describe('rendering', () => {
@@ -145,20 +131,18 @@ describe('PerpsTopMovers', () => {
     });
 
     it('caps the pill grid at the top movers limit', () => {
-      setLiveMarkets(
+      renderSection(
         Array.from(
           { length: PERPS_CONSTANTS.TOP_MOVERS_LIMIT + 4 },
           (_, index) => createMarket(`SYM${index}`, `+${index}.00%`),
         ),
       );
-      renderSection();
 
       expect(getPillSymbols()).toHaveLength(PERPS_CONSTANTS.TOP_MOVERS_LIMIT);
     });
 
     it('renders the loading skeleton while market data is loading', () => {
-      setLiveMarkets([], true);
-      renderSection();
+      renderSection([], true);
 
       expect(
         screen.getByTestId('perps-top-movers-skeleton'),
@@ -169,8 +153,7 @@ describe('PerpsTopMovers', () => {
     });
 
     it('hides the section when loading finished with no markets', () => {
-      setLiveMarkets([]);
-      renderSection();
+      renderSection([]);
 
       expect(screen.queryByTestId('perps-top-movers')).not.toBeInTheDocument();
     });

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
@@ -76,15 +76,6 @@ describe('PerpsTopMovers', () => {
       expect(screen.getByTestId('perps-top-movers')).toBeInTheDocument();
     });
 
-    it('renders the gainers and losers toggle', () => {
-      renderSection();
-
-      expect(
-        screen.getByTestId('perps-top-movers-gainers'),
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('perps-top-movers-losers')).toBeInTheDocument();
-    });
-
     it('displays the section heading copy', () => {
       renderSection();
 
@@ -115,30 +106,6 @@ describe('PerpsTopMovers', () => {
         'aria-pressed',
         'false',
       );
-    });
-
-    it('ranks the biggest risers first while gainers is selected', () => {
-      renderSection();
-
-      expect(getPillSymbols()).toStrictEqual(['ETH', 'BTC', 'SOL']);
-    });
-
-    it('renders one pill per ranked market', () => {
-      renderSection();
-
-      expect(screen.getByTestId('perps-top-movers-list')).toBeInTheDocument();
-      expect(getPillSymbols()).toHaveLength(MARKETS.length);
-    });
-
-    it('caps the pill grid at the top movers limit', () => {
-      renderSection(
-        Array.from(
-          { length: PERPS_CONSTANTS.TOP_MOVERS_LIMIT + 4 },
-          (_, index) => createMarket(`SYM${index}`, `+${index}.00%`),
-        ),
-      );
-
-      expect(getPillSymbols()).toHaveLength(PERPS_CONSTANTS.TOP_MOVERS_LIMIT);
     });
 
     it('splits the ranked pills evenly across two rows', () => {
@@ -227,38 +194,27 @@ describe('PerpsTopMovers', () => {
         screen.queryByTestId('perps-top-movers-skeleton'),
       ).not.toBeInTheDocument();
     });
-
-    it('returns to the risers ranking when gainers is selected again', () => {
-      renderSection();
-
-      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
-      fireEvent.click(screen.getByTestId('perps-top-movers-gainers'));
-
-      expect(getPillSymbols()).toStrictEqual(['ETH', 'BTC', 'SOL']);
-    });
   });
 
   describe('navigation', () => {
-    it('opens the market list sorted by descending price change from the header', () => {
-      renderSection();
+    it.each([
+      ['desc', undefined],
+      ['asc', 'perps-top-movers-losers'],
+    ])(
+      'opens the market list pre-sorted by price change %s from the header',
+      (expectedDirection, toggleTestId) => {
+        renderSection();
+        if (toggleTestId) {
+          fireEvent.click(screen.getByTestId(toggleTestId));
+        }
 
-      fireEvent.click(screen.getByTestId('perps-top-movers-header'));
+        fireEvent.click(screen.getByTestId('perps-top-movers-header'));
 
-      expect(mockNavigate).toHaveBeenCalledWith(
-        `${PERPS_MARKET_LIST_ROUTE}?sort=priceChange&direction=desc`,
-      );
-    });
-
-    it('carries the losers direction into the market list sort', () => {
-      renderSection();
-
-      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
-      fireEvent.click(screen.getByTestId('perps-top-movers-header'));
-
-      expect(mockNavigate).toHaveBeenCalledWith(
-        `${PERPS_MARKET_LIST_ROUTE}?sort=priceChange&direction=asc`,
-      );
-    });
+        expect(mockNavigate).toHaveBeenCalledWith(
+          `${PERPS_MARKET_LIST_ROUTE}?sort=priceChange&direction=${expectedDirection}`,
+        );
+      },
+    );
 
     it('opens the market detail page from a pill', () => {
       renderSection();
@@ -290,39 +246,39 @@ describe('PerpsTopMovers', () => {
       );
     });
 
-    it('attributes a pill tap to the gainers section', () => {
-      renderSection();
+    it.each([
+      [
+        'gainers',
+        undefined,
+        'ETH',
+        PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_GAINERS,
+      ],
+      [
+        'losers',
+        'perps-top-movers-losers',
+        'SOL',
+        PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_LOSERS,
+      ],
+    ])(
+      'attributes a pill tap to the %s section',
+      (_name, toggleTestId, symbol, sourceSection) => {
+        renderSection();
+        if (toggleTestId) {
+          fireEvent.click(screen.getByTestId(toggleTestId));
+        }
 
-      fireEvent.click(screen.getByTestId('perps-top-movers-pill-ETH'));
+        fireEvent.click(screen.getByTestId(`perps-top-movers-pill-${symbol}`));
 
-      expect(mockTrack).toHaveBeenCalledWith(
-        MetaMetricsEventName.PerpsUiInteraction,
-        {
-          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-            PERPS_EVENT_VALUE.INTERACTION_TYPE.TAP,
-          [PERPS_EVENT_PROPERTY.ASSET]: 'ETH',
-          [PERPS_EVENT_PROPERTY.SOURCE_SECTION]:
-            PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_GAINERS,
-        },
-      );
-    });
-
-    it('attributes a pill tap to the losers section after switching direction', () => {
-      renderSection();
-
-      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
-      fireEvent.click(screen.getByTestId('perps-top-movers-pill-SOL'));
-
-      expect(mockTrack).toHaveBeenCalledWith(
-        MetaMetricsEventName.PerpsUiInteraction,
-        {
-          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-            PERPS_EVENT_VALUE.INTERACTION_TYPE.TAP,
-          [PERPS_EVENT_PROPERTY.ASSET]: 'SOL',
-          [PERPS_EVENT_PROPERTY.SOURCE_SECTION]:
-            PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_LOSERS,
-        },
-      );
-    });
+        expect(mockTrack).toHaveBeenCalledWith(
+          MetaMetricsEventName.PerpsUiInteraction,
+          {
+            [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+              PERPS_EVENT_VALUE.INTERACTION_TYPE.TAP,
+            [PERPS_EVENT_PROPERTY.ASSET]: symbol,
+            [PERPS_EVENT_PROPERTY.SOURCE_SECTION]: sourceSection,
+          },
+        );
+      },
+    );
   });
 });

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
@@ -135,6 +135,25 @@ describe('PerpsTopMovers', () => {
       expect(rowCounts).toStrictEqual([4, 4]);
     });
 
+    it('keeps each pill row on one line so a narrow popup can scroll instead of wrapping', () => {
+      renderSection(
+        Array.from({ length: PERPS_CONSTANTS.TOP_MOVERS_LIMIT }, (_, index) =>
+          createMarket(`SYM${index}`, `+${index}.00%`),
+        ),
+      );
+
+      expect(screen.getByTestId('perps-top-movers-list')).toHaveClass(
+        'overflow-x-auto',
+      );
+      expect(screen.getByTestId('perps-top-movers-list-row-0')).toHaveClass(
+        'w-max',
+        'flex-nowrap',
+      );
+      expect(screen.getByTestId('perps-top-movers-list-row-0')).not.toHaveClass(
+        'flex-wrap',
+      );
+    });
+
     it('keeps the ranking order when splitting an odd number of pills', () => {
       renderSection([
         createMarket('AAA', '+9.00%'),

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
@@ -142,9 +142,11 @@ describe('PerpsTopMovers', () => {
         ),
       );
 
-      expect(screen.getByTestId('perps-top-movers-list')).toHaveClass(
-        'overflow-x-auto',
-      );
+      const list = screen.getByTestId('perps-top-movers-list');
+
+      expect(list).toHaveClass('overflow-x-auto');
+      expect(list).not.toHaveClass('px-4');
+      expect(list.firstElementChild).toHaveClass('w-max', 'px-4');
       expect(screen.getByTestId('perps-top-movers-list-row-0')).toHaveClass(
         'w-max',
         'flex-nowrap',

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
@@ -141,6 +141,40 @@ describe('PerpsTopMovers', () => {
       expect(getPillSymbols()).toHaveLength(PERPS_CONSTANTS.TOP_MOVERS_LIMIT);
     });
 
+    it('splits the ranked pills evenly across two rows', () => {
+      renderSection(
+        Array.from({ length: PERPS_CONSTANTS.TOP_MOVERS_LIMIT }, (_, index) =>
+          createMarket(`SYM${index}`, `+${index}.00%`),
+        ),
+      );
+
+      const rowCounts = [0, 1].map(
+        (rowIndex) =>
+          screen.getByTestId(`perps-top-movers-list-row-${rowIndex}`)
+            .childElementCount,
+      );
+
+      expect(rowCounts).toStrictEqual([4, 4]);
+    });
+
+    it('keeps the ranking order when splitting an odd number of pills', () => {
+      renderSection([
+        createMarket('AAA', '+9.00%'),
+        createMarket('BBB', '+5.00%'),
+        createMarket('CCC', '+1.00%'),
+      ]);
+
+      expect(
+        screen.getByTestId('perps-top-movers-list-row-0'),
+      ).toHaveTextContent('AAA');
+      expect(
+        screen.getByTestId('perps-top-movers-list-row-0'),
+      ).toHaveTextContent('BBB');
+      expect(
+        screen.getByTestId('perps-top-movers-list-row-1'),
+      ).toHaveTextContent('CCC');
+    });
+
     it('renders the loading skeleton while market data is loading', () => {
       renderSection([], true);
 

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
@@ -197,24 +197,26 @@ describe('PerpsTopMovers', () => {
   });
 
   describe('navigation', () => {
-    it.each([
-      ['desc', undefined],
-      ['asc', 'perps-top-movers-losers'],
-    ])(
-      'opens the market list pre-sorted by price change %s from the header',
-      (expectedDirection, toggleTestId) => {
-        renderSection();
-        if (toggleTestId) {
-          fireEvent.click(screen.getByTestId(toggleTestId));
-        }
+    it('opens the market list pre-sorted by descending price change', () => {
+      renderSection();
 
-        fireEvent.click(screen.getByTestId('perps-top-movers-header'));
+      fireEvent.click(screen.getByTestId('perps-top-movers-header'));
 
-        expect(mockNavigate).toHaveBeenCalledWith(
-          `${PERPS_MARKET_LIST_ROUTE}?sort=priceChange&direction=${expectedDirection}`,
-        );
-      },
-    );
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${PERPS_MARKET_LIST_ROUTE}?sort=priceChange&direction=desc`,
+      );
+    });
+
+    it('carries the losers direction into the market list sort', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
+      fireEvent.click(screen.getByTestId('perps-top-movers-header'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${PERPS_MARKET_LIST_ROUTE}?sort=priceChange&direction=asc`,
+      );
+    });
 
     it('opens the market detail page from a pill', () => {
       renderSection();
@@ -246,39 +248,39 @@ describe('PerpsTopMovers', () => {
       );
     });
 
-    it.each([
-      [
-        'gainers',
-        undefined,
-        'ETH',
-        PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_GAINERS,
-      ],
-      [
-        'losers',
-        'perps-top-movers-losers',
-        'SOL',
-        PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_LOSERS,
-      ],
-    ])(
-      'attributes a pill tap to the %s section',
-      (_name, toggleTestId, symbol, sourceSection) => {
-        renderSection();
-        if (toggleTestId) {
-          fireEvent.click(screen.getByTestId(toggleTestId));
-        }
+    it('attributes a pill tap to the gainers section', () => {
+      renderSection();
 
-        fireEvent.click(screen.getByTestId(`perps-top-movers-pill-${symbol}`));
+      fireEvent.click(screen.getByTestId('perps-top-movers-pill-ETH'));
 
-        expect(mockTrack).toHaveBeenCalledWith(
-          MetaMetricsEventName.PerpsUiInteraction,
-          {
-            [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-              PERPS_EVENT_VALUE.INTERACTION_TYPE.TAP,
-            [PERPS_EVENT_PROPERTY.ASSET]: symbol,
-            [PERPS_EVENT_PROPERTY.SOURCE_SECTION]: sourceSection,
-          },
-        );
-      },
-    );
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEventName.PerpsUiInteraction,
+        {
+          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+            PERPS_EVENT_VALUE.INTERACTION_TYPE.TAP,
+          [PERPS_EVENT_PROPERTY.ASSET]: 'ETH',
+          [PERPS_EVENT_PROPERTY.SOURCE_SECTION]:
+            PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_GAINERS,
+        },
+      );
+    });
+
+    it('attributes a pill tap to the losers section', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
+      fireEvent.click(screen.getByTestId('perps-top-movers-pill-SOL'));
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEventName.PerpsUiInteraction,
+        {
+          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+            PERPS_EVENT_VALUE.INTERACTION_TYPE.TAP,
+          [PERPS_EVENT_PROPERTY.ASSET]: 'SOL',
+          [PERPS_EVENT_PROPERTY.SOURCE_SECTION]:
+            PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_LOSERS,
+        },
+      );
+    });
   });
 });

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
+import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import { usePerpsLiveMarketListData } from '../../../../hooks/perps/stream';
 import {
   PERPS_MARKET_DETAIL_ROUTE,
@@ -96,6 +97,25 @@ describe('PerpsTopMovers', () => {
         screen.getByTestId('perps-top-movers-gainers'),
       ).toBeInTheDocument();
       expect(screen.getByTestId('perps-top-movers-losers')).toBeInTheDocument();
+    });
+
+    it('displays the section heading copy', () => {
+      renderSection();
+
+      expect(screen.getByTestId('perps-top-movers-header')).toHaveTextContent(
+        messages.perpsTopMovers.message,
+      );
+    });
+
+    it('displays the toggle copy on both directions', () => {
+      renderSection();
+
+      expect(screen.getByTestId('perps-top-movers-gainers')).toHaveTextContent(
+        messages.perpsTopMoversGainers.message,
+      );
+      expect(screen.getByTestId('perps-top-movers-losers')).toHaveTextContent(
+        messages.perpsTopMoversLosers.message,
+      );
     });
 
     it('selects gainers by default', () => {

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx
@@ -1,0 +1,291 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import configureStore from '../../../../store/store';
+import mockState from '../../../../../test/data/mock-state.json';
+import { usePerpsLiveMarketListData } from '../../../../hooks/perps/stream';
+import {
+  PERPS_MARKET_DETAIL_ROUTE,
+  PERPS_MARKET_LIST_ROUTE,
+} from '../../../../helpers/constants/routes';
+import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '../../../../../shared/constants/perps-events';
+import { PERPS_CONSTANTS } from '../constants';
+import type { PerpsMarketData } from '../types';
+import { PerpsTopMovers } from './perps-top-movers';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../../hooks/perps/stream', () => ({
+  usePerpsLiveMarketListData: jest.fn(),
+}));
+
+const mockTrack = jest.fn();
+
+jest.mock('../../../../hooks/perps', () => ({
+  ...jest.requireActual('../../../../hooks/perps'),
+  usePerpsEventTracking: () => ({ track: mockTrack }),
+}));
+
+const mockUsePerpsLiveMarketListData = jest.mocked(usePerpsLiveMarketListData);
+
+const mockStore = configureStore({ metamask: { ...mockState.metamask } });
+
+const createMarket = (
+  symbol: string,
+  change24hPercent: string,
+): PerpsMarketData =>
+  ({
+    symbol,
+    name: symbol,
+    maxLeverage: '20x',
+    price: '$1.00',
+    change24h: '+$0.00',
+    change24hPercent,
+    volume: '$1M',
+  }) as PerpsMarketData;
+
+const MARKETS = [
+  createMarket('BTC', '+1.00%'),
+  createMarket('ETH', '+9.00%'),
+  createMarket('SOL', '-4.00%'),
+];
+
+const setLiveMarkets = (
+  markets: PerpsMarketData[],
+  isInitialLoading = false,
+) => {
+  mockUsePerpsLiveMarketListData.mockReturnValue({
+    markets,
+    isInitialLoading,
+  } as ReturnType<typeof usePerpsLiveMarketListData>);
+};
+
+const renderSection = () => renderWithProvider(<PerpsTopMovers />, mockStore);
+
+const getPillSymbols = () =>
+  screen
+    .getAllByTestId(/^perps-top-movers-pill-/u)
+    .map((pill) => pill.dataset.testid?.replace('perps-top-movers-pill-', ''));
+
+describe('PerpsTopMovers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setLiveMarkets(MARKETS);
+  });
+
+  describe('rendering', () => {
+    it('renders the top movers section', () => {
+      renderSection();
+
+      expect(screen.getByTestId('perps-top-movers')).toBeInTheDocument();
+    });
+
+    it('renders the gainers and losers toggle', () => {
+      renderSection();
+
+      expect(
+        screen.getByTestId('perps-top-movers-gainers'),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('perps-top-movers-losers')).toBeInTheDocument();
+    });
+
+    it('selects gainers by default', () => {
+      renderSection();
+
+      expect(screen.getByTestId('perps-top-movers-gainers')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+      expect(screen.getByTestId('perps-top-movers-losers')).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      );
+    });
+
+    it('ranks the biggest risers first while gainers is selected', () => {
+      renderSection();
+
+      expect(getPillSymbols()).toStrictEqual(['ETH', 'BTC', 'SOL']);
+    });
+
+    it('renders one pill per ranked market', () => {
+      renderSection();
+
+      expect(screen.getByTestId('perps-top-movers-list')).toBeInTheDocument();
+      expect(getPillSymbols()).toHaveLength(MARKETS.length);
+    });
+
+    it('caps the pill grid at the top movers limit', () => {
+      setLiveMarkets(
+        Array.from(
+          { length: PERPS_CONSTANTS.TOP_MOVERS_LIMIT + 4 },
+          (_, index) => createMarket(`SYM${index}`, `+${index}.00%`),
+        ),
+      );
+      renderSection();
+
+      expect(getPillSymbols()).toHaveLength(PERPS_CONSTANTS.TOP_MOVERS_LIMIT);
+    });
+
+    it('renders the loading skeleton while market data is loading', () => {
+      setLiveMarkets([], true);
+      renderSection();
+
+      expect(
+        screen.getByTestId('perps-top-movers-skeleton'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('perps-top-movers-list'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the section when loading finished with no markets', () => {
+      setLiveMarkets([]);
+      renderSection();
+
+      expect(screen.queryByTestId('perps-top-movers')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('direction toggle', () => {
+    it('re-ranks the pills to the biggest fallers when losers is selected', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
+
+      expect(getPillSymbols()).toStrictEqual(['SOL', 'BTC', 'ETH']);
+    });
+
+    it('moves the pressed state onto losers when losers is selected', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
+
+      expect(screen.getByTestId('perps-top-movers-losers')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+      expect(screen.getByTestId('perps-top-movers-gainers')).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      );
+    });
+
+    it('keeps the pill grid mounted through a direction change', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
+
+      expect(screen.getByTestId('perps-top-movers-list')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('perps-top-movers-skeleton'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('returns to the risers ranking when gainers is selected again', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
+      fireEvent.click(screen.getByTestId('perps-top-movers-gainers'));
+
+      expect(getPillSymbols()).toStrictEqual(['ETH', 'BTC', 'SOL']);
+    });
+  });
+
+  describe('navigation', () => {
+    it('opens the market list sorted by descending price change from the header', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-header'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${PERPS_MARKET_LIST_ROUTE}?sort=priceChange&direction=desc`,
+      );
+    });
+
+    it('carries the losers direction into the market list sort', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
+      fireEvent.click(screen.getByTestId('perps-top-movers-header'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${PERPS_MARKET_LIST_ROUTE}?sort=priceChange&direction=asc`,
+      );
+    });
+
+    it('opens the market detail page from a pill', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-pill-ETH'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${PERPS_MARKET_DETAIL_ROUTE}/ETH`,
+      );
+    });
+  });
+
+  describe('analytics', () => {
+    it('reports the top movers header click', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-header'));
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEventName.PerpsUiInteraction,
+        {
+          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+            PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+          [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]:
+            PERPS_EVENT_VALUE.BUTTON_CLICKED.TOP_MOVERS,
+          [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+            PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_HOME,
+        },
+      );
+    });
+
+    it('attributes a pill tap to the gainers section', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-pill-ETH'));
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEventName.PerpsUiInteraction,
+        {
+          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+            PERPS_EVENT_VALUE.INTERACTION_TYPE.TAP,
+          [PERPS_EVENT_PROPERTY.ASSET]: 'ETH',
+          [PERPS_EVENT_PROPERTY.SOURCE_SECTION]:
+            PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_GAINERS,
+        },
+      );
+    });
+
+    it('attributes a pill tap to the losers section after switching direction', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByTestId('perps-top-movers-losers'));
+      fireEvent.click(screen.getByTestId('perps-top-movers-pill-SOL'));
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEventName.PerpsUiInteraction,
+        {
+          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+            PERPS_EVENT_VALUE.INTERACTION_TYPE.TAP,
+          [PERPS_EVENT_PROPERTY.ASSET]: 'SOL',
+          [PERPS_EVENT_PROPERTY.SOURCE_SECTION]:
+            PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_LOSERS,
+        },
+      );
+    });
+  });
+});

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
@@ -243,7 +243,7 @@ export const PerpsTopMovers = ({
         <Box
           flexDirection={BoxFlexDirection.Column}
           gap={3}
-          className="px-4"
+          className="overflow-x-auto px-4"
           data-testid="perps-top-movers-list"
         >
           {pillRows.map((row, rowIndex) => (
@@ -252,7 +252,7 @@ export const PerpsTopMovers = ({
               flexDirection={BoxFlexDirection.Row}
               alignItems={BoxAlignItems.Center}
               gap={2}
-              className="w-full flex-wrap"
+              className="w-max flex-nowrap"
               data-testid={`perps-top-movers-list-row-${rowIndex}`}
             >
               {row.map((market) => (

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
@@ -4,6 +4,7 @@ import {
   BoxFlexDirection,
   BoxAlignItems,
   ButtonBase,
+  ButtonFilter,
   Text,
   TextVariant,
   TextColor,
@@ -181,56 +182,42 @@ export const PerpsTopMovers = ({
         />
       </ButtonBase>
 
-      {/* One joined segmented track, split in half — mobile's SegmentedControl */}
-      <Box paddingLeft={4} paddingRight={4}>
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          className="w-full rounded-full border border-muted p-0.5"
-          data-testid="perps-top-movers-toggle"
+      {/* Segmented track: ButtonFilter supplies the selected fill/contrast
+          (bg-icon-default + inverse text), matching mobile's SegmentedControl. */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={1}
+        paddingLeft={4}
+        paddingRight={4}
+        className="w-full rounded-full border border-muted p-1"
+        data-testid="perps-top-movers-toggle"
+      >
+        <ButtonFilter
+          isActive={isGainers}
+          onClick={handleSelectGainers}
+          aria-pressed={isGainers}
+          className="flex-1 h-7 rounded-full"
+          data-testid="perps-top-movers-gainers"
         >
-          <ButtonBase
-            className={`flex-1 h-8 rounded-full ${
-              isGainers ? 'bg-muted' : 'bg-transparent hover:bg-hover'
-            }`}
-            onClick={handleSelectGainers}
-            aria-pressed={isGainers}
-            data-testid="perps-top-movers-gainers"
-          >
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              color={
-                isGainers ? TextColor.TextDefault : TextColor.TextAlternative
-              }
-            >
-              {t('perpsTopMoversGainers')}
-            </Text>
-          </ButtonBase>
-          <ButtonBase
-            className={`flex-1 h-8 rounded-full ${
-              isGainers ? 'bg-transparent hover:bg-hover' : 'bg-muted'
-            }`}
-            onClick={handleSelectLosers}
-            aria-pressed={!isGainers}
-            data-testid="perps-top-movers-losers"
-          >
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              color={
-                isGainers ? TextColor.TextAlternative : TextColor.TextDefault
-              }
-            >
-              {t('perpsTopMoversLosers')}
-            </Text>
-          </ButtonBase>
-        </Box>
+          {t('perpsTopMoversGainers')}
+        </ButtonFilter>
+        <ButtonFilter
+          isActive={!isGainers}
+          onClick={handleSelectLosers}
+          aria-pressed={!isGainers}
+          className="flex-1 h-7 rounded-full"
+          data-testid="perps-top-movers-losers"
+        >
+          {t('perpsTopMoversLosers')}
+        </ButtonFilter>
       </Box>
 
       {isLoading ? (
         <Box
-          className="flex-col gap-1.5 overflow-hidden px-4"
+          flexDirection={BoxFlexDirection.Column}
+          gap={3}
+          className="overflow-hidden px-4"
           data-testid="perps-top-movers-skeleton"
         >
           {Array.from({ length: PILL_ROW_COUNT }).map((_, rowIndex) => (
@@ -238,7 +225,8 @@ export const PerpsTopMovers = ({
               key={`perps-top-movers-skeleton-row-${rowIndex}`}
               flexDirection={BoxFlexDirection.Row}
               alignItems={BoxAlignItems.Center}
-              className="flex-nowrap gap-2"
+              gap={2}
+              className="flex-nowrap"
             >
               {SKELETON_PILL_KEYS.map((pillKey) => (
                 <Skeleton
@@ -251,7 +239,9 @@ export const PerpsTopMovers = ({
         </Box>
       ) : (
         <Box
-          className="flex-col gap-1.5 overflow-x-auto px-4"
+          flexDirection={BoxFlexDirection.Column}
+          gap={3}
+          className="px-4"
           data-testid="perps-top-movers-list"
         >
           {pillRows.map((row, rowIndex) => (
@@ -259,7 +249,8 @@ export const PerpsTopMovers = ({
               key={`perps-top-movers-row-${rowIndex}`}
               flexDirection={BoxFlexDirection.Row}
               alignItems={BoxAlignItems.Center}
-              className="w-max flex-nowrap gap-2"
+              gap={2}
+              className="w-full flex-wrap"
               data-testid={`perps-top-movers-list-row-${rowIndex}`}
             >
               {row.map((market) => (

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
@@ -1,0 +1,187 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Box,
+  BoxFlexDirection,
+  ButtonBase,
+  ButtonFilter,
+  Text,
+  FontWeight,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
+  Skeleton,
+} from '@metamask/design-system-react';
+import { useNavigate } from 'react-router-dom';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { usePerpsEventTracking } from '../../../../hooks/perps';
+import {
+  PERPS_MARKET_DETAIL_ROUTE,
+  PERPS_MARKET_LIST_ROUTE,
+} from '../../../../helpers/constants/routes';
+import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '../../../../../shared/constants/perps-events';
+import type { SortDirection } from '../../../../pages/perps/utils/sortMarkets';
+import { MARKET_SORTING_CONFIG, PERPS_CONSTANTS } from '../constants';
+import { usePerpsTopMovers } from '../hooks/usePerpsTopMovers';
+import type { PerpsMarketData } from '../types';
+import { PerpsTopMoverPill } from './perps-top-mover-pill';
+
+/**
+ * Ranking directions the toggle offers. `desc` puts the biggest risers first
+ * (Gainers), `asc` the biggest fallers (Losers) — the same mapping mobile's
+ * `PerpsTopMoversSection` uses.
+ */
+const GAINERS_DIRECTION: SortDirection =
+  MARKET_SORTING_CONFIG.DEFAULT_DIRECTION;
+const LOSERS_DIRECTION: SortDirection = 'asc';
+
+/**
+ * Two columns wide, so `PERPS_CONSTANTS.TOP_MOVERS_LIMIT` (8) pills fill four
+ * stacked rows and the section never needs to scroll.
+ */
+const PILL_GRID_STYLES = 'grid grid-cols-2 gap-2 px-4';
+
+/**
+ * PerpsTopMovers ranks the live perps markets by 24h price change and shows
+ * the strongest movers as a 2-column pill grid. The Gainers/Losers toggle
+ * flips the ranking direction in place, and the header opens the full market
+ * list already sorted by price change in the selected direction.
+ */
+export const PerpsTopMovers = () => {
+  const t = useI18nContext();
+  const navigate = useNavigate();
+  const { track } = usePerpsEventTracking();
+  const [direction, setDirection] = useState<SortDirection>(GAINERS_DIRECTION);
+  const { markets, isInitialLoading } = usePerpsTopMovers({ direction });
+
+  const isGainers = direction === GAINERS_DIRECTION;
+
+  const handleSelectGainers = useCallback(() => {
+    setDirection(GAINERS_DIRECTION);
+  }, []);
+
+  const handleSelectLosers = useCallback(() => {
+    setDirection(LOSERS_DIRECTION);
+  }, []);
+
+  const handleSeeAll = useCallback(() => {
+    track(MetaMetricsEventName.PerpsUiInteraction, {
+      [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+        PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+      [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]:
+        PERPS_EVENT_VALUE.BUTTON_CLICKED.TOP_MOVERS,
+      [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+        PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_HOME,
+    });
+    navigate(
+      `${PERPS_MARKET_LIST_ROUTE}?sort=${MARKET_SORTING_CONFIG.SORT_FIELDS.PRICE_CHANGE}&direction=${direction}`,
+    );
+  }, [direction, navigate, track]);
+
+  const handleMarketClick = useCallback(
+    (market: PerpsMarketData) => {
+      track(MetaMetricsEventName.PerpsUiInteraction, {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.TAP,
+        [PERPS_EVENT_PROPERTY.ASSET]: market.symbol,
+        [PERPS_EVENT_PROPERTY.SOURCE_SECTION]: isGainers
+          ? PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_GAINERS
+          : PERPS_EVENT_VALUE.SOURCE_SECTION.TOP_LOSERS,
+      });
+      navigate(
+        `${PERPS_MARKET_DETAIL_ROUTE}/${encodeURIComponent(market.symbol)}`,
+      );
+    },
+    [isGainers, navigate, track],
+  );
+
+  const skeletonPills = useMemo(
+    () =>
+      Array.from({ length: PERPS_CONSTANTS.TOP_MOVERS_LIMIT }).map(
+        (_, index) => (
+          <Skeleton
+            key={`perps-top-movers-skeleton-pill-${index}`}
+            className="h-12 w-full rounded-xl"
+          />
+        ),
+      ),
+    [],
+  );
+
+  // Once the markets have loaded, an empty ranking means there is nothing to
+  // rank at all (no market data reached the tab), so the section has no content
+  // to justify its heading.
+  if (!isInitialLoading && markets.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Column}
+      gap={2}
+      data-testid="perps-top-movers"
+    >
+      <ButtonBase
+        className="w-full flex flex-row justify-between items-center px-4 py-3 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
+        onClick={handleSeeAll}
+        data-testid="perps-top-movers-header"
+      >
+        <Text fontWeight={FontWeight.Medium}>{t('perpsTopMovers')}</Text>
+        <Icon
+          name={IconName.ArrowRight}
+          size={IconSize.Sm}
+          color={IconColor.IconAlternative}
+        />
+      </ButtonBase>
+
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        gap={2}
+        paddingLeft={4}
+        paddingRight={4}
+      >
+        <ButtonFilter
+          isActive={isGainers}
+          onClick={handleSelectGainers}
+          aria-pressed={isGainers}
+          data-testid="perps-top-movers-gainers"
+        >
+          {t('perpsTopMoversGainers')}
+        </ButtonFilter>
+        <ButtonFilter
+          isActive={!isGainers}
+          onClick={handleSelectLosers}
+          aria-pressed={!isGainers}
+          data-testid="perps-top-movers-losers"
+        >
+          {t('perpsTopMoversLosers')}
+        </ButtonFilter>
+      </Box>
+
+      {isInitialLoading ? (
+        <Box
+          className={PILL_GRID_STYLES}
+          data-testid="perps-top-movers-skeleton"
+        >
+          {skeletonPills}
+        </Box>
+      ) : (
+        <Box className={PILL_GRID_STYLES} data-testid="perps-top-movers-list">
+          {markets.map((market) => (
+            <PerpsTopMoverPill
+              key={market.symbol}
+              market={market}
+              onPress={handleMarketClick}
+            />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default PerpsTopMovers;

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
@@ -240,30 +240,34 @@ export const PerpsTopMovers = ({
           ))}
         </Box>
       ) : (
-        <Box
-          flexDirection={BoxFlexDirection.Column}
-          gap={3}
-          className="overflow-x-auto px-4"
-          data-testid="perps-top-movers-list"
-        >
-          {pillRows.map((row, rowIndex) => (
-            <Box
-              key={`perps-top-movers-row-${rowIndex}`}
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              gap={2}
-              className="w-max flex-nowrap"
-              data-testid={`perps-top-movers-list-row-${rowIndex}`}
-            >
-              {row.map((market) => (
-                <PerpsTopMoverPill
-                  key={market.symbol}
-                  market={market}
-                  onPress={handleMarketClick}
-                />
-              ))}
-            </Box>
-          ))}
+        <Box className="overflow-x-auto" data-testid="perps-top-movers-list">
+          {/* Padding lives on the scroll content, matching mobile's
+              PillScrollList. On a flex overflow container, px-4 on the
+              scroller itself is dropped at the inline end. */}
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            gap={3}
+            className="w-max px-4"
+          >
+            {pillRows.map((row, rowIndex) => (
+              <Box
+                key={`perps-top-movers-row-${rowIndex}`}
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                gap={2}
+                className="w-max flex-nowrap"
+                data-testid={`perps-top-movers-list-row-${rowIndex}`}
+              >
+                {row.map((market) => (
+                  <PerpsTopMoverPill
+                    key={market.symbol}
+                    market={market}
+                    onPress={handleMarketClick}
+                  />
+                ))}
+              </Box>
+            ))}
+          </Box>
         </Box>
       )}
     </Box>

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
@@ -186,11 +186,11 @@ export const PerpsTopMovers = ({
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
-          className="w-full rounded-lg border border-muted p-1"
+          className="w-full rounded-full border border-muted p-0.5"
           data-testid="perps-top-movers-toggle"
         >
           <ButtonBase
-            className={`flex-1 h-8 rounded-md ${
+            className={`flex-1 h-8 rounded-full ${
               isGainers ? 'bg-muted' : 'bg-transparent hover:bg-hover'
             }`}
             onClick={handleSelectGainers}
@@ -208,7 +208,7 @@ export const PerpsTopMovers = ({
             </Text>
           </ButtonBase>
           <ButtonBase
-            className={`flex-1 h-8 rounded-md ${
+            className={`flex-1 h-8 rounded-full ${
               isGainers ? 'bg-transparent hover:bg-hover' : 'bg-muted'
             }`}
             onClick={handleSelectLosers}
@@ -230,7 +230,7 @@ export const PerpsTopMovers = ({
 
       {isLoading ? (
         <Box
-          className="flex-col gap-2 overflow-hidden px-4"
+          className="flex-col gap-1.5 overflow-hidden px-4"
           data-testid="perps-top-movers-skeleton"
         >
           {Array.from({ length: PILL_ROW_COUNT }).map((_, rowIndex) => (
@@ -251,7 +251,7 @@ export const PerpsTopMovers = ({
         </Box>
       ) : (
         <Box
-          className="flex-col gap-2 overflow-x-auto px-4"
+          className="flex-col gap-1.5 overflow-x-auto px-4"
           data-testid="perps-top-movers-list"
         >
           {pillRows.map((row, rowIndex) => (

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
@@ -183,34 +183,36 @@ export const PerpsTopMovers = ({
       </ButtonBase>
 
       {/* Segmented track: ButtonFilter supplies the selected fill/contrast
-          (bg-icon-default + inverse text), matching mobile's SegmentedControl. */}
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        gap={1}
-        paddingLeft={4}
-        paddingRight={4}
-        className="w-full rounded-full border border-muted p-1"
-        data-testid="perps-top-movers-toggle"
-      >
-        <ButtonFilter
-          isActive={isGainers}
-          onClick={handleSelectGainers}
-          aria-pressed={isGainers}
-          className="flex-1 h-7 rounded-full"
-          data-testid="perps-top-movers-gainers"
+          (bg-icon-default + inverse text), matching mobile's SegmentedControl.
+          Inset lives on a wrapper because Box twMerges className last, so
+          `p-1` on the same node would drop `paddingLeft`/`paddingRight`. */}
+      <Box paddingLeft={4} paddingRight={4}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={1}
+          className="w-full rounded-full border border-muted p-1"
+          data-testid="perps-top-movers-toggle"
         >
-          {t('perpsTopMoversGainers')}
-        </ButtonFilter>
-        <ButtonFilter
-          isActive={!isGainers}
-          onClick={handleSelectLosers}
-          aria-pressed={!isGainers}
-          className="flex-1 h-7 rounded-full"
-          data-testid="perps-top-movers-losers"
-        >
-          {t('perpsTopMoversLosers')}
-        </ButtonFilter>
+          <ButtonFilter
+            isActive={isGainers}
+            onClick={handleSelectGainers}
+            aria-pressed={isGainers}
+            className="flex-1 h-7 rounded-full"
+            data-testid="perps-top-movers-gainers"
+          >
+            {t('perpsTopMoversGainers')}
+          </ButtonFilter>
+          <ButtonFilter
+            isActive={!isGainers}
+            onClick={handleSelectLosers}
+            aria-pressed={!isGainers}
+            className="flex-1 h-7 rounded-full"
+            data-testid="perps-top-movers-losers"
+          >
+            {t('perpsTopMoversLosers')}
+          </ButtonFilter>
+        </Box>
       </Box>
 
       {isLoading ? (

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
@@ -2,9 +2,11 @@ import React, { useCallback, useMemo, useState } from 'react';
 import {
   Box,
   BoxFlexDirection,
+  BoxAlignItems,
   ButtonBase,
-  ButtonFilter,
   Text,
+  TextVariant,
+  TextColor,
   FontWeight,
   Icon,
   IconName,
@@ -25,7 +27,7 @@ import {
   PERPS_EVENT_VALUE,
 } from '../../../../../shared/constants/perps-events';
 import type { SortDirection } from '../../../../pages/perps/utils/sortMarkets';
-import { MARKET_SORTING_CONFIG, PERPS_CONSTANTS } from '../constants';
+import { MARKET_SORTING_CONFIG } from '../constants';
 import { usePerpsTopMovers } from '../hooks/usePerpsTopMovers';
 import type { PerpsMarketData } from '../types';
 import { PerpsTopMoverPill } from './perps-top-mover-pill';
@@ -39,11 +41,40 @@ const GAINERS_DIRECTION: SortDirection =
   MARKET_SORTING_CONFIG.DEFAULT_DIRECTION;
 const LOSERS_DIRECTION: SortDirection = 'asc';
 
+/** Pills are split evenly across this many rows, as mobile's PillScrollList does. */
+const PILL_ROW_COUNT = 2;
+
+/** Skeleton pill footprint, matching mobile's SectionPillsSkeleton (104x32). */
+const SKELETON_PILL_STYLES = 'h-8 w-[104px] shrink-0 rounded-full';
+const SKELETON_PILL_KEYS = ['a', 'b', 'c', 'd', 'e', 'f'];
+
 /**
- * Two columns wide, so `PERPS_CONSTANTS.TOP_MOVERS_LIMIT` (8) pills fill four
- * stacked rows and the section never needs to scroll.
+ * Splits the ranked markets evenly across rows, filling each row in turn —
+ * the same distribution mobile's `PillScrollList` uses, so the two clients
+ * order their pills identically.
+ *
+ * @param markets - Ranked markets to lay out.
+ * @param rowCount - How many rows to split across.
+ * @returns One array of markets per row.
  */
-const PILL_GRID_STYLES = 'grid grid-cols-2 gap-2 px-4';
+const splitIntoRows = (
+  markets: PerpsMarketData[],
+  rowCount: number,
+): PerpsMarketData[][] => {
+  const rows: PerpsMarketData[][] = [];
+  let start = 0;
+
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    const rowSize = Math.ceil((markets.length - start) / (rowCount - rowIndex));
+    const row = markets.slice(start, start + rowSize);
+    if (row.length > 0) {
+      rows.push(row);
+    }
+    start += rowSize;
+  }
+
+  return rows;
+};
 
 export type PerpsTopMoversProps = {
   /** Live markets to rank, owned by the Perps tab's market-list stream. */
@@ -54,9 +85,9 @@ export type PerpsTopMoversProps = {
 
 /**
  * PerpsTopMovers ranks the live perps markets by 24h price change and shows
- * the strongest movers as a 2-column pill grid. The Gainers/Losers toggle
- * flips the ranking direction in place, and the header opens the full market
- * list already sorted by price change in the selected direction.
+ * the strongest movers as two horizontally scrolling rows of pills. The
+ * Gainers/Losers toggle flips the ranking direction in place, and the header
+ * opens the full market list already sorted by price change in that direction.
  *
  * Receives markets from the Perps tab rather than subscribing itself, so the
  * tab keeps a single owner of the shared market-list price stream.
@@ -116,17 +147,9 @@ export const PerpsTopMovers = ({
     [isGainers, navigate, track],
   );
 
-  const skeletonPills = useMemo(
-    () =>
-      Array.from({ length: PERPS_CONSTANTS.TOP_MOVERS_LIMIT }).map(
-        (_, index) => (
-          <Skeleton
-            key={`perps-top-movers-skeleton-pill-${index}`}
-            className="h-12 w-full rounded-xl"
-          />
-        ),
-      ),
-    [],
+  const pillRows = useMemo(
+    () => splitIntoRows(markets, PILL_ROW_COUNT),
+    [markets],
   );
 
   // Once the markets have loaded, an empty ranking means there is nothing to
@@ -139,61 +162,114 @@ export const PerpsTopMovers = ({
   return (
     <Box
       flexDirection={BoxFlexDirection.Column}
-      gap={2}
+      gap={3}
       data-testid="perps-top-movers"
     >
+      {/* Heading with the chevron tucked directly after the title, as on mobile */}
       <ButtonBase
-        className="w-full flex flex-row justify-between items-center px-4 py-3 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
+        className="w-auto self-start h-auto justify-start gap-1 bg-transparent px-4 pt-4 rounded-none hover:bg-transparent active:bg-transparent"
         onClick={handleSeeAll}
         data-testid="perps-top-movers-header"
       >
-        <Text fontWeight={FontWeight.Medium}>{t('perpsTopMovers')}</Text>
+        <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
+          {t('perpsTopMovers')}
+        </Text>
         <Icon
           name={IconName.ArrowRight}
-          size={IconSize.Sm}
+          size={IconSize.Md}
           color={IconColor.IconAlternative}
         />
       </ButtonBase>
 
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        gap={2}
-        paddingLeft={4}
-        paddingRight={4}
-      >
-        <ButtonFilter
-          isActive={isGainers}
-          onClick={handleSelectGainers}
-          aria-pressed={isGainers}
-          data-testid="perps-top-movers-gainers"
+      {/* One joined segmented track, split in half — mobile's SegmentedControl */}
+      <Box paddingLeft={4} paddingRight={4}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          className="w-full rounded-lg border border-muted p-1"
+          data-testid="perps-top-movers-toggle"
         >
-          {t('perpsTopMoversGainers')}
-        </ButtonFilter>
-        <ButtonFilter
-          isActive={!isGainers}
-          onClick={handleSelectLosers}
-          aria-pressed={!isGainers}
-          data-testid="perps-top-movers-losers"
-        >
-          {t('perpsTopMoversLosers')}
-        </ButtonFilter>
+          <ButtonBase
+            className={`flex-1 h-8 rounded-md ${
+              isGainers ? 'bg-muted' : 'bg-transparent hover:bg-hover'
+            }`}
+            onClick={handleSelectGainers}
+            aria-pressed={isGainers}
+            data-testid="perps-top-movers-gainers"
+          >
+            <Text
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={
+                isGainers ? TextColor.TextDefault : TextColor.TextAlternative
+              }
+            >
+              {t('perpsTopMoversGainers')}
+            </Text>
+          </ButtonBase>
+          <ButtonBase
+            className={`flex-1 h-8 rounded-md ${
+              isGainers ? 'bg-transparent hover:bg-hover' : 'bg-muted'
+            }`}
+            onClick={handleSelectLosers}
+            aria-pressed={!isGainers}
+            data-testid="perps-top-movers-losers"
+          >
+            <Text
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={
+                isGainers ? TextColor.TextAlternative : TextColor.TextDefault
+              }
+            >
+              {t('perpsTopMoversLosers')}
+            </Text>
+          </ButtonBase>
+        </Box>
       </Box>
 
       {isLoading ? (
         <Box
-          className={PILL_GRID_STYLES}
+          className="flex-col gap-2 overflow-hidden px-4"
           data-testid="perps-top-movers-skeleton"
         >
-          {skeletonPills}
+          {Array.from({ length: PILL_ROW_COUNT }).map((_, rowIndex) => (
+            <Box
+              key={`perps-top-movers-skeleton-row-${rowIndex}`}
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              className="flex-nowrap gap-2"
+            >
+              {SKELETON_PILL_KEYS.map((pillKey) => (
+                <Skeleton
+                  key={`perps-top-movers-skeleton-pill-${rowIndex}-${pillKey}`}
+                  className={SKELETON_PILL_STYLES}
+                />
+              ))}
+            </Box>
+          ))}
         </Box>
       ) : (
-        <Box className={PILL_GRID_STYLES} data-testid="perps-top-movers-list">
-          {markets.map((market) => (
-            <PerpsTopMoverPill
-              key={market.symbol}
-              market={market}
-              onPress={handleMarketClick}
-            />
+        <Box
+          className="flex-col gap-2 overflow-x-auto px-4"
+          data-testid="perps-top-movers-list"
+        >
+          {pillRows.map((row, rowIndex) => (
+            <Box
+              key={`perps-top-movers-row-${rowIndex}`}
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              className="w-max flex-nowrap gap-2"
+              data-testid={`perps-top-movers-list-row-${rowIndex}`}
+            >
+              {row.map((market) => (
+                <PerpsTopMoverPill
+                  key={market.symbol}
+                  market={market}
+                  onPress={handleMarketClick}
+                />
+              ))}
+            </Box>
           ))}
         </Box>
       )}

--- a/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
+++ b/ui/components/app/perps/perps-top-movers/perps-top-movers.tsx
@@ -45,18 +45,35 @@ const LOSERS_DIRECTION: SortDirection = 'asc';
  */
 const PILL_GRID_STYLES = 'grid grid-cols-2 gap-2 px-4';
 
+export type PerpsTopMoversProps = {
+  /** Live markets to rank, owned by the Perps tab's market-list stream. */
+  markets: PerpsMarketData[];
+  /** Whether the tab's market data is still loading its first snapshot. */
+  isLoading: boolean;
+};
+
 /**
  * PerpsTopMovers ranks the live perps markets by 24h price change and shows
  * the strongest movers as a 2-column pill grid. The Gainers/Losers toggle
  * flips the ranking direction in place, and the header opens the full market
  * list already sorted by price change in the selected direction.
+ *
+ * Receives markets from the Perps tab rather than subscribing itself, so the
+ * tab keeps a single owner of the shared market-list price stream.
+ *
+ * @param options0 - Component props.
+ * @param options0.markets - Live markets to rank.
+ * @param options0.isLoading - Whether the first market snapshot is still loading.
  */
-export const PerpsTopMovers = () => {
+export const PerpsTopMovers = ({
+  markets: liveMarkets,
+  isLoading,
+}: PerpsTopMoversProps) => {
   const t = useI18nContext();
   const navigate = useNavigate();
   const { track } = usePerpsEventTracking();
   const [direction, setDirection] = useState<SortDirection>(GAINERS_DIRECTION);
-  const { markets, isInitialLoading } = usePerpsTopMovers({ direction });
+  const markets = usePerpsTopMovers({ markets: liveMarkets, direction });
 
   const isGainers = direction === GAINERS_DIRECTION;
 
@@ -115,7 +132,7 @@ export const PerpsTopMovers = () => {
   // Once the markets have loaded, an empty ranking means there is nothing to
   // rank at all (no market data reached the tab), so the section has no content
   // to justify its heading.
-  if (!isInitialLoading && markets.length === 0) {
+  if (!isLoading && markets.length === 0) {
     return null;
   }
 
@@ -162,7 +179,7 @@ export const PerpsTopMovers = () => {
         </ButtonFilter>
       </Box>
 
-      {isInitialLoading ? (
+      {isLoading ? (
         <Box
           className={PILL_GRID_STYLES}
           data-testid="perps-top-movers-skeleton"

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -145,20 +145,12 @@ jest.mock('../../../hooks/perps/stream', () => {
     usePerpsAssetNames: jest.fn(() => ({
       resolveAssetName: (symbol: string) => symbol,
     })),
-    // Read directly by the Top movers section, which ranks the live market
-    // list rather than going through usePerpsTabExploreData.
-    usePerpsLiveMarketListData: jest.fn(() => ({
-      markets: [
-        ...streamMocks.mockCryptoMarkets,
-        ...streamMocks.mockHip3Markets,
-      ],
-      isInitialLoading: false,
-    })),
   };
 });
 
 jest.mock('./hooks/usePerpsTabExploreData', () => ({
   usePerpsTabExploreData: jest.fn(() => ({
+    allMarkets: [...mocks.mockCryptoMarkets, ...mocks.mockHip3Markets],
     exploreMarkets: [
       ...mocks.mockCryptoMarkets,
       ...mocks.mockHip3Markets,
@@ -268,6 +260,7 @@ describe('PerpsView', () => {
       isInitialLoading: false,
     });
     jest.mocked(usePerpsTabExploreData).mockReturnValue({
+      allMarkets: [...mocks.mockCryptoMarkets, ...mocks.mockHip3Markets],
       exploreMarkets: [...mocks.mockCryptoMarkets, ...mocks.mockHip3Markets],
       watchlistMarkets: mocks.mockCryptoMarkets.filter((market) =>
         ['BTC', 'ETH'].includes(market.symbol),
@@ -989,6 +982,7 @@ describe('PerpsView', () => {
 
   it('passes tab explore and watchlist markets from the tab hook', () => {
     jest.mocked(usePerpsTabExploreData).mockReturnValue({
+      allMarkets: [...mocks.mockCryptoMarkets, ...mocks.mockHip3Markets],
       exploreMarkets: [mocks.mockCryptoMarkets[0]],
       watchlistMarkets: [mocks.mockCryptoMarkets[1]],
       isInitialLoading: false,

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -145,6 +145,15 @@ jest.mock('../../../hooks/perps/stream', () => {
     usePerpsAssetNames: jest.fn(() => ({
       resolveAssetName: (symbol: string) => symbol,
     })),
+    // Read directly by the Top movers section, which ranks the live market
+    // list rather than going through usePerpsTabExploreData.
+    usePerpsLiveMarketListData: jest.fn(() => ({
+      markets: [
+        ...streamMocks.mockCryptoMarkets,
+        ...streamMocks.mockHip3Markets,
+      ],
+      isInitialLoading: false,
+    })),
   };
 });
 
@@ -320,6 +329,12 @@ describe('PerpsView', () => {
       expect(
         screen.getByTestId('perps-explore-markets-row'),
       ).toBeInTheDocument();
+    });
+
+    it('shows the top movers section', () => {
+      renderWithProvider(<PerpsView />, mockStore);
+
+      expect(screen.getByTestId('perps-top-movers')).toBeInTheDocument();
     });
 
     it('renders position cards for each position', () => {

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -108,6 +108,7 @@ export const PerpsView = () => {
     usePerpsLiveOrders();
   const { account, isInitialLoading: accountLoading } = usePerpsLiveAccount();
   const {
+    allMarkets,
     exploreMarkets,
     watchlistMarkets,
     isInitialLoading: marketsLoading,
@@ -494,7 +495,7 @@ export const PerpsView = () => {
       <PerpsWatchlist markets={watchlistMarkets} />
 
       {/* Top movers */}
-      <PerpsTopMovers />
+      <PerpsTopMovers markets={allMarkets} isLoading={marketsLoading} />
 
       {/* Explore markets */}
       <PerpsExploreMarkets markets={exploreMarkets} />

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -61,6 +61,7 @@ import {
 } from './perps-skeletons';
 import { PerpsSupportLearn } from './perps-support-learn';
 import { PerpsTutorialModal } from './perps-tutorial-modal';
+import { PerpsTopMovers } from './perps-top-movers';
 import { PerpsWatchlist } from './perps-watchlist';
 import { usePerpsTabExploreData } from './hooks/usePerpsTabExploreData';
 
@@ -491,6 +492,9 @@ export const PerpsView = () => {
 
       {/* Watchlist */}
       <PerpsWatchlist markets={watchlistMarkets} />
+
+      {/* Top movers */}
+      <PerpsTopMovers />
 
       {/* Explore markets */}
       <PerpsExploreMarkets markets={exploreMarkets} />

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -404,12 +404,16 @@ describe('MarketListView', () => {
       });
     });
 
-    it.each([
+    const priceChangeSortCases: [
+      queryDirection: 'asc' | 'desc',
+      expectedOrder: string[],
+    ][] = [
       ['asc', ['SOL', 'BTC', 'ETH']],
       ['desc', ['ETH', 'BTC', 'SOL']],
-    ])(
-      'ranks the list by %s price change from the query params',
-      async (queryDirection, expectedOrder) => {
+    ];
+
+    priceChangeSortCases.forEach(([queryDirection, expectedOrder]) => {
+      it(`ranks the list by ${queryDirection} price change from the query params`, async () => {
         mockUsePerpsLiveMarketListData.mockReturnValue({
           markets: [
             {
@@ -449,8 +453,8 @@ describe('MarketListView', () => {
             .getAllByTestId(/^market-row-/u)
             .map((row) => row.dataset.testid?.replace('market-row-', '')),
         ).toStrictEqual(expectedOrder);
-      },
-    );
+      });
+    });
 
     it('falls back to the volume sort when the query params are unknown', async () => {
       renderWithProvider(

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -404,6 +404,82 @@ describe('MarketListView', () => {
       });
     });
 
+    it('ranks the list by ascending price change from the query params', async () => {
+      const markets = [
+        { ...mockCryptoMarkets[0], symbol: 'BTC', change24hPercent: '+1.00%' },
+        { ...mockCryptoMarkets[1], symbol: 'ETH', change24hPercent: '+9.00%' },
+        { ...mockCryptoMarkets[2], symbol: 'SOL', change24hPercent: '-4.00%' },
+      ];
+      mockUsePerpsLiveMarketListData.mockReturnValue({
+        markets,
+        isInitialLoading: false,
+        error: null,
+        refresh: jest.fn(),
+      });
+
+      renderWithProvider(
+        <MarketListView />,
+        mockStore,
+        '/perps/market-list?sort=priceChange&direction=asc',
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sort-dropdown-button')).toHaveTextContent(
+          messages.perpsSortByPriceChange.message,
+        );
+      });
+      expect(
+        screen
+          .getAllByTestId(/^market-row-/u)
+          .map((row) => row.dataset.testid?.replace('market-row-', '')),
+      ).toStrictEqual(['SOL', 'BTC', 'ETH']);
+    });
+
+    it('ranks the list by descending price change from the query params', async () => {
+      const markets = [
+        { ...mockCryptoMarkets[0], symbol: 'BTC', change24hPercent: '+1.00%' },
+        { ...mockCryptoMarkets[1], symbol: 'ETH', change24hPercent: '+9.00%' },
+        { ...mockCryptoMarkets[2], symbol: 'SOL', change24hPercent: '-4.00%' },
+      ];
+      mockUsePerpsLiveMarketListData.mockReturnValue({
+        markets,
+        isInitialLoading: false,
+        error: null,
+        refresh: jest.fn(),
+      });
+
+      renderWithProvider(
+        <MarketListView />,
+        mockStore,
+        '/perps/market-list?sort=priceChange&direction=desc',
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sort-dropdown-button')).toHaveTextContent(
+          messages.perpsSortByPriceChange.message,
+        );
+      });
+      expect(
+        screen
+          .getAllByTestId(/^market-row-/u)
+          .map((row) => row.dataset.testid?.replace('market-row-', '')),
+      ).toStrictEqual(['ETH', 'BTC', 'SOL']);
+    });
+
+    it('falls back to the volume sort when the query params are unknown', async () => {
+      renderWithProvider(
+        <MarketListView />,
+        mockStore,
+        '/perps/market-list?sort=bogus&direction=sideways',
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sort-dropdown-button')).toHaveTextContent(
+          messages.perpsSortByVolume.message,
+        );
+      });
+    });
+
     it('shows stock markets on Stocks tab even when perpsHip3AllowlistMarkets flag is absent', async () => {
       // mockStore has no perpsHip3AllowlistMarkets flag → allowedHip3Sources defaults to Set()
       renderWithProvider(<MarketListView />, mockStore);

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -404,67 +404,53 @@ describe('MarketListView', () => {
       });
     });
 
-    it('ranks the list by ascending price change from the query params', async () => {
-      const markets = [
-        { ...mockCryptoMarkets[0], symbol: 'BTC', change24hPercent: '+1.00%' },
-        { ...mockCryptoMarkets[1], symbol: 'ETH', change24hPercent: '+9.00%' },
-        { ...mockCryptoMarkets[2], symbol: 'SOL', change24hPercent: '-4.00%' },
-      ];
-      mockUsePerpsLiveMarketListData.mockReturnValue({
-        markets,
-        isInitialLoading: false,
-        error: null,
-        refresh: jest.fn(),
-      });
+    it.each([
+      ['asc', ['SOL', 'BTC', 'ETH']],
+      ['desc', ['ETH', 'BTC', 'SOL']],
+    ])(
+      'ranks the list by %s price change from the query params',
+      async (queryDirection, expectedOrder) => {
+        mockUsePerpsLiveMarketListData.mockReturnValue({
+          markets: [
+            {
+              ...mockCryptoMarkets[0],
+              symbol: 'BTC',
+              change24hPercent: '+1.00%',
+            },
+            {
+              ...mockCryptoMarkets[1],
+              symbol: 'ETH',
+              change24hPercent: '+9.00%',
+            },
+            {
+              ...mockCryptoMarkets[2],
+              symbol: 'SOL',
+              change24hPercent: '-4.00%',
+            },
+          ],
+          isInitialLoading: false,
+          error: null,
+          refresh: jest.fn(),
+        });
 
-      renderWithProvider(
-        <MarketListView />,
-        mockStore,
-        '/perps/market-list?sort=priceChange&direction=asc',
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId('sort-dropdown-button')).toHaveTextContent(
-          messages.perpsSortByPriceChange.message,
+        renderWithProvider(
+          <MarketListView />,
+          mockStore,
+          `/perps/market-list?sort=priceChange&direction=${queryDirection}`,
         );
-      });
-      expect(
-        screen
-          .getAllByTestId(/^market-row-/u)
-          .map((row) => row.dataset.testid?.replace('market-row-', '')),
-      ).toStrictEqual(['SOL', 'BTC', 'ETH']);
-    });
 
-    it('ranks the list by descending price change from the query params', async () => {
-      const markets = [
-        { ...mockCryptoMarkets[0], symbol: 'BTC', change24hPercent: '+1.00%' },
-        { ...mockCryptoMarkets[1], symbol: 'ETH', change24hPercent: '+9.00%' },
-        { ...mockCryptoMarkets[2], symbol: 'SOL', change24hPercent: '-4.00%' },
-      ];
-      mockUsePerpsLiveMarketListData.mockReturnValue({
-        markets,
-        isInitialLoading: false,
-        error: null,
-        refresh: jest.fn(),
-      });
-
-      renderWithProvider(
-        <MarketListView />,
-        mockStore,
-        '/perps/market-list?sort=priceChange&direction=desc',
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId('sort-dropdown-button')).toHaveTextContent(
-          messages.perpsSortByPriceChange.message,
-        );
-      });
-      expect(
-        screen
-          .getAllByTestId(/^market-row-/u)
-          .map((row) => row.dataset.testid?.replace('market-row-', '')),
-      ).toStrictEqual(['ETH', 'BTC', 'SOL']);
-    });
+        await waitFor(() => {
+          expect(screen.getByTestId('sort-dropdown-button')).toHaveTextContent(
+            messages.perpsSortByPriceChange.message,
+          );
+        });
+        expect(
+          screen
+            .getAllByTestId(/^market-row-/u)
+            .map((row) => row.dataset.testid?.replace('market-row-', '')),
+        ).toStrictEqual(expectedOrder);
+      },
+    );
 
     it('falls back to the volume sort when the query params are unknown', async () => {
       renderWithProvider(

--- a/ui/pages/perps/market-list/index.tsx
+++ b/ui/pages/perps/market-list/index.tsx
@@ -69,7 +69,7 @@ import { usePerpsAttribution } from '../../../hooks/perps/usePerpsAttribution';
 import { getTradeableBalance } from '../../../hooks/perps/getTradeableBalance';
 import { MarketRow } from '../../../components/app/perps/market-row';
 import { MarketRowSkeleton } from './components/market-row-skeleton';
-import { SortDropdown } from './components/sort-dropdown';
+import { SortDropdown, SORT_FIELD_OPTIONS } from './components/sort-dropdown';
 import { SearchInput } from './components/search-input';
 import { FilterSelect } from './components/filter-select';
 
@@ -92,6 +92,21 @@ const SEARCH_MODE = {
 
 /** A short ticker-like token ("btc", "hype2") reads as a targeted lookup. */
 const TICKER_LIKE_QUERY = /^[a-z0-9]{1,6}$/u;
+
+/**
+ * Sort values accepted on the `sort` / `direction` search params. The fields
+ * are the ones the sort dropdown itself offers, so a deeplink can never select
+ * a ranking the user could not reach from the UI.
+ */
+const SORT_DIRECTIONS: SortDirection[] = ['asc', 'desc'];
+const DEFAULT_SORT_FIELD: SortField = 'volume';
+const DEFAULT_SORT_DIRECTION: SortDirection = 'desc';
+
+const isSortField = (value: string | null): value is SortField =>
+  SORT_FIELD_OPTIONS.some((option) => option.id === value);
+
+const isSortDirection = (value: string | null): value is SortDirection =>
+  SORT_DIRECTIONS.some((direction) => direction === value);
 
 /**
  * Classify a search for the funnel `mode` property: chips/category narrow the
@@ -236,10 +251,30 @@ export const MarketListView = () => {
     return 'all';
   }, [searchParams, hasWatchlistMarkets]);
 
+  // Read the initial sort from URL params so entry points that already know how
+  // the user wants the list ranked (the Perps tab's Top movers header) land on
+  // that ranking instead of the default volume sort. Unrecognised values fall
+  // back to the default, so an old or hand-edited link never renders unsorted.
+  const initialSort = useMemo<{
+    field: SortField;
+    direction: SortDirection;
+  }>(() => {
+    const sortParam = searchParams.get('sort');
+    const directionParam = searchParams.get('direction');
+    return {
+      field: isSortField(sortParam) ? sortParam : DEFAULT_SORT_FIELD,
+      direction: isSortDirection(directionParam)
+        ? directionParam
+        : DEFAULT_SORT_DIRECTION,
+    };
+  }, [searchParams]);
+
   // State
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortField, setSortField] = useState<SortField>('volume');
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [sortField, setSortField] = useState<SortField>(initialSort.field);
+  const [sortDirection, setSortDirection] = useState<SortDirection>(
+    initialSort.direction,
+  );
   const [selectedFilter, setSelectedFilter] =
     useState<MarketFilter>(initialFilter);
 


### PR DESCRIPTION
## **Description**

Adds a "Top movers" section to the Perps tab that ranks the live perps markets by 24h price change and shows the top eight as two rows of content-width pills. A Gainers/Losers toggle flips the ranking direction in place, and the section header opens the market list already sorted by price change in the selected direction.

Ranking is a client-side sort of the market data the tab already streams, so no new subscription or request is added. Mirrors mobile's `PerpsTopMoversSection` / `usePerpsTopMovers`, including its eight-market cap and its `desc`=gainers / `asc`=losers direction mapping.

Popup width is ~400px. Stretching pills clips labels; wrapping them becomes four rows. We copied mobile's `PillScrollList`: two nowrap rows, scroll sideways.

## **Changelog**

CHANGELOG entry: Added a "Top movers" section to the Perps tab, with a Gainers/Losers toggle and a header link to the market list sorted by 24h price change.

## **Related issues**

Fixes: [TAT-3851](https://consensyssoftware.atlassian.net/browse/TAT-3851)

## **Manual testing steps**

1. Open the extension and go to the **Perps** tab.
2. Scroll to the **Top movers** section below Watchlist — it shows eight markets in two horizontally scrolling rows, Gainers selected, sorted by 24h price change descending.
3. Click **Losers** — the same pills re-rank in place to the biggest fallers. The section stays on screen; no loading skeleton reappears.
4. Click the **Top movers** heading — the market list opens with the sort already set to "Price change", ascending (matching Losers).
5. Go back, click **Gainers**, then the heading again — the market list now opens on "Price change" descending.
6. Click any pill — it opens that market's detail page.

## **Screenshots/Recordings**

Top movers section on the Perps tab: Gainers/Losers toggle, content-width pills, and the header opening the market list pre-sorted by 24h price change.

<table>
<tr><td align="center" valign="top" width="50%"><strong>AC1</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/45940/recipe-run/screenshots/evidence-ac1-top-movers-section.png?sha=f7e857067d3bd4aa" alt="AC1" width="320" /></td><td align="center" valign="top" width="50%"><strong>AC2</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/45940/recipe-run/screenshots/evidence-ac2-losers-selected.png?sha=9090794d753716fa" alt="AC2" width="320" /></td></tr>
<tr><td align="center" valign="top" width="50%"><strong>AC3</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/45940/recipe-run/screenshots/evidence-ac3-market-list-presorted.png?sha=7c8df656a94c0a0d" alt="AC3" width="320" /></td><td></td></tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

Ran against the live extension over CDP: **exit 0, 30/30 nodes**. All four acceptance criteria bind to `ac<N>-*` nodes, and reverting any part of this change fails a named node.

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "TAT-3851 Perps Top movers section",
  "description": "Proves the Perps tab renders a Top movers section with a working Gainers/Losers toggle and a header that opens the market list pre-sorted by 24h price change.",
  "proofTargets": [
    {
      "id": "ac1",
      "claim": "The Perps tab shows a Top movers section with a Gainers/Losers toggle, Gainers selected by default."
    },
    {
      "id": "ac2",
      "claim": "Selecting Losers re-sorts the visible pills in place; the section stays mounted and no skeleton reappears."
    },
    {
      "id": "ac3",
      "claim": "Clicking the Top movers header opens the market list pre-sorted by 24h price change in the selected direction."
    },
    {
      "id": "ac4",
      "claim": "The section renders a skeleton while live market data is still loading."
    }
  ],
  "workflow": {
    "entry": "gate-unlock-wallet",
    "nodes": {
      "gate-unlock-wallet": {
        "action": "metamask.wallet.ensure_unlocked",
        "timeout_ms": 30000,
        "intent": "The wallet is open, so the Perps tab is reachable rather than sitting behind the lock screen.",
        "next": "gate-open-perps"
      },
      "gate-open-perps": {
        "action": "ui.navigate",
        "page": "perps",
        "intent": "Reach the Perps tab, where the Top movers section lives.",
        "next": "gate-perps-loaded"
      },
      "gate-perps-loaded": {
        "action": "ui.wait_for",
        "test_id": "parent-selector-perps-tab",
        "visible": true,
        "timeout_ms": 30000,
        "intent": "The Perps tab has finished loading, so the movers ranking reflects real market data rather than an empty state.",
        "next": "gate-scroll-to-section"
      },
      "gate-scroll-to-section": {
        "action": "ui.scroll",
        "test_id": "perps-top-movers",
        "scroll_into_view": true,
        "settle": true,
        "timeout_ms": 15000,
        "intent": "Bring the Top movers section into the viewport, the way a user scrolling the Perps tab would.",
        "next": "ac1-wait-section"
      },
      "ac1-wait-section": {
        "action": "ui.wait_for",
        "test_id": "perps-top-movers",
        "visible": true,
        "timeout_ms": 30000,
        "intent": "A user browsing the Perps tab can see the Top movers section.",
        "proves": [
          "ac1"
        ],
        "next": "ac1-wait-gainers-active"
      },
      "ac1-wait-gainers-active": {
        "action": "ui.wait_for",
        "selector": "[data-testid=\"perps-top-movers-gainers\"][aria-pressed=\"true\"]",
        "visible": true,
        "timeout_ms": 10000,
        "intent": "Gainers is the direction the section opens on, so the first thing a user sees is the biggest risers.",
        "proves": [
          "ac1"
        ],
        "next": "ac1-wait-losers-inactive"
      },
      "ac1-wait-losers-inactive": {
        "action": "ui.wait_for",
        "selector": "[data-testid=\"perps-top-movers-losers\"][aria-pressed=\"false\"]",
        "visible": true,
        "timeout_ms": 10000,
        "intent": "The Losers half of the toggle is offered but not selected, so the toggle reads as a two-way choice.",
        "proves": [
          "ac1"
        ],
        "next": "ac1-wait-pill-grid"
      },
      "ac1-wait-pill-grid": {
        "action": "ui.wait_for",
        "test_id": "perps-top-movers-list",
        "visible": true,
        "timeout_ms": 15000,
        "intent": "The ranked markets are on screen rather than an empty or errored section.",
        "proves": [
          "ac1"
        ],
        "next": "ac1-read-gainers-order"
      },
      "ac1-read-gainers-order": {
        "action": "metamask.perps.read_visible_state",
        "intent": "Record which markets the Gainers view is showing, so the Losers view can be compared against it.",
        "proves": [
          "ac1"
        ],
        "next": "ac1-clear-capture-orphans"
      },
      "ac1-clear-capture-orphans": {
        "action": "command",
        "cmd": "pkill -9 -f 'capture-helper' || true",
        "intent": "Clear orphan capture-helper processes so the image comes from capture-helper rather than the silent fallback.",
        "next": "ac1-screenshot-section"
      },
      "ac1-screenshot-section": {
        "action": "ui.screenshot",
        "label": "AC1: Top movers section on the Perps tab with Gainers selected and eight ranked pills",
        "intent": "Show a reviewer the Top movers section as a user sees it, with Gainers selected.",
        "proves": [
          "ac1"
        ],
        "next": "ac2-press-losers"
      },
      "ac2-press-losers": {
        "action": "ui.press",
        "test_id": "perps-top-movers-losers",
        "timeout_ms": 10000,
        "intent": "A user switches the section to the biggest fallers.",
        "proves": [
          "ac2"
        ],
        "next": "ac2-scroll-to-section"
      },
      "ac2-scroll-to-section": {
        "action": "ui.scroll",
        "test_id": "perps-top-movers",
        "scroll_into_view": true,
        "settle": true,
        "timeout_ms": 15000,
        "intent": "Keep the Top movers section in the viewport after the direction switch.",
        "next": "ac2-wait-losers-active"
      },
      "ac2-wait-losers-active": {
        "action": "ui.wait_for",
        "selector": "[data-testid=\"perps-top-movers-losers\"][aria-pressed=\"true\"]",
        "visible": true,
        "timeout_ms": 10000,
        "intent": "The Losers half of the toggle now reads as the selected one.",
        "proves": [
          "ac2"
        ],
        "next": "ac2-wait-gainers-inactive"
      },
      "ac2-wait-gainers-inactive": {
        "action": "ui.wait_for",
        "selector": "[data-testid=\"perps-top-movers-gainers\"][aria-pressed=\"false\"]",
        "visible": true,
        "timeout_ms": 10000,
        "intent": "Only one direction is selected at a time, so the toggle is not showing both as active.",
        "proves": [
          "ac2"
        ],
        "next": "ac2-wait-no-skeleton"
      },
      "ac2-wait-no-skeleton": {
        "action": "ui.wait_for",
        "test_id": "perps-top-movers-skeleton",
        "visible": false,
        "timeout_ms": 5000,
        "intent": "Switching direction re-sorts what is already loaded instead of dropping back to a loading state.",
        "proves": [
          "ac2"
        ],
        "next": "ac2-wait-section-still-mounted"
      },
      "ac2-wait-section-still-mounted": {
        "action": "ui.wait_for",
        "test_id": "perps-top-movers-list",
        "visible": true,
        "timeout_ms": 5000,
        "intent": "The list of markets stays on screen through the switch, so nothing flashes away and back.",
        "proves": [
          "ac2"
        ],
        "next": "ac2-read-losers-order"
      },
      "ac2-read-losers-order": {
        "action": "metamask.perps.read_visible_state",
        "intent": "Record the markets the Losers view is showing, so the change from the Gainers view is on record.",
        "proves": [
          "ac2"
        ],
        "next": "ac2-clear-capture-orphans"
      },
      "ac2-clear-capture-orphans": {
        "action": "command",
        "cmd": "pkill -9 -f 'capture-helper' || true",
        "intent": "Clear orphan capture-helper processes so the image comes from capture-helper rather than the silent fallback.",
        "next": "ac2-screenshot-losers"
      },
      "ac2-screenshot-losers": {
        "action": "ui.screenshot",
        "label": "AC2: Losers selected; the same section now lists falling markets with negative changes",
        "intent": "Show a reviewer that the same section, still on screen, now ranks the biggest fallers.",
        "proves": [
          "ac2"
        ],
        "next": "ac3-scroll-to-header"
      },
      "ac3-scroll-to-header": {
        "action": "ui.scroll",
        "test_id": "perps-top-movers-header",
        "scroll_into_view": true,
        "settle": true,
        "timeout_ms": 15000,
        "intent": "Bring the Top movers heading into reach so it can be tapped like a user would.",
        "next": "ac3-press-header"
      },
      "ac3-press-header": {
        "action": "ui.press",
        "test_id": "perps-top-movers-header",
        "timeout_ms": 10000,
        "intent": "A user taps the Top movers heading to see the full ranked market list.",
        "proves": [
          "ac3"
        ],
        "next": "ac3-wait-market-list"
      },
      "ac3-wait-market-list": {
        "action": "ui.wait_for",
        "test_id": "parent-selector-perps-market-list",
        "visible": true,
        "timeout_ms": 20000,
        "intent": "The tap lands the user on the full market list.",
        "proves": [
          "ac3"
        ],
        "next": "ac3-wait-sort-preset"
      },
      "ac3-wait-sort-preset": {
        "action": "ui.wait_for",
        "selector": "[data-testid=\"sort-dropdown-button\"]",
        "text_match": "Price change",
        "visible": true,
        "timeout_ms": 15000,
        "intent": "The market list arrives already sorted by 24h price change rather than the default volume sort.",
        "proves": [
          "ac3"
        ],
        "next": "ac3-clear-capture-orphans"
      },
      "ac3-clear-capture-orphans": {
        "action": "command",
        "cmd": "pkill -9 -f 'capture-helper' || true",
        "intent": "Clear orphan capture-helper processes so the image comes from capture-helper rather than the silent fallback.",
        "next": "ac3-screenshot-market-list"
      },
      "ac3-screenshot-market-list": {
        "action": "ui.screenshot",
        "label": "AC3: market list opened from the Top movers header, sorted by price change ascending (Losers)",
        "intent": "Show a reviewer the market list carrying the direction the user had selected in the section.",
        "proves": [
          "ac3"
        ],
        "next": "ac4-skeleton-unit-test"
      },
      "ac4-skeleton-unit-test": {
        "action": "command",
        "cmd": "yarn jest ui/components/app/perps/perps-top-movers/perps-top-movers.test.tsx --no-coverage -t 'renders the loading skeleton while market data is loading'",
        "timeout_ms": 300000,
        "intent": "The section shows a skeleton, not an empty gap, while live market data is still arriving.",
        "proves": [
          "ac4"
        ],
        "next": "ac4-assert-test-ran"
      },
      "ac4-assert-test-ran": {
        "action": "assert_output",
        "contains": "1 passed",
        "intent": "Confirm the skeleton case actually executed instead of silently matching no test.",
        "proves": [
          "ac4"
        ],
        "next": "teardown-return-to-perps",
        "source": "ac4-skeleton-unit-test",
        "stream": "stderr"
      },
      "teardown-return-to-perps": {
        "action": "ui.navigate",
        "page": "perps",
        "intent": "Leave the wallet back on the Perps tab for the next run.",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}```

</details>

[TAT-3851]: https://consensyssoftware.atlassian.net/browse/TAT-3851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only discovery and navigation on existing market data; no trading, auth, or new network subscriptions beyond URL sort initialization.
> 
> **Overview**
> Adds a **Top movers** block on the Perps home tab (below watchlist) that ranks live markets by 24h price change, shows up to eight as two horizontally scrollable pill rows, and toggles **Gainers** vs **Losers** without reloading. Tapping the section header or a pill navigates to the market list (pre-sorted by price change in the active direction) or market detail, with analytics for header taps and pill taps (`top_gainers` / `top_losers`).
> 
> `usePerpsTabExploreData` now exposes **`allMarkets`** so Top movers reuses the tab’s single market-list stream instead of subscribing again. The market list honors **`sort`** and **`direction`** query params (validated against the sort dropdown), with fallback to volume when params are invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d0f0515d23780804888a68d7cfd27897863ff13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



