### PR TITLE
fix(tokens): hide search toggle only for assets in assetsBalance

### DIFF
--- a/ui/pages/asset/components/asset-options.js
+++ b/ui/pages/asset/components/asset-options.js
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { ERC20 } from '@metamask/controller-utils';
+import { toAssetId } from '../../../../shared/lib/asset-utils';
 import { I18nContext } from '../../../contexts/i18n';
 import { useAnalytics } from '../../../hooks/useAnalytics';
 import { Menu, MenuItem } from '../../../components/ui/menu';
 import { getBlockExplorerLinkText } from '../../../selectors';
+import { selectIsAssetInAssetsBalance } from '../../../selectors/assets';
 import { NETWORKS_ROUTE } from '../../../helpers/constants/routes';
 import {
   ButtonIcon,
@@ -34,6 +36,16 @@ const AssetOptions = ({
   const navigate = useNavigate();
   const blockExplorerLinkText = useSelector(getBlockExplorerLinkText);
   const ref = useRef(false);
+
+  const assetId =
+    token?.address && token?.chainId
+      ? toAssetId(token.address, token.chainId)
+      : undefined;
+
+  const hasBalanceEntry = useSelector((state) =>
+    selectIsAssetInAssetsBalance(state, assetId),
+  );
+  const canHideToken = !isNativeAsset && hasBalanceEntry;
 
   const routeToAddBlockExplorerUrl = () => {
     navigate(`${NETWORKS_ROUTE}#blockExplorerUrl`);
@@ -97,7 +109,7 @@ const AssetOptions = ({
                 : [t('blockExplorerAssetAction')],
             )}
           </MenuItem>
-          {!isNativeAsset && (
+          {canHideToken && (
             <MenuItem
               iconNameLegacy={IconName.Trash}
               data-testid="asset-options__hide"

--- a/ui/pages/asset/components/asset-options.test.tsx
+++ b/ui/pages/asset/components/asset-options.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+import mockState from '../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import AssetOptions from './asset-options';
+
+// EVM account of the selected account group in `mock-state.json`.
+const SELECTED_ACCOUNT_ID = 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3';
+
+const token = {
+  address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  chainId: CHAIN_IDS.MAINNET,
+  symbol: 'DAI',
+  decimals: 18,
+};
+
+const tokenAssetId = `eip155:1/erc20:${token.address}`;
+
+type AssetsBalance = Record<string, Record<string, { amount: string }>>;
+
+async function renderOpenedMenu({
+  assetsBalance = {},
+  isNativeAsset = false,
+}: {
+  assetsBalance?: AssetsBalance;
+  isNativeAsset?: boolean;
+} = {}) {
+  const store = configureMockStore()({
+    metamask: { ...mockState.metamask, assetsBalance },
+  });
+
+  renderWithProvider(
+    <AssetOptions
+      isNativeAsset={isNativeAsset}
+      token={token}
+      onRemove={jest.fn()}
+      onClickBlockExplorer={jest.fn()}
+    />,
+    store,
+  );
+
+  fireEvent.click(screen.getByTestId('asset-options__button'));
+  // The menu positions itself asynchronously; wait for it to settle.
+  await screen.findByTestId('asset-options__etherscan');
+}
+
+type HideOptionCase = {
+  testName: string;
+  isNativeAsset: boolean;
+  assetsBalance: AssetsBalance;
+  expectHideButtonVisible: boolean;
+};
+
+describe('AssetOptions', () => {
+  const selectedAccountTokenBalance = {
+    [SELECTED_ACCOUNT_ID]: { [tokenAssetId]: { amount: '1' } },
+  };
+
+  const hideTokenButtonTestCases: HideOptionCase[] = [
+    {
+      testName: 'offers to hide a token the selected account group holds',
+      isNativeAsset: false,
+      assetsBalance: selectedAccountTokenBalance,
+      expectHideButtonVisible: true,
+    },
+  ];
+
+  const noHideTokenButtonTestCases: HideOptionCase[] = [
+    {
+      testName: 'does not offer to hide a token without a balance entry',
+      isNativeAsset: false,
+      assetsBalance: {},
+      expectHideButtonVisible: false,
+    },
+    {
+      testName:
+        'does not offer to hide a token held by an account outside the selected group',
+      isNativeAsset: false,
+      assetsBalance: {
+        'other-group-account-id': { [tokenAssetId]: { amount: '1' } },
+      },
+      expectHideButtonVisible: false,
+    },
+    {
+      testName: 'does not offer to hide a native asset',
+      isNativeAsset: true,
+      assetsBalance: selectedAccountTokenBalance,
+      expectHideButtonVisible: false,
+    },
+  ];
+
+  const testCases: HideOptionCase[] = [
+    ...hideTokenButtonTestCases,
+    ...noHideTokenButtonTestCases,
+  ];
+
+  // @ts-expect-error This function is missing from the Mocha type definitions
+  it.each(testCases)(
+    '$testName',
+    async ({
+      isNativeAsset,
+      assetsBalance,
+      expectHideButtonVisible,
+    }: HideOptionCase) => {
+      await renderOpenedMenu({ isNativeAsset, assetsBalance });
+
+      if (expectHideButtonVisible) {
+        expect(screen.getByTestId('asset-options__hide')).toBeInTheDocument();
+      } else {
+        expect(
+          screen.queryByTestId('asset-options__hide'),
+        ).not.toBeInTheDocument();
+      }
+    },
+  );
+});

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -1,5 +1,6 @@
 import {
   EthScope,
+  SolAccountType,
   SolScope,
   XlmAccountType,
   XlmScope,
@@ -10,15 +11,12 @@ import { AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS } from '@metamask/multichai
 import { cloneDeep } from 'lodash';
 import {
   calculateBalanceForAllWallets,
-  calculateBalanceChangeForAllWallets,
   selectAllAssets,
   selectAssetsBySelectedAccountGroup,
 } from '@metamask/assets-controllers';
-import type {
-  AccountGroupAssets,
-  BalanceChangeResult,
-} from '@metamask/assets-controllers';
+import type { AccountGroupAssets } from '@metamask/assets-controllers';
 import type { MetaMaskReduxState } from '../store/store';
+import { createMockInternalAccount } from '../../test/jest/mocks';
 import {
   AssetsRatesState,
   AssetsState,
@@ -26,6 +24,7 @@ import {
   getAssetsInfo,
   getAssetsMetadata,
   getAssetsBalance,
+  selectIsAssetInAssetsBalance,
   getAssetsPrice,
   getAssetPreferences,
   getCustomAssets,
@@ -215,6 +214,137 @@ describe('getAssetsBalance', () => {
     expect(
       getAssetsBalance({ metamask: {} } as AssetSelectorTestState),
     ).toEqual({});
+  });
+});
+
+describe('selectIsAssetInAssetsBalance', () => {
+  const evmAccountId = 'evm-account-id';
+  const solanaAccountId = 'solana-account-id';
+  const otherGroupAccountId = 'other-group-account-id';
+  const walletId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ';
+  const groupId = `${walletId}/0`;
+  const assetId = 'eip155:1/erc20:0xabc' as CaipAssetType;
+  const solanaAssetId =
+    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:abc' as CaipAssetType;
+
+  const evmAccount = createMockInternalAccount({
+    id: evmAccountId,
+    address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+    name: 'Test Account',
+  });
+  const solanaAccount = createMockInternalAccount({
+    id: solanaAccountId,
+    address: '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV',
+    type: SolAccountType.DataAccount,
+    name: 'Test Solana Account',
+  });
+  const otherGroupAccount = createMockInternalAccount({
+    id: otherGroupAccountId,
+    address: '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b',
+    name: 'Other Account',
+  });
+
+  const buildState = ({
+    assetsBalance = {},
+    selectedAccountGroup = groupId,
+  }: {
+    assetsBalance?: Record<string, unknown>;
+    selectedAccountGroup?: string | null;
+  }): AssetSelectorTestState => ({
+    metamask: {
+      selectedAccountGroup,
+      accountTree: {
+        wallets: {
+          [walletId]: {
+            id: walletId,
+            type: 'entropy',
+            groups: {
+              [groupId]: {
+                id: groupId,
+                type: 'multichain-account',
+                // The selected group holds both accounts; the third account
+                // below belongs to another group.
+                accounts: [evmAccountId, solanaAccountId],
+                metadata: { name: 'Account 1' },
+              },
+            },
+            metadata: { name: 'Wallet 1' },
+          },
+        },
+      },
+      internalAccounts: {
+        accounts: {
+          [evmAccountId]: evmAccount,
+          [solanaAccountId]: solanaAccount,
+          [otherGroupAccountId]: otherGroupAccount,
+        },
+        selectedAccount: evmAccountId,
+      },
+      assetsBalance,
+    },
+  });
+
+  it('returns true when an account in the selected group holds the asset', () => {
+    const state = buildState({
+      assetsBalance: { [evmAccountId]: { [assetId]: { amount: '1' } } },
+    });
+
+    expect(selectIsAssetInAssetsBalance(state, assetId)).toBe(true);
+  });
+
+  it('returns true when a non-selected account in the group holds the asset', () => {
+    const state = buildState({
+      assetsBalance: {
+        [solanaAccountId]: { [solanaAssetId]: { amount: '1' } },
+      },
+    });
+
+    expect(selectIsAssetInAssetsBalance(state, solanaAssetId)).toBe(true);
+  });
+
+  it('returns true when the asset reference casing differs', () => {
+    const state = buildState({
+      assetsBalance: {
+        [evmAccountId]: { 'eip155:1/erc20:0xABC': { amount: '1' } },
+      },
+    });
+
+    expect(selectIsAssetInAssetsBalance(state, assetId)).toBe(true);
+  });
+
+  it('returns false when no account in the group holds the asset', () => {
+    const state = buildState({
+      assetsBalance: {
+        [evmAccountId]: { 'eip155:1/erc20:0xdef': { amount: '1' } },
+      },
+    });
+
+    expect(selectIsAssetInAssetsBalance(state, assetId)).toBe(false);
+  });
+
+  it('returns false when the group accounts have no assetsBalance entry', () => {
+    const state = buildState({ assetsBalance: {} });
+
+    expect(selectIsAssetInAssetsBalance(state, assetId)).toBe(false);
+  });
+
+  it('returns false when only an account outside the group holds the asset', () => {
+    const state = buildState({
+      assetsBalance: {
+        [otherGroupAccountId]: { [assetId]: { amount: '1' } },
+      },
+    });
+
+    expect(selectIsAssetInAssetsBalance(state, assetId)).toBe(false);
+  });
+
+  it('returns false when there is no selected account group', () => {
+    const state = buildState({
+      assetsBalance: { [evmAccountId]: { [assetId]: { amount: '1' } } },
+      selectedAccountGroup: null,
+    });
+
+    expect(selectIsAssetInAssetsBalance(state, assetId)).toBe(false);
   });
 });
 

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -56,6 +56,7 @@ import { TEST_CHAINS } from '../../shared/constants/network';
 import {
   createDeepEqualSelector,
   createParameterizedSelector,
+  createShallowEqualSelector,
 } from '../../shared/lib/selectors/selector-creators';
 import { Token, TokenWithFiatAmount } from '../components/app/assets/types';
 import { calculateTokenBalance } from '../components/app/assets/util/calculateTokenBalance';
@@ -117,7 +118,12 @@ import {
   getSelectedMultichainNetworkConfiguration,
   MultichainNetworkControllerState,
 } from './multichain/networks';
-import { getInternalAccountBySelectedAccountGroupAndCaip } from './multichain-accounts/account-tree';
+import {
+  getInternalAccountBySelectedAccountGroupAndCaip,
+  getInternalAccountsFromGroupById,
+  getSelectedAccountGroup,
+} from './multichain-accounts/account-tree';
+import type { MultichainAccountsState } from './multichain-accounts/account-tree.types';
 
 export type AssetsState = {
   metamask: MultichainAssetsControllerState;
@@ -180,6 +186,40 @@ export function getAssetsInfo(state: { metamask?: AssetsControllerState }) {
 export function getAssetsBalance(state: { metamask?: AssetsControllerState }) {
   return state.metamask?.assetsBalance ?? defaultState.assetsBalance;
 }
+
+type AssetsBalanceLookupState = MultichainAccountsState & {
+  metamask?: AssetsControllerState;
+};
+
+const selectSelectedAccountGroupAccountsIds = createShallowEqualSelector(
+  (state: AssetsBalanceLookupState) =>
+    getInternalAccountsFromGroupById(state, getSelectedAccountGroup(state)),
+  (accounts: InternalAccount[]) => accounts.map((account) => account.id),
+);
+
+/**
+ * Whether any account in the selected account group has a balance entry for the
+ * given asset, i.e. whether the wallet owns the asset rather than merely
+ * knowing about it.
+ *
+ * @param _state - Redux state object.
+ * @param assetId - CAIP asset id to look up.
+ * @returns `true` when the asset has a balance entry in the group.
+ */
+export const selectIsAssetInAssetsBalance = createParameterizedSelector(100)(
+  [
+    getAssetsBalance,
+    selectSelectedAccountGroupAccountsIds,
+    (_state: unknown, assetId?: CaipAssetType) => assetId?.toLowerCase(),
+  ],
+  (assetsBalance, accountIds, assetIdLower) =>
+    Boolean(assetIdLower) &&
+    accountIds.some((accountId) =>
+      Object.keys(assetsBalance[accountId] ?? {}).some(
+        (key) => key.toLowerCase() === assetIdLower,
+      ),
+    ),
+);
 
 /**
  * Returns the assets price (AssetsController state).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

We should not show the hide button for:
- native tokens
- tokens you do not have balances for (this is a new case because we have launched search for any token in extension)

## **Changelog**

CHANGELOG entry: Fixed token search showing a hide toggle for tokens you do not own

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3859

## **Manual testing steps**

1. Go to native token TDP - the hide button should not be visible
2. Go to an asset you have balances for - the hide button should be visible
3. Go to an asset you do not have balances for (e.g. via search) - the hide button should not be visible

## **Screenshots/Recordings**

### **Before**

### **After**

https://www.loom.com/share/92657595628844258bcb5b2047abfd36

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e351bde7-f292-4fb6-bb89-31481850150d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e351bde7-f292-4fb6-bb89-31481850150d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

