### PR TITLE
fix(perps):  failed to fetch account state error

### DIFF
--- a/ui/hooks/perps/stream/usePerpsChannel.test.tsx
+++ b/ui/hooks/perps/stream/usePerpsChannel.test.tsx
@@ -1,11 +1,14 @@
 import { renderHook, act } from '@testing-library/react';
-import type { OrderBookData } from '@metamask/perps-controller';
+import type { AccountState, OrderBookData } from '@metamask/perps-controller';
 import { PerpsStreamManager } from '../../../providers/perps/PerpsStreamManager';
 import { usePerpsChannel } from './usePerpsChannel';
 import { usePerpsStreamManager } from './usePerpsStreamManager';
 
+const mockSubmitRequestToBackground = jest.fn().mockResolvedValue(undefined);
+
 jest.mock('../../../store/background-connection', () => ({
-  submitRequestToBackground: jest.fn().mockResolvedValue(undefined),
+  submitRequestToBackground: (...args: unknown[]) =>
+    mockSubmitRequestToBackground(...args),
 }));
 
 jest.mock('../../../providers/perps/CandleStreamChannel', () => ({
@@ -357,5 +360,105 @@ describe('usePerpsChannel', () => {
     expect(result.current.data).toBeNull();
     expect(result.current.isInitialLoading).toBe(true);
     expect(manager.orderBookAggregated.hasCachedData()).toBe(false);
+  });
+  describe('account fetch failure', () => {
+    const EMPTY_ACCOUNT: AccountState | null = null;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('keeps the loading state when the account fetch fails, so the balance header cannot render a fabricated $0.00', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      try {
+        mockSubmitRequestToBackground.mockImplementation((method: string) => {
+          if (method === 'perpsGetAccountState') {
+            return Promise.reject(
+              new Error(
+                'Failed to fetch account state (failedDexs=[main,xyz], spotError=WebSocket connection permanently terminated)',
+              ),
+            );
+          }
+          return Promise.resolve(undefined);
+        });
+
+        const manager = new PerpsStreamManager();
+        mockUsePerpsStreamManager.mockReturnValue({
+          streamManager: manager,
+          isInitializing: false,
+          error: null,
+          selectedAddress: '0xacc',
+        });
+
+        const { result } = renderHook(() =>
+          usePerpsChannel((sm) => sm.account, EMPTY_ACCOUNT),
+        );
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3_000);
+        });
+
+        // Still loading: PerpsMarketBalanceActions renders its skeleton here.
+        // If the failure were delivered as data, isInitialLoading would flip to
+        // false and `account?.totalBalance ?? '0'` would render $0.00 with the
+        // Withdraw button hidden on a funded account.
+        expect(result.current.isInitialLoading).toBe(true);
+        expect(result.current.data).toBeNull();
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    });
+
+    it('clears the loading state once account data arrives after a failed fetch', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      try {
+        mockSubmitRequestToBackground.mockImplementation((method: string) => {
+          if (method === 'perpsGetAccountState') {
+            return Promise.reject(new Error('network'));
+          }
+          return Promise.resolve(undefined);
+        });
+
+        const manager = new PerpsStreamManager();
+        mockUsePerpsStreamManager.mockReturnValue({
+          streamManager: manager,
+          isInitializing: false,
+          error: null,
+          selectedAddress: '0xacc',
+        });
+
+        const { result } = renderHook(() =>
+          usePerpsChannel((sm) => sm.account, EMPTY_ACCOUNT),
+        );
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3_000);
+        });
+        expect(result.current.isInitialLoading).toBe(true);
+
+        const recoveredAccount = { totalBalance: '632.69' } as AccountState;
+        act(() => {
+          manager.handleBackgroundUpdate({
+            channel: 'account',
+            data: recoveredAccount,
+          });
+        });
+
+        expect(result.current.isInitialLoading).toBe(false);
+        expect(result.current.data).toBe(recoveredAccount);
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    });
   });
 });

