### PR TITLE
chore(44547): extract loadStateFromPersistence from background.js

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -16,7 +16,7 @@ import { lightTheme } from '@metamask/design-tokens';
 import { finished } from 'readable-stream';
 import log from 'loglevel';
 import browser from 'webextension-polyfill';
-import { isObject, hasProperty } from '@metamask/utils';
+import { isObject } from '@metamask/utils';
 import { deriveStateFromMetadata } from '@metamask/base-controller';
 import { ExtensionPortStream } from 'extension-port-stream';
 import { withResolvers } from '../../shared/lib/promise-with-resolvers';
@@ -70,9 +70,6 @@ import {
   backedUpStateKeys,
   hasVault,
 } from '../../shared/lib/stores/persistence-manager';
-import Migrator from './lib/migrator';
-import migrations from './migrations';
-import { useSplitStateStorage } from './lib/use-split-state-storage';
 import { getAttentionRequiredApprovalCount } from './lib/approval/utils';
 import { CorruptionHandler } from './lib/state-corruption/state-corruption-recovery';
 import { CriticalErrorHandler } from './lib/critical-error/critical-error-recovery';
@@ -93,7 +90,6 @@ import MetamaskController, {
   METAMASK_CONTROLLER_EVENTS,
 } from './metamask-controller';
 import { createEventBuilder, trackEvent } from './controllers/analytics';
