### PR TITLE
fix(onboarding): align privacy settings UI with design system

### DIFF
--- a/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
@@ -33,7 +33,7 @@ class OnboardingPrivacySettingsPage {
 
   private readonly assetsSettings = '[data-testid="category-item-Assets"]';
 
-  private readonly assetsSettingsMessage = { text: 'Assets', tag: 'h2' };
+  private readonly assetsSettingsMessage = { text: 'Assets', tag: 'h4' };
 
   // General settings
   private readonly basicFunctionalityCheckbox =
@@ -72,7 +72,7 @@ class OnboardingPrivacySettingsPage {
 
   private readonly generalSettings = '[data-testid="category-item-General"]';
 
-  private readonly generalSettingsMessage = { text: 'General', tag: 'h2' };
+  private readonly generalSettingsMessage = { text: 'General', tag: 'h4' };
 
   private readonly networkNameInput =
     '[data-testid="network-form-network-name"]';

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
@@ -260,19 +260,21 @@ export const BackupAndSyncToggle = ({
 
   return (
     <Box
-      marginTop={4}
-      marginBottom={4}
-      paddingLeft={4}
-      paddingRight={4}
-      className="privacy-settings__setting__wrapper"
+      marginTop={isOnboarding ? 3 : 4}
+      marginBottom={isOnboarding ? 3 : 4}
+      paddingLeft={isOnboarding ? 0 : 4}
+      paddingRight={isOnboarding ? 0 : 4}
+      className="w-full"
       id="backup-and-sync-toggle"
       data-testid={backupAndSyncToggleTestIds.container}
     >
       <Box
         flexDirection={BoxFlexDirection.Row}
         justifyContent={BoxJustifyContent.Between}
-        alignItems={BoxAlignItems.Start}
-        marginBottom={1}
+        alignItems={BoxAlignItems.Center}
+        marginBottom={isOnboarding ? 4 : 1}
+        className="w-full"
+        gap={4}
       >
         <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
           {t('backupAndSyncEnable')}
@@ -283,52 +285,47 @@ export const BackupAndSyncToggle = ({
             <Preloader size={36} />
           </Box>
         ) : (
-          <div
-            className="privacy-settings__setting__toggle"
-            data-testid={backupAndSyncToggleTestIds.toggleContainer}
-          >
+          <Box data-testid={backupAndSyncToggleTestIds.toggleContainer}>
             <ToggleButton
               value={displayedBackupAndSyncEnabled}
               onToggle={handleBackupAndSyncToggleSetValue}
               dataTestId={backupAndSyncToggleTestIds.toggleButton}
             />
-          </div>
-        )}
-      </Box>
-      <div className="privacy-settings__setting__description">
-        <Text
-          variant={TextVariant.BodyMd}
-          color={TextColor.TextAlternative}
-          asChild
-        >
-          <div>
-            {t('backupAndSyncEnableDescription', [
-              <Text
-                asChild
-                variant={TextVariant.BodyMd}
-                key="privacy-link"
-                color={TextColor.InfoDefault}
-              >
-                <a
-                  href={ZENDESK_URLS.PROFILE_PRIVACY}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {t('backupAndSyncPrivacyLink')}
-                </a>
-              </Text>,
-            ])}
-          </div>
-        </Text>
-
-        {error && (
-          <Box marginTop={4} paddingBottom={4}>
-            <Text color={TextColor.ErrorDefault} variant={TextVariant.BodySm}>
-              {t('notificationsSettingsBoxError')}
-            </Text>
           </Box>
         )}
-      </div>
+      </Box>
+      <Text
+        variant={isOnboarding ? TextVariant.BodySm : TextVariant.BodyMd}
+        color={TextColor.TextAlternative}
+        asChild
+        className="w-full"
+      >
+        <div>
+          {t('backupAndSyncEnableDescription', [
+            <Text
+              asChild
+              variant={isOnboarding ? TextVariant.BodySm : TextVariant.BodyMd}
+              key="privacy-link"
+              color={TextColor.InfoDefault}
+            >
+              <a
+                href={ZENDESK_URLS.PROFILE_PRIVACY}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t('backupAndSyncPrivacyLink')}
+              </a>
+            </Text>,
+          ])}
+          {error && (
+            <Box marginTop={4} paddingBottom={4}>
+              <Text color={TextColor.ErrorDefault} variant={TextVariant.BodySm}>
+                {t('notificationsSettingsBoxError')}
+              </Text>
+            </Box>
+          )}
+        </div>
+      </Text>
     </Box>
   );
 };

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -271,15 +271,15 @@ export default function CreationSuccessful() {
       )}
       {renderDoneButton()}
       {!isFromSettingsSRPBackup && (
-        <Box>
-          <TextButton
-            onClick={() => navigate(ONBOARDING_PRIVACY_SETTINGS_ROUTE)}
-            className="hover:bg-transparent active:bg-transparent w-full text-center"
-            data-testid="manage-default-settings"
-          >
-            {t('manageDefaultSettings')}
-          </TextButton>
-        </Box>
+        <Button
+          variant={ButtonVariant.Tertiary}
+          size={ButtonSize.Lg}
+          className="w-full"
+          data-testid="manage-default-settings"
+          onClick={() => navigate(ONBOARDING_PRIVACY_SETTINGS_ROUTE)}
+        >
+          {t('manageDefaultSettings')}
+        </Button>
       )}
     </Box>
   );

