### PR TITLE
feat: support withdrawals from  money account

### DIFF
--- a/ui/hooks/money/useMoneyAccountWithdrawal.test.ts
+++ b/ui/hooks/money/useMoneyAccountWithdrawal.test.ts
@@ -1,6 +1,7 @@
 import { act } from '@testing-library/react';
 import { EthAccountType, BtcAccountType } from '@metamask/keyring-api';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { MONEY_HOME_ROUTE } from '../../helpers/constants/routes';
 import {
   ConfirmationLoader,
   useConfirmationNavigation,
@@ -76,6 +77,24 @@ describe('useMoneyAccountWithdrawal', () => {
     );
     expect(navigateToTransactionMock).toHaveBeenCalledWith(TRANSACTION_ID, {
       loader: ConfirmationLoader.CustomAmount,
+      goBackTo: '/',
+    });
+  });
+
+  it('passes the originating route as goBackTo so the confirmation returns there', async () => {
+    const { result } = renderHookWithProvider(
+      () => useMoneyAccountWithdrawal(),
+      EVM_ACCOUNT_STATE,
+      MONEY_HOME_ROUTE,
+    );
+
+    await act(async () => {
+      await result.current.initiateWithdrawal();
+    });
+
+    expect(navigateToTransactionMock).toHaveBeenCalledWith(TRANSACTION_ID, {
+      loader: ConfirmationLoader.CustomAmount,
+      goBackTo: MONEY_HOME_ROUTE,
     });
   });
 

