### PR TITLE
feat: migrate users with all toggles on/off to consolidated toggle on/off state without toast

### DIFF
--- a/ui/selectors/multichain/basic-functionality.ts
+++ b/ui/selectors/multichain/basic-functionality.ts
@@ -1,0 +1,68 @@
+import { createSelector } from 'reselect';
+import { getBooleanFeatureFlag } from '../../../shared/lib/remote-feature-flag-utils';
+import { getRemoteFeatureFlags } from '../../../shared/lib/selectors/remote-feature-flags';
+
+export const BFT_CHILD_PREFERENCES = [
+  'useCurrencyRateCheck',
+  'securityAlertsEnabled',
+  'usePhishDetect',
+  'useMultiAccountBalanceChecker',
+  'useSafeChainsListValidation',
+  'useTokenDetection',
+  'useTransactionSimulations',
+  'use4ByteResolution',
+  'openSeaEnabled',
+  'useNftDetection',
+  'useExternalNameSources',
+] as const;
+
+/**
+ * Gets whether the Basic Functionality consolidation rollout is enabled.
+ */
+export const getIsBasicFunctionalityToggleEnabled = createSelector(
+  getRemoteFeatureFlags,
+  ({ extensionBasicFunctionalityToggle }) =>
+    getBooleanFeatureFlag(extensionBasicFunctionalityToggle, false),
+);
+
+/**
+ * Gets whether a user has a consistent all-on or all-off BFT configuration.
+ */
+const getIsBasicFunctionalityConsistent = createSelector(
+  (state) => state.metamask,
+  (metamaskState) => {
+    const bftValue = metamaskState.useExternalServices;
+    const areAllChildrenEnabled = BFT_CHILD_PREFERENCES.every(
+      (preference) => metamaskState[preference] === true,
+    );
+    const areAllChildrenDisabled = BFT_CHILD_PREFERENCES.every(
+      (preference) => metamaskState[preference] === false,
+    );
+
+    return (
+      (bftValue === true && areAllChildrenEnabled) ||
+      (bftValue === false && areAllChildrenDisabled)
+    );
+  },
+);
+
+/**
+ * Gets whether the consolidated Basic Functionality experience should be shown.
+ * The LD flag controls rollout eligibility. Persisted cohort users and legacy
+ * users with a consistent all-on or all-off configuration are eligible.
+ */
+export const getIsBasicFunctionalityConsolidationEnabled = createSelector(
+  getIsBasicFunctionalityToggleEnabled,
+  (state) =>
+    Boolean(
+      state.metamask.preferences?.isBasicFunctionalityConsolidatedEnabled,
+    ),
+  getIsBasicFunctionalityConsistent,
+  (
+    isBasicFunctionalityToggleEnabled,
+    isPersistedConsolidatedUser,
+    isConsistentLegacyUser,
+  ) =>
+    isBasicFunctionalityToggleEnabled &&
+    (isPersistedConsolidatedUser || isConsistentLegacyUser),
+);

