### PR TITLE
feat: add hidden and edit modes to MultichainAccountCell

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-cell/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-cell/index.scss
@@ -10,11 +10,23 @@
     flex-shrink: 0;
   }
 
+  &__edit-mode-visibility-icon {
+    margin-left: 8px;
+  }
+
   &:hover:not(.multichain-account-cell--no-hover):not(.is-selected) {
     background: var(--color-background-default-hover);
 
     .multichain-account-cell__account-name {
       color: var(--color-primary-default);
     }
+  }
+
+  &--hidden {
+    opacity: 0.6;
+  }
+
+  &--edit-mode {
+    cursor: default;
   }
 }

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { StoryFn, Meta } from '@storybook/react';
 import { MultichainAccountCell } from './multichain-account-cell';
 import { MultichainAccountCellProps } from './multichain-account-cell';
@@ -48,7 +48,7 @@ export default {
     docs: {
       description: {
         component:
-          'A reusable component for displaying account information in a compact cell format.',
+          'A reusable component for displaying account information in a compact cell format. Supports `isHidden` and `isEditMode` props (both default to `false`).',
       },
     },
     controls: { sort: 'alpha' },
@@ -89,12 +89,30 @@ export default {
       description:
         'Whether to show the network avatars and copy functionality with optional default address',
     },
+    isHidden: {
+      control: 'boolean',
+      description: 'Whether the account is in hidden mode with muted styling',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    isEditMode: {
+      control: 'boolean',
+      description:
+        'Whether the cell is in edit mode, suppressing menu and default-address controls',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    onVisibilityIconClick: {
+      control: false,
+      description: 'Called when the edit-mode visibility icon is clicked',
+      action: 'visibilityIconClicked',
+    },
   },
   args: {
     accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
     accountName: 'Account 1',
     balance: '$2,400.00',
     selected: false,
+    isHidden: false,
+    isEditMode: false,
     endAccessory: <MoreOptionsAccessory />,
   },
 } as Meta<typeof MultichainAccountCell>;
@@ -242,4 +260,32 @@ WithHoverableNetworkGroup.parameters = {
         'Shows the network avatars and copy functionality below the account name with optional default address.',
     },
   },
+};
+
+export const Hidden = Template.bind({});
+Hidden.args = {
+  accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
+  accountName: 'Hidden Account',
+  balance: '$2,400.00',
+  isHidden: true,
+  endAccessory: <MoreOptionsAccessory />,
+};
+
+export const Edit = Template.bind({});
+Edit.args = {
+  accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
+  accountName: 'Account in Edit Mode',
+  balance: '$2,400.00',
+  isEditMode: true,
+  onVisibilityIconClick: () => console.log('Visibility icon clicked'),
+};
+
+export const HiddenAndEdit = Template.bind({});
+HiddenAndEdit.args = {
+  accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
+  accountName: 'Hidden Account in Edit Mode',
+  balance: '$2,400.00',
+  isHidden: true,
+  isEditMode: true,
+  onVisibilityIconClick: () => console.log('Visibility icon clicked'),
 };

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
@@ -374,4 +374,185 @@ describe('MultichainAccountCell', () => {
       expect(avatarContainer).toBeInTheDocument();
     });
   });
