### PR TITLE
fix: setup TransactionController listeners before Wallet initialization

### DIFF
--- a/app/scripts/wallet-init/initialization.test.ts
+++ b/app/scripts/wallet-init/initialization.test.ts
@@ -247,6 +247,29 @@ describe('initializeWallet', () => {
       messenger: 'transaction-controller-init-messenger',
     });
   });
+
+  it('sets up TransactionController listeners before constructing the Wallet, so the TransactionController can emit events to the wallet messenger during initialization', () => {
+    const messenger = createMockMessenger();
+    const state = { KeyringController: { vault: 'encrypted-vault-blob' } };
+
+    initializeWallet({
+      connectivityAdapter,
+      getFlatState,
+      getPermittedAccounts,
+      getTransactionMetricsRequest,
+      infuraProjectId: 'fake-infura-project-id',
+      messenger,
+      platform,
+      state,
+    });
+
+    const setupListenersCallOrder = jest.mocked(
+      setupTransactionControllerListeners,
+    ).mock.invocationCallOrder[0];
+    const walletConstructorCallOrder = MockWallet.mock.invocationCallOrder[0];
+
+    expect(setupListenersCallOrder).toBeLessThan(walletConstructorCallOrder);
+  });
 });
 
 describe('initializeWallet — RemoteFeatureFlagController toggle', () => {

--- a/app/scripts/wallet-init/initialization.ts
+++ b/app/scripts/wallet-init/initialization.ts
@@ -51,6 +51,13 @@ export function initializeWallet(request: InitializeWalletRequest) {
   const seedlessOnboardingControllerInitMessenger =
     getSeedlessOnboardingControllerInitMessenger(messenger);
 
+  // TC event listeners must be set up before the wallet is initialized.
+  // So that the TC can emit events to the wallet's messenger during initialization.
+  setupTransactionControllerListeners({
+    getTransactionMetricsRequest,
+    messenger: transactionControllerInitMessenger,
+  });
+
   const wallet = new Wallet({
     instanceOptions: {
       approvalController: getApprovalControllerInstanceOptions({
@@ -107,11 +114,6 @@ export function initializeWallet(request: InitializeWalletRequest) {
       useExternalServices:
         state.PreferencesController?.useExternalServices !== false,
     },
-  });
-
-  setupTransactionControllerListeners({
-    getTransactionMetricsRequest,
-    messenger: transactionControllerInitMessenger,
   });
 
   wallet.init().catch((error) => console.error(error));


### PR DESCRIPTION
## **Description**

`setupTransactionControllerListeners()` was previously called *after* the `Wallet` was constructed and initialized. During `Wallet` construction/`init()`, the `TransactionController` can already start emitting events (e.g. via its init messenger), but the extension-specific listeners were not yet subscribed at that point, meaning early events could be missed.

This PR moves `setupTransactionControllerListeners()` to run **before** `new Wallet(...)` is constructed, ensuring the listeners are attached to the `TransactionController` init messenger before the wallet (and by extension the `TransactionController`) is initialized.

This mirrors the same fix applied to metamask-mobile in [MetaMask/metamask-mobile#35673](https://github.com/MetaMask/metamask-mobile/pull/35673), which shares the same `wallet-init` architecture.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Launch the extension fresh (cold start / reload the background service worker)
2. Trigger a transaction lifecycle event during initialization (e.g. a pending unapproved transaction persisted from a previous session)
3. Confirm the TransactionController listeners (metrics, notifications, etc.) are already subscribed before any TransactionController event can fire, and no transaction lifecycle event is missed during startup

## **Screenshots/Recordings**

### **Before**

<img width="1303" height="1161" alt="before" src="https://github.com/user-attachments/assets/ed7a4c0e-2a8b-4c3b-a79a-efc5d6df1972" />


### **After**

<img width="1303" height="1161" alt="after" src="https://github.com/user-attachments/assets/e5848861-280d-4762-bd36-9826f73611c7" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-order change only; behavior is to subscribe listeners earlier so fewer events are missed, with no auth or persistence logic altered.
> 
> **Overview**
> **Moves `setupTransactionControllerListeners` to run before `new Wallet(...)`** so extension listeners on the TransactionController init messenger are subscribed before wallet construction/`init()` can trigger early transaction lifecycle events.
> 
> A unit test asserts `setupTransactionControllerListeners` is invoked before the `Wallet` constructor, locking in the startup ordering fix (aligned with the same change on MetaMask Mobile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cb7c13195a4134c0e79b8cfa4268a0e784b9c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->