--- a/ui/pages/onboarding-flow/privacy-settings/index.scss
+++ b/ui/pages/onboarding-flow/privacy-settings/index.scss
@@ -32,12 +32,6 @@
     }
   }
 
-  &__setting {
-    &__toggle {
-      margin-left: 42px;
-    }
-  }
-
   &__network {
     position: relative;
   }

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.tsx
@@ -180,6 +180,20 @@ describe('Privacy Settings Onboarding View', () => {
     expect(setUse4ByteResolutionStub.mock.calls[0][0]).toStrictEqual(false);
   });
 
+  it('renders category rows as keyboard-operable buttons', () => {
+    const { getByRole } = renderWithProvider(<PrivacySettings />, store);
+
+    expect(
+      getByRole('button', { name: messages.general.message }),
+    ).toBeInTheDocument();
+    expect(
+      getByRole('button', { name: messages.assets.message }),
+    ).toBeInTheDocument();
+    expect(
+      getByRole('button', { name: messages.security.message }),
+    ).toBeInTheDocument();
+  });
+
   describe('Social Login Flow', () => {
     it('should update the default settings for social login', async () => {
       const updatedMockStore = configureMockStore([thunk])({

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
@@ -312,35 +312,42 @@ export default function PrivacySettings() {
                 <ul>
                   {items.map((item) => (
                     <Box
+                      asChild
                       key={item.id}
-                      className="categories-item"
-                      onClick={() => handleItemSelected(item)}
+                      className="categories-item w-full border-0 bg-transparent p-0 text-left"
                     >
-                      <Box
-                        flexDirection={BoxFlexDirection.Row}
-                        alignItems={BoxAlignItems.Start}
-                        justifyContent={BoxJustifyContent.Between}
+                      <button
+                        type="button"
+                        aria-label={item.title}
                         data-testid={`category-item-${item.title}`}
+                        onClick={() => handleItemSelected(item)}
                       >
-                        <Text
-                          variant={TextVariant.BodyMd}
-                          fontWeight={FontWeight.Medium}
+                        <Box
+                          flexDirection={BoxFlexDirection.Row}
+                          alignItems={BoxAlignItems.Start}
+                          justifyContent={BoxJustifyContent.Between}
                         >
-                          {item.title}
+                          <Text
+                            variant={TextVariant.BodyMd}
+                            fontWeight={FontWeight.Medium}
+                          >
+                            {item.title}
+                          </Text>
+                          <Icon
+                            name={IconName.ArrowRight}
+                            size={IconSize.Md}
+                            color={IconColor.IconDefault}
+                            aria-hidden
+                          />
+                        </Box>
+                        <Text
+                          className="description"
+                          variant={TextVariant.BodyMd}
+                          color={TextColor.TextAlternative}
+                        >
+                          {item.subtitle}
                         </Text>
-                        <Icon
-                          name={IconName.ArrowRight}
-                          size={IconSize.Md}
-                          color={IconColor.IconDefault}
-                        />
-                      </Box>
-                      <Text
-                        className="description"
-                        variant={TextVariant.BodyMd}
-                        color={TextColor.TextAlternative}
-                      >
-                        {item.subtitle}
-                      </Text>
+                      </button>
                     </Box>
                   ))}
                 </ul>

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
@@ -11,6 +11,7 @@ import {
   ButtonIcon,
   ButtonIconSize,
   Icon,
+  IconSize,
   TextColor,
   TextVariant,
   IconColor,
@@ -19,6 +20,7 @@ import {
   BoxAlignItems,
   FontWeight,
   TextButton,
+  TextAlign,
 } from '@metamask/design-system-react';
 import { addUrlProtocolPrefix } from '../../../../shared/lib/url-utils';
 import { useOnboardingSearchParams } from '../hooks/useOnboardingSearchParams';
@@ -264,7 +266,7 @@ export default function PrivacySettings() {
                 <ButtonIcon
                   iconName={IconName.ArrowLeft}
                   ariaLabel="Back"
-                  size={ButtonIconSize.Lg}
+                  size={ButtonIconSize.Md}
                   data-testid="privacy-settings-back-button"
                   onClick={handleSubmit}
                 />
@@ -274,30 +276,31 @@ export default function PrivacySettings() {
                   justifyContent={BoxJustifyContent.Center}
                   className="w-full"
                 >
-                  <Text variant={TextVariant.HeadingMd}>
+                  <Text
+                    variant={TextVariant.HeadingSm}
+                    textAlign={TextAlign.Center}
+                  >
                     {t('defaultSettingsTitle')}
                   </Text>
                 </Box>
                 <Box className="privacy-settings__empty-space" />
               </Box>
               <Text
-                variant={TextVariant.BodyLg}
-                fontWeight={FontWeight.Medium}
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
                 className="mt-5"
               >
                 {t('defaultSettingsSubTitle')}
               </Text>
-              <a
-                href={ZENDESK_URLS.PRIVACY_BEST_PRACTICES}
-                target="_blank"
-                rel="noreferrer"
-                key="learnMoreAboutPrivacy"
-                style={{
-                  fontSize: 'var(--font-size-5)',
-                }}
-              >
-                {t('learnMoreAboutPrivacy')}
-              </a>
+              <TextButton asChild className="mt-1 self-start">
+                <a
+                  href={ZENDESK_URLS.PRIVACY_BEST_PRACTICES}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {t('learnMoreAboutPrivacy')}
+                </a>
+              </TextButton>
             </Box>
             <Box>
               <Box
@@ -322,17 +325,15 @@ export default function PrivacySettings() {
                         data-testid={`category-item-${item.title}`}
                       >
                         <Text
-                          variant={TextVariant.BodyLg}
+                          variant={TextVariant.BodyMd}
                           fontWeight={FontWeight.Medium}
                         >
                           {item.title}
                         </Text>
-                        <ButtonIcon
-                          iconName={IconName.ArrowRight}
-                          ariaLabel="Next"
-                          size={ButtonIconSize.Lg}
+                        <Icon
+                          name={IconName.ArrowRight}
+                          size={IconSize.Md}
                           color={IconColor.IconDefault}
-                          onClick={() => handleItemSelected(item)}
                         />
                       </Box>
                       <Text
@@ -360,12 +361,13 @@ export default function PrivacySettings() {
               marginBottom={5}
               flexDirection={BoxFlexDirection.Row}
               justifyContent={BoxJustifyContent.Between}
+              alignItems={BoxAlignItems.Center}
             >
               <ButtonIcon
                 data-testid="category-back-button"
                 iconName={IconName.ArrowLeft}
                 ariaLabel="Back"
-                size={ButtonIconSize.Lg}
+                size={ButtonIconSize.Md}
                 onClick={handleBack}
               />
               <Box
@@ -374,7 +376,10 @@ export default function PrivacySettings() {
                 justifyContent={BoxJustifyContent.Center}
                 className="w-full"
               >
-                <Text variant={TextVariant.HeadingLg}>
+                <Text
+                  variant={TextVariant.HeadingSm}
+                  textAlign={TextAlign.Center}
+                >
                   {selectedItem?.title}
                 </Text>
               </Box>

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
@@ -253,7 +253,7 @@ export default function PrivacySettings() {
           <Box className="list-view">
             <Box
               className="privacy-settings__header"
-              marginTop={6}
+              marginTop={2}
               marginBottom={6}
               flexDirection={BoxFlexDirection.Column}
               justifyContent={BoxJustifyContent.Start}
@@ -288,7 +288,7 @@ export default function PrivacySettings() {
               <Text
                 variant={TextVariant.BodyMd}
                 color={TextColor.TextAlternative}
-                className="mt-5"
+                className="mt-4"
               >
                 {t('defaultSettingsSubTitle')}
               </Text>
@@ -304,16 +304,14 @@ export default function PrivacySettings() {
             </Box>
             <Box>
               <Box
-                marginTop={4}
-                marginBottom={4}
                 className="privacy-settings__categories-list list-none"
+                gap={6}
+                flexDirection={BoxFlexDirection.Column}
                 asChild
               >
                 <ul>
                   {items.map((item) => (
                     <Box
-                      marginTop={5}
-                      marginBottom={5}
                       key={item.id}
                       className="categories-item"
                       onClick={() => handleItemSelected(item)}
@@ -357,8 +355,8 @@ export default function PrivacySettings() {
           >
             <Box
               className="privacy-settings__header"
-              marginTop={6}
-              marginBottom={5}
+              marginTop={2}
+              marginBottom={6}
               flexDirection={BoxFlexDirection.Row}
               justifyContent={BoxJustifyContent.Between}
               alignItems={BoxAlignItems.Center}

--- a/ui/pages/onboarding-flow/privacy-settings/setting.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/setting.tsx
@@ -10,11 +10,6 @@ import {
   TextColor,
   FontWeight,
 } from '@metamask/design-system-react';
-import {
-  TextVariant as TextVariantComponent,
-  TextColor as TextColorComponent,
-} from '../../../helpers/constants/design-system';
-import { Text as TextComponent } from '../../../components/component-library';
 import ToggleButton from '../../../components/ui/toggle-button';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
@@ -77,14 +72,14 @@ export const Setting = ({
           </Box>
         ) : null}
       </Box>
-      <TextComponent
-        variant={TextVariantComponent.bodySm}
-        color={TextColorComponent.textAlternative}
-        as="div"
+      <Text
+        variant={TextVariant.BodySm}
+        color={TextColor.TextAlternative}
+        asChild
         className="w-full"
       >
-        {description}
-      </TextComponent>
+        <div>{description}</div>
+      </Text>
     </Box>
   );
 };


### PR DESCRIPTION
## **Description**

Updates the onboarding default privacy settings flow to use design system components consistently:

- Use `HeadingSm` for page titles and `BodyMd` for intro copy on the default privacy settings page
- Replace oversized category chevrons with medium `Icon` components
- Tighten page spacing to 24px increments above the title and between General, Assets, and Security
- Fix left padding on the onboarding backup and sync toggle so it aligns with other settings
- Migrate the onboarding `Setting` component to design system `Text`
- Switch the onboarding "Manage default settings" action from a blue `TextButton` to a tertiary `Button`

## **Changelog**

CHANGELOG entry: Fixed onboarding default privacy settings typography, spacing, icon sizing, and button styling.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Complete onboarding and open "Manage default settings" on the wallet-ready screen.
2. Verify the button uses the standard black tertiary link style.
3. On the default privacy settings page, confirm the title, intro paragraph, and category chevrons look correct with tighter spacing.
4. Open General, Assets, and Security and confirm subpage titles and backup and sync alignment.


## **Screenshots/Recordings**
### **Before**

https://github.com/user-attachments/assets/5e2aaf56-03be-4dfb-a6af-bc2c8fdf64ff


### **After**

https://github.com/user-attachments/assets/6370e2b2-2e82-4dcc-a1f4-f61ca3ba61af




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and markup changes in onboarding privacy UI only; behavior and settings persistence are unchanged aside from improved category button semantics.
> 
> **Overview**
> Onboarding **default privacy settings** and related screens are restyled to match the design system: smaller centered titles (`HeadingSm`), alternative-color intro copy, tighter vertical spacing, and medium chevron icons instead of large `ButtonIcon` controls.
> 
> Category rows (General, Assets, Security) are now full-width **`<button>`** elements with `aria-label`, improving keyboard access; a unit test asserts they expose the correct button roles. Detail subpage headings move from `h2` to match the new typography, and E2E selectors follow (`h4`).
> 
> The wallet-ready **“Manage default settings”** control switches from a link-style `TextButton` to a full-width tertiary **`Button`**. **`BackupAndSyncToggle`** uses onboarding-specific margins/padding (no horizontal inset), centers the row with the toggle, drops legacy `privacy-settings__setting__*` wrappers, and uses smaller body text on onboarding. The shared **`Setting`** row uses design-system **`Text`** for descriptions instead of the component-library text helper; unused SCSS for toggle offset is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec3489b43ab940910812a2b437ef4224f2983db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->