### PR TITLE
chore: fix `--minify=false` build flag

### DIFF
--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -588,7 +588,9 @@ const config = {
     // chunk changes, but the parent chunk does not.
     moduleIds: 'deterministic',
     chunkIds: 'deterministic',
-    ...(args.minify ? { minimize: true, minimizer: getMinimizers() } : {}),
+    ...(args.minify
+      ? { minimize: true, minimizer: getMinimizers() }
+      : { minimize: false }),
     // Make most chunks share a single runtime file, which contains the
     // webpack "runtime". The exception is @lavamoat/snow and all scripts
     // found in the extension manifest; these scripts must be self-contained


### PR DESCRIPTION
## **Description**

Disable minification when the `--minify=false` flag is used. Currently on `main`, the `--minify=false` flag causes the build to use default minification settings rather than disabling it.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

1. Run standard setup commands (e.g. `nvm use && yarn && yarn webpack:tsc`)
2. Build using the `--minify=false` flag (e.g. `yarn build:dev --minify=false`)
3. Inspect the build in `dist/` to ensure variable/function names are preserved rather than mangled.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time webpack configuration only; no runtime auth, data, or extension behavior changes.
> 
> **Overview**
> Fixes **`--minify=false`** so JS bundles are not minified. When minification was off, webpack **`optimization`** no longer omitted **`minimize`** (which left webpack’s defaults and could still mangle names in production). The config now sets **`minimize: false`** explicitly when **`args.minify`** is false, matching the intended debug-friendly **`dist/`** output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95122af38c3812d2f41dc233f86c5fe046278bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->