--- a/ui/hooks/perps/stream/usePerpsChannel.test.tsx
+++ b/ui/hooks/perps/stream/usePerpsChannel.test.tsx
@@ -432,6 +432,7 @@ describe('usePerpsChannel', () => {
       const { manager, result } = await renderAccountChannelAfterFailedFetch(
         new Error('network'),
       );
+
       expect(result.current.isInitialLoading).toBe(true);
 
       const recoveredAccount = { totalBalance: '632.69' } as AccountState;

--- a/ui/hooks/perps/stream/usePerpsChannel.test.tsx
+++ b/ui/hooks/perps/stream/usePerpsChannel.test.tsx
@@ -361,104 +361,89 @@ describe('usePerpsChannel', () => {
     expect(result.current.isInitialLoading).toBe(true);
     expect(manager.orderBookAggregated.hasCachedData()).toBe(false);
   });
+
   describe('account fetch failure', () => {
     const EMPTY_ACCOUNT: AccountState | null = null;
 
+    let consoleErrorSpy: jest.SpyInstance;
+
     beforeEach(() => {
       jest.useFakeTimers();
+      consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
     });
 
     afterEach(() => {
+      consoleErrorSpy.mockRestore();
       jest.useRealTimers();
     });
 
+    /**
+     * Renders the account channel with `perpsGetAccountState` rejecting, then
+     * advances past the WebSocket grace period so the REST fallback has run.
+     *
+     * @param error - The rejection surfaced to the account channel.
+     * @returns The stream manager and the rendered hook result.
+     */
+    async function renderAccountChannelAfterFailedFetch(error: Error) {
+      mockSubmitRequestToBackground.mockImplementation((method: string) => {
+        if (method === 'perpsGetAccountState') {
+          return Promise.reject(error);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const manager = new PerpsStreamManager();
+      mockUsePerpsStreamManager.mockReturnValue({
+        streamManager: manager,
+        isInitializing: false,
+        error: null,
+        selectedAddress: '0xacc',
+      });
+
+      const { result } = renderHook(() =>
+        usePerpsChannel((sm) => sm.account, EMPTY_ACCOUNT),
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(3_000);
+      });
+
+      return { manager, result };
+    }
+
     it('keeps the loading state when the account fetch fails, so the balance header cannot render a fabricated $0.00', async () => {
-      const consoleErrorSpy = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => undefined);
+      const { result } = await renderAccountChannelAfterFailedFetch(
+        new Error(
+          'Failed to fetch account state (failedDexs=[main,xyz], spotError=WebSocket connection permanently terminated)',
+        ),
+      );
 
-      try {
-        mockSubmitRequestToBackground.mockImplementation((method: string) => {
-          if (method === 'perpsGetAccountState') {
-            return Promise.reject(
-              new Error(
-                'Failed to fetch account state (failedDexs=[main,xyz], spotError=WebSocket connection permanently terminated)',
-              ),
-            );
-          }
-          return Promise.resolve(undefined);
-        });
-
-        const manager = new PerpsStreamManager();
-        mockUsePerpsStreamManager.mockReturnValue({
-          streamManager: manager,
-          isInitializing: false,
-          error: null,
-          selectedAddress: '0xacc',
-        });
-
-        const { result } = renderHook(() =>
-          usePerpsChannel((sm) => sm.account, EMPTY_ACCOUNT),
-        );
-
-        await act(async () => {
-          await jest.advanceTimersByTimeAsync(3_000);
-        });
-
-        // Still loading: PerpsMarketBalanceActions renders its skeleton here.
-        // If the failure were delivered as data, isInitialLoading would flip to
-        // false and `account?.totalBalance ?? '0'` would render $0.00 with the
-        // Withdraw button hidden on a funded account.
-        expect(result.current.isInitialLoading).toBe(true);
-        expect(result.current.data).toBeNull();
-      } finally {
-        consoleErrorSpy.mockRestore();
-      }
+      // Still loading: PerpsMarketBalanceActions renders its skeleton here.
+      // If the failure were delivered as data, isInitialLoading would flip to
+      // false and `account?.totalBalance ?? '0'` would render $0.00 with the
+      // Withdraw button hidden on a funded account.
+      expect(result.current.isInitialLoading).toBe(true);
+      expect(result.current.data).toBeNull();
     });
 
     it('clears the loading state once account data arrives after a failed fetch', async () => {
-      const consoleErrorSpy = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => undefined);
+      const { manager, result } = await renderAccountChannelAfterFailedFetch(
+        new Error('network'),
+      );
+      expect(result.current.isInitialLoading).toBe(true);
 
-      try {
-        mockSubmitRequestToBackground.mockImplementation((method: string) => {
-          if (method === 'perpsGetAccountState') {
-            return Promise.reject(new Error('network'));
-          }
-          return Promise.resolve(undefined);
+      const recoveredAccount = { totalBalance: '632.69' } as AccountState;
+      act(() => {
+        manager.handleBackgroundUpdate({
+          channel: 'account',
+          data: recoveredAccount,
         });
+      });
 
-        const manager = new PerpsStreamManager();
-        mockUsePerpsStreamManager.mockReturnValue({
-          streamManager: manager,
-          isInitializing: false,
-          error: null,
-          selectedAddress: '0xacc',
-        });
-
-        const { result } = renderHook(() =>
-          usePerpsChannel((sm) => sm.account, EMPTY_ACCOUNT),
-        );
-
-        await act(async () => {
-          await jest.advanceTimersByTimeAsync(3_000);
-        });
-        expect(result.current.isInitialLoading).toBe(true);
-
-        const recoveredAccount = { totalBalance: '632.69' } as AccountState;
-        act(() => {
-          manager.handleBackgroundUpdate({
-            channel: 'account',
-            data: recoveredAccount,
-          });
-        });
-
-        expect(result.current.isInitialLoading).toBe(false);
-        expect(result.current.data).toBe(recoveredAccount);
-      } finally {
-        consoleErrorSpy.mockRestore();
-      }
+      expect(result.current.isInitialLoading).toBe(false);
+      expect(result.current.data).toBe(recoveredAccount);
     });
   });
 });

--- a/ui/providers/perps/PerpsStreamManager.test.ts
+++ b/ui/providers/perps/PerpsStreamManager.test.ts
@@ -1378,6 +1378,7 @@ describe('PerpsStreamManager', () => {
       manager.account.subscribe(onData);
 
       await jest.advanceTimersByTimeAsync(3_000);
+
       expect(onData).not.toHaveBeenCalled();
 
       const recoveredAccount = { totalBalance: '632.69' };

--- a/ui/providers/perps/PerpsStreamManager.test.ts
+++ b/ui/providers/perps/PerpsStreamManager.test.ts
@@ -1349,6 +1349,10 @@ describe('PerpsStreamManager', () => {
       );
     });
 
+    // Pre-existing-behaviour guard, not proof of this fix: the old code's
+    // `!hasCachedData()` check already suppressed the push once a cache
+    // existed, so this passes with or without the fix. Kept to pin the
+    // behaviour that a later failure must never clobber a good balance.
     it('keeps previously cached account data when a later REST fallback fails', async () => {
       const cachedAccount = { totalBalance: '632.69' };
       manager.handleBackgroundUpdate({

--- a/ui/providers/perps/PerpsStreamManager.test.ts
+++ b/ui/providers/perps/PerpsStreamManager.test.ts
@@ -1295,33 +1295,95 @@ describe('PerpsStreamManager', () => {
         expect.anything(),
       );
     });
+  });
 
-    it('notifies subscribers with null when REST fallback fails without cache', async () => {
-      const consoleErrorSpy = jest
+  describe('account fetch failure', () => {
+    /**
+     * Rejects `perpsGetAccountState` the way a total HyperLiquid outage does —
+     * the TAT-3832 report's `Failed to fetch account state
+     * (failedDexs=[main,xyz], spotError=WebSocket connection permanently
+     * terminated)`.
+     *
+     * @param error - The rejection surfaced to the account channel.
+     */
+    function rejectAccountStateWith(error: Error) {
+      mockSubmitRequestToBackground.mockImplementation((method: string) => {
+        if (method === 'perpsGetAccountState') {
+          return Promise.reject(error);
+        }
+        return Promise.resolve(undefined);
+      });
+    }
+
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      consoleErrorSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
+    });
 
-      try {
-        mockSubmitRequestToBackground.mockImplementation((method: string) => {
-          if (method === 'perpsGetAccountState') {
-            return Promise.reject(new Error('network'));
-          }
-          return Promise.resolve(undefined);
-        });
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
 
-        const onData = jest.fn();
-        manager.account.subscribe(onData);
+    it('does not notify subscribers when the REST fallback fails without cache', async () => {
+      rejectAccountStateWith(
+        new Error(
+          'Failed to fetch account state (failedDexs=[main,xyz], spotError=WebSocket connection permanently terminated)',
+        ),
+      );
 
-        await jest.advanceTimersByTimeAsync(3_000);
+      const onData = jest.fn();
+      manager.account.subscribe(onData);
 
-        expect(onData).toHaveBeenCalledWith(null);
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          '[PerpsStreamManager] Failed to fetch account',
-          expect.any(Error),
-        );
-      } finally {
-        consoleErrorSpy.mockRestore();
-      }
+      await jest.advanceTimersByTimeAsync(3_000);
+
+      // A failed fetch is not data. Notifying here is what let the balance
+      // header leave its loading state and render a funded account as $0.00.
+      expect(onData).not.toHaveBeenCalled();
+      expect(manager.account.hasCachedData()).toBe(false);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[PerpsStreamManager] Failed to fetch account',
+        expect.any(Error),
+      );
+    });
+
+    it('keeps previously cached account data when a later REST fallback fails', async () => {
+      const cachedAccount = { totalBalance: '632.69' };
+      manager.handleBackgroundUpdate({
+        channel: 'account',
+        data: cachedAccount,
+      });
+
+      rejectAccountStateWith(new Error('network'));
+
+      const onData = jest.fn();
+      manager.account.subscribe(onData);
+
+      await jest.advanceTimersByTimeAsync(3_000);
+
+      expect(manager.account.getCachedData()).toBe(cachedAccount);
+      expect(onData).not.toHaveBeenCalledWith(null);
+    });
+
+    it('still delivers account data pushed after an account fetch failure', async () => {
+      rejectAccountStateWith(new Error('network'));
+
+      const onData = jest.fn();
+      manager.account.subscribe(onData);
+
+      await jest.advanceTimersByTimeAsync(3_000);
+      expect(onData).not.toHaveBeenCalled();
+
+      const recoveredAccount = { totalBalance: '632.69' };
+      manager.handleBackgroundUpdate({
+        channel: 'account',
+        data: recoveredAccount,
+      });
+
+      expect(onData).toHaveBeenCalledWith(recoveredAccount);
+      expect(manager.account.hasCachedData()).toBe(true);
     });
   });
 

--- a/ui/providers/perps/PerpsStreamManager.ts
+++ b/ui/providers/perps/PerpsStreamManager.ts
@@ -241,9 +241,13 @@ class PerpsStreamManager {
                 '[PerpsStreamManager] Failed to fetch account',
                 err,
               );
-              if (!cancelled && !this.account.hasCachedData()) {
-                push(null);
-              }
+              // Deliberately do NOT push here. `null` is this channel's own
+              // initialValue, so pushing it leaves hasCachedData() false while
+              // still notifying subscribers — usePerpsChannel then clears
+              // isInitialLoading and the balance header renders the failure as
+              // a settled `$0.00`, hiding Withdraw on a funded account. Staying
+              // silent keeps the skeleton up until real data arrives from the
+              // WebSocket or a later fetch.
             });
         }, WS_GRACE_PERIOD_MS);
 


