### PR TITLE
chore: upgrade design system packages (v63.0.0)

### DIFF
--- a/attribution.txt
+++ b/attribution.txt
@@ -24950,7 +24950,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ******************************
 
 @metamask/design-system-react
-0.38.1 <https://github.com/MetaMask/metamask-design-system>
+0.35.0 <https://github.com/MetaMask/metamask-design-system>
 MIT License
 
 Copyright (c) 2024 MetaMask

--- a/attribution.txt
+++ b/attribution.txt
@@ -24950,7 +24950,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ******************************
 
 @metamask/design-system-react
-0.35.0 <https://github.com/MetaMask/metamask-design-system>
+0.38.1 <https://github.com/MetaMask/metamask-design-system>
 MIT License
 
 Copyright (c) 2024 MetaMask

--- a/package.json
+++ b/package.json
@@ -398,7 +398,7 @@
     "@metamask/delegation-controller": "^3.0.2",
     "@metamask/delegation-core": "^2.0.0",
     "@metamask/delegation-deployments": "^1.3.0",
-    "@metamask/design-system-react": "^0.38.0",
+    "@metamask/design-system-react": "^0.38.1",
     "@metamask/design-system-tailwind-preset": "^0.12.0",
     "@metamask/design-tokens": "^10.0.0",
     "@metamask/dummy-package": "workspace:*",

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -486,13 +486,13 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                       to="/snaps?from=%2F"
                     >
                       <div
-                        class="relative inline-flex self-start"
+                        class="relative inline-flex self-start mr-3"
                       >
                         <div
                           class="inline-flex"
                         >
                           <svg
-                            class="inline-block w-6 h-6 text-icon-alternative mr-2"
+                            class="inline-block w-6 h-6 text-icon-alternative"
                             fill="currentColor"
                             viewBox="0 0 24 24"
                             xmlns="http://www.w3.org/2000/svg"

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -503,8 +503,8 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="absolute"
-                          style="top: 0px; right: 4px;"
+                          class="absolute inline-flex items-center justify-center"
+                          style="top: 7%; right: 7%; transform: translate(calc(50% + 4px), -50%);"
                         >
                           <div
                             class="inline-flex rounded-full border-2 border-background-default"

--- a/ui/components/ui/menu/menu-item.tsx
+++ b/ui/components/ui/menu/menu-item.tsx
@@ -96,20 +96,21 @@ const MenuItem = React.forwardRef<
             badge={<BadgeStatus status={BadgeStatusStatus.New} />}
             position={BadgeWrapperPosition.TopRight}
             positionXOffset={4}
+            // Keep spacing outside BadgeWrapper so the badge anchors to the
+            // icon bounds, not icon + margin (which pushed it into the label).
+            className="mr-3"
           >
             {useNewSystem && iconName && (
               <Icon
                 name={iconName}
                 size={iconSize || IconSize.Md}
                 color={iconColor}
-                className="mr-2"
               />
             )}
             {!useNewSystem && iconNameLegacy && (
               <IconLegacy
                 name={iconNameLegacy}
                 size={iconSizeLegacy || IconSizeLegacy.Sm}
-                marginRight={2}
               />
             )}
           </BadgeWrapper>

--- a/ui/pages/bridge/__snapshots__/index.test.tsx.snap
+++ b/ui/pages/bridge/__snapshots__/index.test.tsx.snap
@@ -117,8 +117,8 @@ exports[`Bridge renders the component with initial props 1`] = `
                       </div>
                     </div>
                     <div
-                      class="absolute"
-                      style="bottom: 0px; right: 0px;"
+                      class="absolute inline-flex items-center justify-center"
+                      style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
                     >
                       <div
                         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-sm h-[18px] w-[18px] border-background-default border"
@@ -231,8 +231,8 @@ exports[`Bridge renders the component with initial props 1`] = `
                         </div>
                       </div>
                       <div
-                        class="absolute"
-                        style="bottom: 0px; right: 0px;"
+                        class="absolute inline-flex items-center justify-center"
+                        style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
                       >
                         <div
                           class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-sm h-[18px] w-[18px] border-background-default border"

--- a/ui/pages/bridge/asset-picker/__snapshots__/asset.test.tsx.snap
+++ b/ui/pages/bridge/asset-picker/__snapshots__/asset.test.tsx.snap
@@ -23,9 +23,9 @@ exports[`BridgeAsset should render ERC20 asset 1`] = `
       </div>
     </div>
     <div
-      class="absolute"
+      class="absolute inline-flex items-center justify-center"
       color="background-default"
-      style="bottom: 0px; right: 0px;"
+      style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
     >
       <div
         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative h-[34px] w-[34px] border-background-default border rounded-md"
@@ -118,9 +118,9 @@ exports[`BridgeAsset should render asset with accountType 1`] = `
       </div>
     </div>
     <div
-      class="absolute"
+      class="absolute inline-flex items-center justify-center"
       color="background-default"