--- a/ui/hooks/money/useMoneyAccountWithdrawal.ts
+++ b/ui/hooks/money/useMoneyAccountWithdrawal.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import type { Hex } from '@metamask/utils';
 import { getMaybeSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
@@ -34,6 +35,7 @@ export type InitiateWithdrawalOptions = {
  */
 export function useMoneyAccountWithdrawal() {
   const { navigateToTransaction } = useConfirmationNavigation();
+  const location = useLocation();
   const selectedAccount = useSelector(getMaybeSelectedInternalAccount);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -51,6 +53,7 @@ export function useMoneyAccountWithdrawal() {
 
         navigateToTransaction(transactionId, {
           loader: ConfirmationLoader.CustomAmount,
+          goBackTo: location.pathname + location.search,
         });
       } catch (error) {
         const errorObj =
@@ -64,7 +67,12 @@ export function useMoneyAccountWithdrawal() {
         setIsLoading(false);
       }
     },
-    [navigateToTransaction, selectedAccount],
+    [
+      location.pathname,
+      location.search,
+      navigateToTransaction,
+      selectedAccount,
+    ],
   );
 
   return { initiateWithdrawal, isLoading };

--- a/ui/pages/money/money-home-page.test.tsx
+++ b/ui/pages/money/money-home-page.test.tsx
@@ -17,6 +17,8 @@ const mockUseMoneyDepositTokens = jest.fn();
 const mockUseMoneyActivityItems = jest.fn();
 const mockUseMoneyAccountDeposit = jest.fn();
 const mockInitiateDeposit = jest.fn();
+const mockUseMoneyAccountWithdrawal = jest.fn();
+const mockInitiateWithdrawal = jest.fn();
 const mockNavigate = jest.fn();
 const mockSelectMoneyEarningSectionEnabled = jest.mocked(
   selectMoneyEarningSectionEnabled,
@@ -76,6 +78,9 @@ jest.mock('../../hooks/money/use-money-activity-items', () => ({
 jest.mock('../../hooks/money/useMoneyAccountDeposit', () => ({
   useMoneyAccountDeposit: () => mockUseMoneyAccountDeposit(),
 }));
+jest.mock('../../hooks/money/useMoneyAccountWithdrawal', () => ({
+  useMoneyAccountWithdrawal: () => mockUseMoneyAccountWithdrawal(),
+}));
 
 describe('MoneyHomePage', () => {
   beforeEach(() => {
@@ -117,6 +122,11 @@ describe('MoneyHomePage', () => {
     mockInitiateDeposit.mockResolvedValue(undefined);
     mockUseMoneyAccountDeposit.mockReturnValue({
       initiateDeposit: mockInitiateDeposit,
+      isLoading: false,
+    });
+    mockInitiateWithdrawal.mockResolvedValue(undefined);
+    mockUseMoneyAccountWithdrawal.mockReturnValue({
+      initiateWithdrawal: mockInitiateWithdrawal,
       isLoading: false,
     });
   });
@@ -175,15 +185,16 @@ describe('MoneyHomePage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('keeps groundwork actions other than the deposit entry points inert', () => {
+  it('keeps groundwork actions other than the transfer entry points inert', () => {
     renderWithLocalization(<MoneyHomePage />);
 
-    const depositLabels = [
+    const transferLabels = [
       messages.moneyAdd.message,
       messages.addFunds.message,
+      messages.moneySend.message,
     ];
     screen.getAllByRole('button').forEach((button) => {
-      if (depositLabels.includes(button.textContent ?? '')) {
+      if (transferLabels.includes(button.textContent ?? '')) {
         expect(button).toBeEnabled();
       } else {
         expect(button).toBeDisabled();
@@ -224,6 +235,34 @@ describe('MoneyHomePage', () => {
     expect(
       screen.getByRole('button', { name: messages.moneyAdd.message }),
     ).toBeDisabled();
+  });
+
+  it('initiates a withdrawal from the Send action card', () => {
+    renderWithLocalization(<MoneyHomePage />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: messages.moneySend.message }),
+    );
+
+    expect(mockInitiateWithdrawal).toHaveBeenCalledTimes(1);
+    expect(mockInitiateWithdrawal).toHaveBeenCalledWith();
+    expect(mockInitiateDeposit).not.toHaveBeenCalled();
+  });
+
+  it('disables the Send action card while a withdrawal is initiating', () => {
+    mockUseMoneyAccountWithdrawal.mockReturnValue({
+      initiateWithdrawal: mockInitiateWithdrawal,
+      isLoading: true,
+    });
+
+    renderWithLocalization(<MoneyHomePage />);
+
+    expect(
+      screen.getByRole('button', { name: messages.moneySend.message }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: messages.moneyAdd.message }),
+    ).toBeEnabled();
   });
 
   it('renders the filled-state composition for a funded Money account', () => {
@@ -283,7 +322,11 @@ describe('MoneyHomePage', () => {
       screen.queryByText(messages.moneyBenefits.message),
     ).not.toBeInTheDocument();
     screen.getAllByRole('button').forEach((button) => {
-      if (button.textContent === messages.moneyAdd.message) {
+      if (
+        [messages.moneyAdd.message, messages.moneySend.message].includes(
+          button.textContent ?? '',
+        )
+      ) {
         expect(button).toBeEnabled();
       } else {
         expect(button).toBeDisabled();

--- a/ui/pages/money/money-home-page.tsx
+++ b/ui/pages/money/money-home-page.tsx
@@ -26,6 +26,7 @@ import { useMoneyDepositTokens } from '../../hooks/money/use-money-deposit-token
 import { useMoneyAccountBalance } from '../../hooks/money/useMoneyAccountBalance';
 import { useMoneyAccountDeposit } from '../../hooks/money/useMoneyAccountDeposit';
 import { useMoneyAccountInterest } from '../../hooks/money/useMoneyAccountInterest';
+import { useMoneyAccountWithdrawal } from '../../hooks/money/useMoneyAccountWithdrawal';
 import { useMoneyActivityItems } from '../../hooks/money/use-money-activity-items';
 import { moneyFormatUsd } from '../../helpers/money/format';
 import { selectMoneyEarningSectionEnabled } from '../../selectors/money/money-account-feature-flags';
@@ -161,6 +162,13 @@ export function MoneyHomePage() {
       console.error('Failed to initiate money account deposit', error),
     );
   }, [initiateDeposit]);
+  const { initiateWithdrawal, isLoading: isWithdrawalLoading } =
+    useMoneyAccountWithdrawal();
+  const handleSend = useCallback(() => {
+    initiateWithdrawal().catch((error) =>
+      console.error('Failed to initiate money account withdrawal', error),
+    );
+  }, [initiateWithdrawal]);
 
   if (isAvailabilityLoading || (availability.isAvailable && isBalanceLoading)) {
     return (
@@ -258,7 +266,8 @@ export function MoneyHomePage() {
           <MoneyActionCard
             icon={IconName.Arrow2UpRight}
             label={t('moneySend')}
-            disabled
+            onClick={handleSend}
+            disabled={isWithdrawalLoading}
           />
         </div>
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR connects the 'send' button in the money account to allow us to trigger withdrawals from the account. In future this send button will open a menu to allow users to also select sending money directly to a predict or perps account. But for this initial version it just points to the primary account.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: allow withdrawals from the money account

## **Related issues**

Fixes:

## **Manual testing steps**

1. Ensure the money flags enabled (they are currently enabled in the dev environment)
2. Use an account that has already been upgraded by the mobile client (upgrade is not implemented in the extension client yet)
3. Send money into the money account
4. withdraw it
5. you should still have the money!

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**

Uploading SEND OUT.mov…


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Pay confirmation navigation and money withdrawal initiation; incorrect `goBackTo` or recipient handling could strand users or mis-route funds, though logic mirrors the deposit hook pattern.
> 
> **Overview**
> Enables **withdrawals from the Money home screen** by connecting the **Send** action card to the existing `useMoneyAccountWithdrawal` flow (mirroring how Add uses deposits).
> 
> `useMoneyAccountWithdrawal` now passes **`goBackTo`** from the current router location (`pathname` + `search`) into `navigateToTransaction`, so dismissing or completing the custom-amount confirmation returns users to Money home instead of a generic route. The Money home page wires **Send** with loading/disabled state during initiation and logs setup failures.
> 
> Tests cover **`goBackTo`** behavior (including `MONEY_HOME_ROUTE`) and home-page Send click / loading interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a0b774fc8690d683fee1332912ff1d9dda1e29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->