### PR TITLE
test: fix flaky test `Perps Withdraw submits a valid withdrawal from the confirmation flow`

### DIFF
--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -306,6 +306,46 @@ async function mockEligibleFeatureFlags(
     }));
 }
 
+const GAS_API_BASE_URL = 'https://gas.api.cx.metamask.io';
+
+async function mockArbitrumGasData(server: Mockttp): Promise<void> {
+  await server
+    .forGet(
+      `${GAS_API_BASE_URL}/networks/${ARBITRUM_CHAIN_ID_DECIMAL}/suggestedGasFees`,
+    )
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        low: {
+          suggestedMaxPriorityFeePerGas: '0.01',
+          suggestedMaxFeePerGas: '0.02',
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 30000,
+        },
+        medium: {
+          suggestedMaxPriorityFeePerGas: '0.025',
+          suggestedMaxFeePerGas: '0.05',
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 45000,
+        },
+        high: {
+          suggestedMaxPriorityFeePerGas: '0.05',
+          suggestedMaxFeePerGas: '0.1',
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 60000,
+        },
+        estimatedBaseFee: '0.01',
+        networkCongestion: 0.1,
+        latestPriorityFeeRange: ['0.01', '0.05'],
+        historicalPriorityFeeRange: ['0.01', '0.1'],
+        historicalBaseFeeRange: ['0.01', '0.02'],
+        priorityFeeTrend: 'stable',
+        baseFeeTrend: 'stable',
+      },
+    }));
+}
+
 async function mockArbitrumUsdcPriceData(server: Mockttp): Promise<void> {
   await server
     .forGet(`${PRICE_API_BASE_URL}/v1/exchange-rates`)
@@ -687,6 +727,7 @@ export function getPerpsConfigEligibleWithArbitrumUsdc(title?: string) {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         confirmations_pay_post_quote: PERPS_WITHDRAW_CONFIRMATION_ENABLED_FLAG,
       });
+      await mockArbitrumGasData(server);
       await mockArbitrumUsdcPriceData(server);
       await mockRelayWithdrawData(server);
     },

