### PR TITLE
fix(money): use filled icon for active Money tab

### DIFF
--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
@@ -170,7 +170,7 @@ export function BottomNavBar() {
       {moneyAccountAvailability.isAvailable && (
         <NavTab
           isActive={isMoney}
-          icon={IconName.Coin}
+          icon={isMoney ? IconName.MusdFilled : IconName.Musd}
           label={t('money')}
           onClick={handleMoneyClick}
           data-testid="bottom-nav-money"


### PR DESCRIPTION
## **Description**

Uses the outlined mUSD icon when the Money tab is inactive and the filled mUSD icon when active, matching MetaMask Mobile.

## **Changelog**

CHANGELOG entry: Fixed the Money tab to display a filled icon when selected

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Open the extension with the Money tab available.
2. Verify its icon is outlined while inactive.
3. Select Money and verify its icon becomes filled.
4. Leave Money and verify the icon becomes outlined again.

## **Screenshots/Recordings**

### **Before**

The selected Money tab uses the outlined coin icon.
<img width="373" height="285" alt="Screenshot 2026-09-01 at 11 27 53 AM" src="https://github.com/user-attachments/assets/123d4ab6-d1ad-46bb-bff8-9541c900ee9c" />


### **After**

The selected Money tab uses the filled mUSD icon.
<img width="369" height="222" alt="Screenshot 2026-09-01 at 2 12 56 PM" src="https://github.com/user-attachments/assets/49964a2c-8e7f-4775-9553-a8e2bb04b5de" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI icon swap in the bottom nav with no routing, auth, or data-handling impact.
> 
> **Overview**
> Updates the bottom navigation **Money** tab so its icon follows the same active/inactive pattern as Home, Perps, and Activity.
> 
> When Money is selected, the tab uses **`IconName.MusdFilled`**; when it is not, it uses **`IconName.Musd`**. This replaces the static **`IconName.Coin`** icon so the selected state matches MetaMask Mobile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8a4a0845e092c4155b355e7c5c118e51935832d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->