### PR TITLE
chore: remove broken npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "start:flask": "yarn start --type flask",
     "start:beta": "yarn start --type beta",
     "start:flask:mv2": "yarn start:mv2 --type flask",
-    "start:lavamoat": "yarn start --lavamoat",
     "dist": "yarn webpack:lavamoat:build --zip",
     "dist:mv2": "yarn webpack:lavamoat:build:mv2 --zip",
     "build": "yarn webpack:lavamoat:build",


### PR DESCRIPTION
## **Description**

Remove broken `start:lavamoat` script. It uses two incompatible flags: `--watch` and `--lavamoat`.

I considered adding a replacement npm script, but I'm not sure that it would be valuable enough to warrant it, so I've left it for now.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer tooling only; removes a non-functional npm script with no runtime or build-pipeline behavior change.
> 
> **Overview**
> Removes the **`start:lavamoat`** entry from `package.json` scripts. That command forwarded to `yarn start --lavamoat`, which combined **`--watch`** with **`--lavamoat`**—a combination the webpack dev flow does not support, so the script was misleading or broken.
> 
> LavaMoat-related workflows are unchanged: production-style builds still use scripts such as **`webpack:lavamoat:build`**, **`build`**, and **`build:test`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16c553bc7b39ad2d9be2619297e9b04ef66c8b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->