### PR TITLE
fix(confirmations): fix Send-edit confirm-page Back navigation race conditions (CONF-1865)

### DIFF
--- a/test/e2e/tests/send/send-edit.spec.ts
+++ b/test/e2e/tests/send/send-edit.spec.ts
@@ -70,9 +70,6 @@ describe('Send - Edit Transaction', function () {
 
         await transactionConfirmation.checkGasFeeFiat('$0.07');
 
-        // Adding unrelated check for stability, to prevent issue where clicking Back navigates to Homepage instead of Sendpage(#CONF-1865)
-        await transactionConfirmation.checkSecurityProviderBannerAlertIsNotPresent();
-
         await transactionConfirmation.clickBackButton();
 
         await sendPage.editAmountByKeys([driver.Key.BACK_SPACE, '2', '.', '2']);
@@ -136,9 +133,6 @@ describe('Send - Edit Transaction', function () {
         await transactionConfirmation.checkSendAmount('1 ETH');
 
         await transactionConfirmation.checkGasFeeFiat('$0.75');
-
-        // Adding unrelated check for stability, to prevent issue where clicking Back navigates to Homepage instead of Sendpage(#CONF-1865)
-        await transactionConfirmation.checkSecurityProviderBannerAlertIsNotPresent();
 
         await transactionConfirmation.clickBackButton();
 

--- a/test/lib/confirmations/render-helpers.tsx
+++ b/test/lib/confirmations/render-helpers.tsx
@@ -84,6 +84,7 @@ export function renderWithConfirmContext(
     isScrollToBottomCompleted: true,
     setIsScrollToBottomCompleted: () => undefined,
     goBackTo: undefined,
+    suppressAutoExit: () => undefined,
   });
 }
 

--- a/ui/pages/confirmations/components/confirm/info/info.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.test.tsx
@@ -290,6 +290,7 @@ describe('Info', () => {
         isScrollToBottomCompleted: true,
         setIsScrollToBottomCompleted: jest.fn(),
         goBackTo: undefined,
+        suppressAutoExit: jest.fn(),
       };
     });
 

--- a/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
@@ -48,6 +48,7 @@ describe('BridgeTimeRow', () => {
       isScrollToBottomCompleted: true,
       setIsScrollToBottomCompleted: jest.fn(),
       goBackTo: undefined,
+      suppressAutoExit: jest.fn(),
     } as ReturnType<typeof useConfirmContext>);
 
     useIsTransactionPayQuotePendingMock.mockReturnValue(false);

--- a/ui/pages/confirmations/context/confirm/index.test.tsx
+++ b/ui/pages/confirmations/context/confirm/index.test.tsx
@@ -87,6 +87,17 @@ describe('ConfirmContextProvider', () => {
     expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, { replace: true });
   });
 