-import getObjStructure from './lib/getObjStructure';
 import setupEnsIpfsResolver from './lib/ens-ipfs/setup';
 import {
   getPlatform,
@@ -104,6 +100,7 @@ import {
 import { createOffscreen, addOffscreenConnectivityListener } from './offscreen';
 import { setupMultiplex } from './lib/stream-utils';
 import rawFirstTimeState from './first-time-state';
+import { loadStateFromPersistence } from './lib/startup/load-state-from-persistence';
 import {
   handleOnInstalled,
   onUpdateAvailable,
@@ -195,7 +192,6 @@ global.logEncryptedVault = () => {
 };
 
 const { sentry } = global;
-let firstTimeState = { ...rawFirstTimeState };
 
 const metamaskInternalProcessHash = {
   [ENVIRONMENT_TYPE_POPUP]: true,
@@ -641,7 +637,9 @@ async function initialize(backup) {
     });
   }
 
-  const initData = await loadStateFromPersistence(backup);
+  const { versionedData: initData } = await loadStateFromPersistence(backup, {
+    ...rawFirstTimeState,
+  });
 
   const initState = initData.data;
   const initLangCode = await getFirstPreferredLangCode();
@@ -752,275 +750,6 @@ async function loadPreinstalledSnaps() {
   });
 
   return Promise.all(promises);
-}
-
-//
-// State and Persistence
-//
-
-/**
- * Loads any stored data, prioritizing the latest storage strategy.
- * Migrates that data schema in case it was last loaded on an older version.
- *
- * @param {Backup | null} backup
- * @returns {Promise<{data: MetaMaskState meta: {version: number}}>} Last data emitted from previous instance of MetaMask.
- */
-export async function loadStateFromPersistence(backup) {
-  if (process.env.WITH_STATE) {
-    const withState = JSON.parse(process.env.WITH_STATE);
-
-    // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
-    // eslint-disable-next-line n/global-require
-    const { generateWalletState } = require('./fixtures/generate-wallet-state');
-    const fixtureBuilder = await generateWalletState(withState, false);
-
-    const stateOverrides = fixtureBuilder.fixture.data;
-    firstTimeState = { ...firstTimeState, ...stateOverrides };
-  }
-
-  // read from disk
-  // first from preferred, async API:
-  /**
-   * @type {import("../../shared/lib/stores/base-store").MetaMaskStorageStructure | undefined}
-   */
-  let preMigrationVersionedData;
-  if (backup) {
-    preMigrationVersionedData = { data: {}, meta: {} };
-    for (const key of backedUpStateKeys) {
-      if (hasProperty(backup, key)) {
-        preMigrationVersionedData.data[key] = backup[key];
-      }
-    }
-    // use the meta property from the backup if it exists, that way the
-    // migrations will behave correctly.
-    if (hasProperty(backup, 'meta') && isObject(backup.meta)) {
-      preMigrationVersionedData.meta = backup.meta;
-      // old versions of meta used "data" as the storage kind, without
-      // explicitly setting the "storageKind" to data. If it is missing, we just
-      // always default to "data" ("data" was the default before "split"
-      // existed).
-      // We need to set it properly here so that the persistence manager uses
-      // the correct storage kind when restoring from the `backup`.
-      if (
-        backup.meta.storageKind === 'split' ||
-        backup.meta.storageKind === 'data'
-      ) {
-        persistenceManager.storageKind = backup.meta.storageKind;
-      } else {
-        persistenceManager.storageKind = 'data';
-      }
-    }
-    // sanity check on the meta property
-    if (typeof preMigrationVersionedData.meta.version !== 'number') {
-      log.error(
-        "The `backup`'s `meta.version` property was missing during backup restore.",
-      );
-      // the last migration version before we started storing backups was `155`
-      // so we can use that version as a fallback.
-      preMigrationVersionedData.meta.version = 155;
-    }
-  } else {
-    const validateVault = true;
-    preMigrationVersionedData = await persistenceManager.get({ validateVault });
-  }
-
-  const migrator = new Migrator({
-    migrations,
-    defaultVersion: process.env.WITH_STATE
-      ? // eslint-disable-next-line n/global-require
-        require('../../test/e2e/fixtures/default-fixture.json').meta.version
-      : null,
-  });
-
-  // report migration errors to sentry
-  migrator.on('error', (err) => {
-    console.warn(err);
-    // get vault structure without secrets
-    const vaultStructure = getObjStructure(preMigrationVersionedData);
-    sentry?.captureException(err, {
-      // "extra" key is required by Sentry
-      extra: { vaultStructure },
-    });
-  });
-
-  let writeAllKeysToState = false;
-  if (!preMigrationVersionedData?.data && !preMigrationVersionedData?.meta) {
-    // brand new state; write all keys!
-    writeAllKeysToState = true;
-    preMigrationVersionedData = migrator.generateInitialState(firstTimeState);
-  }
-
-  // migrate data
-  const { state: versionedData, changedKeys } = await migrator.migrateData(
-    preMigrationVersionedData,
-  );
-
-  /**
-   * Creates an Error with sentryTags for migration failures.
-   * Tags help identify if user should have had a backup (v12.20.0+, migration 157+),
-   * and include installation info for diagnostics.
-   * These are captured via the critical error page's "Send error report" checkbox
-   * flow (see ui/helpers/utils/display-critical-error.ts).
-   *
-   * @param {string} message - The error message
-   * @returns {Promise<Error>} Error object with sentryTags property
-   */
-  const createMigrationError = async (message) => {
-    const preMigrationVersion = preMigrationVersionedData?.meta?.version;
-    const backupShouldExist =
-      typeof preMigrationVersion === 'number' && preMigrationVersion >= 157;
-
-    // Try to get firstTimeInfo for Sentry tags (installation version and date)
-    // Check in-memory sources first (fast, synchronous checks)
-    // Check both new location (AppMetadataController) and old location (top-level)
-    // for compatibility with pre-migration-190 state
-    let firstTimeInfo =
-      backup?.AppMetadataController?.firstTimeInfo ??
-      versionedData?.data?.AppMetadataController?.firstTimeInfo ??
-      versionedData?.data?.firstTimeInfo ??
-      preMigrationVersionedData?.data?.AppMetadataController?.firstTimeInfo ??
-      preMigrationVersionedData?.data?.firstTimeInfo;
-
-    // Fallback to IndexedDB backup if in-memory sources don't have it
-    // (handles corruption scenarios where storage.local is damaged)
-    if (!firstTimeInfo) {
-      try {
-        const indexedDbBackup = await persistenceManager.getBackup();
-        firstTimeInfo = indexedDbBackup?.AppMetadataController?.firstTimeInfo;
-      } catch {
-        // Ignore backup fetch errors - we still want to report the migration error
-      }
-    }
-
-    const error = new Error(message);
-
-    // Add sentryTags for searchable/filterable fields in Sentry UI
-    // These are extracted by sendErrorToSentry in display-critical-error.ts
-    error.sentryTags = {
-      'corruption.preMigrationVersion': String(
-        preMigrationVersion ?? 'unknown',
-      ),
-      'corruption.backupShouldExist': String(backupShouldExist),
-      'corruption.installVersion': String(firstTimeInfo?.version ?? 'unknown'),
-      'corruption.installDate': String(firstTimeInfo?.date ?? 'unknown'),
-    };
-
-    return error;
-  };
-
-  if (!versionedData) {
-    throw await createMigrationError('MetaMask - migrator returned undefined');
-  } else if (!isObject(versionedData.meta)) {
-    throw await createMigrationError(
-      `MetaMask - migrator metadata has invalid type '${typeof versionedData.meta}'`,
-    );
-  } else if (typeof versionedData.meta.version !== 'number') {
-    throw await createMigrationError(
-      `MetaMask - migrator metadata version has invalid type '${typeof versionedData.meta.version}'`,
-    );
-  } else if (
-    !['data', 'split', undefined].includes(versionedData.meta.storageKind)
-  ) {
-    throw await createMigrationError(
-      `MetaMask - migrator metadata storageKind has invalid value '${versionedData.meta.storageKind}'`,
-    );
-  } else if (!isObject(versionedData.data)) {
-    throw await createMigrationError(
-      `MetaMask - migrator data has invalid type '${typeof versionedData.data}'`,
-    );
-  }
-
-  // `yarn start:with-state` builds a local fixture wallet via WITH_STATE.
-  // Account/contact sync can otherwise pull remote user-storage for the same
-  // SRP and replace the generated local state. Applying this after migration
-  // covers both fresh fixture state and existing persisted state before
-  // controllers initialize; marking the key changed ensures split-state
-  // persistence writes the override.
-  if (
-    process.env.WITH_STATE &&
-    isObject(versionedData.data.UserStorageController)
-  ) {
-    versionedData.data.UserStorageController.isBackupAndSyncEnabled = false;
-    versionedData.data.UserStorageController.isAccountSyncingEnabled = false;
-    versionedData.data.UserStorageController.isContactSyncingEnabled = false;
-    if (!changedKeys.has('UserStorageController')) {
-      changedKeys.add('UserStorageController');
-    }
-  }
-
-  // this initializes the meta/version data as a class variable to be used for future writes
-  persistenceManager.setMetadata(versionedData.meta);
-
-  log.debug(
-    "[Split State]: Loaded data from persistence with storageKind '%s'",
-    persistenceManager.storageKind,
-  );
-  if (persistenceManager.storageKind === 'data') {
-    const alreadyTried =
-      versionedData.meta.platformSplitStateGradualRolloutAttempted === true;
-    const shouldUseSplitStateStorage =
-      !alreadyTried && (await useSplitStateStorage(versionedData.data));
-    log.debug(
-      '[Split State]: shouldUseSplitStateStorage: %s (alreadyTried: %s)',
-      shouldUseSplitStateStorage,
-      alreadyTried,
-    );
-    if (shouldUseSplitStateStorage) {
-      // a sigil to mark that we *tried* to migrate to split state storage
-      versionedData.meta.platformSplitStateGradualRolloutAttempted = true;
-      persistenceManager.setMetadata(versionedData.meta);
-    }
-
-    log.debug(
-      "[Split State]: Writing data to persistence with storageKind 'data'",
-    );
-    // write to disk
-    await persistenceManager.set(versionedData.data);
-
-    if (shouldUseSplitStateStorage) {
-      await persistenceManager.migrateToSplitState(versionedData.data);
-      versionedData.meta = persistenceManager.getMetaData();
-      if (versionedData.meta !== undefined) {
-        delete versionedData.meta.platformSplitStateGradualRolloutAttempted;
-        // persist the new metadata one more time
-        persistenceManager.setMetadata(versionedData.meta);
-      }
-      await persistenceManager.persist();
-    }
-  } else if (persistenceManager.storageKind === 'split') {
-    if (writeAllKeysToState) {
-      // New state needs every controller persisted.
-      for (const key of Object.keys(versionedData.data)) {
-        persistenceManager.update(key, versionedData.data[key]);
-      }
-    } else {
-      // Existing state starts with explicitly changed controllers.
-      for (const key of changedKeys) {
-        persistenceManager.update(key, versionedData.data[key]);
-      }
-      if (backup) {
-        // Recovery also needs every backed-up controller.
-        for (const key of backedUpStateKeys) {
-          const value = versionedData.data[key];
-          // Avoid queuing the same key twice.
-          // Missing backup values would delete existing state.
-          if (!changedKeys.has(key) && value !== undefined) {
-            persistenceManager.update(key, value);
-          }
-        }
-      }
-    }
-    // write to disk
-    await persistenceManager.persist();
-  } else {
-    throw new Error(
-      `MetaMask - persistenceManager has invalid storageKind '${persistenceManager.storageKind}'`,
-    );
-  }
-  log.debug('[Split State]: Load complete.');
-
-  // return just the data
-  return versionedData;
 }
 
 /**

--- a/app/scripts/lib/startup/load-state-from-persistence.test.ts
+++ b/app/scripts/lib/startup/load-state-from-persistence.test.ts
@@ -1,0 +1,217 @@
+import type { MetaMaskStorageStructure } from '../../../../shared/lib/stores/base-store';
+import type { Backup } from '../../../../shared/lib/stores/persistence-manager';
+import type { FirstTimeState } from './load-state-from-persistence';
+
+const mockGet = jest.fn();
+const mockGetBackup = jest.fn();
+const mockSet = jest.fn();
+const mockSetMetadata = jest.fn();
+const mockGetMetaData = jest.fn();
+const mockUpdate = jest.fn();
+const mockPersist = jest.fn();
+const mockMigrateToSplitState = jest.fn();
+const mockUseSplitStateStorage = jest.fn();
+
+let mockStorageKind: 'data' | 'split' = 'split';
+
+const mockMigrateData = jest.fn();
+const mockGenerateInitialState = jest.fn();
+
+jest.mock('../setup-initial-state-hooks', () => ({
+  persistenceManager: {
+    get storageKind() {
+      return mockStorageKind;
+    },
+    set storageKind(value: 'data' | 'split') {
+      mockStorageKind = value;
+    },
+    get: (...args: unknown[]) => mockGet(...args),
+    getBackup: (...args: unknown[]) => mockGetBackup(...args),
+    set: (...args: unknown[]) => mockSet(...args),
+    setMetadata: (...args: unknown[]) => mockSetMetadata(...args),
+    getMetaData: (...args: unknown[]) => mockGetMetaData(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+    persist: (...args: unknown[]) => mockPersist(...args),
+    migrateToSplitState: (...args: unknown[]) =>
+      mockMigrateToSplitState(...args),
+  },
+}));
+
+jest.mock('../migrator', () => {
+  return jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    migrateData: (...args: unknown[]) => mockMigrateData(...args),
+    generateInitialState: (...args: unknown[]) =>
+      mockGenerateInitialState(...args),
+  }));
+});
+
+jest.mock('../use-split-state-storage', () => ({
+  useSplitStateStorage: (...args: unknown[]) =>
+    mockUseSplitStateStorage(...args),
+}));
+
+jest.mock('../../migrations', () => []);
+
+const mockGenerateWalletState = jest.fn();
+
+jest.mock('../../fixtures/generate-wallet-state', () => ({
+  generateWalletState: (...args: unknown[]) => mockGenerateWalletState(...args),
+}));
+
+jest.mock('../getObjStructure', () => jest.fn(() => ({})));
+
+const defaultFirstTimeState: FirstTimeState = { config: {} };
+
+const migratedState: MetaMaskStorageStructure = {
+  data: {
+    KeyringController: { vault: 'encrypted' },
+    AppMetadataController: { firstTimeInfo: { version: '1.0.0' } },
+    NetworkController: { networkConfigurationsByChainId: {} },
+  },
+  meta: { version: 200, storageKind: 'split' },
+};
+
+describe('loadStateFromPersistence', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockStorageKind = 'split';
+    mockGet.mockResolvedValue({
+      data: { KeyringController: { vault: 'encrypted' } },
+      meta: { version: 199, storageKind: 'split' },
+    });
+    mockMigrateData.mockResolvedValue({
+      state: migratedState,
+      changedKeys: new Set(['KeyringController']),
+    });
+    mockUseSplitStateStorage.mockResolvedValue(false);
+    mockGetMetaData.mockReturnValue({ version: 200, storageKind: 'split' });
+    delete process.env.WITH_STATE;
+  });
+
+  async function loadState(
+    backup: Backup | null = null,
+    firstTimeState: FirstTimeState = defaultFirstTimeState,
+  ) {
+    const { loadStateFromPersistence } =
+      await import('./load-state-from-persistence');
+    return loadStateFromPersistence(backup, firstTimeState);
+  }
+
+  it('loads persisted state when no backup is provided', async () => {
+    const { versionedData } = await loadState();
+
+    expect(mockGet).toHaveBeenCalledWith({ validateVault: true });
+    expect(mockMigrateData).toHaveBeenCalled();
+    expect(mockPersist).toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'KeyringController',
+      migratedState.data?.KeyringController,
+    );
+    expect(versionedData).toStrictEqual(migratedState);
+  });
+
+  it('restores from backup and sets storageKind from backup meta', async () => {
+    mockStorageKind = 'data';
+    const backup: Backup = {
+      KeyringController: { vault: 'from-backup' },
+      AppMetadataController: { firstTimeInfo: { version: '1.0.0' } },
+      meta: { version: 157, storageKind: 'split' },
+    };
+
+    await loadState(backup);
+
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockStorageKind).toBe('split');
+    expect(mockMigrateData).toHaveBeenCalledWith({
+      data: {
+        KeyringController: { vault: 'from-backup' },
+        AppMetadataController: { firstTimeInfo: { version: '1.0.0' } },
+      },
+      meta: { version: 157, storageKind: 'split' },
+    });
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'KeyringController',
+      migratedState.data?.KeyringController,
+    );
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'AppMetadataController',
+      migratedState.data?.AppMetadataController,
+    );
+    expect(mockPersist).toHaveBeenCalled();
+  });
+
+  it('defaults backup storageKind to data when meta.storageKind is missing', async () => {
+    mockStorageKind = 'split';
+    const backup: Backup = {
+      KeyringController: { vault: 'from-backup' },
+      meta: { version: 155 },
+    };
+
+    await loadState(backup);
+
+    expect(mockStorageKind).toBe('data');
+  });
+
+  it('migrates data storage to split state when rollout criteria are met', async () => {
+    mockStorageKind = 'data';
+    const dataStorageState: MetaMaskStorageStructure = {
+      data: { KeyringController: { vault: 'encrypted' } },
+      meta: { version: 200, storageKind: 'data' },
+    };
+    mockGet.mockResolvedValue(dataStorageState);
+    mockMigrateData.mockResolvedValue({
+      state: dataStorageState,
+      changedKeys: new Set(['KeyringController']),
+    });
+    mockUseSplitStateStorage.mockResolvedValue(true);
+    mockGetMetaData.mockReturnValue({ version: 200, storageKind: 'split' });
+
+    const { versionedData } = await loadState();
+
+    expect(mockUseSplitStateStorage).toHaveBeenCalledWith(
+      dataStorageState.data,
+    );
+    expect(mockSet).toHaveBeenCalledWith(dataStorageState.data);
+    expect(mockMigrateToSplitState).toHaveBeenCalledWith(dataStorageState.data);
+    expect(mockPersist).toHaveBeenCalled();
+    expect(versionedData.meta).toStrictEqual({
+      version: 200,
+      storageKind: 'split',
+    });
+  });
+
+  it('generates initial state for brand-new installs', async () => {
+    mockGet.mockResolvedValue(undefined);
+    const initialVersionedData: MetaMaskStorageStructure = {
+      data: { config: { onboarding: true } },
+      meta: { version: 200, storageKind: 'split' },
+    };
+    mockGenerateInitialState.mockReturnValue(initialVersionedData);
+    mockMigrateData.mockResolvedValue({
+      state: initialVersionedData,
+      changedKeys: new Set(Object.keys(initialVersionedData.data ?? {})),
+    });
+
+    await loadState(null, { config: { onboarding: true } });
+
+    expect(mockGenerateInitialState).toHaveBeenCalledWith({
+      config: { onboarding: true },
+    });
+    expect(mockUpdate).toHaveBeenCalledWith('config', { onboarding: true });
+  });
+
+  it('returns updated firstTimeState when WITH_STATE overrides are applied', async () => {
+    process.env.WITH_STATE = JSON.stringify({ seedPhrase: 'test' });
+    mockGenerateWalletState.mockResolvedValue({
+      fixture: { data: { config: { fromFixture: true } } },
+    });
+
+    const { firstTimeState } = await loadState(null, { config: {} });
+
+    expect(firstTimeState).toStrictEqual({
+      config: { fromFixture: true },
+    });
+  });
+});

--- a/app/scripts/lib/startup/load-state-from-persistence.ts
+++ b/app/scripts/lib/startup/load-state-from-persistence.ts
@@ -38,7 +38,9 @@ function isValidMetaData(value: unknown): value is MetaData {
     typeof value.version === 'number' &&
     (value.storageKind === undefined ||
       value.storageKind === 'data' ||
-      value.storageKind === 'split')
+      value.storageKind === 'split') &&
+    (value.platformSplitStateGradualRolloutAttempted === undefined ||
+      typeof value.platformSplitStateGradualRolloutAttempted === 'boolean')
   );
 }
 

--- a/app/scripts/lib/startup/load-state-from-persistence.ts
+++ b/app/scripts/lib/startup/load-state-from-persistence.ts
@@ -1,0 +1,392 @@
+import log from 'loglevel';
+import { hasProperty, isObject } from '@metamask/utils';
+import type {
+  MetaData,
+  MetaMaskStateType,
+  MetaMaskStorageStructure,
+} from '../../../../shared/lib/stores/base-store';
+import {
+  backedUpStateKeys,
+  type Backup,
+} from '../../../../shared/lib/stores/persistence-manager';
+import { persistenceManager } from '../setup-initial-state-hooks';
+import Migrator from '../migrator';
+import migrations from '../../migrations';
+import { useSplitStateStorage } from '../use-split-state-storage';
+import getObjStructure from '../getObjStructure';
+import type rawFirstTimeState from '../../first-time-state';
+
+export type FirstTimeState = typeof rawFirstTimeState;
+
+type MigrationError = Error & {
+  sentryTags?: Record<string, string>;
+};
+
+type ValidatedVersionedData = {
+  data: MetaMaskStateType;
+  meta: MetaData;
+};
+
+export type LoadStateFromPersistenceResult = {
+  versionedData: ValidatedVersionedData;
+  firstTimeState: FirstTimeState;
+};
+
+function isValidMetaData(value: unknown): value is MetaData {
+  return (
+    isObject(value) &&
+    typeof value.version === 'number' &&
+    (value.storageKind === undefined ||
+      value.storageKind === 'data' ||
+      value.storageKind === 'split')
+  );
+}
+
+async function validateVersionedData(
+  versionedData: unknown,
+  createMigrationError: (message: string) => Promise<MigrationError>,
+): Promise<ValidatedVersionedData> {
+  if (!versionedData) {
+    throw await createMigrationError('MetaMask - migrator returned undefined');
+  }
+
+  if (!isObject(versionedData) || !isValidMetaData(versionedData.meta)) {
+    throw await createMigrationError(
+      `MetaMask - migrator metadata has invalid type '${typeof (versionedData as { meta?: unknown }).meta}'`,
+    );
+  }
+
+  if (typeof versionedData.meta.version !== 'number') {
+    throw await createMigrationError(
+      `MetaMask - migrator metadata version has invalid type '${typeof versionedData.meta.version}'`,
+    );
+  }
+
+  if (
+    versionedData.meta.storageKind !== undefined &&
+    versionedData.meta.storageKind !== 'data' &&
+    versionedData.meta.storageKind !== 'split'
+  ) {
+    throw await createMigrationError(
+      `MetaMask - migrator metadata storageKind has invalid value '${String(versionedData.meta.storageKind)}'`,
+    );
+  }
+
+  if (!isObject(versionedData.data)) {
+    throw await createMigrationError(
+      `MetaMask - migrator data has invalid type '${typeof (versionedData as { data?: unknown }).data}'`,
+    );
+  }
+
+  return {
+    data: versionedData.data,
+    meta: versionedData.meta,
+  };
+}
+
+function getFirstTimeInfo(
+  source: MetaMaskStateType | Backup | null | undefined,
+) {
+  if (!source) {
+    return undefined;
+  }
+
+  // Check both new location (AppMetadataController) and old location (top-level)
+  // for compatibility with pre-migration-190 state.
+  if (
+    hasProperty(source, 'AppMetadataController') &&
+    isObject(source.AppMetadataController)
+  ) {
+    if (hasProperty(source.AppMetadataController, 'firstTimeInfo')) {
+      return source.AppMetadataController.firstTimeInfo;
+    }
+  }
+
+  if (hasProperty(source, 'firstTimeInfo')) {
+    return source.firstTimeInfo;
+  }
+
+  return undefined;
+}
+
+/**
+ * Loads any stored data, prioritizing the latest storage strategy.
+ * Migrates that data schema in case it was last loaded on an older version.
+ *
+ * @param backup - Optional backup state for recovery flows.
+ * @param initialFirstTimeState - Default controller state for brand-new installs.
+ * @returns Migrated state and any WITH_STATE overrides applied to first-time state.
+ */
+export async function loadStateFromPersistence(
+  backup: Backup | null,
+  initialFirstTimeState: FirstTimeState,
+): Promise<LoadStateFromPersistenceResult> {
+  let firstTimeState: FirstTimeState = { ...initialFirstTimeState };
+
+  if (process.env.WITH_STATE) {
+    const withState = JSON.parse(process.env.WITH_STATE);
+
+    // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
+    /* eslint-disable @typescript-eslint/no-require-imports -- dynamic test-only import */
+    const {
+      generateWalletState,
+    } = require('../../fixtures/generate-wallet-state');
+    /* eslint-enable @typescript-eslint/no-require-imports */
+    const fixtureBuilder = await generateWalletState(withState, false);
+
+    const stateOverrides = fixtureBuilder.fixture.data;
+    firstTimeState = { ...firstTimeState, ...stateOverrides };
+  }
+
+  // read from disk
+  // first from preferred, async API:
+  let preMigrationVersionedData: MetaMaskStorageStructure | undefined;
+  if (backup) {
+    preMigrationVersionedData = {
+      data: {},
+    };
+    for (const key of backedUpStateKeys) {
+      if (hasProperty(backup, key)) {
+        preMigrationVersionedData.data ??= {};
+        preMigrationVersionedData.data[key] = backup[key];
+      }
+    }
+    if (hasProperty(backup, 'meta') && isObject(backup.meta)) {
+      preMigrationVersionedData.meta = backup.meta as MetaData;
+      // use the meta property from the backup if it exists, that way the
+      // migrations will behave correctly.
+      // old versions of meta used "data" as the storage kind, without
+      // explicitly setting the "storageKind" to data. If it is missing, we just
+      // always default to "data" ("data" was the default before "split"
+      // existed).
+      // We need to set it properly here so that the persistence manager uses
+      // the correct storage kind when restoring from the `backup`.
+      if (
+        backup.meta.storageKind === 'split' ||
+        backup.meta.storageKind === 'data'
+      ) {
+        persistenceManager.storageKind = backup.meta.storageKind;
+      } else {
+        persistenceManager.storageKind = 'data';
+      }
+    }
+    // sanity check on the meta property
+    if (typeof preMigrationVersionedData.meta?.version !== 'number') {
+      log.error(
+        "The `backup`'s `meta.version` property was missing during backup restore.",
+      );
+      // the last migration version before we started storing backups was `155`
+      // so we can use that version as a fallback.
+      preMigrationVersionedData.meta = {
+        ...preMigrationVersionedData.meta,
+        version: 155,
+      };
+    }
+  } else {
+    const validateVault = true;
+    preMigrationVersionedData = await persistenceManager.get({ validateVault });
+  }
+
+  const migrator = new Migrator({
+    migrations,
+    defaultVersion: process.env.WITH_STATE
+      ? // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('../../../../test/e2e/fixtures/default-fixture.json').meta
+          .version
+      : null,
+  });
+
+  // report migration errors to sentry
+  migrator.on('error', (err: Error) => {
+    console.warn(err);
+    // get vault structure without secrets
+    const vaultStructure = getObjStructure(preMigrationVersionedData);
+    globalThis.sentry?.captureException?.(err, {
+      // "extra" key is required by Sentry
+      extra: { vaultStructure },
+    });
+  });
+
+  let writeAllKeysToState = false;
+  if (!preMigrationVersionedData?.data && !preMigrationVersionedData?.meta) {
+    // brand new state; write all keys!
+    writeAllKeysToState = true;
+    preMigrationVersionedData = migrator.generateInitialState(
+      firstTimeState,
+    ) as MetaMaskStorageStructure;
+  }
+
+  // migrate data
+  const { state: migratedVersionedData, changedKeys } =
+    await migrator.migrateData(
+      preMigrationVersionedData as {
+        data: MetaMaskStateType;
+        meta: { version: number };
+      },
+    );
+
+  /**
+   * Creates an Error with sentryTags for migration failures.
+   * Tags help identify if user should have had a backup (v12.20.0+, migration 157+),
+   * and include installation info for diagnostics.
+   * These are captured via the critical error page's "Send error report" checkbox
+   * flow (see ui/helpers/utils/display-critical-error.ts).
+   *
+   * @param message - The error message
+   * @returns Error object with sentryTags property
+   */
+  const createMigrationError = async (
+    message: string,
+  ): Promise<MigrationError> => {
+    const preMigrationVersion = preMigrationVersionedData?.meta?.version;
+    const backupShouldExist =
+      typeof preMigrationVersion === 'number' && preMigrationVersion >= 157;
+
+    // Try to get firstTimeInfo for Sentry tags (installation version and date)
+    // Check in-memory sources first (fast, synchronous checks)
+    // Check both new location (AppMetadataController) and old location (top-level)
+    // for compatibility with pre-migration-190 state
+    let firstTimeInfo =
+      getFirstTimeInfo(backup) ??
+      getFirstTimeInfo(
+        isObject(migratedVersionedData?.data)
+          ? migratedVersionedData.data
+          : undefined,
+      ) ??
+      getFirstTimeInfo(preMigrationVersionedData?.data);
+
+    // Fallback to IndexedDB backup if in-memory sources don't have it
+    // (handles corruption scenarios where storage.local is damaged)
+    if (!firstTimeInfo) {
+      try {
+        const indexedDbBackup = await persistenceManager.getBackup();
+        firstTimeInfo = getFirstTimeInfo(indexedDbBackup);
+      } catch {
+        // Ignore backup fetch errors - we still want to report the migration error
+      }
+    }
+
+    const error = new Error(message) as MigrationError;
+
+    // Add sentryTags for searchable/filterable fields in Sentry UI
+    // These are extracted by sendErrorToSentry in display-critical-error.ts
+    error.sentryTags = {
+      'corruption.preMigrationVersion': String(
+        preMigrationVersion ?? 'unknown',
+      ),
+      'corruption.backupShouldExist': String(backupShouldExist),
+      'corruption.installVersion': String(
+        isObject(firstTimeInfo) && hasProperty(firstTimeInfo, 'version')
+          ? firstTimeInfo.version
+          : 'unknown',
+      ),
+      'corruption.installDate': String(
+        isObject(firstTimeInfo) && hasProperty(firstTimeInfo, 'date')
+          ? firstTimeInfo.date
+          : 'unknown',
+      ),
+    };
+
+    return error;
+  };
+
+  let versionedData = await validateVersionedData(
+    migratedVersionedData,
+    createMigrationError,
+  );
+
+  // `yarn start:with-state` builds a local fixture wallet via WITH_STATE.
+  // Account/contact sync can otherwise pull remote user-storage for the same
+  // SRP and replace the generated local state. Applying this after migration
+  // covers both fresh fixture state and existing persisted state before
+  // controllers initialize; marking the key changed ensures split-state
+  // persistence writes the override.
+  if (
+    process.env.WITH_STATE &&
+    isObject(versionedData.data.UserStorageController)
+  ) {
+    versionedData.data.UserStorageController.isBackupAndSyncEnabled = false;
+    versionedData.data.UserStorageController.isAccountSyncingEnabled = false;
+    versionedData.data.UserStorageController.isContactSyncingEnabled = false;
+    if (!changedKeys.has('UserStorageController')) {
+      changedKeys.add('UserStorageController');
+    }
+  }
+
+  // this initializes the meta/version data as a class variable to be used for future writes
+  persistenceManager.setMetadata(versionedData.meta);
+
+  log.debug(
+    "[Split State]: Loaded data from persistence with storageKind '%s'",
+    persistenceManager.storageKind,
+  );
+  if (persistenceManager.storageKind === 'data') {
+    const alreadyTried =
+      versionedData.meta.platformSplitStateGradualRolloutAttempted === true;
+    const shouldUseSplitStateStorage =
+      !alreadyTried && (await useSplitStateStorage(versionedData.data));
+    log.debug(
+      '[Split State]: shouldUseSplitStateStorage: %s (alreadyTried: %s)',
+      shouldUseSplitStateStorage,
+      alreadyTried,
+    );
+    if (shouldUseSplitStateStorage) {
+      // a sigil to mark that we *tried* to migrate to split state storage
+      versionedData.meta.platformSplitStateGradualRolloutAttempted = true;
+      persistenceManager.setMetadata(versionedData.meta);
+    }
+
+    log.debug(
+      "[Split State]: Writing data to persistence with storageKind 'data'",
+    );
+    // write to disk
+    await persistenceManager.set(versionedData.data);
+
+    if (shouldUseSplitStateStorage) {
+      await persistenceManager.migrateToSplitState(versionedData.data);
+      const migratedMeta = persistenceManager.getMetaData();
+      if (migratedMeta !== undefined) {
+        versionedData = {
+          ...versionedData,
+          meta: { ...migratedMeta },
+        };
+        delete versionedData.meta.platformSplitStateGradualRolloutAttempted;
+        // persist the new metadata one more time
+        persistenceManager.setMetadata(versionedData.meta);
+      }
+      await persistenceManager.persist();
+    }
+  } else if (persistenceManager.storageKind === 'split') {
+    if (writeAllKeysToState) {
+      // New state needs every controller persisted.
+      for (const key of Object.keys(versionedData.data)) {
+        persistenceManager.update(key, versionedData.data[key]);
+      }
+    } else {
+      // Existing state starts with explicitly changed controllers.
+      for (const key of changedKeys) {
+        persistenceManager.update(key, versionedData.data[key]);
+      }
+      if (backup) {
+        // Recovery also needs every backed-up controller.
+        for (const key of backedUpStateKeys) {
+          const value = versionedData.data[key];
+          // Avoid queuing the same key twice.
+          // Missing backup values would delete existing state.
+          if (!changedKeys.has(key) && value !== undefined) {
+            persistenceManager.update(key, value);
+          }
+        }
+      }
+    }
+    // write to disk
+    await persistenceManager.persist();
+  } else {
+    throw new Error(
+      `MetaMask - persistenceManager has invalid storageKind '${String(persistenceManager.storageKind)}'`,
+    );
+  }
+  log.debug('[Split State]: Load complete.');
+
+  return { versionedData, firstTimeState };
+}

