### PR TITLE
chore: exclude Storybook stories from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -367,3 +367,5 @@ app/scripts/wallet-init/instance-options/storage-service*                @MetaMa
 /.github/scripts/known-feature-flag-constants.mts
 # Snapshots – *.snap files
 **/*.snap
+# Storybook stories – low-risk, often bulk-updated (e.g. Storybook upgrades)
+**/*.stories.*

--- a/.github/scripts/identify-codeowners.mts
+++ b/.github/scripts/identify-codeowners.mts
@@ -139,6 +139,13 @@ function matchFilesToCodeowners(files: PullRequestFile[], codeowners: CodeOwnerR
   files.forEach(file => {
     for (const { pattern, owners } of codeowners) {
       if (isFileMatchingPattern(file.filename, pattern)) {
+        // Later unowned patterns (CODEOWNERS exclusions) clear prior owners,
+        // matching GitHub's last-match-wins behavior for lines with no owners.
+        if (owners.length === 0) {
+          fileOwners.delete(file.filename);
+          continue;
+        }
+
         // Not breaking here to allow for multiple patterns to match the same file
         const ownerSet = fileOwners.get(file.filename);
         if (!ownerSet) {

--- a/.github/scripts/identify-codeowners.mts
+++ b/.github/scripts/identify-codeowners.mts
@@ -139,13 +139,6 @@ function matchFilesToCodeowners(files: PullRequestFile[], codeowners: CodeOwnerR
   files.forEach(file => {
     for (const { pattern, owners } of codeowners) {
       if (isFileMatchingPattern(file.filename, pattern)) {
-        // Later unowned patterns (CODEOWNERS exclusions) clear prior owners,
-        // matching GitHub's last-match-wins behavior for lines with no owners.
-        if (owners.length === 0) {
-          fileOwners.delete(file.filename);
-          continue;
-        }
-
         // Not breaking here to allow for multiple patterns to match the same file
         const ownerSet = fileOwners.get(file.filename);
         if (!ownerSet) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Storybook story files (`*.stories.*`) currently inherit CODEOWNERS from their parent directories. That means bulk Storybook upgrades (for example [PR #46014](https://github.com/MetaMask/metamask-extension/pull/46014)) request reviews from many product teams even though the edits are low-risk import/API churn.

This change treats stories the same way snapshot files are already treated: they are listed in the last CODEOWNERS exclusions section with no owners, so GitHub will not require codeowner review for those files.

1. What is the reason for the change? Reduce review friction for Storybook-only updates without weakening ownership of production UI/runtime code.
2. What is the improvement/solution? Exclude `**/*.stories.*` from CODEOWNERS, matching the existing `**/*.snap` exclusion.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Open a PR that only changes files matching `**/*.stories.*` under a CODEOWNERS-owned directory (for example `ui/pages/swaps/**`).
2. Confirm GitHub does not request a review from the directory's codeowners for those files.
3. Open a PR that changes both a story file and a non-story file in an owned directory.
4. Confirm the non-story file still requests the expected codeowner review.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d7736e0-be67-405a-8723-f77811a58a32?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d7736e0-be67-405a-8723-f77811a58a32&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