+  it('does not navigate when confirmation disappears after suppressAutoExit is called', () => {
+    const store = createStore();
+    const { result, rerender } = renderContextProvider(store);
+
+    result.current.suppressAutoExit();
+    mockCurrentConfirmation = undefined;
+    rerender();
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('navigates to goBackTo when confirmation disappears and goBackTo is present', () => {
     mockWindowSearch = '?goBackTo=/perps/trade/BTC';
     window.history.replaceState({}, '', '/?goBackTo=/perps/trade/BTC');

--- a/ui/pages/confirmations/context/confirm/index.tsx
+++ b/ui/pages/confirmations/context/confirm/index.tsx
@@ -1,6 +1,7 @@
 import React, {
   ReactElement,
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -25,6 +26,13 @@ export type ConfirmContextType = {
   setIsScrollToBottomCompleted: (isScrollToBottomCompleted: boolean) => void;
   /** Route to use for cancel / reject / auto-exit; captured once from URL on mount. */
   goBackTo: string | undefined;
+  /**
+   * Call before triggering a navigation elsewhere (e.g. navigating back to
+   * the Send page) to prevent the auto-exit effect below from racing it with
+   * its own navigate(goBackTo ?? DEFAULT_ROUTE) once the confirmation is
+   * rejected/removed. See CONF-1865.
+   */
+  suppressAutoExit: () => void;
 };
 
 export const ConfirmContext = createContext<ConfirmContextType | undefined>(
@@ -56,14 +64,20 @@ export const ConfirmContextProvider = ({
   const navigate = useNavigate();
   const previousConfirmation = usePrevious(currentConfirmation);
   const shouldNavigateHomeRef = useRef(false);
+  const autoExitSuppressedRef = useRef(false);
   const isHardwareWalletErrorModalVisible = useSelector(
     getIsHardwareWalletErrorModalVisible,
   );
 
+  const suppressAutoExit = useCallback(() => {
+    autoExitSuppressedRef.current = true;
+  }, []);
+
   /**
    * The hook below takes care of navigating to the home page when the confirmation not acted on by user
    * but removed by us, this can happen in cases like when dapp changes network.
-   * We also skip navigation if the hardware wallet error modal is visible to allow for retry functionality.
+   * We also skip navigation if the hardware wallet error modal is visible to allow for retry functionality,
+   * or if suppressAutoExit() was called (e.g. a caller is already navigating elsewhere, such as back to Send).
    */
   useEffect(() => {
     if (currentConfirmationOverride !== undefined) {
@@ -75,6 +89,10 @@ export const ConfirmContextProvider = ({
 
     if (shouldNavigateHomeRef.current && !isHardwareWalletErrorModalVisible) {
       shouldNavigateHomeRef.current = false;
+      if (autoExitSuppressedRef.current) {
+        autoExitSuppressedRef.current = false;
+        return;
+      }
       navigate(goBackTo ?? DEFAULT_ROUTE, { replace: true });
     }
   }, [
@@ -92,12 +110,14 @@ export const ConfirmContextProvider = ({
       isScrollToBottomCompleted,
       setIsScrollToBottomCompleted,
       goBackTo,
+      suppressAutoExit,
     }),
     [
       currentConfirmation,
       isScrollToBottomCompleted,
       setIsScrollToBottomCompleted,
       goBackTo,
+      suppressAutoExit,
     ],
   );
 
@@ -121,5 +141,6 @@ export const useConfirmContext = <CurrentConfirmation = Confirmation>() => {
     isScrollToBottomCompleted: boolean;
     setIsScrollToBottomCompleted: (isScrollToBottomCompleted: boolean) => void;
     goBackTo: string | undefined;
+    suppressAutoExit: () => void;
   };
 };

--- a/ui/pages/confirmations/hooks/useConfirmActions.ts
+++ b/ui/pages/confirmations/hooks/useConfirmActions.ts
@@ -18,7 +18,7 @@ import { useConfirmSendNavigation } from './useConfirmSendNavigation';
 export const useConfirmActions = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { currentConfirmation, goBackTo } =
+  const { currentConfirmation, goBackTo, suppressAutoExit } =
     useConfirmContext<TransactionMeta>();
   const { navigateBackIfSend } = useConfirmSendNavigation();
   const { id: currentConfirmationId } = currentConfirmation || {};
@@ -60,6 +60,7 @@ export const useConfirmActions = () => {
         return;
       }
       if (navigateBackForSend) {
+        suppressAutoExit();
         navigateBackIfSend();
       }
       await rejectApproval({ location });
@@ -82,6 +83,7 @@ export const useConfirmActions = () => {
       rejectApproval,
       resetTransactionState,
       goBackTo,
+      suppressAutoExit,
     ],
   );
 

--- a/ui/pages/confirmations/hooks/useConfirmationAlertActions.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertActions.test.ts
@@ -61,6 +61,7 @@ describe('useConfirmationAlertActions', () => {
       isScrollToBottomCompleted: true,
       setIsScrollToBottomCompleted: jest.fn(),
       goBackTo: undefined,
+      suppressAutoExit: jest.fn(),
     });
   });
 
@@ -92,6 +93,7 @@ describe('useConfirmationAlertActions', () => {
       isScrollToBottomCompleted: true,
       setIsScrollToBottomCompleted: jest.fn(),
       goBackTo: undefined,
+      suppressAutoExit: jest.fn(),
     });
 
     processAlertActionKey(AlertActionKey.ShowAdvancedGasFeeModal);

--- a/ui/pages/confirmations/hooks/useTransactionFocusEffect.ts
+++ b/ui/pages/confirmations/hooks/useTransactionFocusEffect.ts
@@ -29,7 +29,15 @@ export const useTransactionFocusEffect = () => {
 
   const setTransactionFocus = useCallback(
     async (transactionId: string, isFocused: boolean) => {
-      await dispatch(setTransactionActive(transactionId, isFocused));
+      try {
+        await dispatch(setTransactionActive(transactionId, isFocused));
+      } catch (error) {
+        // The transaction may have already been rejected, confirmed, or
+        // otherwise removed from state (e.g. via the confirm page's back
+        // button) by the time this focus update runs. Unfocusing a
+        // transaction that no longer exists is a no-op, so swallow the
+        // resulting "not found" error instead of surfacing it. See CONF-1865.
+      }
     },
     [dispatch],
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The Send - Edit Transaction confirmation flow has two race conditions on the confirm page's Back button (CONF-1865):

1. **Uncaught "not found" error**: clicking Back rejects the pending approval, which causes `TransactionController` to synchronously delete the transaction from state. If `useTransactionFocusEffect`'s cleanup fires `setTransactionActive(id, false)` after that deletion, `TransactionController.setTransactionActive` throws `Transaction with id ... not found`. This surfaces as an uncaught console error, which fails E2E tests via the `driver.summarizeErrorsAndExceptions()` gate, even though the UI behaves correctly.
2. **Back navigates to Home instead of Send**: `navigateBackIfSend()` fires `navigate(-1)` to return to the Send page, but once the rejected approval disappears from state, `ConfirmContextProvider`'s auto-exit safety net (meant for cases like the dapp switching networks mid-confirmation) also fires `navigate(goBackTo ?? DEFAULT_ROUTE, { replace: true })`. Since `goBackTo` is never set for the internal Send flow, this defaults to Home. Whichever navigation's re-render lands first wins, so the outcome is timing-dependent.

`test/e2e/tests/send/send-edit.spec.ts` previously worked around bug 1 by waiting for the security-provider banner to disappear before clicking Back, adding enough delay to avoid the race in practice. That mitigation was test-only and didn't fix the underlying issues.

1. What is the reason for the change?
   - `useTransactionFocusEffect` can call `setTransactionActive` for an already-removed transaction, throwing an unhandled error.
   - Two independent navigations (`navigate(-1)` and the confirm context's auto-exit `navigate`) race for control of the route after Back is clicked, sometimes landing on Home.
2. What is the improvement/solution?
   - Wrap the `setTransactionActive` dispatch in a try/catch. Unfocusing a transaction that no longer exists is a no-op by definition, so the resulting error is swallowed.
   - Add a `suppressAutoExit()` escape hatch to the confirm context, called synchronously before `navigateBackIfSend()`, so the auto-exit effect skips its own navigation when a caller is already navigating elsewhere.
   - Remove the now-unnecessary `checkSecurityProviderBannerAlertIsNotPresent()` stability workaround from `send-edit.spec.ts`, since both races are handled defensively at the source.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: CONF-1865

## **Manual testing steps**

1. Build a test extension (`yarn build:test` or `yarn start:test`).
2. Run `yarn test:e2e:single test/e2e/tests/send/send-edit.spec.ts --browser=chrome` locally, repeatedly, and confirm both tests pass consistently.
3. Manually: start a native ETH send, review the confirm page, click the Back arrow, edit the amount/gas, and confirm the transaction. No console errors should appear, the app should return to the Send page (not Home), and the transaction should confirm normally.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirm auto-exit navigation and cancel/back behavior for Send flows; scope is narrow but routing races are easy to regress without the new test coverage.
> 
> **Overview**
> Fixes **CONF-1865** race conditions when leaving the Send transaction confirm screen via **Back**.
> 
> **`suppressAutoExit()`** is added to confirm context so callers can opt out of the auto-exit `navigate(goBackTo ?? DEFAULT_ROUTE)` when they already navigate elsewhere. **`useConfirmActions`** invokes it before **`navigateBackIfSend()`**, so Back returns to Send instead of sometimes winning a race with Home.
> 
> **`useTransactionFocusEffect`** wraps **`setTransactionActive`** in try/catch so unfocusing a transaction already removed by rejection no longer throws an uncaught “not found” error (which broke E2E via error summarization).
> 
> Send-edit E2E drops the **`checkSecurityProviderBannerAlertIsNotPresent`** timing workaround; unit/render mocks and a context test cover **`suppressAutoExit`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea91a985b9e4d305ed71a2e906a630d143c9ee32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->