### PR TITLE
test: flaky and refactor anti-pattern `Perps Withdraw submits a valid withdrawal from the confirmation flow`

### DIFF
--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -43,7 +43,6 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import type { AssetsControllerState } from '@metamask/assets-controller';
-import type { GasFeeState } from '@metamask/gas-fee-controller';
 import type { PerpsControllerState } from '@metamask/perps-controller';
 import type { PasskeyControllerState } from '@metamask/passkey-controller';
 import type { AppStateControllerState } from '../../../app/scripts/controllers/app-state-controller';
@@ -292,11 +291,6 @@ class FixtureBuilderV2 {
 
   withCurrencyController(data: Partial<CurrencyRateState>): this {
     merge(this.fixture.data.CurrencyController, data);
-    return this;
-  }
-
-  withGasFeeController(data: Partial<GasFeeState>): this {
-    merge(this.fixture.data.GasFeeController, data);
     return this;
   }
 

--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -43,6 +43,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import type { AssetsControllerState } from '@metamask/assets-controller';
+import type { GasFeeState } from '@metamask/gas-fee-controller';
 import type { PerpsControllerState } from '@metamask/perps-controller';
 import type { PasskeyControllerState } from '@metamask/passkey-controller';
 import type { AppStateControllerState } from '../../../app/scripts/controllers/app-state-controller';
@@ -291,6 +292,11 @@ class FixtureBuilderV2 {
 
   withCurrencyController(data: Partial<CurrencyRateState>): this {
     merge(this.fixture.data.CurrencyController, data);
+    return this;
+  }
+
+  withGasFeeController(data: Partial<GasFeeState>): this {
+    merge(this.fixture.data.GasFeeController, data);
     return this;
   }
 

--- a/test/e2e/page-objects/pages/home/perps-tab.ts
+++ b/test/e2e/page-objects/pages/home/perps-tab.ts
@@ -180,6 +180,17 @@ export class PerpsTab extends PerpsPositionsBase {
   }
 
   /**
+   * Opens Withdraw from Perps Home. The destination is fixture-dependent:
+   * the legacy form (`PerpsWithdrawPage`) or the confirmation flow
+   * (`PerpsWithdrawConfirmation`).
+   */
+  async openWithdraw(): Promise<void> {
+    await this.navigateToPerpsHome();
+    await this.waitForBalanceSection();
+    await this.clickWithdraw();
+  }
+
+  /**
    * Waits for the balance section to be visible (empty or with balance).
    */
   async waitForBalanceSection(): Promise<void> {

--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -4,6 +4,7 @@ import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import {
   DEFAULT_FIXTURE_ACCOUNT_ID,
   DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+  NETWORK_CLIENT_ID,
 } from '../../constants';
 import {
   getProductionRemoteFlagApiResponse,
@@ -69,11 +70,11 @@ const ARBITRUM_GAS_FEE_ESTIMATES = {
   },
   estimatedBaseFee: '0.01',
   networkCongestion: 0.1,
-  latestPriorityFeeRange: ['0.01', '0.05'] as [string, string],
-  historicalPriorityFeeRange: ['0.01', '0.1'] as [string, string],
-  historicalBaseFeeRange: ['0.01', '0.02'] as [string, string],
-  priorityFeeTrend: 'level' as const,
-  baseFeeTrend: 'level' as const,
+  latestPriorityFeeRange: ['0.01', '0.05'],
+  historicalPriorityFeeRange: ['0.01', '0.1'],
+  historicalBaseFeeRange: ['0.01', '0.02'],
+  priorityFeeTrend: 'stable',
+  baseFeeTrend: 'stable',
 };
 const RELAY_REQUEST_ID = 'perps-withdraw-e2e-request-id';
 const RELAY_TRANSACTION_HASH =
@@ -772,29 +773,13 @@ export function getPerpsConfigEligibleWithArbitrumUsdc(title?: string) {
         },
       },
     })
