### PR TITLE
fix(ramps): show payment method limits as up to max

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -8339,10 +8339,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "Min."
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "Min. $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -8340,11 +8340,7 @@
     "message": "Min."
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Max. $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -8339,10 +8339,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "λεπτά"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "Ελάχιστο ποσό: $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -8340,11 +8340,7 @@
     "message": "λεπτά"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Μέγιστο ποσό: $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -8665,11 +8665,7 @@
     "message": "mins"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Max $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -8665,11 +8665,7 @@
     "message": "mins"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Max $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -8347,10 +8347,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "min"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "Mín. $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -8348,11 +8348,7 @@
     "message": "min"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Máx. $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -8339,10 +8339,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "min"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "$1 au minimum",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -8340,11 +8340,7 @@
     "message": "min"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "$1 au maximum",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -8340,11 +8340,7 @@
     "message": "मिनट"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "अधिकतम $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -8339,10 +8339,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "मिनट"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "न्यूनतम $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -8347,10 +8347,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "menit"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "Min $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -8348,11 +8348,7 @@
     "message": "menit"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Maks $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -8344,11 +8344,7 @@
     "message": "分"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1〜$2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "最大 $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -8343,10 +8343,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "分"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "最小 $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -8347,10 +8347,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "분"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "최소 $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -8348,11 +8348,7 @@
     "message": "분"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "최대 $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -8340,11 +8340,7 @@
     "message": "min"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Máx. $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -8339,10 +8339,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "min"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "Mín. $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -8339,10 +8339,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "мин."
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "Мин. $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -8340,11 +8340,7 @@
     "message": "мин."
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Макс. $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -8339,10 +8339,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "na min"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "Pinakamababa $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -8340,11 +8340,7 @@
     "message": "na min"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Pinakamataas $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -8347,10 +8347,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "dk."
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "Min $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -8348,11 +8348,7 @@
     "message": "dk."
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Maks $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -8347,10 +8347,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "phút"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "Tối thiểu $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -8348,11 +8348,7 @@
     "message": "phút"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "Tối đa $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -8340,11 +8340,7 @@
     "message": "分钟"
   },
   "rampsPaymentMethodLimits": {
-    "message": "$1 – $2",
-    "description": "$1 is the minimum fiat buy amount, $2 is the maximum"
-  },
-  "rampsPaymentMethodMaxLimit": {
-    "message": "最高 $1",
+    "message": "Up to $1",
     "description": "$1 is the maximum fiat buy amount"
   },
   "rampsPaymentMethodMinLimit": {

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -8339,10 +8339,6 @@
   "rampsPaymentDelayMinutes": {
     "message": "分钟"
   },
-  "rampsPaymentMethodLimits": {
-    "message": "Up to $1",
-    "description": "$1 is the maximum fiat buy amount"
-  },
   "rampsPaymentMethodMinLimit": {
     "message": "最低 $1",
     "description": "$1 is the minimum fiat buy amount"

--- a/ui/pages/ramps/payment-method/components/__snapshots__/ramps-payment-method-list-item.test.tsx.snap
+++ b/ui/pages/ramps/payment-method/components/__snapshots__/ramps-payment-method-list-item.test.tsx.snap
@@ -179,7 +179,7 @@ exports[`RampsPaymentMethodListItem matches snapshot with delay and limits 1`] =
             class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default truncate text-left"
             data-testid="ramps-payment-method-item-delay-debit-credit-card"
           >
-            5 - 10 mins • $25.00 – $2,000.00
+            5 - 10 mins • Up to $2,000
           </p>
         </div>
       </div>

--- a/ui/pages/ramps/payment-method/components/ramps-payment-method-list-item.test.tsx
+++ b/ui/pages/ramps/payment-method/components/ramps-payment-method-list-item.test.tsx
@@ -62,7 +62,7 @@ describe('RampsPaymentMethodListItem', () => {
       <RampsPaymentMethodListItem
         paymentMethod={debitCard}
         isSelected
-        limitText="$25.00 – $2,000.00"
+        limitText="Up to $2,000"
         onClick={jest.fn()}
       />,
       createStore(),

--- a/ui/pages/ramps/payment-method/payment-method.tsx
+++ b/ui/pages/ramps/payment-method/payment-method.tsx
@@ -20,7 +20,7 @@ import { useRampsScreenViewed } from '../../../hooks/ramps/useRampsScreenViewed'
 import { useRampsQuotes } from '../../../hooks/ramps/useRampsQuotes';
 import { getRampCallbackBaseUrl } from '../../../hooks/ramps/utils/getRampCallbackBaseUrl';
 import { normalizeAssetIdForApi } from '../../../hooks/ramps/utils/normalizeAssetIdForApi';
-import { useFiatFormatter } from '../../../hooks/useFiatFormatter';
+import { getIntlLocale } from '../../../ducks/locale/locale';
 import { useFormatters } from '../../../hooks/useFormatters';
 import { ScrollContainer } from '../../../contexts/scroll-container';
 import RampsListSkeleton from '../components/ramps-list-skeleton';
@@ -65,7 +65,22 @@ export function RampsPaymentMethodScreen() {
   } = useRampsController();
   const fiatCurrency = userRegion?.country?.currency ?? 'USD';
   const regionCode = userRegion?.regionCode ?? '';
-  const formatFiat = useFiatFormatter({ overrideCurrency: fiatCurrency });
+  const locale = useSelector(getIntlLocale);
+  const formatLimitFiat = useCallback(
+    (amount: number) => {
+      try {
+        return new Intl.NumberFormat(locale, {
+          style: 'currency',
+          currency: fiatCurrency,
+          maximumFractionDigits: 0,
+          minimumFractionDigits: 0,
+        }).format(amount);
+      } catch {
+        return new Intl.NumberFormat(locale).format(amount);
+      }
+    },
+    [fiatCurrency, locale],
+  );
   const { formatCurrency } = useFormatters();
   useRampsScreenViewed('Payment Method');
   const [isSelecting, setIsSelecting] = useState(false);
@@ -241,7 +256,7 @@ export function RampsPaymentMethodScreen() {
                     fiatCurrency,
                     paymentMethod.id,
                   ),
-                  formatFiat,
+                  formatLimitFiat,
                   t,
                 )}
                 showQuote={amount > 0}

--- a/ui/pages/ramps/payment-method/utils/__snapshots__/format-payment-method-limits.test.ts.snap
+++ b/ui/pages/ramps/payment-method/utils/__snapshots__/format-payment-method-limits.test.ts.snap
@@ -2,7 +2,8 @@
 
 exports[`formatPaymentMethodLimits matches snapshot for min/max formatting 1`] = `
 {
-  "both": "$25 – $2000",
+  "both": "Up to $2000",
+  "maxOnly": "Up to $2000",
   "minOnly": "Min $25",
   "missing": null,
 }

--- a/ui/pages/ramps/payment-method/utils/format-payment-method-limits.test.ts
+++ b/ui/pages/ramps/payment-method/utils/format-payment-method-limits.test.ts
@@ -6,13 +6,10 @@ import {
 
 const t = (key: string, substitutions?: string[]) => {
   if (key === 'rampsPaymentMethodLimits') {
-    return `${substitutions?.[0]} – ${substitutions?.[1]}`;
+    return `Up to ${substitutions?.[0]}`;
   }
   if (key === 'rampsPaymentMethodMinLimit') {
     return `Min ${substitutions?.[0]}`;
-  }
-  if (key === 'rampsPaymentMethodMaxLimit') {
-    return `Max ${substitutions?.[0]}`;
   }
   return key;
 };
@@ -59,6 +56,11 @@ describe('formatPaymentMethodLimits', () => {
       ),
       minOnly: formatPaymentMethodLimits(
         { minAmount: 25, maxAmount: Number.NaN },
+        formatFiat,
+        t,
+      ),
+      maxOnly: formatPaymentMethodLimits(
+        { minAmount: Number.NaN, maxAmount: 2000 },
         formatFiat,
         t,
       ),

--- a/ui/pages/ramps/payment-method/utils/format-payment-method-limits.ts
+++ b/ui/pages/ramps/payment-method/utils/format-payment-method-limits.ts
@@ -31,7 +31,10 @@ export function getProviderBuyLimit(
 type TranslateFn = ReturnType<typeof useI18nContext>;
 
 /**
- * Formats a provider min/max buy limit for payment method list display.
+ * Formats a provider buy limit for payment method list display.
+ *
+ * Shows "Up to {max}" when a maximum is published, or a minimum-only
+ * label when only a min is available.
  *
  * @param limit - Structured buy limit, when available.
  * @param formatFiat - Fiat amount formatter.
@@ -50,19 +53,12 @@ export function formatPaymentMethodLimits(
   const hasMin = Number.isFinite(limit.minAmount);
   const hasMax = Number.isFinite(limit.maxAmount);
 
-  if (hasMin && hasMax) {
-    return t('rampsPaymentMethodLimits', [
-      formatFiat(limit.minAmount),
-      formatFiat(limit.maxAmount),
-    ]);
+  if (hasMax) {
+    return t('rampsPaymentMethodLimits', [formatFiat(limit.maxAmount)]);
   }
 
   if (hasMin) {
     return t('rampsPaymentMethodMinLimit', [formatFiat(limit.minAmount)]);
-  }
-
-  if (hasMax) {
-    return t('rampsPaymentMethodMaxLimit', [formatFiat(limit.maxAmount)]);
   }
 
   return null;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Payment method rows in ramps currently show a min–max range (for example `$20.00 - $10,000.00`). That reads as a required band rather than a simple purchase cap.

This change shows the maximum only, as **Up to $10,000**, without cents, whenever a max limit is published.

## **Changelog**

CHANGELOG entry: Updated ramps payment method limits to show an “Up to” maximum instead of a min–max range

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run the extension and start a buy (ramps) flow.
2. Proceed to the payment method selection screen.
3. Confirm each payment method shows a limit like **Up to $10,000** instead of a min–max range such as `$20.00 - $10,000.00`.
4. If a method only has a minimum published, confirm it still shows the minimum-only label.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

<img width="694" height="267" alt="Screenshot 2026-09-02 at 11 43 38 AM" src="https://github.com/user-attachments/assets/34a6a75e-fcb2-41c5-9128-046484f47107" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)