### PR DESCRIPTION
## **Description**

When the Perps account-state fetch failed, the extension rendered the failure as a settled value: a funded account showed **$0.00** and lost its **Withdraw** button. The account channel's REST-fallback `catch` pushed `null`, which notified every subscriber and cleared the loading state, so `account?.totalBalance ?? '0'` rendered as a real balance. Because `null` is that channel's own `initialValue`, `hasCachedData()` stayed `false` and nothing retried, so the fabricated `$0.00` persisted until a WebSocket push or a remount.

This PR stops pushing on failure. The channel stays in its no-data state and the balance header keeps its loading skeleton until real data arrives. The thrown error itself comes from `@metamask/perps-controller`; what changes here is only the extension's handling of that rejection.

## **Changelog**

CHANGELOG entry: Fixed a bug where a failed Perps account fetch could show a funded account as $0.00 and hide the Withdraw button

## **Related issues**

Fixes: [TAT-3832](https://consensyssoftware.atlassian.net/browse/TAT-3832)

## **Manual testing steps**

1. Open the Perps home screen on a funded account and confirm the balance, the "available" line and the **Withdraw** button render.
2. Make the account-state fetch fail (block the HyperLiquid API, or go offline before the 3s WebSocket grace period elapses) and reopen Perps.
3. The balance header stays on its loading skeleton — it must not show `$0.00`, and **Withdraw** must not disappear.
4. Restore connectivity; when account data arrives the header leaves the loading state and shows the real balance.

## **Screenshots/Recordings**

The fix changes only the failure path, which is proven by revert-sensitive unit tests. The screenshot below is the no-regression check: the funded balance header and Withdraw action still render correctly on a healthy connection.

<table>
<tr><td align="center" valign="top" width="50%"><strong>Perps home — funded balance and Withdraw still render after the fix</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/45994/after-ac3-funded-balance-header.png?sha=1d743def99f248e3" alt="Perps home — funded balance and Withdraw still render after the fix" width="320" /><br/><sub>Withdraw is gated on accountValue > 0, so its presence proves real account data reached the UI rather than the $0.00 fallback this PR removes.</sub></td><td></td></tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "TAT-3832 \u2014 failed perps account fetch must not render as a settled $0.00 balance",
  "description": "Proves that a rejected perpsGetAccountState no longer reaches the UI as data (the account channel stays in its no-data state so the balance header keeps its skeleton instead of fabricating $0.00), that a later successful fetch still recovers, and that the live funded Perps home balance header still renders its real balance and Withdraw action. Preconditions: Extension runtime live on CDP 7665 with a healthy background service worker. Wallet unlocked on a funded Perps account (dev1 / 0x8Dc623E964475D4d669da601Fd15ea9125469003) with a non-zero perps balance.",
  "workflow": {
    "entry": "setup-status",
    "nodes": {
      "setup-status": {
        "action": "app.status",
        "next": "setup-cdp",
        "intent": "Resolve the Extension checkout and adapter status before proving the fix"
      },
      "setup-cdp": {
        "action": "cdp.target",
        "required": true,
        "timeout_ms": 15000,
        "next": "setup-unlock",
        "intent": "Confirm the Extension CDP runtime is reachable"
      },
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "timeout_ms": 45000,
        "next": "ac1-run-failure-branch-tests",
        "intent": "Ensure the wallet is unlocked before reading live Perps state"
      },
      "ac1-run-failure-branch-tests": {
        "action": "command",
        "cmd": "yarn jest ui/providers/perps/PerpsStreamManager.test.ts ui/providers/perps/PerpsDataChannel.test.ts ui/hooks/perps/stream/usePerpsChannel.test.tsx --no-coverage -t 'account fetch failure'",
        "timeout_ms": 600000,
        "next": "ac1-assert-tests-exit-zero",
        "intent": "AC1/AC2: exercise the account-channel failure branch against the real PerpsStreamManager, PerpsDataChannel and usePerpsChannel code"
      },
      "ac1-assert-tests-exit-zero": {
        "action": "assert_exit_code",
        "source": "ac1-run-failure-branch-tests",
        "expected": 0,
        "next": "ac1-assert-tests-actually-ran",
        "intent": "AC1: the failure-branch suite must pass, not merely run"
      },
      "ac1-assert-tests-actually-ran": {
        "action": "assert_output",
        "source": "ac1-run-failure-branch-tests",
        "stream": "stderr",
        "contains": "5 passed",
        "next": "ac1-assert-no-fabricated-zero",
        "intent": "AC1: guard against jest -t matching zero tests, which exits 0 vacuously"
      },
      "ac1-assert-no-fabricated-zero": {
        "action": "assert_output",
        "source": "ac1-run-failure-branch-tests",
        "stream": "stderr",
        "contains": "PASS ui/providers/perps/PerpsStreamManager.test.ts",
        "next": "ac2-assert-recovery-suite-passed",
        "intent": "AC1: the StreamManager suite specifically \u2014 where the failure branch lives \u2014 must be the suite that passed"
      },
      "ac2-assert-recovery-suite-passed": {
        "action": "assert_output",
        "source": "ac1-run-failure-branch-tests",
        "stream": "stderr",
        "contains": "PASS ui/hooks/perps/stream/usePerpsChannel.test.tsx",
        "next": "ac3-open-perps",
        "intent": "AC2: the hook-level suite proving a post-failure success still clears loading and delivers the value must pass"
      },
      "ac3-open-perps": {
        "action": "ui.navigate",
        "page": "perps",
        "next": "ac3-wait-balance-header",
        "intent": "AC3: open the live Perps home surface where the bug rendered $0.00"
      },
      "ac3-wait-balance-header": {
        "action": "ui.wait_for",
        "test_id": "perps-balance-actions-total",
        "visible": true,
        "timeout_ms": 45000,
        "next": "ac3-wait-withdraw-action",
        "intent": "AC3: the real balance figure must render \u2014 not the skeleton and not a fabricated $0.00"
      },
      "ac3-wait-withdraw-action": {
        "action": "ui.wait_for",
        "test_id": "perps-balance-actions-withdraw",
        "visible": true,
        "timeout_ms": 30000,
        "next": "ac3-read-live-account-state",
        "intent": "AC3: Withdraw is gated on accountValue > 0, so its presence proves a real funded balance reached the UI"
      },
      "ac3-read-live-account-state": {
        "action": "metamask.perps.read_visible_state",
        "next": "ac3-screenshot-funded-balance-header",
        "intent": "AC3: record the live visible Perps state backing the screenshot"
      },
      "ac3-screenshot-funded-balance-header": {
        "action": "ui.screenshot",
        "path": "evidence-ac3-funded-balance-header.png",
        "label": "AC3: Perps home renders the real funded balance and the Withdraw action",
        "next": "done",
        "intent": "AC3: visual proof that the funded balance header still renders correctly after the fix"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
    setup-status["setup-status<br/>app.status"]
    setup-cdp["setup-cdp<br/>cdp.target"]
    setup-unlock["setup-unlock<br/>metamask.wallet.ensure_unlocked"]

    ac1-run["ac1-run-failure-branch-tests<br/>command: jest -t 'account fetch failure'"]
    ac1-exit["ac1-assert-tests-exit-zero<br/>assert_exit_code 0"]
    ac1-ran["ac1-assert-tests-actually-ran<br/>assert_output '5 passed'"]
    ac1-zero["ac1-assert-no-fabricated-zero<br/>assert_output PASS PerpsStreamManager"]

    ac2-recovery["ac2-assert-recovery-suite-passed<br/>assert_output PASS usePerpsChannel"]

    ac3-open["ac3-open-perps<br/>ui.navigate page=perps"]
    ac3-total["ac3-wait-balance-header<br/>ui.wait_for perps-balance-actions-total"]
    ac3-withdraw["ac3-wait-withdraw-action<br/>ui.wait_for perps-balance-actions-withdraw"]
    ac3-read["ac3-read-live-account-state<br/>metamask.perps.read_visible_state"]
    ac3-shot["ac3-screenshot-funded-balance-header<br/>ui.screenshot"]

    done(["done<br/>end: pass"])

    setup-status --> setup-cdp --> setup-unlock --> ac1-run
    ac1-run --> ac1-exit --> ac1-ran --> ac1-zero --> ac2-recovery
    ac2-recovery --> ac3-open --> ac3-total --> ac3-withdraw --> ac3-read --> ac3-shot --> done
```

</details>

[TAT-3832]: https://consensyssoftware.atlassian.net/browse/TAT-3832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to the account channel error path in Perps streaming; success and cached-account paths are unchanged and covered by new tests.
> 
> **Overview**
> When Perps account state could not be loaded (e.g. HyperLiquid outage after the WebSocket grace period), the extension treated the failure like real data: the account channel’s REST fallback **pushed `null`**, subscribers updated, **`usePerpsChannel` left the loading state**, and the balance header showed **$0.00** with **Withdraw** hidden on funded accounts.
> 
> **`PerpsStreamManager`** no longer notifies the account channel on REST failure—it still logs the error but stays silent until WebSocket or a later push delivers real **`AccountState`**, so the skeleton stays up instead of a fabricated zero balance.
> 
> Tests cover stream-manager behavior (no subscriber call without cache, cache preserved, recovery after background update) and hook-level loading through **`usePerpsChannel`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874a91f58fda3b9bc57d386805e0f702523e0087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->