--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -10,6 +10,7 @@ import {
   getProductionRemoteFlagDefaults,
 } from '../../feature-flags/feature-flag-registry';
 import { BOTTOM_NAV_AB_TEST_KEY } from '../../../../shared/lib/ab-testing/configs/bottom-nav-bar';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { formatUnits } from '../../../../shared/lib/unit';
 import {
   MOCK_ETH_OPEN_LONG_FILL,
@@ -31,15 +32,13 @@ const {
   ...PERPS_PROD_REMOTE_FLAGS
 } = PROD_REMOTE_FLAGS;
 
-const ARBITRUM_CHAIN_ID = '0xa4b1';
-const ARBITRUM_CHAIN_ID_DECIMAL = Number(ARBITRUM_CHAIN_ID);
+const ARBITRUM_CHAIN_ID_DECIMAL = Number(CHAIN_IDS.ARBITRUM);
 const ARBITRUM_USDC_ADDRESS: Hex = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
 const ARBITRUM_USDC_ASSET_ID =
   'eip155:42161/erc20:0xaf88d065e77c8cc2239327c5edb3a432268e5831';
 const ARBITRUM_NATIVE_ASSET_ID = 'eip155:42161/slip44:60';
 const ARBITRUM_USDC_PRICE_IN_ETH = 1 / 1700;
-const HYPERCORE_CHAIN_ID = '0x539';
-const HYPERCORE_CHAIN_ID_DECIMAL = Number(HYPERCORE_CHAIN_ID);
+const HYPERCORE_CHAIN_ID_DECIMAL = Number(CHAIN_IDS.LOCALHOST);
 const PRICE_API_BASE_URL = 'https://price.api.cx.metamask.io';
 const RELAY_API_BASE_URL = 'https://api.relay.link';
 const RELAY_REQUEST_ID = 'perps-withdraw-e2e-request-id';
@@ -309,6 +308,22 @@ async function mockEligibleFeatureFlags(
 const GAS_API_BASE_URL = 'https://gas.api.cx.metamask.io';
 
 async function mockArbitrumGasData(server: Mockttp): Promise<void> {
+  // Mock the supportedNetworks endpoint to include Arbitrum.
+  // GasFeeController checks this to determine which networks can use gas estimates.
+  await server
+    .forGet(`${GAS_API_BASE_URL}/v1/supportedNetworks`)
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: [
+        CHAIN_IDS.MAINNET,
+        CHAIN_IDS.POLYGON,
+        CHAIN_IDS.BSC,
+        CHAIN_IDS.OPTIMISM,
+        CHAIN_IDS.ARBITRUM,
+      ],
+    }));
+
   await server
     .forGet(
       `${GAS_API_BASE_URL}/networks/${ARBITRUM_CHAIN_ID_DECIMAL}/suggestedGasFees`,
@@ -648,7 +663,7 @@ export function getPerpsConfigEligibleWithArbitrumUsdc(title?: string) {
       })
       .withTokensController({
         allTokens: {
-          [ARBITRUM_CHAIN_ID]: {
+          [CHAIN_IDS.ARBITRUM]: {
             [DEFAULT_FIXTURE_ACCOUNT_LOWERCASE]: [
               {
                 address: ARBITRUM_USDC_ADDRESS,
@@ -665,7 +680,7 @@ export function getPerpsConfigEligibleWithArbitrumUsdc(title?: string) {
       })
       .withTokenRatesController({
         marketData: {
-          [ARBITRUM_CHAIN_ID]: {
+          [CHAIN_IDS.ARBITRUM]: {
             [ARBITRUM_USDC_ADDRESS]: ARBITRUM_USDC_MARKET_DATA,
           },
         },

--- a/test/e2e/tests/perps/perps-withdraw.spec.ts
+++ b/test/e2e/tests/perps/perps-withdraw.spec.ts
@@ -63,7 +63,7 @@ async function openPerpsWithdrawConfirmation(
   return withdrawConfirmation;
 }
 
-describe('Perps Withdraw', function (this: Suite) {
+describe('Perps Withdraw TEST', function (this: Suite) {
   this.timeout(120000);
 
   it('withdraw page loads with header and summary rows visible', async function () {

--- a/test/e2e/tests/perps/perps-withdraw.spec.ts
+++ b/test/e2e/tests/perps/perps-withdraw.spec.ts
@@ -63,7 +63,7 @@ async function openPerpsWithdrawConfirmation(
   return withdrawConfirmation;
 }
 
-describe('Perps Withdraw TEST', function (this: Suite) {
+describe('Perps Withdraw', function (this: Suite) {
   this.timeout(120000);
 
   it('withdraw page loads with header and summary rows visible', async function () {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The Perps Withdraw confirmation sends funds to Arbitrum (chain 42161), but we are missing a gas API mock for that chain, causing the Withdraw button to not be available and display a gas error.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1366" height="682" alt="image" src="https://github.com/user-attachments/assets/2bb57787-f324-4174-bde7-83ddd32fd1a8" />


### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only E2E fixture and mock changes; no production or auth/data-path impact.
> 
> **Overview**
> Stabilizes the **Perps withdraw confirmation** E2E by mocking MetaMask’s gas service for Arbitrum so the confirmation flow can enable **Withdraw** instead of surfacing a gas error.
> 
> Adds `mockArbitrumGasData` to the withdraw-confirmation fixture (`supportedNetworks` plus `suggestedGasFees` for chain 42161) and wires it into `getPerpsConfigEligibleWithArbitrumUsdc`’s `testSpecificMock`. Fixture chain keys/constants are aligned with shared `CHAIN_IDS` (replacing local hex literals) without changing values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d1c341d12ebe7b1208acf0465e02be4055a223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->