+
+  describe('Mode defaults', () => {
+    it('defaults isHidden and isEditMode to false when props are omitted', () => {
+      renderWithProvider(
+        <MultichainAccountCell
+          accountId={defaultProps.accountId}
+          accountName="Default Mode Account"
+          balance="$100"
+          endAccessory={<span data-testid="end-accessory">More</span>}
+        />,
+        store,
+      );
+
+      const cellElement = screen.getByTestId(
+        `multichain-account-cell-${defaultProps.accountId}`,
+      );
+
+      expect(cellElement).not.toHaveClass('multichain-account-cell--hidden');
+      expect(cellElement).not.toHaveClass('multichain-account-cell--edit-mode');
+      expect(cellElement).not.toHaveAttribute('data-hidden');
+      expect(cellElement).not.toHaveAttribute('data-edit-mode');
+      expect(screen.getByTestId('end-accessory')).toBeInTheDocument();
+    });
+  });
+
+  describe('Hidden mode', () => {
+    it('applies hidden styling and data attribute when isHidden is true', () => {
+      renderWithProvider(
+        <MultichainAccountCell {...defaultProps} isHidden={true} />,
+        store,
+      );
+
+      const cellElement = screen.getByTestId(
+        `multichain-account-cell-${defaultProps.accountId}`,
+      );
+
+      expect(cellElement).toHaveClass('multichain-account-cell--hidden');
+      expect(cellElement).toHaveAttribute('data-hidden', 'true');
+    });
+  });
+
+  describe('Edit mode', () => {
+    it('applies edit-mode styling and suppresses end accessory', () => {
+      renderWithProvider(
+        <MultichainAccountCell
+          {...defaultProps}
+          isEditMode={true}
+          showDefaultAddress={true}
+        />,
+        store,
+      );
+
+      const cellElement = screen.getByTestId(
+        `multichain-account-cell-${defaultProps.accountId}`,
+      );
+
+      expect(cellElement).toHaveClass('multichain-account-cell--edit-mode');
+      expect(cellElement).toHaveAttribute('data-edit-mode', 'true');
+      expect(screen.queryByTestId('end-accessory')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('multichain-account-cell-hovered-addresses'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show connection status badge in edit mode', () => {
+      renderWithProvider(
+        <MultichainAccountCell
+          {...defaultProps}
+          isEditMode={true}
+          connectionStatus={STATUS_CONNECTED}
+        />,
+        store,
+      );
+
+      const tooltipElement = document.querySelector(
+        '[data-original-title="Active"]',
+      );
+      expect(tooltipElement).not.toBeInTheDocument();
+    });
+
+    it('shows eye icon next to balance in visible edit mode', () => {
+      renderWithProvider(
+        <MultichainAccountCell {...defaultProps} isEditMode={true} />,
+        store,
+      );
+
+      expect(
+        screen.getByTestId('multichain-account-cell-edit-mode-visible-icon'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('multichain-account-cell-edit-mode-hidden-icon'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows crossed eye icon next to balance in hidden edit mode', () => {
+      renderWithProvider(
+        <MultichainAccountCell
+          {...defaultProps}
+          isEditMode={true}
+          isHidden={true}
+        />,
+        store,
+      );
+
+      expect(
+        screen.getByTestId('multichain-account-cell-edit-mode-hidden-icon'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('multichain-account-cell-edit-mode-visible-icon'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show edit mode visibility icon when not in edit mode', () => {
+      renderWithProvider(<MultichainAccountCell {...defaultProps} />, store);
+
+      expect(
+        screen.queryByTestId('multichain-account-cell-edit-mode-visible-icon'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('multichain-account-cell-edit-mode-hidden-icon'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render startAccessory when in edit mode', () => {
+      renderWithProvider(
+        <MultichainAccountCell
+          {...defaultProps}
+          isEditMode={true}
+          startAccessory={<span data-testid="start-accessory">Start</span>}
+        />,
+        store,
+      );
+
+      expect(screen.queryByTestId('start-accessory')).not.toBeInTheDocument();
+    });
+
+    it('calls onVisibilityIconClick when the visibility icon is clicked', () => {
+      const handleVisibilityIconClick = jest.fn();
+      const handleCellClick = jest.fn();
+
+      renderWithProvider(
+        <MultichainAccountCell
+          {...defaultProps}
+          isEditMode={true}
+          onClick={handleCellClick}
+          onVisibilityIconClick={handleVisibilityIconClick}
+        />,
+        store,
+      );
+
+      fireEvent.click(
+        screen.getByTestId('multichain-account-cell-edit-mode-visible-icon'),
+      );
+
+      expect(handleVisibilityIconClick).toHaveBeenCalledTimes(1);
+      expect(handleVisibilityIconClick).toHaveBeenCalledWith(
+        defaultProps.accountId,
+      );
+      expect(handleCellClick).not.toHaveBeenCalled();
+    });
+
+    it('does not call onVisibilityIconClick when pending is true', () => {
+      const handleVisibilityIconClick = jest.fn();
+
+      renderWithProvider(
+        <MultichainAccountCell
+          {...defaultProps}
+          isEditMode={true}
+          pending={true}
+          onVisibilityIconClick={handleVisibilityIconClick}
+        />,
+        store,
+      );
+
+      fireEvent.click(
+        screen.getByTestId('multichain-account-cell-edit-mode-visible-icon'),
+      );
+
+      expect(handleVisibilityIconClick).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -251,7 +251,7 @@ export const MultichainAccountCell = ({
           : BoxBackgroundColor.Transparent
       }
     >
-      {startAccessory && !isEditMode ? startAccessory : null}
+      {!isEditMode && startAccessory}
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -8,12 +8,18 @@ import {
   BoxBorderColor,
   BoxFlexDirection,
   BoxJustifyContent,
+  ButtonIcon,
+  ButtonIconSize,
   FontWeight,
+  IconColor,
+  IconName,
+  IconSize,
   SensitiveText,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getIconSeedAddressByAccountGroupId } from '../../../selectors/multichain-accounts/account-tree';
 import { ConnectedStatus } from '../../multichain/connected-status/connected-status';
 import {
@@ -88,6 +94,38 @@ const BalanceDisplay = ({
   );
 };
 
+type EditModeVisibilityIconProps = {
+  isHidden: boolean;
+  ariaLabel: string;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
+};
+
+const EditModeVisibilityIcon = ({
+  isHidden,
+  ariaLabel,
+  onClick,
+  disabled = false,
+}: EditModeVisibilityIconProps) => (
+  <ButtonIcon
+    iconName={isHidden ? IconName.EyeSlash : IconName.Eye}
+    size={ButtonIconSize.Sm}
+    ariaLabel={ariaLabel}
+    onClick={onClick}
+    isDisabled={disabled}
+    className="multichain-account-cell__edit-mode-visibility-icon flex-shrink-0"
+    data-testid={
+      isHidden
+        ? 'multichain-account-cell-edit-mode-hidden-icon'
+        : 'multichain-account-cell-edit-mode-visible-icon'
+    }
+    iconProps={{
+      size: IconSize.Sm,
+      color: IconColor.IconAlternative,
+    }}
+  />
+);
+
 export type MultichainAccountCellProps = {
   accountId: AccountGroupId;
   accountName: string | React.ReactNode;
@@ -114,6 +152,21 @@ export type MultichainAccountCellProps = {
    * sees that an account switch is in progress (React useTransition pending).
    */
   pending?: boolean;
+  /**
+   * When true, renders the cell in hidden-account mode with muted styling.
+   * @default false
+   */
+  isHidden?: boolean;
+  /**
+   * When true, renders the cell in edit mode. Suppresses non-edit affordances
+   * such as the end accessory menu and default-address controls.
+   * @default false
+   */
+  isEditMode?: boolean;
+  /**
+   * Called when the edit-mode visibility icon is clicked.
+   */
+  onVisibilityIconClick?: (accountGroupId: AccountGroupId) => void;
 };
 
 export const MultichainAccountCell = ({
@@ -132,7 +185,12 @@ export const MultichainAccountCell = ({
   privacyMode = false,
   showDefaultAddress = false,
   pending = false,
+  isHidden = false,
+  isEditMode = false,
+  onVisibilityIconClick,
 }: MultichainAccountCellProps) => {
+  const t = useI18nContext();
+
   const handleClick = () => {
     if (pending) {
       return;
@@ -155,6 +213,19 @@ export const MultichainAccountCell = ({
     getIconSeedAddressByAccountGroupId(state, accountId),
   );
 
+  const shouldDisableHoverEffect = disableHoverEffect || isEditMode;
+  const shouldShowDefaultAddress = showDefaultAddress && !isEditMode;
+
+  const handleVisibilityIconClick = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.stopPropagation();
+    if (pending) {
+      return;
+    }
+    onVisibilityIconClick?.(accountId);
+  };
+
   return (
     <Box
       flexDirection={BoxFlexDirection.Row}
@@ -168,9 +239,11 @@ export const MultichainAccountCell = ({
       padding={4}
       gap={4}
       onClick={handleClick}
-      className={`multichain-account-cell${disableHoverEffect ? ' multichain-account-cell--no-hover' : ''}${selected && !startAccessory ? ' is-selected' : ''}${pending ? ' is-pending' : ''}`}
+      className={`multichain-account-cell${shouldDisableHoverEffect ? ' multichain-account-cell--no-hover' : ''}${selected && !startAccessory ? ' is-selected' : ''}${pending ? ' is-pending' : ''}${isHidden ? ' multichain-account-cell--hidden' : ''}${isEditMode ? ' multichain-account-cell--edit-mode' : ''}`}
       data-testid={`multichain-account-cell-${accountId}`}
       key={`multichain-account-cell-${accountId}`}
+      data-hidden={isHidden ? 'true' : undefined}
+      data-edit-mode={isEditMode ? 'true' : undefined}
       aria-busy={pending || undefined}
       backgroundColor={
         selected && !startAccessory
@@ -178,7 +251,7 @@ export const MultichainAccountCell = ({
           : BoxBackgroundColor.Transparent
       }
     >
-      {startAccessory}
+      {startAccessory && !isEditMode ? startAccessory : null}
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
@@ -187,7 +260,7 @@ export const MultichainAccountCell = ({
       >
         <AccountCellAvatar
           seedAddress={seedAddressIcon}
-          connectionStatus={connectionStatus}
+          connectionStatus={isEditMode ? undefined : connectionStatus}
         />
         <Box marginLeft={3} style={{ overflow: 'hidden' }}>
           {/* Prevent overflow of account name by long account names */}
@@ -195,6 +268,7 @@ export const MultichainAccountCell = ({
             className="multichain-account-cell__account-name"
             variant={TextVariant.BodyMd}
             fontWeight={FontWeight.Medium}
+            color={isHidden ? TextColor.TextAlternative : undefined}
             ellipsis
             data-testid={`multichain-account-cell-name-${ariaLabelName}`}
           >
@@ -218,7 +292,7 @@ export const MultichainAccountCell = ({
               {walletName}
             </Text>
           )}
-          {showDefaultAddress && (
+          {shouldShowDefaultAddress && (
             <Box
               flexDirection={BoxFlexDirection.Row}
               onClick={(e: React.MouseEvent) => e.stopPropagation()}
@@ -238,6 +312,14 @@ export const MultichainAccountCell = ({
         {balancePosition === 'end' && (
           <BalanceDisplay balance={balance} isHidden={privacyMode} />
         )}
+        {isEditMode && (
+          <EditModeVisibilityIcon
+            isHidden={isHidden}
+            ariaLabel={isHidden ? t('showAccount') : t('hideAccount')}
+            onClick={handleVisibilityIconClick}
+            disabled={pending}
+          />
+        )}
         <Box
           className="multichain-account-cell__end_accessory"
           flexDirection={BoxFlexDirection.Row}
@@ -246,7 +328,7 @@ export const MultichainAccountCell = ({
           data-testid="multichain-account-cell-end-accessory"
           aria-label={`${ariaLabelName} options`}
         >
-          {endAccessory}
+          {!isEditMode && endAccessory}
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
## **Description**

`MultichainAccountCell` needs to support distinct visible/hidden and edit/non-edit display modes for upcoming account list management flows. Changes include

- Added `isHidden` and `isEditMode` props (both default to `false`)
- **Hidden mode:** muted styling (`multichain-account-cell--hidden`), alternative account name color
- **Edit mode:** suppresses end accessory menu, default address, connection status badge, and `startAccessory`
- **Edit mode visibility control:** shows an eye icon (visible) or eye-slash icon (hidden) next to the balance
- Added `onVisibilityIconClick(accountGroupId)` callback for the visibility icon (stops propagation; disabled while `pending`)
- Added Storybook stories (`Hidden`, `Edit`, `HiddenAndEdit`) and unit test coverage

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-2166

## **Manual testing steps**

1. Run `yarn storybook`
2. Open **Components → MultichainAccounts → MultichainAccountCell**
3. Verify **Default** renders unchanged (balance, menu, no eye icon)
4. Open **Hidden** and confirm muted styling on the account row
5. Open **Edit** and confirm:
   - No three-dot menu
   - Eye icon appears next to the balance
   - Clicking the eye icon logs to the console (or triggers the Actions panel callback)
6. Open **HiddenAndEdit** and confirm crossed-eye icon appears next to the balance
7. On **Default**, toggle `isHidden` / `isEditMode` in the Controls panel and confirm behavior updates

## **Screenshots/Recordings**

<img width="450" alt="Screenshot 2026-09-01 at 7 21 29 PM" src="https://github.com/user-attachments/assets/07880e1d-84be-44cd-a5fc-27c01dd6a8ad" />

<img width="450" alt="Screenshot 2026-09-01 at 7 21 35 PM" src="https://github.com/user-attachments/assets/417c74bd-792c-4b18-930c-824f70e1d8bb" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to a reusable cell with defaults preserving existing behavior; no auth or data-layer impact.
> 
> **Overview**
> **`MultichainAccountCell` gains optional hidden and edit display modes** (both default off) to support upcoming account list management.
> 
> **Hidden mode** (`isHidden`) applies muted row styling and alternative account name color via `multichain-account-cell--hidden` and `data-hidden`.
> 
> **Edit mode** (`isEditMode`) turns off hover styling, hides the end accessory menu, default address block, connection badge, and `startAccessory`, and shows an eye / eye-slash control beside the balance. **`onVisibilityIconClick(accountGroupId)`** fires from that button with click propagation stopped and is ignored while `pending`.
> 
> Storybook stories and unit tests cover defaults, styling, suppressed UI, icon variants, and visibility click behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35fcb2be25ddce5dcb1f098c6a7d11f7f6895d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->