--- a/shared/lib/stores/base-store.ts
+++ b/shared/lib/stores/base-store.ts
@@ -20,6 +20,10 @@ export type MetaData = {
    * The kind of storage being used.
    */
   storageKind?: 'data' | 'split';
+  /**
+   * Transient flag used during split-state gradual rollout migration.
+   */
+  platformSplitStateGradualRolloutAttempted?: boolean;
 };
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Extracts `loadStateFromPersistence` from `app/scripts/background.js` into `app/scripts/lib/startup/load-state-from-persistence.ts`

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/44547

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Startup still runs the same persistence, migration, backup, and split-state paths; risk is mainly behavioral drift from the refactor (API and return shape) rather than new product behavior.
> 
> **Overview**
> Moves wallet startup persistence logic out of **`background.js`** into **`app/scripts/lib/startup/load-state-from-persistence.ts`**, shrinking the background entry file and colocating migration, backup restore, and split-state rollout in one typed module.
> 
> **`loadStateFromPersistence`** now takes **`initialFirstTimeState`** as a second argument (instead of mutating a module-level copy in the background script) and returns **`{ versionedData, firstTimeState }`** so `WITH_STATE` fixture overrides are explicit. **`initialize`** destructures `versionedData` and passes spread **`rawFirstTimeState`** into the loader.
> 
> The extracted code adds **`validateVersionedData`**, a shared **`getFirstTimeInfo`** helper for migration Sentry tags, and documents **`platformSplitStateGradualRolloutAttempted`** on **`MetaData`** in `base-store.ts`. **Unit tests** cover normal load, backup restore, storageKind defaults, split-state rollout, fresh install, and `WITH_STATE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8584d8458bfc1e0a5b455545093f126a767189c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->