-      style="bottom: 0px; right: 0px;"
+      style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
     >
       <div
         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative h-[34px] w-[34px] border-background-default border rounded-md"
@@ -222,9 +222,9 @@ exports[`BridgeAsset should render asset with balance 1`] = `
       </div>
     </div>
     <div
-      class="absolute"
+      class="absolute inline-flex items-center justify-center"
       color="background-default"
-      style="bottom: 0px; right: 0px;"
+      style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
     >
       <div
         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative h-[34px] w-[34px] border-background-default border rounded-md"
@@ -325,9 +325,9 @@ exports[`BridgeAsset should render native asset 1`] = `
       </div>
     </div>
     <div
-      class="absolute"
+      class="absolute inline-flex items-center justify-center"
       color="background-default"
-      style="bottom: 0px; right: 0px;"
+      style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
     >
       <div
         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative h-[34px] w-[34px] border-background-default border rounded-md"

--- a/ui/pages/bridge/asset-picker/__snapshots__/selected-asset-button.test.tsx.snap
+++ b/ui/pages/bridge/asset-picker/__snapshots__/selected-asset-button.test.tsx.snap
@@ -26,8 +26,8 @@ exports[`SelectedAssetButton renders with a native asset 1`] = `
           </div>
         </div>
         <div
-          class="absolute"
-          style="bottom: 0px; right: 0px;"
+          class="absolute inline-flex items-center justify-center"
+          style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
         >
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-sm h-[18px] w-[18px] border-background-default border"
@@ -84,8 +84,8 @@ exports[`SelectedAssetButton renders with a non-EVM asset 1`] = `
           </div>
         </div>
         <div
