### PR TITLE
fix(ramps): select available browser provider and center amount input

### DIFF
--- a/ui/hooks/ramps/utils/determinePreferredProvider.test.ts
+++ b/ui/hooks/ramps/utils/determinePreferredProvider.test.ts
@@ -31,6 +31,15 @@ describe('determinePreferredProvider', () => {
     });
   });
 
+  it('auto-selects the first provider when Transak is unavailable', () => {
+    const result = determinePreferredProvider([], [moonpayProvider]);
+
+    expect(result).toEqual({
+      provider: moonpayProvider,
+      autoSelected: true,
+    });
+  });
+
   it('prefers the most recent completed order provider without auto-selecting', () => {
     const result = determinePreferredProvider(
       [{ providerId: 'moonpay', completedAt: 1000 }],

--- a/ui/hooks/ramps/utils/determinePreferredProvider.ts
+++ b/ui/hooks/ramps/utils/determinePreferredProvider.ts
@@ -57,5 +57,5 @@ export function determinePreferredProvider(
     return { provider: transakProvider, autoSelected: true };
   }
 
-  return null;
+  return { provider: providers[0], autoSelected: true };
 }

--- a/ui/pages/ramps/build-quote/__snapshots__/build-quote.test.tsx.snap
+++ b/ui/pages/ramps/build-quote/__snapshots__/build-quote.test.tsx.snap
@@ -51,15 +51,24 @@ exports[`RampsBuildQuoteScreen matches snapshot after user edits amount before r
           >
             GBP
           </span>
-          <input
-            aria-label="Amount"
-            class="min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-default"
-            data-testid="ramps-build-quote-amount-input"
-            inputmode="decimal"
-            size="2"
-            type="text"
-            value="25"
-          />
+          <span
+            class="relative w-max min-w-[1ch]"
+          >
+            <span
+              aria-hidden="true"
+              class="block invisible min-w-[1ch] whitespace-pre text-[56px] font-normal leading-none text-default"
+            >
+              25
+            </span>
+            <input
+              aria-label="Amount"
+              class="absolute inset-0 min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-default"
+              data-testid="ramps-build-quote-amount-input"
+              inputmode="decimal"
+              type="text"
+              value="25"
+            />
+          </span>
         </div>
         <button
           class="justify-center font-medium text-default overflow-hidden relative transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] inline-flex items-center gap-2 rounded-full bg-background-alternative px-3 py-2 min-w-0 h-auto hover:bg-hover active:bg-pressed"
@@ -740,15 +749,24 @@ exports[`RampsBuildQuoteScreen matches snapshot when falling back without region
           >
             $
           </span>
-          <input
-            aria-label="Amount"
-            class="min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-default"
-            data-testid="ramps-build-quote-amount-input"
-            inputmode="decimal"
-            size="3"
-            type="text"
-            value="100"
-          />
+          <span
+            class="relative w-max min-w-[1ch]"
+          >
+            <span
+              aria-hidden="true"
+              class="block invisible min-w-[1ch] whitespace-pre text-[56px] font-normal leading-none text-default"
+            >
+              100
+            </span>
+            <input
+              aria-label="Amount"
+              class="absolute inset-0 min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-default"
+              data-testid="ramps-build-quote-amount-input"
+              inputmode="decimal"
+              type="text"
+              value="100"
+            />
+          </span>
         </div>
         <button
           class="justify-center font-medium text-default overflow-hidden relative transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] inline-flex items-center gap-2 rounded-full bg-background-alternative px-3 py-2 min-w-0 h-auto hover:bg-hover active:bg-pressed"
@@ -863,15 +881,24 @@ exports[`RampsBuildQuoteScreen matches snapshot when quote fetch fails 1`] = `
           >
             $
           </span>
-          <input
-            aria-label="Amount"
-            class="min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-error-default"
-            data-testid="ramps-build-quote-amount-input"
-            inputmode="decimal"
-            size="3"
-            type="text"
-            value="100"
-          />
+          <span
+            class="relative w-max min-w-[1ch]"
+          >
+            <span
+              aria-hidden="true"
+              class="block invisible min-w-[1ch] whitespace-pre text-[56px] font-normal leading-none text-error-default"
+            >
+              100
+            </span>
+            <input
+              aria-label="Amount"
+              class="absolute inset-0 min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-error-default"
+              data-testid="ramps-build-quote-amount-input"
+              inputmode="decimal"
+              type="text"
+              value="100"
+            />
+          </span>
         </div>
         <button
           class="justify-center font-medium text-default overflow-hidden relative transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] inline-flex items-center gap-2 rounded-full bg-background-alternative px-3 py-2 min-w-0 h-auto hover:bg-hover active:bg-pressed"
@@ -995,15 +1022,24 @@ exports[`RampsBuildQuoteScreen matches snapshot when quote is available 1`] = `
           >
             $
           </span>
-          <input
-            aria-label="Amount"
-            class="min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-default"
-            data-testid="ramps-build-quote-amount-input"
-            inputmode="decimal"
-            size="3"
-            type="text"
-            value="100"
-          />
+          <span
+            class="relative w-max min-w-[1ch]"
+          >
+            <span
+              aria-hidden="true"
+              class="block invisible min-w-[1ch] whitespace-pre text-[56px] font-normal leading-none text-default"
+            >
+              100
+            </span>
+            <input
+              aria-label="Amount"
+              class="absolute inset-0 min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-default"
+              data-testid="ramps-build-quote-amount-input"
+              inputmode="decimal"
+              type="text"
+              value="100"
+            />
+          </span>
         </div>
         <button
           class="justify-center font-medium text-default overflow-hidden relative transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] inline-flex items-center gap-2 rounded-full bg-background-alternative px-3 py-2 min-w-0 h-auto hover:bg-hover active:bg-pressed"
@@ -1118,15 +1154,24 @@ exports[`RampsBuildQuoteScreen matches snapshot while quote is loading 1`] = `
           >
             $
           </span>
-          <input
-            aria-label="Amount"
-            class="min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-default"
-            data-testid="ramps-build-quote-amount-input"
-            inputmode="decimal"
-            size="3"
-            type="text"
-            value="100"
-          />
+          <span
+            class="relative w-max min-w-[1ch]"
+          >
+            <span
+              aria-hidden="true"
+              class="block invisible min-w-[1ch] whitespace-pre text-[56px] font-normal leading-none text-default"
+            >
+              100
+            </span>
+            <input
+              aria-label="Amount"
+              class="absolute inset-0 min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-default"
+              data-testid="ramps-build-quote-amount-input"
+              inputmode="decimal"
+              type="text"
+              value="100"
+            />
+          </span>
         </div>
         <button
           class="justify-center font-medium text-default overflow-hidden relative transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] inline-flex items-center gap-2 rounded-full bg-background-alternative px-3 py-2 min-w-0 h-auto hover:bg-hover active:bg-pressed"
@@ -1558,15 +1603,24 @@ exports[`RampsBuildQuoteScreen matches snapshot with provider quote error 1`] = 
           >
             $
           </span>
-          <input
-            aria-label="Amount"
-            class="min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-error-default"
-            data-testid="ramps-build-quote-amount-input"
-            inputmode="decimal"
-            size="3"
-            type="text"
-            value="100"
-          />
+          <span
+            class="relative w-max min-w-[1ch]"
+          >
+            <span
+              aria-hidden="true"
+              class="block invisible min-w-[1ch] whitespace-pre text-[56px] font-normal leading-none text-error-default"
+            >
+              100
+            </span>
+            <input
+              aria-label="Amount"
+              class="absolute inset-0 min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-error-default"
+              data-testid="ramps-build-quote-amount-input"
+              inputmode="decimal"
+              type="text"
+              value="100"
+            />
+          </span>
         </div>
         <button
           class="justify-center font-medium text-default overflow-hidden relative transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] inline-flex items-center gap-2 rounded-full bg-background-alternative px-3 py-2 min-w-0 h-auto hover:bg-hover active:bg-pressed"
@@ -1690,15 +1744,24 @@ exports[`RampsBuildQuoteScreen matches snapshot with regional default amount 1`]
           >
             GBP
           </span>
-          <input
-            aria-label="Amount"
-            class="min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-default"
-            data-testid="ramps-build-quote-amount-input"
-            inputmode="decimal"
-            size="2"
-            type="text"
-            value="50"
-          />
+          <span
+            class="relative w-max min-w-[1ch]"
+          >
+            <span
+              aria-hidden="true"
+              class="block invisible min-w-[1ch] whitespace-pre text-[56px] font-normal leading-none text-default"
+            >
+              50
+            </span>
+            <input
+              aria-label="Amount"
+              class="absolute inset-0 min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none text-[56px] font-normal leading-none text-default"
+              data-testid="ramps-build-quote-amount-input"
+              inputmode="decimal"
+              type="text"
+              value="50"
+            />
+          </span>
         </div>
         <button
           class="justify-center font-medium text-default overflow-hidden relative transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] inline-flex items-center gap-2 rounded-full bg-background-alternative px-3 py-2 min-w-0 h-auto hover:bg-hover active:bg-pressed"

--- a/ui/pages/ramps/build-quote/build-quote.test.tsx
+++ b/ui/pages/ramps/build-quote/build-quote.test.tsx
@@ -172,6 +172,25 @@ describe('RampsBuildQuoteScreen', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('sizes the amount input from an inaccessible text twin', () => {
+    renderWithProvider(
+      <RampsBuildQuoteScreen />,
+      createStore(),
+      '/ramps/build-quote',
+    );
+
+    const amountInput = screen.getByTestId('ramps-build-quote-amount-input');
+    const amountSizeContainer = amountInput.parentElement;
+    const amountSizeTwin = amountSizeContainer?.querySelector(
+      '[aria-hidden="true"]',
+    );
+
+    expect(amountSizeContainer).toHaveClass('relative', 'w-max', 'min-w-[1ch]');
+    expect(amountSizeTwin).toHaveTextContent('100');
+    expect(amountInput).toHaveClass('absolute', 'inset-0');
+    expect(amountInput).not.toHaveAttribute('size');
+  });
+
   it('matches snapshot while quote is loading', () => {
     useRampsQuotes.mockReturnValue({
       data: null,

--- a/ui/pages/ramps/build-quote/components/ramps-build-quote-view.tsx
+++ b/ui/pages/ramps/build-quote/components/ramps-build-quote-view.tsx
@@ -64,16 +64,24 @@ export default function RampsBuildQuoteView({
             alignItems={BoxAlignItems.Center}
           >
             <span className={amountTextClassName}>{currencySymbol}</span>
-            <input
-              aria-label={t('amount')}
-              className={`min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none ${amountTextClassName}`}
-              data-testid="ramps-build-quote-amount-input"
-              inputMode="decimal"
-              onChange={handleAmountChange}
-              size={Math.max(amount.length, 1)}
-              type="text"
-              value={amount}
-            />
+            {/* The hidden amount sets an exact cross-browser input width. */}
+            <span className="relative w-max min-w-[1ch]">
+              <span
+                aria-hidden="true"
+                className={`block invisible min-w-[1ch] whitespace-pre ${amountTextClassName}`}
+              >
+                {amount || '0'}
+              </span>
+              <input
+                aria-label={t('amount')}
+                className={`absolute inset-0 min-w-[1ch] max-w-full border-0 bg-transparent p-0 text-left outline-none ${amountTextClassName}`}
+                data-testid="ramps-build-quote-amount-input"
+                inputMode="decimal"
+                onChange={handleAmountChange}
+                type="text"
+                value={amount}
+              />
+            </span>
           </Box>
 
           <RampsPaymentMethodPill


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updated the Ramps build-quote flow to select an available browser provider reliably. The flow now reuses the provider from the user's most recent completed order when it is still available, otherwise defaults to Transak when available and falls back to the first available provider. The amount input is also centered consistently with its currency symbol, using a hidden text twin to maintain the exact input width across browsers. The change preserves the provider status in the quote UI and keeps checkout handling covered for provider redirects and missing widget URLs.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Ramps provider selection and improved amount input alignment in the buy flow.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/45993

## **Manual testing steps**

1. Open the Ramps buy flow and navigate to the build-quote amount screen.
2. Confirm that an available provider is selected and displayed in the provider status label.
3. Enter a purchase amount and confirm that the Continue button remains disabled until the quote is available.
4. Select a payment method, continue with a valid quote, and verify that the provider checkout opens and the extension returns to the home screen.
5. Verify that redirect-only checkouts without an order code are watched successfully and that a checkout response without a URL displays an error without navigating home.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- TODO: Add a screenshot or recording showing the provider-selection issue before this change. -->

<img width="779" height="1137" alt="645549167-ec7590f8-3dc9-4802-9cf8-e00b009022fd" src="https://github.com/user-attachments/assets/6a3e3609-6a0d-40e9-b312-1f36a065c3ae" />

### **After**

<!-- TODO: Add a screenshot or recording showing the corrected provider selection and checkout flow. -->

https://github.com/user-attachments/assets/30389b99-1509-4e6a-b969-9cee48e66772


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Provider auto-selection now picks the first listed provider when Transak is absent, which affects which ramp checkout opens but is scoped and covered by unit tests.
> 
> **Overview**
> Fixes Ramps buy flow when **Transak is not in the provider list** by changing `determinePreferredProvider` to **auto-select the first available provider** (still `null` only when the list is empty), instead of leaving no selection. Order-history and Transak-first behavior are unchanged.
> 
> On the build-quote screen, the **amount field** no longer uses the HTML `size` attribute. It uses an **invisible `aria-hidden` text twin** with the same typography so the input width tracks the displayed amount consistently across browsers and stays aligned with the currency symbol.
> 
> Tests cover the new provider fallback and the twin-based input layout; snapshots reflect the updated markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36cd48353f67461d50668bec2f0c513e01b1d375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->