### PR TITLE
fix(confirmations): fail closed enforced simulations cp-13.47.0

### DIFF
--- a/app/scripts/lib/transaction/hooks/enforce-simulation-hook.test.ts
+++ b/app/scripts/lib/transaction/hooks/enforce-simulation-hook.test.ts
@@ -9,10 +9,12 @@ import {
   Messenger,
   MockAnyNamespace,
 } from '@metamask/messenger';
+import { accountSupports7702 } from '../../account-supports-7702';
 import { TransactionControllerInitMessenger } from '../../../wallet-init/messengers/transaction-controller-messenger';
 import { applyTransactionContainers } from '../containers/util';
 import { EnforceSimulationHook } from './enforce-simulation-hook';
 
+jest.mock('../../account-supports-7702');
 jest.mock('../containers/util');
 
 const BALANCE_CHANGE_MOCK = {
@@ -56,6 +58,7 @@ describe('EnforceSimulationHook', () => {
     jest.resetAllMocks();
 
     isEligibleMock.mockReturnValue(true);
+    jest.mocked(accountSupports7702).mockResolvedValue(true);
 
     applyTransactionContainersMock.mockResolvedValue({
       updateTransaction: jest.fn(),
@@ -106,6 +109,31 @@ describe('EnforceSimulationHook', () => {
     );
   });
 
+  it('fails closed when the UI has not initialized container types', async () => {
+    const updateTransactionMock = jest.fn();
+
+    applyTransactionContainersMock.mockResolvedValue({
+      enforcedSimulationsSlippage: 2.5,
+      updateTransaction: updateTransactionMock,
+    });
+
+    const hook = new EnforceSimulationHook({
+      messenger,
+      isEligible: isEligibleMock,
+    }).getBeforeSignHook();
+
+    const { updateTransaction } =
+      (await hook({ transactionMeta: TRANSACTION_META_MOCK })) ?? {};
+
+    expect(updateTransaction).toBe(updateTransactionMock);
+    expect(applyTransactionContainersMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isApproved: true,
+        types: [TransactionContainerType.EnforcedSimulations],
+      }),
+    );
+  });
+
   describe('does nothing if', () => {
     it('not eligible', async () => {
       isEligibleMock.mockReturnValue(false);
@@ -123,7 +151,9 @@ describe('EnforceSimulationHook', () => {
       expect(result).toEqual({});
     });
 
-    it('no container types set', async () => {
+    it('container types are unset for an unsupported account', async () => {
+      jest.mocked(accountSupports7702).mockResolvedValue(false);
+
       const hook = new EnforceSimulationHook({
         messenger,
         isEligible: isEligibleMock,

--- a/app/scripts/lib/transaction/hooks/enforce-simulation-hook.ts
+++ b/app/scripts/lib/transaction/hooks/enforce-simulation-hook.ts
@@ -4,6 +4,7 @@ import {
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import { createProjectLogger } from '@metamask/utils';
+import { accountSupports7702 } from '../../account-supports-7702';
 import { TransactionControllerInitMessenger } from '../../../wallet-init/messengers/transaction-controller-messenger';
 import { applyTransactionContainers } from '../containers/util';
 
@@ -40,12 +41,26 @@ export class EnforceSimulationHook {
       return {};
     }
 
-    if (!containerTypes) {
-      log('Skipping as no container types set');
+    // The confirmation UI normally initializes containerTypes before the user
+    // confirms. If confirmation wins that race, fail closed rather than
+    // silently signing an eligible transaction without enforcement. Preserve
+    // the UI's hardware-wallet exclusion when no explicit selection exists.
+    const canApplyDefault =
+      containerTypes !== undefined ||
+      (await accountSupports7702(
+        transactionMeta.txParams.from,
+        this.#messenger,
+      ));
+    if (!canApplyDefault) {
+      log('Skipping as account does not support EIP-7702');
       return {};
     }
 
-    const hasEnforcedSimulations = containerTypes.includes(
+    const effectiveContainerTypes = containerTypes ?? [
+      TransactionContainerType.EnforcedSimulations,
+    ];
+
+    const hasEnforcedSimulations = effectiveContainerTypes.includes(
       TransactionContainerType.EnforcedSimulations,
     );
 
@@ -63,7 +78,7 @@ export class EnforceSimulationHook {
       isApproved: true,
       messenger: this.#messenger,
       transactionMeta,
-      types: containerTypes,
+      types: effectiveContainerTypes,
     });
 
     return {

--- a/app/scripts/lib/transaction/hooks/index.test.ts
+++ b/app/scripts/lib/transaction/hooks/index.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@metamask/transaction-controller';
 import { TransactionPayPublishHook } from '@metamask/transaction-pay-controller';
 import { TransactionControllerInitMessenger } from '../../../wallet-init/messengers/transaction-controller-messenger';
+import * as enforcedSimulationsModule from '../../../../../shared/lib/transaction/enforced-simulations';
 import * as smartTransactionsModule from '../../smart-transaction/smart-transactions';
 import * as sentinelApiModule from '../sentinel-api';
 import { Delegation7702PublishHook } from './delegation-7702-publish';
@@ -177,6 +178,75 @@ describe('Transaction Controller Hooks', () => {
         }),
       );
       expect(beforeSign).toBe(expectedHook);
+    });
+
+    it('uses the shared UI eligibility check with current background state', () => {
+      const addressSecurityAlertResponses = {
+        '0x1:0xrecipient': {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          result_type: 'Loading',
+          label: '',
+          timestamp: Date.now(),
+        },
+      };
+      const messenger = buildMockMessenger();
+      (messenger.call as jest.Mock).mockImplementation((action: string) => {
+        if (action === 'AppStateController:getState') {
+          return { addressSecurityAlertResponses };
+        }
+        if (action === 'RemoteFeatureFlagController:getState') {
+          return {
+            remoteFeatureFlags: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              confirmations_enforced_simulations: { enabled: true },
+            },
+          };
+        }
+        if (action === 'AccountsController:getState') {
+          return { internalAccounts: { accounts: {} } };
+        }
+        return undefined;
+      });
+      const eligibilitySpy = jest
+        .spyOn(enforcedSimulationsModule, 'isEnforcedSimulationsEligible')
+        .mockReturnValue(true);
+
+      getTransactionControllerHooks(buildMockRequest({ messenger }));
+
+      const { isEligible } = jest.mocked(EnforceSimulationHook).mock
+        .calls[0][0];
+      expect(isEligible(mockTransactionMeta)).toBe(true);
+      expect(eligibilitySpy).toHaveBeenCalledWith(mockTransactionMeta, {
+        addressSecurityAlertResponses,
+        eip7702SupportedChains: [],
+        internalAddresses: [],
+      });
+      eligibilitySpy.mockRestore();
+    });
+
+    it('skips the shared eligibility check when the feature is disabled', () => {
+      const messenger = buildMockMessenger();
+      (messenger.call as jest.Mock).mockImplementation((action: string) => {
+        if (action === 'AppStateController:getState') {
+          return { addressSecurityAlertResponses: {} };
+        }
+        if (action === 'RemoteFeatureFlagController:getState') {
+          return { remoteFeatureFlags: {} };
+        }
+        return undefined;
+      });
+      const eligibilitySpy = jest.spyOn(
+        enforcedSimulationsModule,
+        'isEnforcedSimulationsEligible',
+      );
+
+      getTransactionControllerHooks(buildMockRequest({ messenger }));
+
+      const { isEligible } = jest.mocked(EnforceSimulationHook).mock
+        .calls[0][0];
+      expect(isEligible(mockTransactionMeta)).toBe(false);
+      expect(eligibilitySpy).not.toHaveBeenCalled();
+      eligibilitySpy.mockRestore();
     });
   });
 

--- a/app/scripts/lib/transaction/hooks/index.ts
+++ b/app/scripts/lib/transaction/hooks/index.ts
@@ -18,7 +18,9 @@ import { AccountOverviewTabKey } from '../../../../../shared/constants/app-state
 import { getEip7702SupportedChains } from '../../../../../shared/lib/eip7702-support-utils';
 import {
   getInternalEvmAddresses,
+  getIsEnforcedSimulationsEnabled,
   isEnforcedSimulationsEligible,
+  isEnforcedSimulationsForceEnabled,
 } from '../../../../../shared/lib/transaction/enforced-simulations';
 import { TransactionMetricsRequest } from '../../../../../shared/types/metametrics';
 import { accountSupports7702ForRelay } from '../../account-supports-7702';
@@ -95,6 +97,13 @@ function beforeSignHook({ messenger }: TransactionControllerHookRequest) {
       const featureFlagState = messenger.call(
         'RemoteFeatureFlagController:getState',
       );
+
+      if (
+        !getIsEnforcedSimulationsEnabled(featureFlagState) &&
+        !isEnforcedSimulationsForceEnabled()
+      ) {
+        return false;
+      }
 
       const {
         internalAccounts: { accounts },

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -143,7 +143,12 @@ describe('enforced-simulations', () => {
       delete process.env.FORCE_ENFORCED_SIMULATIONS;
     });
 
-    for (const resultType of [ResultType.Warning, ResultType.Malicious]) {
+    for (const resultType of [
+      ResultType.ErrorResult,
+      ResultType.Loading,
+      ResultType.Warning,
+      ResultType.Malicious,
+    ]) {
       it(`returns true for a ${resultType} trust signal`, () => {
         expect(
           isEnforcedSimulationsDefaultEnabled(
@@ -154,12 +159,7 @@ describe('enforced-simulations', () => {
       });
     }
 
-    for (const resultType of [
-      ResultType.Benign,
-      ResultType.Trusted,
-      ResultType.ErrorResult,
-      ResultType.Loading,
-    ]) {
+    for (const resultType of [ResultType.Benign, ResultType.Trusted]) {
       it(`returns false for a ${resultType} trust signal`, () => {
         expect(
           isEnforcedSimulationsDefaultEnabled(
@@ -208,6 +208,16 @@ describe('enforced-simulations', () => {
       ).toBe(false);
     });
 
+    it('returns true when a relevant recipient has no cached verdict', () => {
+      expect(
+        isEnforcedSimulationsDefaultEnabled(BASE_TRANSACTION_META, {
+          addressSecurityAlertResponses: {},
+          eip7702SupportedChains: [ETHEREUM_CHAIN_ID],
+          internalAddresses: [],
+        }),
+      ).toBe(true);
+    });
+
     it('returns true when enforced simulations are force enabled', () => {
       process.env.FORCE_ENFORCED_SIMULATIONS = 'true';
 
@@ -239,6 +249,16 @@ describe('enforced-simulations', () => {
             [NESTED_ADDRESS_A]: ResultType.Loading,
           }),
         ),
+      ).toBe(true);
+    });
+
+    it('returns true when a relevant recipient has no cached verdict', () => {
+      expect(
+        hasPendingEnforcedSimulationsTrustSignals(BASE_TRANSACTION_META, {
+          addressSecurityAlertResponses: {},
+          eip7702SupportedChains: [ETHEREUM_CHAIN_ID],
+          internalAddresses: [],
+        }),
       ).toBe(true);
     });
 
@@ -685,23 +705,23 @@ describe('enforced-simulations', () => {
         ).toBe(false);
       });
 
-      it('returns false when trust signal is still loading', () => {
+      it('returns true when trust signal is still loading', () => {
         expect(
           isEnforcedSimulationsEligible(
             BASE_TRANSACTION_META,
             buildState(ResultType.Loading),
           ),
-        ).toBe(false);
+        ).toBe(true);
       });
 
-      it('returns false when no cache entry exists', () => {
+      it('returns true when no cache entry exists', () => {
         expect(
           isEnforcedSimulationsEligible(BASE_TRANSACTION_META, {
             addressSecurityAlertResponses: {},
             eip7702SupportedChains: [ETHEREUM_CHAIN_ID],
             internalAddresses: [],
           }),
-        ).toBe(false);
+        ).toBe(true);
       });
 
       it('returns false when the chain is not address-scan supported even with a non-trusted cached result', () => {
@@ -766,7 +786,7 @@ describe('enforced-simulations', () => {
         ).toBe(false);
       });
 
-      it('exempts a chain with no slug mapping when the recipient has never been scanned', () => {
+      it('enforces on a supported chain when the recipient has never been scanned', () => {
         expect(
           isEnforcedSimulationsEligible(
             {
@@ -779,7 +799,7 @@ describe('enforced-simulations', () => {
               internalAddresses: [],
             },
           ),
-        ).toBe(false);
+        ).toBe(true);
       });
 
       it('still enforces when the cached verdict is ErrorResult on an address-scan supported chain', () => {
@@ -990,7 +1010,7 @@ describe('enforced-simulations', () => {
         ).toBe(false);
       });
 
-      it('returns false when nested addresses are all loading', () => {
+      it('returns true when nested addresses are all loading', () => {
         expect(
           isEnforcedSimulationsEligible(
             {
@@ -1006,7 +1026,40 @@ describe('enforced-simulations', () => {
               [NESTED_ADDRESS_B]: ResultType.Loading,
             }),
           ),
-        ).toBe(false);
+        ).toBe(true);
+      });
+
+      it('returns true when a trusted recipient has a loading nested recipient', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              nestedTransactions: [
+                { to: NESTED_ADDRESS_A as `0x${string}`, data: '0xabcd' },
+              ],
+            },
+            buildStateForAddresses({
+              [TO_ADDRESS]: ResultType.Trusted,
+              [NESTED_ADDRESS_A]: ResultType.Loading,
+            }),
+          ),
+        ).toBe(true);
+      });
+
+      it('returns true when a trusted recipient has an uncached nested recipient', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              nestedTransactions: [
+                { to: NESTED_ADDRESS_A as `0x${string}`, data: '0xabcd' },
+              ],
+            },
+            buildStateForAddresses({
+              [TO_ADDRESS]: ResultType.Trusted,
+            }),
+          ),
+        ).toBe(true);
       });
 
       it('returns true with mix of trusted and untrusted nested addresses', () => {

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -137,12 +137,13 @@ export function getEnforcedSimulationsSlippageBasisPoints(
  * Also requires that Blockaid address screening supports the chain. On
  * unsupported chains, `scanAddress` returns Error without hitting the API;
  * that must not turn enforcement on. Then requires that at least one
- * recipient address is loaded and not trusted, based on cached trust signal
- * scan results keyed by chain and address. A recipient with no cache entry,
- * or one still loading, does not disqualify the transaction; only a cached
- * non-Trusted verdict does. Callers that persist a trust-dependent default
- * must separately wait for pending signals via
- * {@link hasPendingEnforcedSimulationsTrustSignals}.
+ * recipient address is not confirmed as trusted, based on cached trust signal
+ * scan results keyed by chain and address. Missing and Loading verdicts fail
+ * closed so confirming during an asynchronous scan cannot remove enforcement.
+ *
+ * Re-simulation drift checks compare snapshots from the same simulation
+ * provider. They are not an independent defense against execution-time
+ * divergence and do not replace this eligibility gate.
  *
  * @param transactionMeta - The transaction metadata.
  * @param state - Trust signal state and EIP-7702 supported chains.
@@ -202,8 +203,10 @@ export function isEnforcedSimulationsEligible(
  * simulations enabled by default.
  *
  * Enforced simulations are enabled by default when at least one relevant
- * recipient has a Warning or Malicious trust signal. Force-enabled
- * transactions keep the existing enabled-by-default behavior.
+ * recipient has a Warning, Malicious, or Error trust signal, or when its
+ * verdict is missing or still Loading. This fail-closed default keeps
+ * enforcement active unless every relevant verdict is Trusted or Benign.
+ * Force-enabled transactions keep the existing enabled-by-default behavior.
  *
  * @param transactionMeta - The transaction metadata.
  * @param state - Trust signal state and EIP-7702 supported chains.
@@ -219,7 +222,10 @@ export function isEnforcedSimulationsDefaultEnabled(
 
   return getRelevantTrustSignalResults(transactionMeta, state).some(
     (resultType) =>
-      resultType === ResultType.Warning || resultType === ResultType.Malicious,
+      resultType === ResultType.Loading ||
+      resultType === ResultType.ErrorResult ||
+      resultType === ResultType.Warning ||
+      resultType === ResultType.Malicious,
   );
 }
 
@@ -228,7 +234,7 @@ export function isEnforcedSimulationsDefaultEnabled(
  *
  * @param transactionMeta - The transaction metadata.
  * @param state - Trust signal state and EIP-7702 supported chains.
- * @returns Whether a relevant recipient trust signal is still loading.
+ * @returns Whether a relevant recipient trust signal is missing or loading.
  */
 export function hasPendingEnforcedSimulationsTrustSignals(
   transactionMeta: TransactionMeta,
@@ -255,9 +261,9 @@ function isTrusted(
   transactionMeta: TransactionMeta,
   state: EnforcedSimulationsState,
 ): boolean {
-  return getRelevantTrustSignalResults(transactionMeta, state)
-    .filter((resultType) => resultType !== ResultType.Loading)
-    .every((resultType) => resultType === ResultType.Trusted);
+  return getRelevantTrustSignalResults(transactionMeta, state).every(
+    (resultType) => resultType === ResultType.Trusted,
+  );
 }
 
 function getRelevantTrustSignalResults(
@@ -267,18 +273,17 @@ function getRelevantTrustSignalResults(
   const { chainId, type, txParams, txParamsOriginal, nestedTransactions } =
     transactionMeta;
 
-  // Trust verdicts are cache-driven. Only a cached non-Trusted verdict
-  // disqualifies a recipient. Unsupported chains are excluded earlier in
-  // isEnforcedSimulationsEligible, so an ErrorResult here is a scan failure
+  // Trust verdicts are cache-driven. Unsupported chains are excluded earlier
+  // in isEnforcedSimulationsEligible, so an ErrorResult here is a scan failure
   // on a supported chain (timeout / API error), not "this chain isn't
   // supported".
   //
-  // Recipients that no scan path covers stay cache misses and are treated as
-  // trusted here. The trust-signals middleware scans dapp `eth_sendTransaction`
-  // and `wallet_sendCalls` requests (including each nested call's `to`), but
-  // nothing is scanned when the user has security alerts disabled, and the
-  // outer batch target (`txParamsOriginal.to`, the upgraded EOA for a 7702
-  // batch) is never scanned, so its cache miss never disqualifies.
+  // The trust-signals middleware scans dapp `eth_sendTransaction` and
+  // `wallet_sendCalls` requests (including each nested call's `to`). A cache
+  // miss can still occur while state propagates, when security alerts are
+  // disabled, or when a scan path does not cover a recipient. Represent these
+  // unresolved verdicts as Loading so eligibility and its fail-closed default
+  // remain consistent in both the UI and the before-sign hook.
   if (!chainId) {
     return [];
   }
@@ -317,14 +322,14 @@ function getRelevantTrustSignalResults(
     const cached =
       state.addressSecurityAlertResponses[createCacheKey(chainId, to)];
 
-    // Unknown or still-loading signals don't make a call untrusted.
     if (!cached) {
-      log(`${label} - Trusted - Unknown Signal`, props);
+      log(`${label} - Not Trusted - Unknown Signal`, props);
+      resultTypes.push(ResultType.Loading);
       continue;
     }
 
     if (cached.result_type === ResultType.Loading) {
-      log(`${label} - Trusted - Loading Signal`, props);
+      log(`${label} - Not Trusted - Loading Signal`, props);
       resultTypes.push(cached.result_type);
       continue;
     }

--- a/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.test.tsx
@@ -204,36 +204,12 @@ describe('EnforcedSimulationsRow', () => {
     consoleError.mockRestore();
   });
 
-  it('waits for pending trust signals before initializing the default', async () => {
-    function RerenderableRow() {
-      const [, setRenderCount] = React.useState(0);
-
-      return (
-        <>
-          <button
-            data-testid="settle-trust-signals"
-            onClick={() => setRenderCount((count) => count + 1)}
-          />
-          <EnforcedSimulationsRow />
-        </>
-      );
-    }
-
-    const { getByTestId } = render({
-      isDefaultEnabled: false,
+  it('enables enforcement while trust signals are pending', async () => {
+    render({
+      isDefaultEnabled: true,
       hasPendingTrustSignals: true,
       containerTypes: undefined,
-      component: <RerenderableRow />,
     });
-
-    expect(applyTransactionContainersExisting).not.toHaveBeenCalled();
-
-    useEnforcedSimulationsEligibilityMock.mockReturnValue({
-      isEligible: true,
-      isDefaultEnabled: true,
-      hasPendingTrustSignals: false,
-    });
-    fireEvent.click(getByTestId('settle-trust-signals'));
 
     await waitFor(() => {
       expect(applyTransactionContainersExisting).toHaveBeenCalledTimes(1);
@@ -241,6 +217,18 @@ describe('EnforcedSimulationsRow', () => {
         expect.any(String),
         [TransactionContainerType.EnforcedSimulations],
       );
+    });
+  });
+
+  it('disables the enforcement toggle while trust signals are pending', async () => {
+    const { getByTestId } = render({
+      isDefaultEnabled: true,
+      hasPendingTrustSignals: true,
+      containerTypes: [TransactionContainerType.EnforcedSimulations],
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('enforced-simulations-toggle-input')).toBeDisabled();
     });
   });
 

--- a/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.tsx
+++ b/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.tsx
@@ -66,13 +66,7 @@ export function EnforcedSimulationsRow() {
   }
 
   useEffect(() => {
-    if (
-      isUnavailable ||
-      !isEligible ||
-      hasPendingTrustSignals ||
-      hasInitialized ||
-      !transactionId
-    ) {
+    if (isUnavailable || !isEligible || hasInitialized || !transactionId) {
       return;
     }
 
@@ -124,7 +118,6 @@ export function EnforcedSimulationsRow() {
   }, [
     currentConfirmation,
     isEligible,
-    hasPendingTrustSignals,
     hasInitialized,
     isDefaultEnabled,
     transactionId,
@@ -192,6 +185,7 @@ export function EnforcedSimulationsRow() {
 
         <EnforcedSimulationsCheckbox
           isEnabled={Boolean(hasEnforcedSimulations)}
+          isDisabled={hasPendingTrustSignals}
           containerTypes={containerTypes}
           transactionId={transactionId as string}
           onAppliedSlippage={handleAppliedSlippage}
@@ -205,11 +199,13 @@ export function EnforcedSimulationsRow() {
 
 function EnforcedSimulationsCheckbox({
   isEnabled,
+  isDisabled,
   containerTypes,
   transactionId,
   onAppliedSlippage,
 }: Readonly<{
   isEnabled: boolean;
+  isDisabled: boolean;
   containerTypes?: TransactionContainerType[];
   transactionId: string;
   onAppliedSlippage: (slippage: number | undefined) => void;
@@ -270,6 +266,7 @@ function EnforcedSimulationsCheckbox({
       id="enforced-simulations-toggle"
       data-testid="enforced-simulations-toggle"
       isSelected={isEnabled}
+      isDisabled={isDisabled}
       onChange={() => handleToggle()}
       inputProps={{ 'data-testid': 'enforced-simulations-toggle-input' }}
     />

--- a/ui/pages/confirmations/hooks/useEnforcedSimulationsEligibility.test.ts
+++ b/ui/pages/confirmations/hooks/useEnforcedSimulationsEligibility.test.ts
@@ -103,7 +103,7 @@ describe('useEnforcedSimulationsEligibility', () => {
     });
   });
 
-  it('defers the default check while a relevant trust signal is pending', () => {
+  it('keeps the fail-closed default enabled while a relevant trust signal is pending', () => {
     expect(
       runHook({
         eligible: true,
@@ -112,10 +112,10 @@ describe('useEnforcedSimulationsEligibility', () => {
       }),
     ).toStrictEqual({
       isEligible: true,
-      isDefaultEnabled: false,
+      isDefaultEnabled: true,
       hasPendingTrustSignals: true,
     });
-    expect(isEnforcedSimulationsDefaultEnabledMock).not.toHaveBeenCalled();
+    expect(isEnforcedSimulationsDefaultEnabledMock).toHaveBeenCalled();
   });
 
   it('returns both values false and skips the default check when not eligible', () => {

--- a/ui/pages/confirmations/hooks/useEnforcedSimulationsEligibility.ts
+++ b/ui/pages/confirmations/hooks/useEnforcedSimulationsEligibility.ts
@@ -85,7 +85,6 @@ export function useEnforcedSimulationsEligibility(): {
     isEligible,
     isDefaultEnabled:
       isEligible &&
-      !hasPendingTrustSignals &&
       isEnforcedSimulationsDefaultEnabled(
         currentConfirmation,
         enforcedSimulationsState,


### PR DESCRIPTION
## **Description**

Enforced simulations treated missing or still-loading address-security verdicts as trusted. During that asynchronous scan window, the confirmation UI could leave transaction containers uninitialized and the before-sign hook could silently skip the enforcement wrapper.

This change makes unresolved and degraded verdicts fail closed:

- Missing, `Loading`, and scan-error verdicts remain eligible and default to enforced simulations.
- The confirmation row initializes Added protection immediately and prevents it from being disabled while trust signals are pending.
- The before-sign hook applies enforcement if confirmation wins the UI initialization race, while preserving feature-flag and hardware-wallet exclusions.
- UI and background eligibility continue to use the same shared predicate.
- Nested recipient regressions cover loading and uncached verdicts.

The eligibility documentation also clarifies that re-simulation snapshots use the same simulation provider and are not an independent defense against execution-time divergence.

Related context: https://github.com/MetaMask/metamask-extension/pull/45962#discussion_r3922126083

## **Changelog**

CHANGELOG entry: Fixed enforced simulation protection remaining active while address security checks complete

## **Related issues**

Fixes MetaMask/MetaMask-planning#7589

## **Manual testing steps**

1. Enable the `confirmations_enforced_simulations` remote feature flag and Security Alerts on an EIP-7702-supported network. Do not use `FORCE_ENFORCED_SIMULATIONS`.
2. From a connected dapp, submit a contract interaction and delay its address-security scan so its cached verdict remains `Loading`.
3. Verify Added protection initializes enabled, its toggle is disabled while the verdict is pending, and the confirmation button remains available.
4. Confirm immediately and verify the submitted transaction is routed through the DeleGator enforcement wrapper rather than directly to the target contract.
5. Repeat with `wallet_sendCalls`, delaying or omitting one nested recipient verdict, and verify Added protection remains enabled.
6. Allow all verdicts to settle and verify the toggle becomes interactive for the settled transaction.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
