### PR TITLE
chore(rewards): remove MetaMetrics traits

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -555,24 +555,6 @@ export type MetaMetricsUserTraits = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   chain_id_list?: string[];
   /**
-   * Whether the user has opted into Rewards.
-   */
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  has_rewards_opted_in?: string;
-  /**
-   * Whether the user was referred when opting into Rewards.
-   */
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  rewards_referred?: boolean;
-  /**
-   * The referral code used when opting into Rewards.
-   */
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  rewards_referral_code_used?: string;
-  /**
    * The platform (browser) where the extension is running.
    */
   platform?: Platform;
@@ -760,12 +742,6 @@ export enum MetaMetricsUserTrait {
    * Identified when the user adds or removes configured chains (evm or non-evm)
    */
   ChainIdList = 'chain_id_list',
-  /**
-   * Rewards-specific traits
-   */
-  HasRewardsOptedIn = 'has_rewards_opted_in',
-  RewardsReferred = 'rewards_referred',
-  RewardsReferralCodeUsed = 'rewards_referral_code_used',
   /**
    * The platform (browser) where the extension is running.
    */

--- a/ui/hooks/rewards/useOptIn.test.tsx
+++ b/ui/hooks/rewards/useOptIn.test.tsx
@@ -2,10 +2,7 @@ import { act } from '@testing-library/react';
 import React from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
-import {
-  MetaMetricsEventName,
-  MetaMetricsUserTrait,
-} from '../../../shared/constants/metametrics';
+import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
 import { EMPTY_ARRAY } from '../../selectors/shared';
 import { useOptIn } from './useOptIn';
 
@@ -27,9 +24,6 @@ jest.mock('../../store/actions', () => ({
   rewardsLinkAccountsToSubscriptionCandidate: jest.fn(() => async () => [
     { account: {} as InternalAccount, success: true },
   ]),
-  updateMetaMetricsTraits: jest.fn(() => async () => {
-    // noop
-  }),
   linkRewardToShieldSubscription: jest.fn(() => async () => {
     // noop
   }),
@@ -153,9 +147,6 @@ const { rewardsOptIn } = jest.requireMock('../../store/actions') as {
 const { rewardsLinkAccountsToSubscriptionCandidate } = jest.requireMock(
   '../../store/actions',
 ) as { rewardsLinkAccountsToSubscriptionCandidate: jest.Mock };
-const { updateMetaMetricsTraits } = jest.requireMock('../../store/actions') as {
-  updateMetaMetricsTraits: jest.Mock;
-};
 const { linkRewardToShieldSubscription } = jest.requireMock(
   '../../store/actions',
 ) as { linkRewardToShieldSubscription: jest.Mock };
@@ -200,11 +191,6 @@ describe('useOptIn', () => {
     ).mockImplementation(() => async () => [
       { account: {} as InternalAccount, success: true },
     ]);
-    (updateMetaMetricsTraits as jest.Mock).mockImplementation(
-      () => async () => {
-        // noop
-      },
-    );
     (linkRewardToShieldSubscription as jest.Mock).mockImplementation(
       () => async () => {
         // noop
@@ -246,7 +232,7 @@ describe('useOptIn', () => {
   });
 
   describe('Successful opt-in', () => {
-    it('tracks started/completed, dispatches candidate SID, updates traits, and toggles loading', async () => {
+    it('tracks started/completed, dispatches candidate SID, and toggles loading', async () => {
       (rewardsOptIn as jest.Mock).mockImplementation(
         () => async () => 'sub-abc',
       );
@@ -267,14 +253,11 @@ describe('useOptIn', () => {
       expect(events).toContain(MetaMetricsEventName.RewardsOptInCompleted);
 
       expect(setCandidateSubscriptionId).toHaveBeenCalledWith('sub-abc');
-      expect(updateMetaMetricsTraits).toHaveBeenCalledWith({
-        [MetaMetricsUserTrait.HasRewardsOptedIn]: 'on',
-      });
       expect(result.current.optinLoading).toBe(false);
       expect(result.current.optinError).toBeNull();
     });
 
-    it('includes referral metrics properties and traits when referralCode is provided', async () => {
+    it('includes referral metrics properties when referralCode is provided', async () => {
       const { result } = renderHookWithProvider(
         () => useOptIn(),
         {},
@@ -293,12 +276,6 @@ describe('useOptIn', () => {
       );
       expect(started?.properties?.referred).toBe(true);
       expect(started?.properties?.referral_code_used).toBe('REF-CODE');
-
-      expect(updateMetaMetricsTraits).toHaveBeenCalledWith({
-        [MetaMetricsUserTrait.HasRewardsOptedIn]: 'on',
-        [MetaMetricsUserTrait.RewardsReferred]: true,
-        [MetaMetricsUserTrait.RewardsReferralCodeUsed]: 'REF-CODE',
-      });
     });
 
     it('uses primary wallet group accounts for opt-in when available and links active group accounts', async () => {
@@ -457,36 +434,6 @@ describe('useOptIn', () => {
       const events = mockTrackEvent.mock.calls.map((args) => args[0].name);
       expect(events).toContain(MetaMetricsEventName.RewardsOptInCompleted);
     });
-
-    it('swallows traits update errors without affecting final state', async () => {
-      (rewardsOptIn as jest.Mock).mockImplementation(
-        () => async () => 'sub-traits-error',
-      );
-      (updateMetaMetricsTraits as jest.Mock).mockImplementation(
-        () => async () => {
-          throw new Error('traits fail');
-        },
-      );
-
-      const { result } = renderHookWithProvider(
-        () => useOptIn(),
-        {},
-        undefined,
-        undefined,
-      );
-
-      await act(async () => {
-        await result.current.optin();
-      });
-
-      expect(result.current.optinError).toBeNull();
-      expect(result.current.optinLoading).toBe(false);
-      expect(setCandidateSubscriptionId).toHaveBeenCalledWith(
-        'sub-traits-error',
-      );
-      const events = mockTrackEvent.mock.calls.map((args) => args[0].name);
-      expect(events).toContain(MetaMetricsEventName.RewardsOptInCompleted);
-    });
   });
 
   describe('Error path', () => {
@@ -511,7 +458,6 @@ describe('useOptIn', () => {
       expect(result.current.optinLoading).toBe(false);
       expect(result.current.optinError).toBe('mock error');
       expect(setCandidateSubscriptionId).not.toHaveBeenCalled();
-      expect(updateMetaMetricsTraits).not.toHaveBeenCalled();
     });
 
     it('does not dispatch candidate SID when subscriptionId is null', async () => {
@@ -529,7 +475,6 @@ describe('useOptIn', () => {
       });
 
       expect(setCandidateSubscriptionId).not.toHaveBeenCalled();
-      expect(updateMetaMetricsTraits).not.toHaveBeenCalled();
       const events = mockTrackEvent.mock.calls.map((args) => args[0].name);
       expect(events).not.toContain(MetaMetricsEventName.RewardsOptInCompleted);
     });

--- a/ui/hooks/rewards/useOptIn.ts
+++ b/ui/hooks/rewards/useOptIn.ts
@@ -11,12 +11,10 @@ import { useAnalytics } from '../useAnalytics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
-  MetaMetricsUserTrait,
 } from '../../../shared/constants/metametrics';
 import {
   rewardsOptIn,
   rewardsLinkAccountsToSubscriptionCandidate,
-  updateMetaMetricsTraits,
   linkRewardToShieldSubscription,
 } from '../../store/actions';
 import { handleRewardsErrorMessage } from '../../components/app/rewards/utils/handleRewardsErrorMessage';
@@ -136,19 +134,6 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
               .addProperties(metricsProps)
               .build(),
           );
-
-          // Update user traits
-          try {
-            await updateMetaMetricsTraits({
-              [MetaMetricsUserTrait.HasRewardsOptedIn]: 'on',
-              ...(referralCode && {
-                [MetaMetricsUserTrait.RewardsReferred]: true,
-                [MetaMetricsUserTrait.RewardsReferralCodeUsed]: referralCode,
-              }),
-            });
-          } catch {
-            // Silently fail - traits update should not block opt-in
-          }
 
           // Link the reward to the shield subscription if opt in from the shield subscription
           if (options?.rewardPoints && options?.shieldSubscriptionId) {


### PR DESCRIPTION
## **Description**

Remove Rewards-specific MetaMetrics traits as part of the MetaMetricsController deprecation. The Rewards team confirmed these traits can be removed rather than migrated (see [Slack thread](https://consensys.slack.com/archives/C08MMKNK0KX/p1788188310370579?thread_ts=1787837843.089529&cid=C08MMKNK0KX)).

- has_rewards_opted_in
- rewards_referred
- rewards_referral_code_used

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Build and load the extension with Rewards enabled.
2. Complete the Rewards opt-in flow with and without a referral code.
3. Verify opt-in succeeds and Rewards account linking still completes.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