-          class="absolute"
-          style="bottom: 0px; right: 0px;"
+          class="absolute inline-flex items-center justify-center"
+          style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
         >
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-sm h-[18px] w-[18px] border-background-default border"
@@ -142,8 +142,8 @@ exports[`SelectedAssetButton renders with an ERC20 asset 1`] = `
           </div>
         </div>
         <div
-          class="absolute"
-          style="bottom: 0px; right: 0px;"
+          class="absolute inline-flex items-center justify-center"
+          style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
         >
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-sm h-[18px] w-[18px] border-background-default border"

--- a/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
@@ -52,8 +52,8 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
                 </div>
               </div>
               <div
-                class="absolute"
-                style="bottom: 0px; right: 0px;"
+                class="absolute inline-flex items-center justify-center"
+                style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
               >
                 <div
                   class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-sm h-[18px] w-[18px] border-background-default border"
@@ -166,8 +166,8 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
                   </div>
                 </div>
                 <div
-                  class="absolute"
-                  style="bottom: 0px; right: 0px;"
+                  class="absolute inline-flex items-center justify-center"
+                  style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
                 >
                   <div
                     class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-sm h-[18px] w-[18px] border-background-default border"
@@ -283,8 +283,8 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
                 </div>
               </div>
               <div
-                class="absolute"
-                style="bottom: 0px; right: 0px;"
+                class="absolute inline-flex items-center justify-center"
+                style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
               >
                 <div
                   class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-sm h-[18px] w-[18px] border-background-default border"
@@ -397,8 +397,8 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
                   </div>
                 </div>
                 <div
-                  class="absolute"
-                  style="bottom: 0px; right: 0px;"
+                  class="absolute inline-flex items-center justify-center"
+                  style="bottom: 7%; right: 7%; transform: translate(50%, 50%);"
                 >
                   <div
                     class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-sm h-[18px] w-[18px] border-background-default border"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6459,9 +6459,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react@npm:^0.38.0":
-  version: 0.38.0
-  resolution: "@metamask/design-system-react@npm:0.38.0"
+"@metamask/design-system-react@npm:^0.38.1":
+  version: 0.38.1
+  resolution: "@metamask/design-system-react@npm:0.38.1"
   dependencies:
     "@floating-ui/react-dom": "npm:^2.1.2"
     "@metamask/design-system-shared": "npm:^0.34.0"
@@ -6476,7 +6476,7 @@ __metadata:
     "@metamask/utils": ^11.11.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/6fa0f25fd2979887aef92f0e852d5bf3562e365073184966efb9e2fc4d54bdadd9254e02318a36852406f4d7b4eb98719ca0cc916436836129b67b4b1eb70e36
+  checksum: 10/3507adf5477cc6eb960658bf3a61251dd2ed443df2a0dc87b8b90135a0dd42e97d27f1eef56b51c4302078f3b1e88284eeca08cc4296adf8414a571be4c06651
   languageName: node
   linkType: hard
 
@@ -33291,7 +33291,7 @@ __metadata:
     "@metamask/delegation-controller": "npm:^3.0.2"
     "@metamask/delegation-core": "npm:^2.0.0"
     "@metamask/delegation-deployments": "npm:^1.3.0"
-    "@metamask/design-system-react": "npm:^0.38.0"
+    "@metamask/design-system-react": "npm:^0.38.1"
     "@metamask/design-system-shared": "npm:^0.34.0"
     "@metamask/design-system-tailwind-preset": "npm:^0.12.0"
     "@metamask/design-tokens": "npm:^10.0.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Upgrades design system packages to align with the [v63.0.0 release](https://github.com/MetaMask/metamask-design-system/releases/tag/v63.0.0).

**Packages upgraded:**
- `@metamask/design-system-react`: `^0.38.0` → `^0.38.1`

**Breaking changes addressed:**

None — this is a patch release with no breaking API changes.

**Fix included in this release:**

### BadgeWrapper: layout feedback loop fix
Upstream fixed a `BadgeWrapper` layout feedback loop that could cause continuous layout updates and high CPU usage ([#1474](https://github.com/MetaMask/metamask-design-system/pull/1474)).

**Migration:** No application code changes required. Consumers using `BadgeWrapper` from `@metamask/design-system-react` pick up the fix via the dependency bump.

**Snapshot updates:**
- BadgeWrapper badge positioning now uses percentage-based offsets (`bottom/top: 7%; right: 7%`) with transform instead of fixed `0px` positioning across bridge and app-header snapshots.

### Other breaking changes (no code changes needed)
- N/A — no breaking changes in this release for extension packages.

**New additions available for future use:**
- Content guidelines added to component documentation (upstream docs-only change).

**Legacy component deprecations:**
- No new deprecations added — local `BadgeWrapper` in `ui/components/component-library/badge-wrapper/` already has `@deprecated` JSDoc pointing to `@metamask/design-system-react`.

## **Changelog**

CHANGELOG entry: Fixed a bug that could cause high CPU usage when rendering badge overlays on avatars and icons

## **Related issues**

Fixes:

## **Manual testing steps**

Feature: Design system upgrade to v63.0.0 (BadgeWrapper fix)

  Scenario: Core app functionality is unaffected
    Given I am on the main app screen
    When I navigate through the primary user flows (home, asset list, notifications, bridge)
    Then the UI renders correctly with no visual regressions

  Scenario: BadgeWrapper-heavy views remain stable
    Given I open views that use badge overlays (notifications list, token list items, contact list, bridge asset picker)
    When I interact with and scroll through those lists
    Then badges render correctly and the UI remains responsive with no runaway CPU usage

  Scenario: Bridge asset picker badge positioning
    Given I open the bridge flow and view the selected asset button
    When I inspect the chain badge overlay on the asset icon
    Then the badge is positioned correctly at the bottom-right corner of the icon

## **Screenshots/Recordings**

### **Before**

N/A – dependency-only update

### **After**

Captured from Storybook using `@metamask/design-system-react@0.38.1` — badge positioning looks correct with no visual regressions.

#### AvatarToken + BadgeNetwork
[MMDS token list — AvatarToken with BadgeNetwork badge](https://cursor.com/agents/bc-be8783ab-9ef5-4609-9a15-db5dd5e7dc61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbadgewrapper-after%2Fmmds-avatar-token-badge-network.png)

<img width="624" height="110" alt="image" src="https://github.com/user-attachments/assets/3ee74c1c-1934-40aa-83a2-0b9a25e71ac7" />

[Bridge selected asset — AvatarToken with BadgeNetwork](https://cursor.com/agents/bc-be8783ab-9ef5-4609-9a15-db5dd5e7dc61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbadgewrapper-after%2Fbridge-selected-asset-button.png)

<img width="111" height="70" alt="image" src="https://github.com/user-attachments/assets/ce00d638-7b51-4e55-bcc6-6cf72771a35a" />

#### ButtonIcon + BadgeCount
[MMDS header — ButtonIcon with BadgeCount](https://cursor.com/agents/bc-be8783ab-9ef5-4609-9a15-db5dd5e7dc61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbadgewrapper-after%2Fmmds-button-icon-badge-count.png)

<img width="72" height="72" alt="image" src="https://github.com/user-attachments/assets/245869ae-a15e-4f93-98c2-6f575dc96911" />

#### Notification icon + badge overlay

https://cursor.com/agents/bc-be8783ab-9ef5-4609-9a15-db5dd5e7dc61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbadgewrapper-after%2Fnotification-token-badge.png

<img width="120" height="150" alt="image" src="https://github.com/user-attachments/assets/1f0a9331-6481-475b-9d6e-c3188b6651fb" />

#### App header network badge (topRight + offset)
[App header — network badge on account row](https://cursor.com/agents/bc-be8783ab-9ef5-4609-9a15-db5dd5e7dc61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbadgewrapper-after%2Fapp-header-unlocked-badge.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be8783ab-9ef5-4609-9a15-db5dd5e7dc61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be8783ab-9ef5-4609-9a15-db5dd5e7dc61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

