### PR TITLE
chore: move createDefiReferralMiddleware.ts ownership to core-extension-ux

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,6 +150,7 @@ ui/pages/details/templates/ramps/               @MetaMask/money-movement
 ui/pages/permissions-connect/                   @MetaMask/core-extension-ux
 ui/pages/settings                               @MetaMask/core-extension-ux
 ui/components/multichain/                       @MetaMask/core-extension-ux
+app/scripts/lib/defi-referrals/createDefiReferralMiddleware.ts @MetaMask/core-extension-ux
 ui/pages/settings/notifications-tab/**          @MetaMask/core-extension-ux @MetaMask/engagement
 ui/components/multichain/notification*/**       @MetaMask/core-extension-ux @MetaMask/engagement
 ui/components/multichain/notifications*/**      @MetaMask/core-extension-ux @MetaMask/engagement
@@ -250,7 +251,6 @@ test/e2e/benchmarks/utils/thresholds.ts                               @MetaMask/
 # Wallet Integrations
 test/e2e/page-objects/benchmark                                       @MetaMask/core-platform
 test/e2e/playwright/benchmark                                         @MetaMask/core-platform
-app/scripts/lib/defi-referrals/createDefiReferralMiddleware.ts        @MetaMask/core-extension-ux
 app/scripts/lib/rpc-method-middleware                                 @MetaMask/core-platform
 shared/lib/caip25-caveat-merger.ts                                    @MetaMask/core-platform
 test/e2e/flask/multichain-api                                         @MetaMask/core-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -250,7 +250,7 @@ test/e2e/benchmarks/utils/thresholds.ts                               @MetaMask/
 # Wallet Integrations
 test/e2e/page-objects/benchmark                                       @MetaMask/core-platform
 test/e2e/playwright/benchmark                                         @MetaMask/core-platform
-app/scripts/lib/defi-referrals/createDefiReferralMiddleware.ts        @MetaMask/core-platform
+app/scripts/lib/defi-referrals/createDefiReferralMiddleware.ts        @MetaMask/core-extension-ux
 app/scripts/lib/rpc-method-middleware                                 @MetaMask/core-platform
 shared/lib/caip25-caveat-merger.ts                                    @MetaMask/core-platform
 test/e2e/flask/multichain-api                                         @MetaMask/core-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -137,23 +137,23 @@ app/scripts/metamask-controller.js              @MetaMask/extension-platform @Me
 ui/components/app/metamask-template-renderer @MetaMask/confirmations @MetaMask/core-platform
 
 # Core Extension UX
-ui/components/app/import-token                  @MetaMask/core-extension-ux
-ui/components/app/toast-listener                @MetaMask/core-extension-ux
-ui/components/ui/toast                          @MetaMask/core-extension-ux
-ui/css                                          @MetaMask/core-extension-ux
-shared/lib/activity                             @MetaMask/core-extension-ux
-ui/pages/home                                   @MetaMask/core-extension-ux
-ui/pages/activity                               @MetaMask/core-extension-ux
-ui/pages/core                                   @MetaMask/core-extension-ux
-ui/pages/details                                @MetaMask/core-extension-ux
-ui/pages/details/templates/ramps/               @MetaMask/money-movement
-ui/pages/permissions-connect/                   @MetaMask/core-extension-ux
-ui/pages/settings                               @MetaMask/core-extension-ux
-ui/components/multichain/                       @MetaMask/core-extension-ux
+ui/components/app/import-token                                 @MetaMask/core-extension-ux
+ui/components/app/toast-listener                               @MetaMask/core-extension-ux
+ui/components/ui/toast                                         @MetaMask/core-extension-ux
+ui/css                                                         @MetaMask/core-extension-ux
+shared/lib/activity                                            @MetaMask/core-extension-ux
+ui/pages/home                                                  @MetaMask/core-extension-ux
+ui/pages/activity                                              @MetaMask/core-extension-ux
+ui/pages/core                                                  @MetaMask/core-extension-ux
+ui/pages/details                                               @MetaMask/core-extension-ux
+ui/pages/details/templates/ramps/                              @MetaMask/money-movement
+ui/pages/permissions-connect/                                  @MetaMask/core-extension-ux
+ui/pages/settings                                              @MetaMask/core-extension-ux
+ui/components/multichain/                                      @MetaMask/core-extension-ux
 app/scripts/lib/defi-referrals/createDefiReferralMiddleware.ts @MetaMask/core-extension-ux
-ui/pages/settings/notifications-tab/**          @MetaMask/core-extension-ux @MetaMask/engagement
-ui/components/multichain/notification*/**       @MetaMask/core-extension-ux @MetaMask/engagement
-ui/components/multichain/notifications*/**      @MetaMask/core-extension-ux @MetaMask/engagement
+ui/pages/settings/notifications-tab/**                         @MetaMask/core-extension-ux @MetaMask/engagement
+ui/components/multichain/notification*/**                      @MetaMask/core-extension-ux @MetaMask/engagement
+ui/components/multichain/notifications*/**                     @MetaMask/core-extension-ux @MetaMask/engagement
 
 # Co-owned by accounts and core-extension-ux
 ui/components/multichain/multi-srp/              @MetaMask/accounts-engineers @MetaMask/core-extension-ux


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Moves ownership of `app/scripts/lib/defi-referrals/createDefiReferralMiddleware.ts` in `.github/CODEOWNERS` from `@MetaMask/core-platform` to `@MetaMask/core-extension-ux`. Moves a money-movement owned file to their section.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open `.github/CODEOWNERS`.
2. Verify the entry for `app/scripts/lib/defi-referrals/createDefiReferralMiddleware.ts` is now owned by `@MetaMask/core-extension-ux`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/D0AD7VDJ3U0/p1782396245326519?thread_ts=1782396245.326519&cid=D0AD7VDJ3U0)

<div><a href="https://cursor.com/agents/bc-ab8298d6-ee52-5cdd-885e-050cf2aafa34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab8298d6-ee52-5cdd-885e-050cf2aafa34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

