### PR TITLE
fix(asset): fetch spot price for tokens not in wallet

### DIFF
--- a/ui/pages/asset/components/token-asset.tsx
+++ b/ui/pages/asset/components/token-asset.tsx
@@ -33,7 +33,9 @@ const TokenAsset = ({
   chainId: Hex;
 }) => {
   const { address: hexOrCaipAddress, assetId, symbol, isERC721, image } = token;
-  const address = assetId || hexOrCaipAddress;
+
+  // TODO: refactor AssetPage to be CAIP compliant by default.
+  const address = hexOrCaipAddress || assetId;
 
   const tokenList = useSelector(getTokenList);
   const allNetworks: {
@@ -62,12 +64,12 @@ const TokenAsset = ({
   const tokenData = Object.values(tokenList).find(
     (t) =>
       isEqualCaseInsensitive(t.symbol, symbol) &&
-      isEqualCaseInsensitive(t.address, address),
+      isEqualCaseInsensitive(t.address, address ?? ''),
   );
 
   // If not found in tokenList, try erc20TokensByChain
   const tokenDataFromChain =
-    erc20TokensByChain?.[chainId]?.data?.[address.toLowerCase()];
+    address && erc20TokensByChain?.[chainId]?.data?.[address.toLowerCase()];
 
   const name = tokenData?.name || tokenDataFromChain?.name || symbol;
   const iconUrl =
@@ -91,7 +93,7 @@ const TokenAsset = ({
       asset={{
         chainId,
         type: AssetType.token,
-        address,
+        address: address ?? '',
         symbol,
         name,
         decimals: token.decimals,

--- a/ui/pages/asset/hooks/useCurrentPrice.test.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.test.ts
@@ -1,15 +1,34 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AssetType } from '@metamask/bridge-controller';
 import { EthScope, SolScope } from '@metamask/keyring-api';
+import { waitFor } from '@testing-library/react';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { Asset } from '../types/asset';
 import { useCurrentPrice } from './useCurrentPrice';
 
+jest.mock('../../../ducks/bridge/utils', () => {
+  const actual = jest.requireActual('../../../ducks/bridge/utils');
+  return {
+    ...actual,
+    getTokenExchangeRate: jest.fn(),
+  };
+});
+
+const { getTokenExchangeRate } = jest.requireMock(
+  '../../../ducks/bridge/utils',
+);
+
 describe('useCurrentPrice', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getTokenExchangeRate.mockResolvedValue(undefined);
+  });
+
   const mockBaseState = {
     metamask: {
       isUnlocked: true,
       completedOnboarding: true,
+      currentCurrency: 'usd',
       selectedNetworkClientId: 'selectedNetworkClientId',
       networkConfigurationsByChainId: {
         '0x1': {
@@ -128,23 +147,33 @@ describe('useCurrentPrice', () => {
       expect(result.current.currentPrice).toBe(0.9998967852645477);
     });
 
-    it('returns undefined if market data is missing', () => {
+    it('fetches spot price when market data is missing', async () => {
       const tokenAssetMissingMarket: Asset = {
         chainId: '0x1',
         type: AssetType.token,
-        address: '0xMissingTokenAddress', // An address not in marketData
+        address: '0xe4246B1Ac0Ba6839d9efA41a8A30AE3007185f55',
         symbol: 'MISS',
         decimals: 18,
         name: 'Missing Token',
         image: '',
       };
 
+      getTokenExchangeRate.mockResolvedValue(1.23);
+
       const { result } = renderHookWithProvider(
         () => useCurrentPrice(tokenAssetMissingMarket),
         mockStateIsEvm,
       );
 
-      expect(result.current.currentPrice).toBeUndefined();
+      await waitFor(() => {
+        expect(result.current.currentPrice).toBe(1.23);
+      });
+
+      expect(getTokenExchangeRate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currency: 'usd',
+        }),
+      );
     });
 
     it('returns undefined if currency rate is missing', () => {
@@ -266,23 +295,28 @@ describe('useCurrentPrice', () => {
       expect(result.current.currentPrice).toBe(0.0000029141089909628);
     });
 
-    it('returns undefined if market data is missing', () => {
+    it('fetches spot price when conversion rate is missing', async () => {
       const tokenAssetMissingMarket: Asset = {
         chainId: SolScope.Mainnet as any,
         type: AssetType.token,
-        address: 'solana:MissingTokenAddress/slip44:501',
+        address:
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:MissingTokenAddress',
         symbol: 'MISS',
         decimals: 6,
         name: 'Missing Token',
         image: '',
       };
 
+      getTokenExchangeRate.mockResolvedValue(0.42);
+
       const { result } = renderHookWithProvider(
         () => useCurrentPrice(tokenAssetMissingMarket),
         mockStateIsNonEvm,
       );
 
-      expect(result.current.currentPrice).toBeUndefined();
+      await waitFor(() => {
+        expect(result.current.currentPrice).toBe(0.42);
+      });
     });
   });
 });

--- a/ui/pages/asset/hooks/useCurrentPrice.test.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.test.ts
@@ -3,25 +3,33 @@ import { AssetType } from '@metamask/bridge-controller';
 import { EthScope, SolScope } from '@metamask/keyring-api';
 import { waitFor } from '@testing-library/react';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { apiClient } from '../../../helpers/api-client';
 import { Asset } from '../types/asset';
 import { useCurrentPrice } from './useCurrentPrice';
 
-jest.mock('../../../ducks/bridge/utils', () => {
-  const actual = jest.requireActual('../../../ducks/bridge/utils');
-  return {
-    ...actual,
-    getTokenExchangeRate: jest.fn(),
-  };
-});
+jest.mock('../../../helpers/api-client', () => ({
+  apiClient: {
+    prices: {
+      getV3SpotPricesQueryOptions: jest.fn(),
+    },
+  },
+}));
 
-const { getTokenExchangeRate } = jest.requireMock(
-  '../../../ducks/bridge/utils',
+const mockGetV3SpotPricesQueryOptions = jest.mocked(
+  apiClient.prices.getV3SpotPricesQueryOptions,
 );
+const mockSpotPricesFetch = jest.fn();
 
 describe('useCurrentPrice', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getTokenExchangeRate.mockResolvedValue(undefined);
+    mockSpotPricesFetch.mockResolvedValue({});
+    mockGetV3SpotPricesQueryOptions.mockImplementation(
+      (assetIds, queryOptions) => ({
+        queryKey: ['prices', 'v3SpotPrices', assetIds, queryOptions],
+        queryFn: mockSpotPricesFetch,
+      }),
+    );
   });
 
   const mockBaseState = {
@@ -147,18 +155,20 @@ describe('useCurrentPrice', () => {
       expect(result.current.currentPrice).toBe(0.9998967852645477);
     });
 
-    it('fetches spot price when market data is missing', async () => {
+    it('fetches the spot price when market data is missing', async () => {
+      const address = '0xe4246B1Ac0Ba6839d9efA41a8A30AE3007185f55';
+      const assetId = `eip155:1/erc20:${address}`;
       const tokenAssetMissingMarket: Asset = {
         chainId: '0x1',
         type: AssetType.token,
-        address: '0xe4246B1Ac0Ba6839d9efA41a8A30AE3007185f55',
+        address,
         symbol: 'MISS',
         decimals: 18,
         name: 'Missing Token',
         image: '',
       };
 
-      getTokenExchangeRate.mockResolvedValue(1.23);
+      mockSpotPricesFetch.mockResolvedValue({ [assetId]: { price: 1.23 } });
 
       const { result } = renderHookWithProvider(
         () => useCurrentPrice(tokenAssetMissingMarket),
@@ -169,11 +179,25 @@ describe('useCurrentPrice', () => {
         expect(result.current.currentPrice).toBe(1.23);
       });
 
-      expect(getTokenExchangeRate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          currency: 'usd',
-        }),
-      );
+      expect(mockGetV3SpotPricesQueryOptions).toHaveBeenCalledWith([assetId], {
+        currency: 'usd',
+      });
+    });
+
+    it('does not fetch the spot price when market data is available', () => {
+      const tokenAsset: Asset = {
+        chainId: '0x1',
+        type: AssetType.token,
+        address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        symbol: 'USDC',
+        decimals: 6,
+        name: 'USD Coin',
+        image: '',
+      };
+
+      renderHookWithProvider(() => useCurrentPrice(tokenAsset), mockStateIsEvm);
+
+      expect(mockSpotPricesFetch).not.toHaveBeenCalled();
     });
 
     it('returns undefined if currency rate is missing', () => {
@@ -295,19 +319,20 @@ describe('useCurrentPrice', () => {
       expect(result.current.currentPrice).toBe(0.0000029141089909628);
     });
 
-    it('fetches spot price when conversion rate is missing', async () => {
+    it('fetches the spot price when the conversion rate is missing', async () => {
+      const assetId =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:MissingTokenAddress';
       const tokenAssetMissingMarket: Asset = {
         chainId: SolScope.Mainnet as any,
         type: AssetType.token,
-        address:
-          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:MissingTokenAddress',
+        address: assetId,
         symbol: 'MISS',
         decimals: 6,
         name: 'Missing Token',
         image: '',
       };
 
-      getTokenExchangeRate.mockResolvedValue(0.42);
+      mockSpotPricesFetch.mockResolvedValue({ [assetId]: { price: 0.42 } });
 
       const { result } = renderHookWithProvider(
         () => useCurrentPrice(tokenAssetMissingMarket),
@@ -316,6 +341,10 @@ describe('useCurrentPrice', () => {
 
       await waitFor(() => {
         expect(result.current.currentPrice).toBe(0.42);
+      });
+
+      expect(mockGetV3SpotPricesQueryOptions).toHaveBeenCalledWith([assetId], {
+        currency: 'usd',
       });
     });
   });

--- a/ui/pages/asset/hooks/useCurrentPrice.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.ts
@@ -1,67 +1,141 @@
-import { AssetType } from '@metamask/bridge-controller';
-import { CaipAssetType, Hex } from '@metamask/utils';
+import { AssetType, formatChainIdToCaip } from '@metamask/bridge-controller';
+import { CaipAssetType, Hex, isCaipChainId } from '@metamask/utils';
+import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { toChecksumHexAddress } from '../../../../shared/lib/hexstring-utils';
+import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
+import {
+  getNativeAssetForChainIdSafe,
+  getTokenExchangeRate,
+} from '../../../ducks/bridge/utils';
 import { getCurrencyRates, getMarketData } from '../../../selectors';
 import { getAssetsRates } from '../../../selectors/assets';
 import { Asset } from '../types/asset';
-import { isEvmChainId } from '../../../../shared/lib/asset-utils';
-import { getNativeAssetForChainIdSafe } from '../../../ducks/bridge/utils';
 
 /**
- * Get the current price of an asset.
+ * Get the current price of an asset from Redux cache, falling back to the
+ * price API spot-prices endpoint when the token is not in the wallet.
  *
  * @param asset - The asset to get the current price of
- * @returns The current price of the asset. If the asset is not found, or the price is not found, returns null.
+ * @returns The current price of the asset. If the asset is not found, or the price is not found, returns undefined.
  */
 export const useCurrentPrice = (asset: Asset): { currentPrice?: number } => {
   const isEvm = isEvmChainId(asset.chainId);
   const evmMarketData = useSelector(getMarketData);
   const evmCurrencyRates = useSelector(getCurrencyRates);
   const nonEvmConversionRates = useSelector(getAssetsRates);
+  const currentCurrency = useSelector(getCurrentCurrency);
 
   const { chainId, type } = asset;
 
-  if (isEvm) {
-    if (type === AssetType.native) {
-      return {
-        currentPrice:
-          evmCurrencyRates[asset.symbol]?.conversionRate ?? undefined,
-      };
+  const cachedPrice = useMemo(() => {
+    if (isEvm) {
+      if (type === AssetType.native) {
+        return evmCurrencyRates[asset.symbol]?.conversionRate;
+      }
+
+      const address = toChecksumHexAddress(asset.address) as Hex;
+      const tokenMarketPrice = evmMarketData[chainId]?.[address]?.price;
+      const baseCurrency = evmMarketData[chainId]?.[address]?.currency;
+      const tokenExchangeRate =
+        evmCurrencyRates[baseCurrency]?.conversionRate ?? undefined;
+
+      if (tokenExchangeRate !== undefined && tokenMarketPrice !== undefined) {
+        return tokenExchangeRate * tokenMarketPrice;
+      }
+
+      return undefined;
     }
 
-    // Market and conversion rate data
-    const address = toChecksumHexAddress(asset.address) as Hex;
-    const tokenMarketPrice = evmMarketData[chainId]?.[address]?.price;
-    const baseCurrency = evmMarketData[chainId]?.[address]?.currency;
-    const tokenExchangeRate =
-      evmCurrencyRates[baseCurrency]?.conversionRate ?? undefined;
+    const assetId =
+      type === AssetType.token
+        ? asset.address
+        : getNativeAssetForChainIdSafe(chainId)?.assetId;
 
-    const currentPrice =
-      tokenExchangeRate !== undefined && tokenMarketPrice !== undefined
-        ? tokenExchangeRate * tokenMarketPrice
-        : undefined;
+    if (!assetId && type === AssetType.native) {
+      return undefined;
+    }
 
-    return { currentPrice };
-  }
+    const currentPriceAsString =
+      nonEvmConversionRates?.[assetId as CaipAssetType]?.rate;
 
-  // Format normalization in isEvmChainId should prevent most errors, but using safe wrapper as defensive fallback
-  const assetId =
-    type === AssetType.token
-      ? asset.address
-      : getNativeAssetForChainIdSafe(chainId)?.assetId;
+    return currentPriceAsString ? parseFloat(currentPriceAsString) : undefined;
+  }, [
+    isEvm,
+    asset,
+    chainId,
+    type,
+    evmMarketData,
+    evmCurrencyRates,
+    nonEvmConversionRates,
+  ]);
 
-  // If we can't get the assetId for a native token (unsupported chain), return undefined price
-  if (!assetId && type === AssetType.native) {
-    return { currentPrice: undefined };
-  }
+  const spotPriceAssetId = useMemo((): CaipAssetType | undefined => {
+    if (cachedPrice !== undefined) {
+      return undefined;
+    }
 
-  const currentPriceAsString =
-    nonEvmConversionRates?.[assetId as CaipAssetType]?.rate;
+    const caipChainId = isCaipChainId(chainId)
+      ? chainId
+      : formatChainIdToCaip(chainId);
 
-  const currentPrice = currentPriceAsString
-    ? parseFloat(currentPriceAsString)
-    : undefined;
+    if (type === AssetType.native) {
+      return getNativeAssetForChainIdSafe(chainId)?.assetId;
+    }
 
-  return { currentPrice };
+    if (type === AssetType.token) {
+      const address = isEvm
+        ? toChecksumHexAddress(asset.address)
+        : asset.address;
+      return toAssetId(address, caipChainId);
+    }
+
+    return undefined;
+  }, [cachedPrice, asset, chainId, isEvm, type]);
+
+  const [fetchedPriceState, setFetchedPriceState] = useState<{
+    assetId: CaipAssetType;
+    price?: number;
+  }>();
+
+  useEffect(() => {
+    if (!spotPriceAssetId) {
+      return undefined;
+    }
+
+    const abortController = new AbortController();
+    let isCancelled = false;
+
+    const fetchPrice = async () => {
+      try {
+        const price = await getTokenExchangeRate({
+          assetId: spotPriceAssetId,
+          currency: currentCurrency.toLowerCase(),
+          signal: abortController.signal,
+        });
+        if (!isCancelled) {
+          setFetchedPriceState({ assetId: spotPriceAssetId, price });
+        }
+      } catch {
+        if (!isCancelled) {
+          setFetchedPriceState({ assetId: spotPriceAssetId, price: undefined });
+        }
+      }
+    };
+
+    fetchPrice();
+
+    return () => {
+      isCancelled = true;
+      abortController.abort();
+    };
+  }, [spotPriceAssetId, currentCurrency]);
+
+  const fetchedPrice =
+    fetchedPriceState?.assetId === spotPriceAssetId
+      ? fetchedPriceState.price
+      : undefined;
+
+  return { currentPrice: cachedPrice ?? fetchedPrice };
 };

--- a/ui/pages/asset/hooks/useCurrentPrice.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.ts
@@ -1,141 +1,140 @@
 import { AssetType, formatChainIdToCaip } from '@metamask/bridge-controller';
+import { useQuery } from '@tanstack/react-query';
+import {
+  GC_TIMES,
+  STALE_TIMES,
+  type SupportedCurrency,
+} from '@metamask/core-backend';
 import { CaipAssetType, Hex, isCaipChainId } from '@metamask/utils';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { toChecksumHexAddress } from '../../../../shared/lib/hexstring-utils';
-import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
-import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
-import {
-  getNativeAssetForChainIdSafe,
-  getTokenExchangeRate,
-} from '../../../ducks/bridge/utils';
 import { getCurrencyRates, getMarketData } from '../../../selectors';
 import { getAssetsRates } from '../../../selectors/assets';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
+import { apiClient } from '../../../helpers/api-client';
 import { Asset } from '../types/asset';
+import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
+import { getNativeAssetForChainIdSafe } from '../../../ducks/bridge/utils';
 
 /**
- * Get the current price of an asset from Redux cache, falling back to the
- * price API spot-prices endpoint when the token is not in the wallet.
+ * Get the price of an asset from the rates already held in state. Only assets
+ * the user holds are tracked there, so tokens that aren't in the wallet have no
+ * price here.
  *
- * @param asset - The asset to get the current price of
- * @returns The current price of the asset. If the asset is not found, or the price is not found, returns undefined.
+ * @param asset - The asset to get the cached price of
+ * @returns The cached price of the asset, or undefined if it is not in state.
  */
-export const useCurrentPrice = (asset: Asset): { currentPrice?: number } => {
+const useCachedPrice = (asset: Asset): { currentPrice?: number } => {
   const isEvm = isEvmChainId(asset.chainId);
   const evmMarketData = useSelector(getMarketData);
   const evmCurrencyRates = useSelector(getCurrencyRates);
   const nonEvmConversionRates = useSelector(getAssetsRates);
-  const currentCurrency = useSelector(getCurrentCurrency);
 
   const { chainId, type } = asset;
 
-  const cachedPrice = useMemo(() => {
-    if (isEvm) {
-      if (type === AssetType.native) {
-        return evmCurrencyRates[asset.symbol]?.conversionRate;
-      }
-
-      const address = toChecksumHexAddress(asset.address) as Hex;
-      const tokenMarketPrice = evmMarketData[chainId]?.[address]?.price;
-      const baseCurrency = evmMarketData[chainId]?.[address]?.currency;
-      const tokenExchangeRate =
-        evmCurrencyRates[baseCurrency]?.conversionRate ?? undefined;
-
-      if (tokenExchangeRate !== undefined && tokenMarketPrice !== undefined) {
-        return tokenExchangeRate * tokenMarketPrice;
-      }
-
-      return undefined;
+  if (isEvm) {
+    if (type === AssetType.native) {
+      return {
+        currentPrice:
+          evmCurrencyRates[asset.symbol]?.conversionRate ?? undefined,
+      };
     }
 
-    const assetId =
-      type === AssetType.token
-        ? asset.address
-        : getNativeAssetForChainIdSafe(chainId)?.assetId;
+    // Market and conversion rate data
+    const address = toChecksumHexAddress(asset.address) as Hex;
+    const tokenMarketPrice = evmMarketData[chainId]?.[address]?.price;
+    const baseCurrency = evmMarketData[chainId]?.[address]?.currency;
+    const tokenExchangeRate =
+      evmCurrencyRates[baseCurrency]?.conversionRate ?? undefined;
 
-    if (!assetId && type === AssetType.native) {
-      return undefined;
-    }
+    const currentPrice =
+      tokenExchangeRate !== undefined && tokenMarketPrice !== undefined
+        ? tokenExchangeRate * tokenMarketPrice
+        : undefined;
 
-    const currentPriceAsString =
-      nonEvmConversionRates?.[assetId as CaipAssetType]?.rate;
+    return { currentPrice };
+  }
 
-    return currentPriceAsString ? parseFloat(currentPriceAsString) : undefined;
-  }, [
-    isEvm,
-    asset,
-    chainId,
-    type,
-    evmMarketData,
-    evmCurrencyRates,
-    nonEvmConversionRates,
-  ]);
+  // Format normalization in isEvmChainId should prevent most errors, but using safe wrapper as defensive fallback
+  const assetId =
+    type === AssetType.token
+      ? asset.address
+      : getNativeAssetForChainIdSafe(chainId)?.assetId;
 
-  const spotPriceAssetId = useMemo((): CaipAssetType | undefined => {
-    if (cachedPrice !== undefined) {
-      return undefined;
+  // If we can't get the assetId for a native token (unsupported chain), return undefined price
+  if (!assetId && type === AssetType.native) {
+    return { currentPrice: undefined };
+  }
+
+  const currentPriceAsString =
+    nonEvmConversionRates?.[assetId as CaipAssetType]?.rate;
+
+  const currentPrice = currentPriceAsString
+    ? parseFloat(currentPriceAsString)
+    : undefined;
+
+  return { currentPrice };
+};
+
+/**
+ * Get the price of an asset from the price API spot-prices endpoint. Used for
+ * assets the user doesn't hold, which have no price in state.
+ *
+ * @param asset - The asset to get the spot price of
+ * @param enabled - Whether to fetch. Pass false when a cached price is available.
+ * @returns The spot price of the asset, or undefined while loading or if unavailable.
+ */
+const useSpotPrice = (
+  asset: Asset,
+  enabled: boolean,
+): { currentPrice?: number } => {
+  const currency = useSelector(getCurrentCurrency);
+  const isEvm = isEvmChainId(asset.chainId);
+  const { chainId, type } = asset;
+
+  const assetId = useMemo(() => {
+    if (type === AssetType.native) {
+      return getNativeAssetForChainIdSafe(chainId)?.assetId;
     }
 
     const caipChainId = isCaipChainId(chainId)
       ? chainId
       : formatChainIdToCaip(chainId);
+    const address = isEvm ? toChecksumHexAddress(asset.address) : asset.address;
 
-    if (type === AssetType.native) {
-      return getNativeAssetForChainIdSafe(chainId)?.assetId;
-    }
+    return toAssetId(address, caipChainId);
+  }, [asset, chainId, isEvm, type]);
 
-    if (type === AssetType.token) {
-      const address = isEvm
-        ? toChecksumHexAddress(asset.address)
-        : asset.address;
-      return toAssetId(address, caipChainId);
-    }
+  const queryOptions = apiClient.prices.getV3SpotPricesQueryOptions(
+    assetId ? [assetId] : [],
+    { currency: currency.toLowerCase() as SupportedCurrency },
+  );
 
-    return undefined;
-  }, [cachedPrice, asset, chainId, isEvm, type]);
+  const { data: currentPrice } = useQuery({
+    ...queryOptions,
+    enabled: enabled && Boolean(assetId),
+    retry: false,
+    staleTime: STALE_TIMES.PRICES,
+    gcTime: GC_TIMES.DEFAULT,
+    select: (response) => (assetId ? response?.[assetId]?.price : undefined),
+  });
 
-  const [fetchedPriceState, setFetchedPriceState] = useState<{
-    assetId: CaipAssetType;
-    price?: number;
-  }>();
+  return { currentPrice };
+};
 
-  useEffect(() => {
-    if (!spotPriceAssetId) {
-      return undefined;
-    }
+/**
+ * Get the current price of an asset.
+ *
+ * @param asset - The asset to get the current price of
+ * @returns The current price of the asset. If the asset is not found, or the price is not found, returns undefined.
+ */
+export const useCurrentPrice = (asset: Asset): { currentPrice?: number } => {
+  const { currentPrice: cachedPrice } = useCachedPrice(asset);
+  const { currentPrice: spotPrice } = useSpotPrice(
+    asset,
+    cachedPrice === undefined,
+  );
 
-    const abortController = new AbortController();
-    let isCancelled = false;
-
-    const fetchPrice = async () => {
-      try {
-        const price = await getTokenExchangeRate({
-          assetId: spotPriceAssetId,
-          currency: currentCurrency.toLowerCase(),
-          signal: abortController.signal,
-        });
-        if (!isCancelled) {
-          setFetchedPriceState({ assetId: spotPriceAssetId, price });
-        }
-      } catch {
-        if (!isCancelled) {
-          setFetchedPriceState({ assetId: spotPriceAssetId, price: undefined });
-        }
-      }
-    };
-
-    fetchPrice();
-
-    return () => {
-      isCancelled = true;
-      abortController.abort();
-    };
-  }, [spotPriceAssetId, currentCurrency]);
-
-  const fetchedPrice =
-    fetchedPriceState?.assetId === spotPriceAssetId
-      ? fetchedPriceState.price
-      : undefined;
-
-  return { currentPrice: cachedPrice ?? fetchedPrice };
+  return { currentPrice: cachedPrice ?? spotPrice };
 };

--- a/ui/pages/asset/hooks/useCurrentPrice.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.ts
@@ -1,10 +1,6 @@
 import { AssetType, formatChainIdToCaip } from '@metamask/bridge-controller';
 import { useQuery } from '@tanstack/react-query';
-import {
-  GC_TIMES,
-  STALE_TIMES,
-  type SupportedCurrency,
-} from '@metamask/core-backend';
+import { type SupportedCurrency } from '@metamask/core-backend';
 import { CaipAssetType, Hex, isCaipChainId } from '@metamask/utils';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -18,9 +14,7 @@ import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
 import { getNativeAssetForChainIdSafe } from '../../../ducks/bridge/utils';
 
 /**
- * Get the price of an asset from the rates already held in state. Only assets
- * the user holds are tracked there, so tokens that aren't in the wallet have no
- * price here.
+ * Get cached spot prices from redux state
  *
  * @param asset - The asset to get the cached price of
  * @returns The cached price of the asset, or undefined if it is not in state.
@@ -78,8 +72,7 @@ const useCachedPrice = (asset: Asset): { currentPrice?: number } => {
 };
 
 /**
- * Get the price of an asset from the price API spot-prices endpoint. Used for
- * assets the user doesn't hold, which have no price in state.
+ * Get spot prices from our APIs
  *
  * @param asset - The asset to get the spot price of
  * @param enabled - Whether to fetch. Pass false when a cached price is available.
@@ -114,9 +107,6 @@ const useSpotPrice = (
   const { data: currentPrice } = useQuery({
     ...queryOptions,
     enabled: enabled && Boolean(assetId),
-    retry: false,
-    staleTime: STALE_TIMES.PRICES,
-    gcTime: GC_TIMES.DEFAULT,
     select: (response) => (assetId ? response?.[assetId]?.price : undefined),
   });
 

--- a/ui/pages/asset/hooks/useCurrentPrice.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.ts
@@ -107,7 +107,11 @@ const useSpotPrice = (
   const { data: currentPrice } = useQuery({
     ...queryOptions,
     enabled: enabled && Boolean(assetId),
-    select: (response) => (assetId ? response?.[assetId]?.price : undefined),
+    select: (response) =>
+      assetId
+        ? (response?.[assetId]?.price ??
+          response?.[assetId.toLowerCase()]?.price)
+        : undefined,
   });
 
   return { currentPrice };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

2 Issues & fixes:
1. We only showed the TDP price for tokens we had balances for (so inside our redux cache) - now we make the additional API call (similar to mobile) for tokens you do not have balances for.
2. Swaps page used CAIP, but the underlying Assets Page does not support CAIP format (added a TODO inside the repo)

## **Changelog**

CHANGELOG entry: Fixed token price loading on the asset page for tokens the user does not own.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/45322 https://consensyssoftware.atlassian.net/browse/ASSETS-3882 https://consensyssoftware.atlassian.net/browse/ASSETS-3852

## **Manual testing steps**

1. Open MetaMask and go to **Swap**.
2. Open the token picker and scroll to a token you do not hold (zero balance, not in your token list).
3. Click the **info** icon next to that token.
4. On the token asset page, confirm the price loads instead of staying on the skeleton loader.
5. Repeat with another unowned ERC-20 on mainnet to confirm consistency.
6. Open the asset page for a token you *do* hold and confirm the price still renders immediately from cached rates.

## **Screenshots/Recordings**

### **Before**

### **After**

https://www.loom.com/share/b1f10ffcc0bc458daffafa4616118d1a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-842cbc4a-9d96-42be-920c-da36d0ecea60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-842cbc4a-9d96-42be-920c-da36d0ecea60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

