### PR TITLE
feat(accounts): go home with toast after account import

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -105,6 +105,10 @@
   "accountIdenticon": {
     "message": "Account icon"
   },
+  "accountImported": {
+    "message": "Account imported",
+    "description": "Success toast shown after a private key or JSON account is imported"
+  },
   "accountName": {
     "message": "Account name"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -105,6 +105,10 @@
   "accountIdenticon": {
     "message": "Account icon"
   },
+  "accountImported": {
+    "message": "Account imported",
+    "description": "Success toast shown after a private key or JSON account is imported"
+  },
   "accountName": {
     "message": "Account name"
   },

--- a/test/e2e/page-objects/flows/add-account.flow.ts
+++ b/test/e2e/page-objects/flows/add-account.flow.ts
@@ -77,6 +77,7 @@ export const addMultipleAccounts = async ({
 
 /**
  * Opens the account menu and imports an account from a private key.
+ * After a successful import, the wallet is on home with the imported account selected.
  *
  * @param driver - The WebDriver instance.
  * @param privateKey - The private key to import.
@@ -95,5 +96,5 @@ export async function importPrivateKeyAccount(
   const accountListPage = new AccountListPage(driver);
   await accountListPage.checkPageIsLoaded(options.accountListTimeout);
   await accountListPage.addNewImportedAccount(privateKey);
-  await accountListPage.closeMultichainAccountsPage();
+  await homepage.checkPageIsLoaded();
 }

--- a/test/e2e/page-objects/flows/add-account.flow.ts
+++ b/test/e2e/page-objects/flows/add-account.flow.ts
@@ -97,7 +97,5 @@ export async function importPrivateKeyAccount(
   await accountListPage.checkPageIsLoaded(options.accountListTimeout);
   await accountListPage.addNewImportedAccount(privateKey);
   await homepage.checkPageIsLoaded();
-  // The success toast sits at the bottom of home and intercepts clicks on
-  // later screens (for example the deep-link continue button).
   await homepage.dismissAccountImportedToast();
 }

--- a/test/e2e/page-objects/flows/add-account.flow.ts
+++ b/test/e2e/page-objects/flows/add-account.flow.ts
@@ -97,4 +97,7 @@ export async function importPrivateKeyAccount(
   await accountListPage.checkPageIsLoaded(options.accountListTimeout);
   await accountListPage.addNewImportedAccount(privateKey);
   await homepage.checkPageIsLoaded();
+  // The success toast sits at the bottom of home and intercepts clicks on
+  // later screens (for example the deep-link continue button).
+  await homepage.dismissAccountImportedToast();
 }

--- a/test/e2e/page-objects/pages/accounts/list-page.ts
+++ b/test/e2e/page-objects/pages/accounts/list-page.ts
@@ -351,6 +351,8 @@ class AccountListPage {
   /**
    * Import a new account with a private key.
    *
+   * On success, the wallet navigates home with the imported account selected.
+   *
    * @param privateKey - Private key of the account
    * @param expectedErrorMessage - Expected error message if the import should fail
    */
@@ -373,12 +375,11 @@ class AccountListPage {
     } else {
       // Import + forceUpdateMetamaskState can outlive the default 3s staleness
       // wait under multi-SRP / Solana load on CI before the Add Wallet page
-      // navigates away.
+      // navigates home.
       await this.driver.clickElementAndWaitToDisappear(
         this.importAccountConfirmButton,
         10000,
       );
-      await this.closeChooseWalletTypePage();
     }
   }
 
@@ -933,6 +934,8 @@ class AccountListPage {
   /**
    * Import an account with a JSON file.
    *
+   * On success, the wallet navigates home with the imported account selected.
+   *
    * @param jsonFilePath - Path to the JSON file to import
    * @param password - Password for the imported account
    */
@@ -959,7 +962,6 @@ class AccountListPage {
     await this.driver.clickElementAndWaitToDisappear(
       this.importAccountConfirmButton,
     );
-    await this.closeChooseWalletTypePage();
   }
 
   /**

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -540,7 +540,6 @@ class HomePage {
   }
 
   async dismissAccountImportedToast(): Promise<void> {
-    console.log('Dismiss account imported toast');
     await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 15_000);
   }
 

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -539,6 +539,11 @@ class HomePage {
     );
   }
 
+  async dismissAccountImportedToast(): Promise<void> {
+    console.log('Dismiss account imported toast');
+    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 15_000);
+  }
+
   async dismissSrpAddedToast(): Promise<void> {
     console.log('Dismiss SRP added toast');
     // The toast can take some time to appear

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -38,6 +38,9 @@ const NON_EVM_ICON_TIMEOUT = 20_000;
  * @see ui/pages/home/home.tsx
  */
 class HomePage {
+  private readonly accountImportedToast =
+    '[data-testid="account-imported-toast"]';
+
   protected readonly activityTab = {
     testId: 'account-overview__activity-tab',
   };
@@ -157,6 +160,13 @@ class HomePage {
   constructor(driver: Driver) {
     this.driver = driver;
     this.headerNavbar = new HeaderNavbar(driver);
+  }
+
+  async checkAccountImportedToastIsDisplayed(): Promise<void> {
+    await this.driver.waitForSelector({
+      css: this.accountImportedToast,
+      text: 'Account imported',
+    });
   }
 
   /**

--- a/test/e2e/tests/identity/account-syncing/imported-accounts.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/imported-accounts.spec.ts
@@ -110,13 +110,7 @@ describe('Account syncing - Unsupported Account types', function () {
         // Import a private key account (this should NOT sync)
         await accountListPage.addNewImportedAccount(IMPORTED_PRIVATE_KEY);
 
-        // Verify imported account is visible in current session
-        // TODO: uncomment this when the naming issue is fixed
-        // await accountListPage.checkAccountDisplayedInAccountList(
-        //   IMPORTED_ACCOUNT_NAME,
-        // );
-
-        await accountListPage.closeMultichainAccountsPage();
+        await homePage.checkPageIsLoaded();
       },
     );
 

--- a/test/e2e/tests/multichain-accounts/add-account.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-account.spec.ts
@@ -146,6 +146,7 @@ describe('Add account', function () {
         const accountListPage = new AccountListPage(driver);
         await accountListPage.addNewImportedAccount(TEST_PRIVATE_KEY);
 
+        await headerNavbar.openAccountMenu();
         await accountListPage.checkPageIsLoaded();
         await accountListPage.openMultichainAccountMenu({
           accountLabel: importedAccount.name,
@@ -217,6 +218,8 @@ describe('Add account', function () {
         // Create 3rd account with private key
         await accountListPage.addNewImportedAccount(testPrivateKey);
 
+        await headerNavbar.openAccountMenu();
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.checkAccountDisplayedInAccountList(
           IMPORTED_ACCOUNT_NAME,
         );

--- a/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
@@ -159,7 +159,13 @@ describe('Add wallet', function () {
           'foobarbazqux',
         );
 
-        // Check new imported account has correct name and label
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+        await homePage.checkAccountImportedToastIsDisplayed();
+        await headerNavbar.checkAccountLabel(IMPORTED_ACCOUNT_NAME);
+
+        await headerNavbar.openAccountMenu();
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.checkAccountDisplayedInAccountList(
           IMPORTED_ACCOUNT_NAME,
         );
@@ -168,8 +174,6 @@ describe('Add wallet', function () {
           account: IMPORTED_ACCOUNT_NAME,
         });
         await accountListPage.checkNumberOfAvailableAccounts(4);
-        await accountListPage.switchToAccount(IMPORTED_ACCOUNT_NAME);
-        await headerNavbar.checkAccountLabel(IMPORTED_ACCOUNT_NAME);
       },
     );
   });

--- a/ui/pages/multichain-accounts/add-wallet-page/add-wallet-page.test.tsx
+++ b/ui/pages/multichain-accounts/add-wallet-page/add-wallet-page.test.tsx
@@ -5,6 +5,8 @@ import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import { toast, ToastContent } from '../../../components/ui/toast/toast';
 
 import { AddWalletPage } from './add-wallet-page';
 
@@ -13,6 +15,15 @@ const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../components/ui/toast/toast', () => ({
+  toast: {
+    success: jest.fn(),
+  },
+  ToastContent: jest.fn(({ title, dataTestId }) => (
+    <div data-testid={dataTestId}>{title}</div>
+  )),
 }));
 
 // Mock the ImportAccount component to test onActionComplete function is passed
@@ -70,7 +81,7 @@ describe('AddWalletPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith(-1);
   });
 
-  it('handles successful import completion', () => {
+  it('shows a success toast and navigates home after a successful import', () => {
     renderComponent();
 
     const successButton = screen.getByRole('button', {
@@ -78,7 +89,17 @@ describe('AddWalletPage', () => {
     });
     fireEvent.click(successButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith(-1);
+    expect(toast.success).toHaveBeenCalledWith(
+      <ToastContent
+        title={messages.accountImported.message}
+        dataTestId="account-imported-toast"
+      />,
+      { id: 'account-imported-toast', duration: 5000 },
+    );
+    expect(jest.mocked(toast.success).mock.invocationCallOrder[0]).toBeLessThan(
+      mockNavigate.mock.invocationCallOrder[0],
+    );
+    expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
   });
 
   it('does not navigate on failed import', () => {

--- a/ui/pages/multichain-accounts/add-wallet-page/add-wallet-page.tsx
+++ b/ui/pages/multichain-accounts/add-wallet-page/add-wallet-page.tsx
@@ -16,7 +16,15 @@ import {
 import { TextVariant as LegacyTextVariant } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { ImportAccount } from '../../../components/multichain/import-account/import-account';
-import { PREVIOUS_ROUTE } from '../../../helpers/constants/routes';
+import { toast, ToastContent } from '../../../components/ui/toast/toast';
+import {
+  DEFAULT_ROUTE,
+  PREVIOUS_ROUTE,
+} from '../../../helpers/constants/routes';
+import { SECOND } from '../../../../shared/constants/time';
+
+const toastId = 'account-imported-toast';
+const autoHideToastDelay = 5 * SECOND;
 
 /**
  *
@@ -29,13 +37,25 @@ export const AddWalletPage = () => {
 
   const onActionComplete = useCallback(
     async (confirmed?: boolean) => {
-      // Navigate back if import succeeded (true) or user cancelled (undefined)
-      // Stay on page if import failed (false) to allow retry
+      if (confirmed === true) {
+        toast.success(
+          <ToastContent dataTestId={toastId} title={t('accountImported')} />,
+          {
+            id: toastId,
+            duration: autoHideToastDelay,
+          },
+        );
+        navigate(DEFAULT_ROUTE);
+        return;
+      }
+
+      // Navigate back if the user cancelled (undefined). Stay on the page if
+      // import failed (false) so they can retry.
       if (confirmed !== false) {
         navigate(PREVIOUS_ROUTE);
       }
     },
-    [navigate],
+    [navigate, t],
   );
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

After a private key or JSON account is imported, users were sent back to the add-wallet / choose-wallet page with no confirmation that the import succeeded.

This change navigates to the home page on success, keeps the newly imported account selected, and shows a success toast with the copy "Account imported". Cancel still goes back, and a failed import still stays on the import form so the user can retry.

## **Changelog**

CHANGELOG entry: After importing an account, users are taken to the homepage with an "Account imported" success toast and the imported account selected

## **Related issues**

Fixes:


## **Screenshots/Recordings**
### **Before**

https://github.com/user-attachments/assets/b6aefc28-5336-4501-b99c-06db1463dbb0


### **After**

https://github.com/user-attachments/assets/c7c7622b-2cd7-4982-9fca-eae63a65beaa


## **Manual testing steps**

1. Unlock the extension and open the account menu.
2. Choose Add wallet, then import an account with a private key.
3. Verify you land on the home page with the imported account selected.
4. Verify a success toast says "Account imported".
5. Repeat with a JSON keystore import and confirm the same home + toast + selected-account behavior.
6. Try an invalid or duplicate private key and verify you stay on the import page with the error, and no success toast.
7. Tap Cancel on the import form and verify you go back instead of home.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12a3d82f-cc26-47ee-bb09-139f7cc2bd0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12a3d82f-cc26-47ee-bb09-139f7cc2bd0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