-    // Pre-seed GasFeeController with Arbitrum gas estimates.
-    //
-    // The confirmation reads the global `gasEstimateType` before the per-
-    // transaction estimate is populated by the TransactionController. The
-    // default fixture sets it to `'none'` (localhost has no gas API), which
-    // triggers the blocking "Fee estimate unavailable" alert. The HTTP mock
-    // eventually delivers the data, but the race between the gas API response
-    // and the initial UI render causes flaky failures on slow CI.
-    //
-    // Pre-seeding the GasFeeController state eliminates the race entirely:
-    // the global type starts as `'fee-market'`, so the alert never fires.
-    .withGasFeeController({
-      gasEstimateType: 'fee-market' as const,
-      gasFeeEstimates: ARBITRUM_GAS_FEE_ESTIMATES,
-      estimatedGasFeeTimeBounds: {},
-      gasFeeEstimatesByChainId: {
-        [CHAIN_IDS.ARBITRUM]: {
-          gasEstimateType: 'fee-market' as const,
-          gasFeeEstimates: ARBITRUM_GAS_FEE_ESTIMATES,
-          estimatedGasFeeTimeBounds: {},
-        },
-      },
-    })
+    // Select Arbitrum so the GasFeeController polls gas estimates for the
+    // right chain. The "no gas price" blocking alert checks the *global*
+    // `gasEstimateType` (which only updates for the selected network), so
+    // starting on localhost or a testnet causes the confirmation to stay
+    // permanently stuck. Related bug ticket #46056
+    .withSelectedNetwork(NETWORK_CLIENT_ID.ARBITRUM_MAINNET)
+    .withEnabledNetworks({ eip155: { [CHAIN_IDS.ARBITRUM]: true } })
     .build();
 
   return {

--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -42,6 +42,39 @@ const ARBITRUM_USDC_PRICE_IN_ETH = 1 / 1700;
 const HYPERCORE_CHAIN_ID_DECIMAL = Number(CHAIN_IDS.LOCALHOST);
 const PRICE_API_BASE_URL = 'https://price.api.cx.metamask.io';
 const RELAY_API_BASE_URL = 'https://api.relay.link';
+
+/**
+ * EIP-1559 gas fee estimates for Arbitrum shared by the HTTP mock and the
+ * fixture GasFeeController seed. Keeping a single source of truth avoids
+ * the mock and seed drifting.
+ */
+const ARBITRUM_GAS_FEE_ESTIMATES = {
+  low: {
+    suggestedMaxPriorityFeePerGas: '0.01',
+    suggestedMaxFeePerGas: '0.02',
+    minWaitTimeEstimate: 15000,
+    maxWaitTimeEstimate: 30000,
+  },
+  medium: {
+    suggestedMaxPriorityFeePerGas: '0.025',
+    suggestedMaxFeePerGas: '0.05',
+    minWaitTimeEstimate: 15000,
+    maxWaitTimeEstimate: 45000,
+  },
+  high: {
+    suggestedMaxPriorityFeePerGas: '0.05',
+    suggestedMaxFeePerGas: '0.1',
+    minWaitTimeEstimate: 15000,
+    maxWaitTimeEstimate: 60000,
+  },
+  estimatedBaseFee: '0.01',
+  networkCongestion: 0.1,
+  latestPriorityFeeRange: ['0.01', '0.05'] as [string, string],
+  historicalPriorityFeeRange: ['0.01', '0.1'] as [string, string],
+  historicalBaseFeeRange: ['0.01', '0.02'] as [string, string],
+  priorityFeeTrend: 'level' as const,
+  baseFeeTrend: 'level' as const,
+};
 const RELAY_REQUEST_ID = 'perps-withdraw-e2e-request-id';
 const RELAY_TRANSACTION_HASH =
   '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
@@ -332,33 +365,7 @@ async function mockArbitrumGasData(server: Mockttp): Promise<void> {
     .always()
     .thenCallback(() => ({
       statusCode: 200,
-      json: {
-        low: {
-          suggestedMaxPriorityFeePerGas: '0.01',
-          suggestedMaxFeePerGas: '0.02',
-          minWaitTimeEstimate: 15000,
-          maxWaitTimeEstimate: 30000,
-        },
-        medium: {
-          suggestedMaxPriorityFeePerGas: '0.025',
-          suggestedMaxFeePerGas: '0.05',
-          minWaitTimeEstimate: 15000,
-          maxWaitTimeEstimate: 45000,
-        },
-        high: {
-          suggestedMaxPriorityFeePerGas: '0.05',
-          suggestedMaxFeePerGas: '0.1',
-          minWaitTimeEstimate: 15000,
-          maxWaitTimeEstimate: 60000,
-        },
-        estimatedBaseFee: '0.01',
-        networkCongestion: 0.1,
-        latestPriorityFeeRange: ['0.01', '0.05'],
-        historicalPriorityFeeRange: ['0.01', '0.1'],
-        historicalBaseFeeRange: ['0.01', '0.02'],
-        priorityFeeTrend: 'stable',
-        baseFeeTrend: 'stable',
-      },
+      json: ARBITRUM_GAS_FEE_ESTIMATES,
     }));
 }
 
@@ -684,89 +691,114 @@ export function getPerpsConfigEligibleWithEthLongPosition(title?: string) {
  * @returns Partial withFixtures config to spread into withFixtures().
  */
 export function getPerpsConfigEligibleWithArbitrumUsdc(title?: string) {
+  const fixtures = new FixtureBuilderV2()
+    .withPerpsController({
+      isEligible: true,
+      isFirstTimeUser: { mainnet: false, testnet: false },
+    })
+    .withRemoteFeatureFlagController({
+      remoteFeatureFlags: PERPS_WITHDRAW_CONFIRMATION_FLAG.remoteFeatureFlags,
+    })
+    .withTokensController({
+      allTokens: {
+        [CHAIN_IDS.ARBITRUM]: {
+          [DEFAULT_FIXTURE_ACCOUNT_LOWERCASE]: [
+            {
+              address: ARBITRUM_USDC_ADDRESS,
+              symbol: 'USDC',
+              image: `https://static.cx.metamask.io/api/v1/tokenIcons/42161/${ARBITRUM_USDC_ADDRESS.toLowerCase()}.png`,
+              isERC721: false,
+              decimals: 6,
+              aggregators: ['metamask'],
+              name: 'USD Coin',
+            },
+          ],
+        },
+      },
+    })
+    .withTokenRatesController({
+      marketData: {
+        [CHAIN_IDS.ARBITRUM]: {
+          [ARBITRUM_USDC_ADDRESS]: ARBITRUM_USDC_MARKET_DATA,
+        },
+      },
+    })
+    .withAssetsController({
+      customAssets: {
+        [DEFAULT_FIXTURE_ACCOUNT_ID]: [ARBITRUM_USDC_ASSET_ID],
+      },
+      assetsBalance: {
+        [DEFAULT_FIXTURE_ACCOUNT_ID]: {
+          [ARBITRUM_USDC_ASSET_ID]: { amount: '0' },
+        },
+      },
+      assetsInfo: {
+        [ARBITRUM_USDC_ASSET_ID]: {
+          type: 'erc20',
+          symbol: 'USDC',
+          name: 'USD Coin',
+          decimals: 6,
+        },
+        [ARBITRUM_NATIVE_ASSET_ID]: {
+          type: 'native',
+          symbol: 'ETH',
+          name: 'Ether',
+          decimals: 18,
+        },
+      },
+      assetsPrice: {
+        [ARBITRUM_USDC_ASSET_ID]: {
+          assetPriceType: 'fungible',
+          id: 'usd-coin',
+          lastUpdated: 0,
+          price: 1,
+          usdPrice: 1,
+        },
+        [ARBITRUM_NATIVE_ASSET_ID]: {
+          assetPriceType: 'fungible',
+          id: 'ethereum',
+          lastUpdated: 0,
+          price: 1700,
+          usdPrice: 1700,
+        },
+      },
+    })
+    .withCurrencyController({
+      currencyRates: {
+        ETH: {
+          conversionDate: 0,
+          conversionRate: 1700,
+          usdConversionRate: 1700,
+        },
+      },
+    })
+    // Pre-seed GasFeeController with Arbitrum gas estimates.
+    //
+    // The confirmation reads the global `gasEstimateType` before the per-
+    // transaction estimate is populated by the TransactionController. The
+    // default fixture sets it to `'none'` (localhost has no gas API), which
+    // triggers the blocking "Fee estimate unavailable" alert. The HTTP mock
+    // eventually delivers the data, but the race between the gas API response
+    // and the initial UI render causes flaky failures on slow CI.
+    //
+    // Pre-seeding the GasFeeController state eliminates the race entirely:
+    // the global type starts as `'fee-market'`, so the alert never fires.
+    .withGasFeeController({
+      gasEstimateType: 'fee-market' as const,
+      gasFeeEstimates: ARBITRUM_GAS_FEE_ESTIMATES,
+      estimatedGasFeeTimeBounds: {},
+      gasFeeEstimatesByChainId: {
+        [CHAIN_IDS.ARBITRUM]: {
+          gasEstimateType: 'fee-market' as const,
+          gasFeeEstimates: ARBITRUM_GAS_FEE_ESTIMATES,
+          estimatedGasFeeTimeBounds: {},
+        },
+      },
+    })
+    .build();
+
   return {
-    fixtures: new FixtureBuilderV2()
-      .withPerpsController({
-        isEligible: true,
-        isFirstTimeUser: { mainnet: false, testnet: false },
-      })
-      .withRemoteFeatureFlagController({
-        remoteFeatureFlags: PERPS_WITHDRAW_CONFIRMATION_FLAG.remoteFeatureFlags,
-      })
-      .withTokensController({
-        allTokens: {
-          [CHAIN_IDS.ARBITRUM]: {
-            [DEFAULT_FIXTURE_ACCOUNT_LOWERCASE]: [
-              {
-                address: ARBITRUM_USDC_ADDRESS,
-                symbol: 'USDC',
-                image: `https://static.cx.metamask.io/api/v1/tokenIcons/42161/${ARBITRUM_USDC_ADDRESS.toLowerCase()}.png`,
-                isERC721: false,
-                decimals: 6,
-                aggregators: ['metamask'],
-                name: 'USD Coin',
-              },
-            ],
-          },
-        },
-      })
-      .withTokenRatesController({
-        marketData: {
-          [CHAIN_IDS.ARBITRUM]: {
-            [ARBITRUM_USDC_ADDRESS]: ARBITRUM_USDC_MARKET_DATA,
-          },
-        },
-      })
-      .withAssetsController({
-        customAssets: {
-          [DEFAULT_FIXTURE_ACCOUNT_ID]: [ARBITRUM_USDC_ASSET_ID],
-        },
-        assetsBalance: {
-          [DEFAULT_FIXTURE_ACCOUNT_ID]: {
-            [ARBITRUM_USDC_ASSET_ID]: { amount: '0' },
-          },
-        },
-        assetsInfo: {
-          [ARBITRUM_USDC_ASSET_ID]: {
-            type: 'erc20',
-            symbol: 'USDC',
-            name: 'USD Coin',
-            decimals: 6,
-          },
-          [ARBITRUM_NATIVE_ASSET_ID]: {
-            type: 'native',
-            symbol: 'ETH',
-            name: 'Ether',
-            decimals: 18,
-          },
-        },
-        assetsPrice: {
-          [ARBITRUM_USDC_ASSET_ID]: {
-            assetPriceType: 'fungible',
-            id: 'usd-coin',
-            lastUpdated: 0,
-            price: 1,
-            usdPrice: 1,
-          },
-          [ARBITRUM_NATIVE_ASSET_ID]: {
-            assetPriceType: 'fungible',
-            id: 'ethereum',
-            lastUpdated: 0,
-            price: 1700,
-            usdPrice: 1700,
-          },
-        },
-      })
-      .withCurrencyController({
-        currencyRates: {
-          ETH: {
-            conversionDate: 0,
-            conversionRate: 1700,
-            usdConversionRate: 1700,
-          },
-        },
-      })
-      .build(),
+    fixtures,
     title,
     manifestFlags: PERPS_WITHDRAW_CONFIRMATION_MANIFEST_FLAG,
     testSpecificMock: async (server: Mockttp) => {

--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -44,38 +44,6 @@ const HYPERCORE_CHAIN_ID_DECIMAL = Number(CHAIN_IDS.LOCALHOST);
 const PRICE_API_BASE_URL = 'https://price.api.cx.metamask.io';
 const RELAY_API_BASE_URL = 'https://api.relay.link';
 
-/**
- * EIP-1559 gas fee estimates for Arbitrum shared by the HTTP mock and the
- * fixture GasFeeController seed. Keeping a single source of truth avoids
- * the mock and seed drifting.
- */
-const ARBITRUM_GAS_FEE_ESTIMATES = {
-  low: {
-    suggestedMaxPriorityFeePerGas: '0.01',
-    suggestedMaxFeePerGas: '0.02',
-    minWaitTimeEstimate: 15000,
-    maxWaitTimeEstimate: 30000,
-  },
-  medium: {
-    suggestedMaxPriorityFeePerGas: '0.025',
-    suggestedMaxFeePerGas: '0.05',
-    minWaitTimeEstimate: 15000,
-    maxWaitTimeEstimate: 45000,
-  },
-  high: {
-    suggestedMaxPriorityFeePerGas: '0.05',
-    suggestedMaxFeePerGas: '0.1',
-    minWaitTimeEstimate: 15000,
-    maxWaitTimeEstimate: 60000,
-  },
-  estimatedBaseFee: '0.01',
-  networkCongestion: 0.1,
-  latestPriorityFeeRange: ['0.01', '0.05'],
-  historicalPriorityFeeRange: ['0.01', '0.1'],
-  historicalBaseFeeRange: ['0.01', '0.02'],
-  priorityFeeTrend: 'stable',
-  baseFeeTrend: 'stable',
-};
 const RELAY_REQUEST_ID = 'perps-withdraw-e2e-request-id';
 const RELAY_TRANSACTION_HASH =
   '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
@@ -366,7 +334,33 @@ async function mockArbitrumGasData(server: Mockttp): Promise<void> {
     .always()
     .thenCallback(() => ({
       statusCode: 200,
-      json: ARBITRUM_GAS_FEE_ESTIMATES,
+      json: {
+        low: {
+          suggestedMaxPriorityFeePerGas: '0.01',
+          suggestedMaxFeePerGas: '0.02',
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 30000,
+        },
+        medium: {
+          suggestedMaxPriorityFeePerGas: '0.025',
+          suggestedMaxFeePerGas: '0.05',
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 45000,
+        },
+        high: {
+          suggestedMaxPriorityFeePerGas: '0.05',
+          suggestedMaxFeePerGas: '0.1',
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 60000,
+        },
+        estimatedBaseFee: '0.01',
+        networkCongestion: 0.1,
+        latestPriorityFeeRange: ['0.01', '0.05'],
+        historicalPriorityFeeRange: ['0.01', '0.1'],
+        historicalBaseFeeRange: ['0.01', '0.02'],
+        priorityFeeTrend: 'stable',
+        baseFeeTrend: 'stable',
+      },
     }));
 }
 
@@ -692,98 +686,96 @@ export function getPerpsConfigEligibleWithEthLongPosition(title?: string) {
  * @returns Partial withFixtures config to spread into withFixtures().
  */
 export function getPerpsConfigEligibleWithArbitrumUsdc(title?: string) {
-  const fixtures = new FixtureBuilderV2()
-    .withPerpsController({
-      isEligible: true,
-      isFirstTimeUser: { mainnet: false, testnet: false },
-    })
-    .withRemoteFeatureFlagController({
-      remoteFeatureFlags: PERPS_WITHDRAW_CONFIRMATION_FLAG.remoteFeatureFlags,
-    })
-    .withTokensController({
-      allTokens: {
-        [CHAIN_IDS.ARBITRUM]: {
-          [DEFAULT_FIXTURE_ACCOUNT_LOWERCASE]: [
-            {
-              address: ARBITRUM_USDC_ADDRESS,
-              symbol: 'USDC',
-              image: `https://static.cx.metamask.io/api/v1/tokenIcons/42161/${ARBITRUM_USDC_ADDRESS.toLowerCase()}.png`,
-              isERC721: false,
-              decimals: 6,
-              aggregators: ['metamask'],
-              name: 'USD Coin',
-            },
-          ],
-        },
-      },
-    })
-    .withTokenRatesController({
-      marketData: {
-        [CHAIN_IDS.ARBITRUM]: {
-          [ARBITRUM_USDC_ADDRESS]: ARBITRUM_USDC_MARKET_DATA,
-        },
-      },
-    })
-    .withAssetsController({
-      customAssets: {
-        [DEFAULT_FIXTURE_ACCOUNT_ID]: [ARBITRUM_USDC_ASSET_ID],
-      },
-      assetsBalance: {
-        [DEFAULT_FIXTURE_ACCOUNT_ID]: {
-          [ARBITRUM_USDC_ASSET_ID]: { amount: '0' },
-        },
-      },
-      assetsInfo: {
-        [ARBITRUM_USDC_ASSET_ID]: {
-          type: 'erc20',
-          symbol: 'USDC',
-          name: 'USD Coin',
-          decimals: 6,
-        },
-        [ARBITRUM_NATIVE_ASSET_ID]: {
-          type: 'native',
-          symbol: 'ETH',
-          name: 'Ether',
-          decimals: 18,
-        },
-      },
-      assetsPrice: {
-        [ARBITRUM_USDC_ASSET_ID]: {
-          assetPriceType: 'fungible',
-          id: 'usd-coin',
-          lastUpdated: 0,
-          price: 1,
-          usdPrice: 1,
-        },
-        [ARBITRUM_NATIVE_ASSET_ID]: {
-          assetPriceType: 'fungible',
-          id: 'ethereum',
-          lastUpdated: 0,
-          price: 1700,
-          usdPrice: 1700,
-        },
-      },
-    })
-    .withCurrencyController({
-      currencyRates: {
-        ETH: {
-          conversionDate: 0,
-          conversionRate: 1700,
-          usdConversionRate: 1700,
-        },
-      },
-    })
-    // Select Arbitrum so the GasFeeController polls gas estimates for the
-    // right chain. The "no gas price" blocking alert checks the *global*
-    // `gasEstimateType` (which only updates for the selected network), so
-    // starting on localhost or a testnet causes the confirmation to stay
-    // permanently stuck. Related bug ticket #46056
-    .withSelectedNetwork(NETWORK_CLIENT_ID.ARBITRUM_MAINNET)
-    .withEnabledNetworks({ eip155: { [CHAIN_IDS.ARBITRUM]: true } })
-    .build();
-
   return {
-    fixtures,
+    fixtures: new FixtureBuilderV2()
+      .withPerpsController({
+        isEligible: true,
+        isFirstTimeUser: { mainnet: false, testnet: false },
+      })
+      .withRemoteFeatureFlagController({
+        remoteFeatureFlags: PERPS_WITHDRAW_CONFIRMATION_FLAG.remoteFeatureFlags,
+      })
+      .withTokensController({
+        allTokens: {
+          [CHAIN_IDS.ARBITRUM]: {
+            [DEFAULT_FIXTURE_ACCOUNT_LOWERCASE]: [
+              {
+                address: ARBITRUM_USDC_ADDRESS,
+                symbol: 'USDC',
+                image: `https://static.cx.metamask.io/api/v1/tokenIcons/42161/${ARBITRUM_USDC_ADDRESS.toLowerCase()}.png`,
+                isERC721: false,
+                decimals: 6,
+                aggregators: ['metamask'],
+                name: 'USD Coin',
+              },
+            ],
+          },
+        },
+      })
+      .withTokenRatesController({
+        marketData: {
+          [CHAIN_IDS.ARBITRUM]: {
+            [ARBITRUM_USDC_ADDRESS]: ARBITRUM_USDC_MARKET_DATA,
+          },
+        },
+      })
+      .withAssetsController({
+        customAssets: {
+          [DEFAULT_FIXTURE_ACCOUNT_ID]: [ARBITRUM_USDC_ASSET_ID],
+        },
+        assetsBalance: {
+          [DEFAULT_FIXTURE_ACCOUNT_ID]: {
+            [ARBITRUM_USDC_ASSET_ID]: { amount: '0' },
+          },
+        },
+        assetsInfo: {
+          [ARBITRUM_USDC_ASSET_ID]: {
+            type: 'erc20',
+            symbol: 'USDC',
+            name: 'USD Coin',
+            decimals: 6,
+          },
+          [ARBITRUM_NATIVE_ASSET_ID]: {
+            type: 'native',
+            symbol: 'ETH',
+            name: 'Ether',
+            decimals: 18,
+          },
+        },
+        assetsPrice: {
+          [ARBITRUM_USDC_ASSET_ID]: {
+            assetPriceType: 'fungible',
+            id: 'usd-coin',
+            lastUpdated: 0,
+            price: 1,
+            usdPrice: 1,
+          },
+          [ARBITRUM_NATIVE_ASSET_ID]: {
+            assetPriceType: 'fungible',
+            id: 'ethereum',
+            lastUpdated: 0,
+            price: 1700,
+            usdPrice: 1700,
+          },
+        },
+      })
+      .withCurrencyController({
+        currencyRates: {
+          ETH: {
+            conversionDate: 0,
+            conversionRate: 1700,
+            usdConversionRate: 1700,
+          },
+        },
+      })
+      // Select Arbitrum so the GasFeeController polls gas estimates for the
+      // right chain. The "no gas price" blocking alert checks the *global*
+      // `gasEstimateType` (which only updates for the selected network), so
+      // starting on localhost or a testnet causes the confirmation to stay
+      // permanently stuck. Related bug ticket #46056
+      .withSelectedNetwork(NETWORK_CLIENT_ID.ARBITRUM_MAINNET)
+      .withEnabledNetworks({ eip155: { [CHAIN_IDS.ARBITRUM]: true } })
+      .build(),
     title,
     manifestFlags: PERPS_WITHDRAW_CONFIRMATION_MANIFEST_FLAG,
     testSpecificMock: async (server: Mockttp) => {

--- a/test/e2e/tests/perps/perps-withdraw.spec.ts
+++ b/test/e2e/tests/perps/perps-withdraw.spec.ts
@@ -46,23 +46,6 @@ const withdrawConfirmationFixtures = (title?: string) => {
   };
 };
 
-async function openPerpsWithdrawConfirmation(
-  driver: Driver,
-): Promise<PerpsWithdrawConfirmation> {
-  await login(driver, { validateBalance: false });
-
-  const perpsTab = new PerpsTab(driver);
-  await perpsTab.navigateToPerpsHome();
-  await perpsTab.checkPageIsLoaded();
-  await perpsTab.waitForBalanceSection();
-  await perpsTab.clickWithdraw();
-
-  const withdrawConfirmation = new PerpsWithdrawConfirmation(driver);
-  await withdrawConfirmation.checkPageIsLoaded();
-
-  return withdrawConfirmation;
-}
-
 describe('Perps Withdraw', function (this: Suite) {
   this.timeout(120000);
 
@@ -72,13 +55,10 @@ describe('Perps Withdraw', function (this: Suite) {
         ...withdrawFixtures(this.test?.fullTitle()),
       },
       async ({ driver }: { driver: Driver }) => {
-        await login(driver, { validateBalance: false });
+        await login(driver);
 
         const perpsTab = new PerpsTab(driver);
-        await perpsTab.navigateToPerpsHome();
-        await perpsTab.checkPageIsLoaded();
-        await perpsTab.waitForBalanceSection();
-        await perpsTab.clickWithdraw();
+        await perpsTab.openWithdraw();
 
         const withdrawPage = new PerpsWithdrawPage(driver);
         await withdrawPage.checkPageIsLoaded();
@@ -93,13 +73,10 @@ describe('Perps Withdraw', function (this: Suite) {
         ...withdrawFixtures(this.test?.fullTitle()),
       },
       async ({ driver }: { driver: Driver }) => {
-        await login(driver, { validateBalance: false });
+        await login(driver);
 
         const perpsTab = new PerpsTab(driver);
-        await perpsTab.navigateToPerpsHome();
-        await perpsTab.checkPageIsLoaded();
-        await perpsTab.waitForBalanceSection();
-        await perpsTab.clickWithdraw();
+        await perpsTab.openWithdraw();
 
         const withdrawPage = new PerpsWithdrawPage(driver);
         await withdrawPage.checkPageIsLoaded();
@@ -117,13 +94,10 @@ describe('Perps Withdraw', function (this: Suite) {
         ...withdrawFixtures(this.test?.fullTitle()),
       },
       async ({ driver }: { driver: Driver }) => {
-        await login(driver, { validateBalance: false });
+        await login(driver);
 
         const perpsTab = new PerpsTab(driver);
-        await perpsTab.navigateToPerpsHome();
-        await perpsTab.checkPageIsLoaded();
-        await perpsTab.waitForBalanceSection();
-        await perpsTab.clickWithdraw();
+        await perpsTab.openWithdraw();
 
         const withdrawPage = new PerpsWithdrawPage(driver);
         await withdrawPage.checkPageIsLoaded();
@@ -139,13 +113,10 @@ describe('Perps Withdraw', function (this: Suite) {
         ...withdrawFixtures(this.test?.fullTitle()),
       },
       async ({ driver }: { driver: Driver }) => {
-        await login(driver, { validateBalance: false });
+        await login(driver);
 
         const perpsTab = new PerpsTab(driver);
-        await perpsTab.navigateToPerpsHome();
-        await perpsTab.checkPageIsLoaded();
-        await perpsTab.waitForBalanceSection();
-        await perpsTab.clickWithdraw();
+        await perpsTab.openWithdraw();
 
         const withdrawPage = new PerpsWithdrawPage(driver);
         await withdrawPage.checkPageIsLoaded();
@@ -162,9 +133,13 @@ describe('Perps Withdraw', function (this: Suite) {
         ...withdrawConfirmationFixtures(this.test?.fullTitle()),
       },
       async ({ driver }: { driver: Driver }) => {
-        const withdrawConfirmation =
-          await openPerpsWithdrawConfirmation(driver);
+        await login(driver);
 
+        const perpsTab = new PerpsTab(driver);
+        await perpsTab.openWithdraw();
+
+        const withdrawConfirmation = new PerpsWithdrawConfirmation(driver);
+        await withdrawConfirmation.checkPageIsLoaded();
         await withdrawConfirmation.checkAvailableBalance('$10,000.00');
         await withdrawConfirmation.fillAmount('50');
         await withdrawConfirmation.checkDestinationToken('USDC');
@@ -181,9 +156,13 @@ describe('Perps Withdraw', function (this: Suite) {
         ...withdrawConfirmationFixtures(this.test?.fullTitle()),
       },
       async ({ driver }: { driver: Driver }) => {
-        const withdrawConfirmation =
-          await openPerpsWithdrawConfirmation(driver);
+        await login(driver);
 
+        const perpsTab = new PerpsTab(driver);
+        await perpsTab.openWithdraw();
+
+        const withdrawConfirmation = new PerpsWithdrawConfirmation(driver);
+        await withdrawConfirmation.checkPageIsLoaded();
         await withdrawConfirmation.fillAmount('10001');
         await withdrawConfirmation.waitForInsufficientFundsReason();
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This test is flaky due to a bug in the wallet side related to Perps and selected network (when it's testnet)
[[Bug]: Perps - Cannot Add or Withdraw Perps as confirmation screen stays loading indefinetly
](https://github.com/MetaMask/metamask-extension/issues/46056)


useNoGasPriceAlerts reads the global GasFeeController.gasEstimateType, which only updates for the selected network. Perps withdrawals target Arbitrum, but when we start on a testnet/localhost, the Arbitrum gas API response updates gasFeeEstimatesByChainId['0xa4b1'] correctly, however the global gasEstimateType stays 'none' forever because currentChainId !== chainId in _fetchGasFeeEstimateData. The confirmation never recovers.

- Production symptom: infinite loading spinner on the button (Pay can't resolve primaryRequiredToken without the correct gas chain, masking the gas alert behind isAwaitingRequiredToken).
- E2E test symptom: disabled button with "Fee estimate unavailable" (test mocks let Pay resolve, exposing the gas alert as the visible blocker). This was flaky because sometimes the mock responded before first render.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

See both Perps broken flows, for manual prod (sepolia selection) and failed test with mocks and localhost selected

https://github.com/user-attachments/assets/b8ff564e-fa9d-42c1-b928-9faccac7ada6

<img width="1366" height="682" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/53d0e311-98ba-4eb5-9092-171acd771bbe" />



### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E fixtures, page objects, and specs; no production wallet or Perps UI logic is modified.
> 
> **Overview**
> **Stabilizes Perps withdraw confirmation E2E** by seeding **Arbitrum mainnet** as the selected network in `getPerpsConfigEligibleWithArbitrumUsdc`, so global `gasEstimateType` updates and the confirmation flow is not stuck on “fee estimate unavailable” when the wallet starts on localhost/testnet (issue #46056).
> 
> **Refactors withdraw specs** to use a shared `PerpsTab.openWithdraw()` helper instead of repeated navigate/wait/click steps and the removed `openPerpsWithdrawConfirmation` helper; confirmation tests now follow the same login + `openWithdraw()` pattern as the legacy withdraw page tests, with default `login(driver)` instead of `validateBalance: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ab22c674bcd5f02f038ced04876bc37278058d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->