--- a/ui/selectors/multichain/basic-functionality.ts
+++ b/ui/selectors/multichain/basic-functionality.ts
@@ -14,6 +14,7 @@ export const BFT_CHILD_PREFERENCES = [
   'openSeaEnabled',
   'useNftDetection',
   'useExternalNameSources',
+  'useAddressBarEnsResolution'
 ] as const;
 
 /**

--- a/ui/selectors/multichain/basic-functionality.ts
+++ b/ui/selectors/multichain/basic-functionality.ts
@@ -14,7 +14,7 @@ export const BFT_CHILD_PREFERENCES = [
   'openSeaEnabled',
   'useNftDetection',
   'useExternalNameSources',
-  'useAddressBarEnsResolution'
+  'useAddressBarEnsResolution',
 ] as const;
 
 /**

--- a/ui/selectors/multichain/feature-flags.test.ts
+++ b/ui/selectors/multichain/feature-flags.test.ts
@@ -1,5 +1,6 @@
 import { EXTENSION_TRUST_AND_SECURITY_TDP_FLAG } from '../../../shared/lib/assets/security-trust-feature-flags';
 import {
+  BFT_CHILD_PREFERENCES,
   getIsBasicFunctionalityConsolidationEnabled,
   getIsBasicFunctionalityToggleEnabled,
   getIsNetworkManagementEnabled,
@@ -23,6 +24,29 @@ const buildState = (
     preferences: {
       isBasicFunctionalityConsolidatedEnabled,
     },
+  },
+});
+
+const buildBftState = (
+  useExternalServices: boolean,
+  remoteFlag = true,
+  childOverrides: Partial<
+    Record<(typeof BFT_CHILD_PREFERENCES)[number], boolean>
+  > = {},
+) => ({
+  ...buildState({ extensionBasicFunctionalityToggle: remoteFlag }, false),
+  metamask: {
+    ...buildState().metamask,
+    remoteFeatureFlags: {
+      extensionBasicFunctionalityToggle: remoteFlag,
+    },
+    useExternalServices,
+    ...Object.fromEntries(
+      BFT_CHILD_PREFERENCES.map((preference) => [
+        preference,
+        childOverrides[preference] ?? useExternalServices,
+      ]),
+    ),
   },
 });
 
@@ -246,6 +270,48 @@ describe('getIsBasicFunctionalityToggleEnabled', () => {
 });
 
 describe('getIsBasicFunctionalityConsolidationEnabled', () => {
+  it('returns true for an all-on legacy BFT user when the remote flag is enabled', () => {
+    expect(
+      getIsBasicFunctionalityConsolidationEnabled(
+        buildBftState(true) as unknown as Parameters<
+          typeof getIsBasicFunctionalityConsolidationEnabled
+        >[0],
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for an all-off legacy BFT user when the remote flag is enabled', () => {
+    expect(
+      getIsBasicFunctionalityConsolidationEnabled(
+        buildBftState(false) as unknown as Parameters<
+          typeof getIsBasicFunctionalityConsolidationEnabled
+        >[0],
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a mixed legacy BFT user', () => {
+    expect(
+      getIsBasicFunctionalityConsolidationEnabled(
+        buildBftState(true, true, {
+          useTokenDetection: false,
+        }) as unknown as Parameters<
+          typeof getIsBasicFunctionalityConsolidationEnabled
+        >[0],
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for a consistent legacy BFT user when the remote flag is disabled', () => {
+    expect(
+      getIsBasicFunctionalityConsolidationEnabled(
+        buildBftState(true, false) as unknown as Parameters<
+          typeof getIsBasicFunctionalityConsolidationEnabled
+        >[0],
+      ),
+    ).toBe(false);
+  });
+
   it('returns true when the remote flag and persisted cohort marker are both true', () => {
     expect(
       getIsBasicFunctionalityConsolidationEnabled(

--- a/ui/selectors/multichain/feature-flags.ts
+++ b/ui/selectors/multichain/feature-flags.ts
@@ -6,6 +6,12 @@ import { getBooleanFeatureFlag } from '../../../shared/lib/remote-feature-flag-u
 import { EXTENSION_TRUST_AND_SECURITY_TDP_FLAG } from '../../../shared/lib/assets/security-trust-feature-flags';
 import { getRemoteFeatureFlags } from '../../../shared/lib/selectors/remote-feature-flags';
 
+export {
+  BFT_CHILD_PREFERENCES,
+  getIsBasicFunctionalityConsolidationEnabled,
+  getIsBasicFunctionalityToggleEnabled,
+} from './basic-functionality';
+
 /**
  * Get the state of the `bitcoinAccounts` feature flag with version check.
  *
@@ -114,36 +120,6 @@ export const getIsTokenManagementFilterEnabled = createSelector(
   getRemoteFeatureFlags,
   ({ extensionUxTokenManagementFilter }) =>
     getBooleanFeatureFlag(extensionUxTokenManagementFilter, false),
-);
-
-/**
- * Get the state of the `extensionBasicFunctionalityToggle` remote feature flag.
- *
- * @param _state - The MetaMask state object
- * @returns boolean - True if the feature is enabled, false otherwise.
- */
-export const getIsBasicFunctionalityToggleEnabled = createSelector(
-  getRemoteFeatureFlags,
-  ({ extensionBasicFunctionalityToggle }) =>
-    getBooleanFeatureFlag(extensionBasicFunctionalityToggle, false),
-);
-
-/**
- * Get whether the consolidated Basic Functionality experience should be shown.
- * The remote flag controls rollout eligibility; the persisted marker ensures
- * the experience only applies to users who onboarded into the cohort.
- *
- * @param _state - The MetaMask state object
- * @returns boolean - True if the user is in the consolidated Basic Functionality cohort.
- */
-export const getIsBasicFunctionalityConsolidationEnabled = createSelector(
-  getIsBasicFunctionalityToggleEnabled,
-  (state) =>
-    Boolean(
-      state.metamask.preferences?.isBasicFunctionalityConsolidatedEnabled,
-    ),
-  (isBasicFunctionalityToggleEnabled, isConsolidatedUser) =>
-    isBasicFunctionalityToggleEnabled && isConsolidatedUser,
 );
 
 /**


### PR DESCRIPTION
This PR is to add silent Basic Functionality Toggle migration for the users.

List of toggles 
```
Estimate Balance Changes Toggle
Security Alert Toggle
Phishing Detection Toggle
Show Balance and Token Price Checker Toggle
Network Details Check Toggle
Autodetect Tokens Toggle
Authentication API
Make smart contracts easier to read (i.e. 4byte.directory)
Display NFT media
Autodetect NFTs
Proposed nicknames
```


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: migrate users with all toggles on/off to consolidated toggle on/off state

## **Related issues**

Fixes:

## **Manual testing steps**

1. Keep the BFT and all the toggles enabled in main and then switch to this branch, set     `getBooleanFeatureFlag(extensionBasicFunctionalityToggle, false), to true`. Check all the toggles re consolidated and only BFT is on
2. Keep the BFT off and all the toggles disabled in main and then switch to this branch  set     `getBooleanFeatureFlag(extensionBasicFunctionalityToggle, false), to true`. . Check all the toggles re consolidated and only BFT is off

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which users see the consolidated privacy/settings UI and how legacy toggle state is interpreted, though eligibility is gated on consistency checks and the remote flag.
> 
> **Overview**
> **Basic Functionality consolidation** eligibility is broadened so users who never got the persisted cohort flag can still enter the consolidated experience when their settings already match a single on/off state.
> 
> `getIsBasicFunctionalityConsolidationEnabled` now returns true when the remote `extensionBasicFunctionalityToggle` flag is on **and** either the existing `preferences.isBasicFunctionalityConsolidatedEnabled` marker is set **or** `useExternalServices` is aligned with every listed child preference (`BFT_CHILD_PREFERENCES`) being all `true` or all `false`. Mixed child toggles remain ineligible.
> 
> BFT-related selectors and the child-preference list move into **`basic-functionality.ts`**, with **`feature-flags.ts`** re-exporting them so imports stay stable. Tests cover all-on/all-off legacy users, mixed configs, and disabled remote flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4aa0e8e15ca2cf90c3a00d8a1d268e0b711d085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->