### PR TITLE
fix(ci): align AMO reviewer rebuild with production zip builds

### DIFF
--- a/.github/scripts/bundle.sh
+++ b/.github/scripts/bundle.sh
@@ -59,16 +59,20 @@ nvm install
 # 4. Enable corepack to install yarn
 corepack enable
 
-# 5. Install dependencies
-yarn
+# 5. Install dependencies (match CI: immutable install, skip allow-scripts)
+export CI=true
+yarn install --immutable
 
 # 6. Compile the webpack launcher (generates development/.webpack/launch.js,
 # which the webpack:lavamoat build script loads)
 yarn webpack:tsc
 
-# 7. Set the epoch to the package.json mtime; this is used to set the mtime of the files in the generated zip.
-SOURCE_DATE_EPOCH="$(node -p "Math.floor(require('node:fs').statSync('package.json').mtimeMs / 1000)")"
-export SOURCE_DATE_EPOCH
+# 7. Set zip mtime epoch when not already provided (e.g. by compare_builds.sh).
+# package.json mtime matches the GitHub source archive used for reviewer rebuilds.
+if [ -z "${SOURCE_DATE_EPOCH:-}" ]; then
+  SOURCE_DATE_EPOCH="$(node -p "Math.floor(require('node:fs').statSync('package.json').mtimeMs / 1000)")"
+  export SOURCE_DATE_EPOCH
+fi
 
 # 8. Run the production build command
 if [ "${1:-}" = "--flask" ]; then

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
 # INFRA-3753: includes FIREFOX_BUNDLE_SH_GIT_REF / per-version tag support.
 # SOURCE_DATE_EPOCH alignment for AMO reviewer reproducibility (compare_builds).
-FIREFOX_BUNDLE_SCRIPT_REF="fe722583fa66e6d430fdccffb65c609f5ea525af"
+FIREFOX_BUNDLE_SCRIPT_REF="e938951b63bd6947ff8ee0b83f864371b4c0a6ad"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -21,7 +21,8 @@ set -euo pipefail
 # Pin firefox-bundle-script tooling (prepare_release.sh + scripts). Bump via PR
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
 # INFRA-3753: includes FIREFOX_BUNDLE_SH_GIT_REF / per-version tag support.
-FIREFOX_BUNDLE_SCRIPT_REF="1cb37c0817b319d9846dbca827d533e0ae769984"
+# SOURCE_DATE_EPOCH alignment for AMO reviewer reproducibility (compare_builds).
+FIREFOX_BUNDLE_SCRIPT_REF="fe722583fa66e6d430fdccffb65c609f5ea525af"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
 # INFRA-3753: includes FIREFOX_BUNDLE_SH_GIT_REF / per-version tag support.
 # SOURCE_DATE_EPOCH alignment for AMO reviewer reproducibility (compare_builds).
-FIREFOX_BUNDLE_SCRIPT_REF="e938951b63bd6947ff8ee0b83f864371b4c0a6ad"
+FIREFOX_BUNDLE_SCRIPT_REF="25500291954a9c40587e9dd0a8cc3f70d6c91791"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -90,6 +90,13 @@ jobs:
       - name: Run tsc
         run: yarn webpack:tsc
 
+      - name: Set SOURCE_DATE_EPOCH for reproducible zip builds
+        if: ${{ contains(inputs.build-command, '--zip') }}
+        run: |
+          SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+          echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" >> "${GITHUB_ENV}"
+          echo "Using SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} for zip entry mtimes"
+
       - name: Run build
         run: ${{ inputs.build-command }}${{ inputs.bundle-analyzer && ' --bundleAnalyzer' || '' }}
 


### PR DESCRIPTION
## **Description**

Extension v13.47.0 Runway publish failed on AMO reviewer packaging (deterministic, not flaky — re-run of failed jobs produced the same diff). GitHub release and build assets were published; CWS/AMO store uploads were skipped because Phase 1 failed after release creation.

Failed workflow: https://github.com/MetaMask/metamask-extension/actions/runs/33810815254 (job https://github.com/MetaMask/metamask-extension/actions/runs/33810815254/job/100834709412)

**Problem:** `compare_builds.sh` cold-rebuilds Firefox via `bundle.sh` and compares to the CI-built release zip. The rebuild did not match the published zip (`runtime.*.js` content hash + HTML script references).

**Root cause (stacked changes since Jun 2026):**
- #43100 moved Firefox CI and `bundle.sh` to webpack `--zip` builds with different environments (CI: full git + structured install; reviewer: GitHub source archive + plain `yarn`)
- #43174 added `SOURCE_DATE_EPOCH` to `bundle.sh` from post-`yarn` `package.json` mtime; CI never sets it (uses git commit time)
- INFRA-3683 (#43785) automated `compare_builds` as a release publish gate

**Solution:**
1. Set `SOURCE_DATE_EPOCH` from the release commit in CI for `--zip` builds (`run-build.yml`)
2. Align `bundle.sh` with CI install (`CI=true`, `yarn install --immutable`, no allow-scripts) and honor a pre-set `SOURCE_DATE_EPOCH`
3. Pin updated `firefox-bundle-script` tooling (`FIREFOX_BUNDLE_SCRIPT_REF` → `2550029`) — merge https://github.com/MetaMask/firefox-bundle-script/pull/11 first

**13.47.0 note:** Tag `v13.47.0` still ships the old `bundle.sh`. Cherry-pick this PR to `release/13.47.0` (or active release branch) for future cuts; already-published v13.47.0 zip cannot be re-validated without break-glass for AMO reviewer S3. Stores were unblocked via Runway re-dispatch (Phase 1 skips existing release).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/INFRA-3920

Related PRs:
- https://github.com/MetaMask/firefox-bundle-script/pull/11 (merge first)

## **Manual testing steps**

1. Merge firefox-bundle-script#11, then this PR to `main`.
2. Cherry-pick to an active release branch before the next publish.
3. On a test release (or locally with `compare_builds.sh` for a version whose tag includes the updated `bundle.sh`), verify comparison report shows `IDENTICAL`.
4. Confirm `run-build.yml` zip builds log `SOURCE_DATE_EPOCH` matching `git log -1 --format=%ct` on the release SHA.

## **Screenshots/Recordings**

N/A (CI/tooling only)

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
