### PR TITLE
fix(ramps): fix buy button on non-native asset pages

### DIFF
--- a/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.test.tsx
+++ b/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.test.tsx
@@ -378,12 +378,48 @@ describe('useRampsNavigation goToBuy', () => {
     const opened = await goToBuy(result, { assetId: 'eip155:1/erc20:0xabc' });
     expect(opened).toBe(true);
     expect(mockNavigate).toHaveBeenCalledWith(RAMPS_BUILD_QUOTE_ROUTE, {
-      state: { assetId: 'eip155:1/erc20:0xabc' },
+      state: { assetId: catalogAssetId },
     });
   });
 
+  it('intent with a checksummed EVM assetId pre-selects the catalog spelling', async () => {
+    // Token pages build EVM asset ids from a checksummed address, while the
+    // catalog returns some of them lowercased (mUSD). The controller looks up
+    // the selected token by exact assetId, so the catalog spelling has to win.
+    const catalogAssetId =
+      'eip155:1/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da';
+    const { result, getModalName } = run(
+      buildState({
+        tokens: {
+          data: {
+            topTokens: [],
+            allTokens: [
+              { assetId: catalogAssetId, tokenSupported: true } as RampsToken,
+            ],
+          },
+          selected: null,
+          isLoading: false,
+          error: null,
+        },
+      }),
+    );
+
+    const opened = await goToBuy(result, {
+      assetId: 'eip155:1/erc20:0xACA92E438df0B2401fF60dA7E4337B687a2435DA',
+    });
+
+    expect(opened).toBe(true);
+    expect(mockBackground).toHaveBeenCalledWith('setRampsSelectedToken', [
+      catalogAssetId,
+    ]);
+    expect(mockNavigate).toHaveBeenCalledWith(RAMPS_BUILD_QUOTE_ROUTE, {
+      state: { assetId: catalogAssetId },
+    });
+    expect(getModalName()).toBeNull();
+  });
+
   it('intent with affected-network assetId matches a catalog token with checksum casing', async () => {
-    const assetId = 'eip155:59144/erc20:0xabc';
+    const catalogAssetId = 'eip155:59144/erc20:0xAbC';
     const { result } = run(
       buildState({
         tokens: {
@@ -391,7 +427,7 @@ describe('useRampsNavigation goToBuy', () => {
             topTokens: [],
             allTokens: [
               {
-                assetId: 'eip155:59144/erc20:0xAbC',
+                assetId: catalogAssetId,
                 tokenSupported: true,
               } as RampsToken,
             ],
@@ -403,11 +439,13 @@ describe('useRampsNavigation goToBuy', () => {
       }),
     );
 
-    const opened = await goToBuy(result, { assetId });
+    const opened = await goToBuy(result, {
+      assetId: 'eip155:59144/erc20:0xabc',
+    });
 
     expect(opened).toBe(true);
     expect(mockNavigate).toHaveBeenCalledWith(RAMPS_BUILD_QUOTE_ROUTE, {
-      state: { assetId },
+      state: { assetId: catalogAssetId },
     });
   });
 
@@ -504,6 +542,37 @@ describe('useRampsNavigation goToBuy', () => {
       state: { assetId },
     });
     expect(getModalName()).toBeNull();
+  });
+
+  it('intent with a checksummed assetId still uses the catalog spelling while the catalog refreshes', async () => {
+    // An unsettled catalog does not gate the buy, but the tokens it already
+    // holds are still the best source for the assetId spelling.
+    const catalogAssetId =
+      'eip155:1/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da';
+    const { result } = run(
+      buildState({
+        tokens: {
+          data: {
+            topTokens: [],
+            allTokens: [
+              { assetId: catalogAssetId, tokenSupported: true } as RampsToken,
+            ],
+          },
+          selected: null,
+          isLoading: true,
+          error: null,
+        },
+      }),
+    );
+
+    const opened = await goToBuy(result, {
+      assetId: 'eip155:1/erc20:0xACA92E438df0B2401fF60dA7E4337B687a2435DA',
+    });
+
+    expect(opened).toBe(true);
+    expect(mockBackground).toHaveBeenCalledWith('setRampsSelectedToken', [
+      catalogAssetId,
+    ]);
   });
 
   it('intent with assetId and incomplete settled catalog → fails open to build quote', async () => {

--- a/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.ts
+++ b/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.ts
@@ -5,6 +5,7 @@ import type { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 import { UNKNOWN_LOCATION } from '@metamask/geolocation-controller';
 import type {
   Provider,
+  RampsToken,
   ResourceState,
   TokensResponse,
 } from '@metamask/ramps-controller';
@@ -78,20 +79,21 @@ function isCatalogEmpty(
   return providersEmpty || tokensEmpty;
 }
 
-// True when `assetId` is present in a settled catalog and not flagged off.
-function isAssetSupported(
-  tokensData: TokensResponse,
+// Finds `assetId` in the catalog, ignoring EVM address casing: callers build
+// asset ids from a checksummed address while the API returns a mix of
+// checksummed (USDC, USDT) and lowercase (mUSD) ids.
+function findCatalogToken(
+  tokensData: TokensResponse | null,
   assetId: CaipAssetType,
-): boolean {
+): RampsToken | undefined {
   const catalog = [
-    ...(tokensData.topTokens ?? []),
-    ...(tokensData.allTokens ?? []),
+    ...(tokensData?.topTokens ?? []),
+    ...(tokensData?.allTokens ?? []),
   ];
-  const match = catalog.find(
+  return catalog.find(
     (token) =>
       normalizeAssetIdForApi(token.assetId) === normalizeAssetIdForApi(assetId),
   );
-  return Boolean(match) && match?.tokenSupported !== false;
 }
 
 // Pre-select the token before navigating to build-quote. Fail closed so a
@@ -197,16 +199,28 @@ export default function useRampsNavigation() {
       // Resolve against the catalog. Only block on a settled catalog that
       // definitively lacks/unsupports the token — an unsettled catalog fails
       // open (proceed with it selected, page re-resolves).
-      if (catalogData && !isAssetSupported(catalogData, assetId)) {
+      const catalogToken = findCatalogToken(tokens.data, assetId);
+      if (
+        catalogData &&
+        (!catalogToken || catalogToken.tokenSupported === false)
+      ) {
         dispatch(showModal({ name: 'RAMPS_UNSUPPORTED' }));
         return false;
       }
-      const didPreselect = await preselectToken(assetId);
+
+      // `setSelectedToken` looks the token up by exact assetId, so pre-select
+      // with the catalog's own spelling rather than the caller's checksummed
+      // one. Without a catalog to resolve against, the intent is all we have.
+      const selectedAssetId =
+        (catalogToken?.assetId as CaipAssetType | undefined) ?? assetId;
+      const didPreselect = await preselectToken(selectedAssetId);
       if (!didPreselect) {
         dispatch(showModal({ name: 'RAMPS_UNSUPPORTED' }));
         return false;
       }
-      navigate(RAMPS_BUILD_QUOTE_ROUTE, { state: { assetId } });
+      navigate(RAMPS_BUILD_QUOTE_ROUTE, {
+        state: { assetId: selectedAssetId },
+      });
       return true;
     },
     [


### PR DESCRIPTION
## **Description**

Buying a non-native EVM token (such as mUSD) from the token page showed the region-unsupported modal even when the token was in the ramps catalog and the region was supported.

Token pages build CAIP-19 ids from a checksummed address. `setSelectedToken` looks tokens up with an exact `assetId` match, and the catalog mixes checksummed (USDC, USDT) and lowercase (mUSD) ids. The buy gate now preselects and navigates with the catalog's own spelling so those tokens open build-quote instead of failing the gate.

## **Changelog**

CHANGELOG entry: Fixed buying crypto from token pages for tokens whose catalog asset ids differ in address casing, such as mUSD.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/45963

## **Manual testing steps**

1. Run the extension with native ramps enabled and a wallet that has never connected to Portfolio.
2. Confirm the selected region supports buying.
3. Open Ethereum Mainnet (or Linea / BSC) and go to the mUSD token page.
4. Tap Buy and confirm the in-app buy flow opens on build-quote with mUSD selected, with no "Buying isn’t available here" modal.
5. Repeat from a USDC token page and confirm Buy still opens with USDC selected.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

<img width="320" height="422" alt="token-selecton" src="https://github.com/user-attachments/assets/e31121aa-4b81-4b44-bdc6-5c673c9e7648" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)