### PR TITLE
feat: add perps home navigation after successful hyperliquid mm prompt deposit

### DIFF
--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
@@ -35,6 +35,7 @@ jest.mock('../../../store/controller-actions/transaction-pay-controller');
 
 const mockUsePerpsHomeRoute = jest.fn(() => PERPS_HOME_PAGE_ROUTE);
 jest.mock('../../../hooks/perps/usePerpsHomeRoute', () => ({
+  ...jest.requireActual('../../../hooks/perps/usePerpsHomeRoute'),
   usePerpsHomeRoute: () => mockUsePerpsHomeRoute(),
 }));
 

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
@@ -4,7 +4,11 @@ import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
-import { CONFIRM_TRANSACTION_ROUTE } from '../../../helpers/constants/routes';
+import {
+  CONFIRM_TRANSACTION_ROUTE,
+  PERPS_HOME_PAGE_ROUTE,
+} from '../../../helpers/constants/routes';
+import { PERPS_HOME_TAB_ROUTE } from '../../../hooks/perps/usePerpsHomeRoute';
 import { updateTransactionPaymentToken } from '../../../store/controller-actions/transaction-pay-controller';
 import { useSendTokens } from '../../../pages/confirmations/hooks/send/useSendTokens';
 import {
@@ -28,6 +32,11 @@ jest.mock('../perps/hooks/usePerpsDepositConfirmation', () => ({
 }));
 
 jest.mock('../../../store/controller-actions/transaction-pay-controller');
+
+const mockUsePerpsHomeRoute = jest.fn(() => PERPS_HOME_PAGE_ROUTE);
+jest.mock('../../../hooks/perps/usePerpsHomeRoute', () => ({
+  usePerpsHomeRoute: () => mockUsePerpsHomeRoute(),
+}));
 
 jest.mock('../../../pages/confirmations/selectors/feature-flags', () => ({
   selectBlockedPayTokens: jest.fn(() => ({
@@ -125,6 +134,7 @@ describe('HyperliquidDepositPrompt', () => {
       chainIds: [],
       tokens: [],
     });
+    mockUsePerpsHomeRoute.mockReturnValue(PERPS_HOME_PAGE_ROUTE);
     mockUseSendTokens.mockReturnValue([ETH_TOKEN, USDC_TOKEN]);
     mockStartPerpsDeposit.mockResolvedValue({
       transactionId: 'transaction-id-mock',
@@ -196,7 +206,7 @@ describe('HyperliquidDepositPrompt', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       {
         pathname: `${CONFIRM_TRANSACTION_ROUTE}/transaction-id-mock`,
-        search: '?loader=customAmount',
+        search: `loader=customAmount&goBackTo=${encodeURIComponent(PERPS_HOME_PAGE_ROUTE)}`,
       },
       { replace: true },
     );
@@ -235,6 +245,24 @@ describe('HyperliquidDepositPrompt', () => {
     expect(
       screen.getByTestId('hyperliquid-deposit-prompt-continue'),
     ).toBeDisabled();
+  });
+
+  it('uses the wallet home perps tab as goBackTo when bottom nav is disabled', async () => {
+    mockUsePerpsHomeRoute.mockReturnValue(PERPS_HOME_TAB_ROUTE);
+
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('hyperliquid-deposit-prompt-continue'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        {
+          pathname: `${CONFIRM_TRANSACTION_ROUTE}/transaction-id-mock`,
+          search: `loader=customAmount&goBackTo=${encodeURIComponent(PERPS_HOME_TAB_ROUTE)}`,
+        },
+        { replace: true },
+      );
+    });
   });
 
   it('shows an error and keeps the prompt open when the deposit fails to start', async () => {

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
@@ -36,6 +36,7 @@ import { selectBlockedPayTokens } from '../../../pages/confirmations/selectors/f
 import { getAvailableTokens } from '../../../pages/confirmations/utils/transaction-pay';
 import { Asset } from '../../../pages/confirmations/components/send/asset/asset';
 import type { Asset as AssetType } from '../../../pages/confirmations/types/send';
+import { usePerpsHomeRoute } from '../../../hooks/perps/usePerpsHomeRoute';
 import { usePerpsDepositConfirmation } from '../perps/hooks/usePerpsDepositConfirmation';
 import type { HyperliquidDepositPromptProps } from './hyperliquid-deposit-prompt.types';
 
@@ -153,6 +154,7 @@ export const HyperliquidDepositPrompt: React.FC<
 > = ({ onActionComplete, selectedAddress }) => {
   const t = useI18nContext();
   const navigate = useNavigate();
+  const perpsHomeRoute = usePerpsHomeRoute();
   const tokens = useHyperliquidDepositTokens();
   const currentAccount = useSelector(getSelectedInternalAccount);
 
@@ -231,13 +233,22 @@ export const HyperliquidDepositPrompt: React.FC<
     navigate(
       {
         pathname: `${CONFIRM_TRANSACTION_ROUTE}/${transactionId}`,
-        search: `?loader=${ConfirmationLoader.CustomAmount}`,
+        search: new URLSearchParams({
+          loader: ConfirmationLoader.CustomAmount,
+          goBackTo: perpsHomeRoute,
+        }).toString(),
       },
       { replace: true },
     );
 
     onActionComplete({ action: 'continue', transactionId });
-  }, [displayToken, navigate, onActionComplete, startPerpsDeposit]);
+  }, [
+    displayToken,
+    navigate,
+    onActionComplete,
+    perpsHomeRoute,
+    startPerpsDeposit,
+  ]);
 
   return (
     <Box

--- a/ui/hooks/perps/index.ts
+++ b/ui/hooks/perps/index.ts
@@ -46,6 +46,7 @@ export type {
   UsePerpsEventTrackingDeclarativeOptions,
 } from './usePerpsEventTracking';
 export { usePerpsBottomNavSource } from './usePerpsBottomNavSource';
+export { PERPS_HOME_TAB_ROUTE, usePerpsHomeRoute } from './usePerpsHomeRoute';
 export {
   estimateLiquidationPrice,
   liquidationDistancePercent,

--- a/ui/hooks/perps/usePerpsHomeRoute.test.ts
+++ b/ui/hooks/perps/usePerpsHomeRoute.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react';
+import { PERPS_HOME_PAGE_ROUTE } from '../../helpers/constants/routes';
+import { useABTest } from '../useABTest';
+import { PERPS_HOME_TAB_ROUTE, usePerpsHomeRoute } from './usePerpsHomeRoute';
+
+jest.mock('../useABTest');
+
+const mockUseABTest = jest.mocked(useABTest);
+
+describe('usePerpsHomeRoute', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the perps home page for the bottom-nav treatment', () => {
+    mockUseABTest.mockReturnValue({
+      variant: { withBottomNavBar: true },
+      variantName: 'treatment',
+      isActive: true,
+    });
+
+    const { result } = renderHook(() => usePerpsHomeRoute());
+
+    expect(result.current).toBe(PERPS_HOME_PAGE_ROUTE);
+  });
+
+  it('returns the wallet home perps tab for the bottom-nav control', () => {
+    mockUseABTest.mockReturnValue({
+      variant: { withBottomNavBar: false },
+      variantName: 'control',
+      isActive: true,
+    });
+
+    const { result } = renderHook(() => usePerpsHomeRoute());
+
+    expect(result.current).toBe(PERPS_HOME_TAB_ROUTE);
+  });
+});

--- a/ui/hooks/perps/usePerpsHomeRoute.ts
+++ b/ui/hooks/perps/usePerpsHomeRoute.ts
@@ -1,0 +1,26 @@
+import {
+  BOTTOM_NAV_AB_TEST_KEY,
+  BOTTOM_NAV_AB_TEST_EXPOSURE_METADATA,
+  BOTTOM_NAV_AB_TEST_VARIANTS,
+} from '../../../shared/lib/ab-testing/configs/bottom-nav-bar';
+import { PERPS_HOME_PAGE_ROUTE } from '../../helpers/constants/routes';
+import { useABTest } from '../useABTest';
+
+export const PERPS_HOME_TAB_ROUTE = '/?tab=perps';
+
+/**
+ * Returns the Perps home route for the current user: `/perps-home` when the
+ * bottom nav bar is enabled, otherwise `/?tab=perps` on the wallet home.
+ */
+export function usePerpsHomeRoute(): string {
+  const { variant } = useABTest(
+    BOTTOM_NAV_AB_TEST_KEY,
+    BOTTOM_NAV_AB_TEST_VARIANTS,
+    BOTTOM_NAV_AB_TEST_EXPOSURE_METADATA,
+    { trackExposure: false },
+  );
+
+  return variant.withBottomNavBar
+    ? PERPS_HOME_PAGE_ROUTE
+    : PERPS_HOME_TAB_ROUTE;
+}


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

After adding the new MM Pay prompt for Hyperliquid users [here](https://github.com/MetaMask/metamask-extension/pull/45925/) we want to make sure that if they choose to go through our deposit flow, when they finish they land in the Perps experience. This PR adds the navigation for that.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Land users in the Perps experience after a successful Hyperliquid deposit prompt flow

## **Related issues**

Fixes:

## **Manual testing steps**

Note: there is currently a separate bug where the pay token is not persisted on the perps screen. This is known and will be fixed by the money account team (introduced [here](https://github.com/MetaMask/metamask-extension/pull/45868)).

1. Feature flag `extensionUxHyperliquidDepositPrompt` is already true in dev
2. Ensure wallet has:
No existing Hyperliquid perps balance
Less than $10 USDC on Arbitrum
Some other token balance (ETH, USDC on other chains, etc.)
3. Go to app.hyperliquid.xyz
4. Click "Enable Trading" and sign the transaction in MetaMask
5. After signing, view "Fund Hyperliquid with MetaMask" prompt and choose a token and continue
6. Verify you're navigated to the Perps deposit confirmation and choose a value and submit
7. Verify that the screen displayed is the Perps home screen 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/eabf7871-6b2d-4506-9c27-75d84ff521f1




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only change with A/B-aware routing and unit tests; no auth, payment, or transaction logic changes.
> 
> **Overview**
> After users continue from the Hyperliquid MetaMask Pay deposit prompt, navigation to the deposit confirmation now includes a **`goBackTo`** query param so completing (or backing out of) the flow returns them to the Perps experience instead of a generic destination.
> 
> A new **`usePerpsHomeRoute`** hook picks the target from the bottom-nav A/B test: **`/perps-home`** when the bottom nav treatment is on, otherwise **`/?tab=perps`** on wallet home. The prompt builds search params with **`loader=customAmount`** and that route; tests cover both variants and mock the hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e5ee0ce2c5acfc63e5e2f05b3932fed99d3175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->