### PR TITLE
feat(ramps): migrate Portfolio buy orders

### DIFF
--- a/ui/hooks/ramps/utils/portfolioBuyOrdersMigration.test.ts
+++ b/ui/hooks/ramps/utils/portfolioBuyOrdersMigration.test.ts
@@ -1,0 +1,131 @@
+import {
+  getStorageItem,
+  setStorageItem,
+} from '../../../../shared/lib/storage-helpers';
+import {
+  EXT_MIGRATE_ORDERS_ENTRY,
+  getPortfolioMigrateOrdersUrl,
+  hasCompletedPortfolioBuyOrdersMigration,
+  MIGRATE_STATUS_DONE,
+  MIGRATE_STATUS_QUERY_PARAM,
+  PORTFOLIO_BUY_ORDERS_MIGRATION_STORAGE_KEY,
+  runPortfolioBuyOrdersMigration,
+} from './portfolioBuyOrdersMigration';
+
+jest.mock('../../../../shared/lib/storage-helpers', () => ({
+  getStorageItem: jest.fn(),
+  setStorageItem: jest.fn(),
+}));
+jest.mock('../../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../../store/controller-actions/ramps-controller', () => ({
+  setRampsSelectedProvider: jest.fn().mockResolvedValue(undefined),
+  syncRampsOrdersWithUserStorage: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetStorageItem = getStorageItem as jest.Mock;
+const mockSetStorageItem = setStorageItem as jest.Mock;
+const doneUrl = `https://app.metamask.io/buy?metamaskEntry=${EXT_MIGRATE_ORDERS_ENTRY}&${MIGRATE_STATUS_QUERY_PARAM}=${MIGRATE_STATUS_DONE}`;
+
+function createPlatform(tabId: number) {
+  return {
+    openTab: jest.fn().mockResolvedValue({ id: tabId }),
+    closeTab: jest.fn().mockResolvedValue(undefined),
+    addTabUpdatedListener: jest.fn((listener) => {
+      queueMicrotask(() => listener(tabId, { url: doneUrl }));
+    }),
+    removeTabUpdatedListener: jest.fn(),
+  };
+}
+
+describe('portfolioBuyOrdersMigration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetStorageItem.mockResolvedValue(undefined);
+    mockSetStorageItem.mockResolvedValue(undefined);
+  });
+
+  it('builds a migrate URL with the Extension entry param', () => {
+    expect(getPortfolioMigrateOrdersUrl('https://app.metamask.io')).toBe(
+      `https://app.metamask.io/buy?metamaskEntry=${EXT_MIGRATE_ORDERS_ENTRY}`,
+    );
+  });
+
+  it('hasCompletedPortfolioBuyOrdersMigration reads storage', async () => {
+    mockGetStorageItem.mockResolvedValue(true);
+    await expect(hasCompletedPortfolioBuyOrdersMigration()).resolves.toBe(true);
+    expect(mockGetStorageItem).toHaveBeenCalledWith(
+      PORTFOLIO_BUY_ORDERS_MIGRATION_STORAGE_KEY,
+    );
+  });
+
+  it('no-ops when migration already completed', async () => {
+    mockGetStorageItem.mockResolvedValue(true);
+    const platform = createPlatform(1);
+    const syncOrders = jest.fn();
+    await runPortfolioBuyOrdersMigration({ platform, syncOrders });
+    expect(platform.openTab).not.toHaveBeenCalled();
+    expect(syncOrders).not.toHaveBeenCalled();
+  });
+
+  it('opens Portfolio, waits for done URL, closes tab, syncs, and marks complete', async () => {
+    const platform = createPlatform(42);
+    const syncOrders = jest.fn().mockResolvedValue(undefined);
+    await runPortfolioBuyOrdersMigration({
+      platform,
+      syncOrders,
+      timeoutMs: 5_000,
+    });
+    expect(platform.openTab).toHaveBeenCalledWith({
+      url: expect.stringContaining(`metamaskEntry=${EXT_MIGRATE_ORDERS_ENTRY}`),
+      active: false,
+    });
+    expect(platform.closeTab).toHaveBeenCalledWith(42);
+    expect(syncOrders).toHaveBeenCalledTimes(1);
+    expect(mockSetStorageItem).toHaveBeenCalledWith(
+      PORTFOLIO_BUY_ORDERS_MIGRATION_STORAGE_KEY,
+      true,
+    );
+  });
+
+  it('does not mark complete when sync fails so Buy can retry', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const platform = createPlatform(7);
+    const syncOrders = jest
+      .fn()
+      .mockRejectedValue(new Error('invalid access token'));
+    await runPortfolioBuyOrdersMigration({
+      platform,
+      syncOrders,
+      timeoutMs: 5_000,
+    });
+    expect(syncOrders).toHaveBeenCalledTimes(1);
+    expect(mockSetStorageItem).not.toHaveBeenCalledWith(
+      PORTFOLIO_BUY_ORDERS_MIGRATION_STORAGE_KEY,
+      true,
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('does not sync or mark complete when Portfolio times out', async () => {
+    const platform = createPlatform(8);
+    platform.addTabUpdatedListener.mockImplementation();
+    const syncOrders = jest.fn();
+
+    await runPortfolioBuyOrdersMigration({
+      platform,
+      syncOrders,
+      timeoutMs: 0,
+    });
+
+    expect(syncOrders).not.toHaveBeenCalled();
+    expect(mockSetStorageItem).not.toHaveBeenCalled();
+  });
+
+  it('does not mark complete without the tab API', async () => {
+    await runPortfolioBuyOrdersMigration({ platform: {} as never });
+
+    expect(mockSetStorageItem).not.toHaveBeenCalled();
+  });
+});

--- a/ui/hooks/ramps/utils/portfolioBuyOrdersMigration.ts
+++ b/ui/hooks/ramps/utils/portfolioBuyOrdersMigration.ts
@@ -1,0 +1,205 @@
+import {
+  getStorageItem,
+  setStorageItem,
+} from '../../../../shared/lib/storage-helpers';
+import { isProduction } from '../../../../shared/lib/environment';
+import { submitRequestToBackground } from '../../../store/background-connection';
+import {
+  setRampsSelectedProvider,
+  syncRampsOrdersWithUserStorage,
+} from '../../../store/controller-actions/ramps-controller';
+
+export const PORTFOLIO_BUY_ORDERS_MIGRATION_STORAGE_KEY =
+  'portfolio-buy-orders-migration-v13';
+export const EXT_MIGRATE_ORDERS_ENTRY = 'ext_migrate_orders';
+export const MIGRATE_STATUS_QUERY_PARAM = 'migrateStatus';
+export const MIGRATE_STATUS_DONE = 'done';
+const DEFAULT_PORTFOLIO_URL = 'https://app.metamask.io';
+const MIGRATE_TIMEOUT_MS = 45_000;
+const SYNC_TIMEOUT_MS = 12_000;
+
+type PlatformTabApi = {
+  openTab: (options: {
+    url: string;
+    active?: boolean;
+  }) => Promise<{ id?: number }>;
+  closeTab: (tabId: number) => Promise<void>;
+  addTabUpdatedListener: (
+    listener: (
+      tabId: number,
+      changeInfo: { url?: string; pendingUrl?: string },
+      tab?: { url?: string },
+    ) => void,
+  ) => void;
+  removeTabUpdatedListener: (listener: (...args: unknown[]) => void) => void;
+};
+
+type MigrationOptions = {
+  platform?: PlatformTabApi;
+  timeoutMs?: number;
+  syncOrders?: () => Promise<void>;
+};
+
+export async function hasCompletedPortfolioBuyOrdersMigration(): Promise<boolean> {
+  const value = await getStorageItem(
+    PORTFOLIO_BUY_ORDERS_MIGRATION_STORAGE_KEY,
+  );
+  return value === true || value === '1';
+}
+
+export function getPortfolioMigrateOrdersUrl(
+  portfolioBaseUrl: string = process.env.PORTFOLIO_URL || DEFAULT_PORTFOLIO_URL,
+): string {
+  const url = new URL(portfolioBaseUrl);
+  url.pathname = 'buy';
+  url.searchParams.set('metamaskEntry', EXT_MIGRATE_ORDERS_ENTRY);
+  return url.toString();
+}
+
+function isMigrateDoneUrl(candidateUrl: string | undefined): boolean {
+  if (!candidateUrl) {
+    return false;
+  }
+  try {
+    const url = new URL(candidateUrl);
+    return (
+      url.searchParams.get('metamaskEntry') === EXT_MIGRATE_ORDERS_ENTRY &&
+      url.searchParams.get(MIGRATE_STATUS_QUERY_PARAM) === MIGRATE_STATUS_DONE
+    );
+  } catch {
+    return false;
+  }
+}
+
+let migrationInFlight: Promise<void> | null = null;
+
+export async function runPortfolioBuyOrdersMigration(
+  options?: MigrationOptions,
+): Promise<void> {
+  migrationInFlight ??= runPortfolioBuyOrdersMigrationInner(options).finally(
+    () => {
+      migrationInFlight = null;
+    },
+  );
+  await migrationInFlight;
+}
+
+async function runPortfolioBuyOrdersMigrationInner(
+  options?: MigrationOptions,
+): Promise<void> {
+  if (await hasCompletedPortfolioBuyOrdersMigration()) {
+    return;
+  }
+
+  const platform =
+    options?.platform ?? (globalThis as { platform?: PlatformTabApi }).platform;
+  if (!platform?.openTab || !platform?.closeTab) {
+    return;
+  }
+
+  const timeoutMs = options?.timeoutMs ?? MIGRATE_TIMEOUT_MS;
+  const syncOrders = options?.syncOrders ?? syncRampsOrdersWithUserStorage;
+  let openedTabId: number | undefined;
+  let didMigrate = false;
+
+  try {
+    const openedTab = await platform.openTab({
+      url: getPortfolioMigrateOrdersUrl(),
+      active: false,
+    });
+    openedTabId = openedTab.id;
+    if (openedTabId !== undefined) {
+      didMigrate = await waitForMigrateDone(platform, openedTabId, timeoutMs);
+    }
+  } catch (error) {
+    console.error('Portfolio Buy-order migration tab failed', error);
+  } finally {
+    if (openedTabId !== undefined) {
+      await platform.closeTab(openedTabId).catch(() => undefined);
+    }
+  }
+
+  if (!didMigrate) {
+    return;
+  }
+
+  try {
+    if (!isProduction()) {
+      await submitRequestToBackground('performSignOut').catch((error) =>
+        console.error('performSignOut before migrate sync failed', error),
+      );
+    }
+    await submitRequestToBackground('performSignIn');
+    let syncTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        syncOrders(),
+        new Promise((_, reject) => {
+          syncTimeoutId = setTimeout(
+            () => reject(new Error('Ramps order sync timed out')),
+            SYNC_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } finally {
+      clearTimeout(syncTimeoutId);
+    }
+    await setRampsSelectedProvider(null).catch((error) =>
+      console.error(
+        'Failed to clear selected provider after migrate sync',
+        error,
+      ),
+    );
+    await setStorageItem(PORTFOLIO_BUY_ORDERS_MIGRATION_STORAGE_KEY, true);
+  } catch (error) {
+    console.error(
+      'syncRampsOrdersWithUserStorage after Portfolio migrate failed',
+      error,
+    );
+  }
+}
+
+function waitForMigrateDone(
+  platform: PlatformTabApi,
+  openedTabId: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const wait = {
+      settled: false,
+      timeoutId: undefined as ReturnType<typeof setTimeout> | undefined,
+    };
+
+    const finish = (didMigrate: boolean) => {
+      if (wait.settled) {
+        return;
+      }
+      wait.settled = true;
+      platform.removeTabUpdatedListener(
+        onUpdated as (...args: unknown[]) => void,
+      );
+      if (wait.timeoutId !== undefined) {
+        clearTimeout(wait.timeoutId);
+      }
+      resolve(didMigrate);
+    };
+
+    function onUpdated(
+      tabId: number,
+      changeInfo: { url?: string; pendingUrl?: string },
+      tab?: { url?: string },
+    ) {
+      if (tabId !== openedTabId) {
+        return;
+      }
+      if (
+        isMigrateDoneUrl(changeInfo?.url || changeInfo?.pendingUrl || tab?.url)
+      ) {
+        finish(true);
+      }
+    }
+
+    wait.timeoutId = setTimeout(() => finish(false), timeoutMs);
+    platform.addTabUpdatedListener(onUpdated);
+  });
+}

--- a/ui/hooks/ramps/utils/portfolioConnection.ts
+++ b/ui/hooks/ramps/utils/portfolioConnection.ts
@@ -22,10 +22,9 @@ function getConfiguredPortfolioOrigin(): string | null {
 
 /**
  * Whether this wallet has ever connected accounts to Portfolio (live accounts
- * permission or eth_accounts history). Used to send returning Portfolio buyers
- * back to Portfolio while in-app Buy rolls out — never-connected wallets use
- * in-app. Includes `PORTFOLIO_URL` origin so local Portfolio (e.g.
- * localhost:3000) works.
+ * permission or eth_accounts history). Used as a proxy for "may have local Buy
+ * orders" (silent Portfolio migrate) and related Buy entry gating. Includes
+ * `PORTFOLIO_URL` origin so local Portfolio (e.g. localhost:3000) works.
  *
  * Portfolio origins are present in `subjects` on a fresh install because
  * preinstalled snaps pre-approve them via `initialConnections`, so a subject


### PR DESCRIPTION
## **Description**

Part 4 of 5 replacing #44367. Stacked on #46044.

Adds the one-time Portfolio Buy-order migration utility. It opens Portfolio's `ext_migrate_orders` entry in a background tab, waits for an explicit `migrateStatus=done`, refreshes Profile Sync authentication when required, runs ramps order sync with a bounded timeout, clears the auto-selected provider, and records completion only after migration and sync both succeed.

Concurrent calls coalesce, failed or timed-out attempts remain retryable, and the temporary tab and timers are always cleaned up. This PR intentionally does not invoke the migration from Buy navigation yet.

Ownership is limited to `@MetaMask/money-movement`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Depends on #46044.
Works with consensys-vertical-apps/metamask-portfolio#2053.
Replaces part of #44367.

## **Manual testing steps**

1. Connect the test wallet to Portfolio and ensure its `on-ramp-orders` storage contains a Buy order.
2. Load the extension with Backup & Sync and **Buy & sell orders** enabled for the same SRP.
3. Clear `portfolio-buy-orders-migration-v13` from extension storage and invoke the migration helper through the development harness.
4. Confirm a background Portfolio tab opens and closes after `migrateStatus=done`.
5. Confirm the Portfolio order reaches `RampsController.orders` and the completion key is set.
6. Repeat with Portfolio unavailable and confirm the key remains unset so the migration can retry.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

Stack: #46042 → #46043 → #46044 → #46045 → #46046