### PR TITLE
fix: skip profile metrics when basic functionality is off

### DIFF
--- a/app/scripts/messenger-client-init/profile-metrics-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/profile-metrics-controller-init.test.ts
@@ -10,9 +10,9 @@ import { ProfileMetricsControllerInit } from './profile-metrics-controller-init'
 
 jest.mock('@metamask/profile-metrics-controller');
 
-function getInitRequestMock(): jest.Mocked<
-  MessengerClientInitRequest<ProfileMetricsControllerMessenger>
-> {
+function getInitRequestMock(
+  useExternalServices = true,
+): jest.Mocked<MessengerClientInitRequest<ProfileMetricsControllerMessenger>> {
   const baseMessenger = getRootMessenger<never, never>();
 
   const requestMock = {
@@ -21,10 +21,27 @@ function getInitRequestMock(): jest.Mocked<
     initMessenger: undefined,
   };
 
+  requestMock.getMessengerClient.mockImplementation((name) => {
+    if (name === 'AnalyticsController') {
+      return { state: { optedIn: true, analyticsId: 'test-id' } } as never;
+    }
+    if (name === 'AppStateController') {
+      return { state: { pna25Acknowledged: true } } as never;
+    }
+    if (name === 'PreferencesController') {
+      return { state: { useExternalServices } } as never;
+    }
+    throw new Error(`Unexpected messenger client: ${name}`);
+  });
+
   return requestMock;
 }
 
 describe('ProfileMetricsControllerInit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('initializes the controller', () => {
     const { messengerClient } =
       ProfileMetricsControllerInit(getInitRequestMock());
@@ -43,5 +60,13 @@ describe('ProfileMetricsControllerInit', () => {
       initialDelayDuration: expect.any(Number),
       getMetaMetricsId: expect.any(Function),
     });
+    expect(controllerMock.mock.calls[0][0].assertUserOptedIn()).toBe(true);
+  });
+
+  it('prevents profile metrics when basic functionality is disabled', () => {
+    ProfileMetricsControllerInit(getInitRequestMock(false));
+
+    const controllerMock = jest.mocked(ProfileMetricsController);
+    expect(controllerMock.mock.calls[0][0].assertUserOptedIn()).toBe(false);
   });
 });

--- a/app/scripts/messenger-client-init/profile-metrics-controller-init.ts
+++ b/app/scripts/messenger-client-init/profile-metrics-controller-init.ts
@@ -24,9 +24,11 @@ export const ProfileMetricsControllerInit: MessengerClientInitFunction<
 > = ({ controllerMessenger, persistedState, getMessengerClient }) => {
   const analyticsController = getMessengerClient('AnalyticsController');
   const appStateController = getMessengerClient('AppStateController');
+  const preferencesController = getMessengerClient('PreferencesController');
   const assertUserOptedIn = () =>
     appStateController.state.pna25Acknowledged === true &&
-    analyticsController.state.optedIn === true;
+    analyticsController.state.optedIn === true &&
+    preferencesController.state.useExternalServices === true;
 
   const messengerClient = new ProfileMetricsController({
     messenger: controllerMessenger,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-2209

## **Manual testing steps**

1. Disable basic functionality during onboarding (or after)
2. Verify that profile metrics does not submit data after onboarding (or after adding an account / SRP)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow privacy/compliance tightening in init wiring and tests; no auth or payment paths, with behavior covered by new unit tests.
> 
> **Overview**
> Profile metrics now treats **basic functionality** (the `PreferencesController` `useExternalServices` flag) as a required opt-in gate, alongside existing PNA acknowledgment and analytics opt-in.
> 
> `assertUserOptedIn` in `profile-metrics-controller-init` also reads `PreferencesController` and returns false when `useExternalServices` is false, so the controller should not submit profile metrics when users disable basic functionality.
> 
> Tests mock `getMessengerClient` for Analytics, App State, and Preferences, assert `assertUserOptedIn()` is true when external services are enabled, and add a case that expects false when `useExternalServices` is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41d787ed90a4d21a7ca9bb000367443ca1ec9adf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->