### PR TITLE
refactor(confirmations): use approval callbacks instead of prep mutations

### DIFF
--- a/app/scripts/lib/transaction/hooks/index.test.ts
+++ b/app/scripts/lib/transaction/hooks/index.test.ts
@@ -10,6 +10,7 @@ import { TransactionPayPublishHook } from '@metamask/transaction-pay-controller'
 import { TransactionControllerInitMessenger } from '../../../wallet-init/messengers/transaction-controller-messenger';
 import * as smartTransactionsModule from '../../smart-transaction/smart-transactions';
 import * as sentinelApiModule from '../sentinel-api';
+import { isRelaySupported } from '../transaction-relay';
 import { Delegation7702PublishHook } from './delegation-7702-publish';
 import { EnforceSimulationHook } from './enforce-simulation-hook';
 import {
@@ -21,6 +22,7 @@ jest.mock('@metamask/transaction-controller');
 jest.mock('@metamask/transaction-pay-controller');
 jest.mock('../../smart-transaction/smart-transactions');
 jest.mock('../sentinel-api');
+jest.mock('../transaction-relay');
 jest.mock('./delegation-7702-publish');
 jest.mock('./enforce-simulation-hook');
 
@@ -36,7 +38,11 @@ function buildMockRequest(
   overrides: Partial<TransactionControllerHookRequest> = {},
 ): TransactionControllerHookRequest {
   return {
-    getFlatState: jest.fn().mockReturnValue({}),
+    getFlatState: jest.fn().mockReturnValue({
+      metamask: {
+        preferences: {},
+      },
+    }),
     getTransactionMetricsRequest: jest.fn().mockReturnValue({
       upsertTransactionUIMetricsFragment: jest.fn(),
     }),
@@ -112,6 +118,8 @@ describe('Transaction Controller Hooks', () => {
       expect(hooks).toStrictEqual(
         expect.objectContaining({
           afterAdd: expect.any(Function),
+          isSponsored: expect.any(Function),
+          shouldSign: expect.any(Function),
           beforePublish: expect.any(Function),
           beforeSign: expect.any(Function),
           publish: expect.any(Function),
@@ -144,6 +152,26 @@ describe('Transaction Controller Hooks', () => {
       });
 
       expect(result).toStrictEqual({});
+    });
+  });
+
+  describe('approval callbacks', () => {
+    it('returns sponsorship and signing decisions', async () => {
+      jest.mocked(sentinelApiModule.isSendBundleSupported).mockResolvedValue(false);
+      jest.mocked(isRelaySupported).mockResolvedValue(false);
+
+      const request = buildMockRequest();
+      const hooks = getTransactionControllerHooks(request);
+
+      await expect(
+        hooks.isSponsored?.({ transactionMeta: mockTransactionMeta }),
+      ).resolves.toBe(false);
+      await expect(
+        hooks.shouldSign?.({
+          transactionMeta: mockTransactionMeta,
+          isSponsored: false,
+        }),
+      ).resolves.toBe(true);
     });
   });
 

--- a/app/scripts/lib/transaction/hooks/index.ts
+++ b/app/scripts/lib/transaction/hooks/index.ts
@@ -15,7 +15,6 @@ import {
 import { Hex } from '@metamask/utils';
 
 import { AccountOverviewTabKey } from '../../../../../shared/constants/app-state';
-import { EIP_7702_REVOKE_ADDRESS } from '../../../../../shared/lib/eip7702-utils';
 import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import { getEip7702SupportedChains } from '../../../../../shared/lib/eip7702-support-utils';
 import {
@@ -109,10 +108,6 @@ async function getTransactionApprovalDecision(
       (await isRelaySupported(transactionMeta.chainId)) &&
       transactionMeta.txParams?.to !== undefined,
   );
-
-  const isDowngradeTransaction =
-    transactionMeta.txParams?.authorizationList?.[0]?.address ===
-    EIP_7702_REVOKE_ADDRESS;
 
   const isMoneyAccountWithdraw =
     transactionMeta.type === TransactionType.moneyAccountWithdraw;

--- a/app/scripts/lib/transaction/hooks/index.ts
+++ b/app/scripts/lib/transaction/hooks/index.ts
@@ -15,6 +15,8 @@ import {
 import { Hex } from '@metamask/utils';
 
 import { AccountOverviewTabKey } from '../../../../../shared/constants/app-state';
+import { EIP_7702_REVOKE_ADDRESS } from '../../../../../shared/lib/eip7702-utils';
+import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import { getEip7702SupportedChains } from '../../../../../shared/lib/eip7702-support-utils';
 import {
   getInternalEvmAddresses,
@@ -31,6 +33,7 @@ import {
 import { MessengerClientFlatState } from '../../../messenger-client-init/controller-list';
 import { TransactionControllerInitMessenger } from '../../../wallet-init/messengers/transaction-controller-messenger';
 import { getTransactionById } from '../util';
+import { isRelaySupported } from '../transaction-relay';
 import { isSendBundleSupported } from '../sentinel-api';
 import { Delegation7702PublishHook } from './delegation-7702-publish';
 import { EnforceSimulationHook } from './enforce-simulation-hook';
@@ -61,6 +64,8 @@ export function getTransactionControllerHooks(
 ): TransactionControllerOptions['hooks'] {
   return {
     afterAdd: afterAddHook(request),
+    isSponsored: isSponsoredHook(request),
+    shouldSign: shouldSignHook(request),
     beforePublish: beforePublishHook(request),
     beforeSign: beforeSignHook(request),
     // @ts-expect-error - Controller type is missing signedTx parameter
@@ -76,6 +81,93 @@ function afterAddHook({ messenger }: TransactionControllerHookRequest) {
       transactionMeta,
     );
     return {};
+  };
+}
+
+type TransactionApprovalDecision = {
+  signingMode: 'local' | 'external';
+  sponsorshipEnabled: boolean;
+};
+
+async function getTransactionApprovalDecision(
+  { getFlatState }: TransactionControllerHookRequest,
+  transactionMeta: TransactionMeta,
+): Promise<TransactionApprovalDecision> {
+  const flatState = getFlatState();
+  const { gasSponsorshipOptOutByChainId } = getPreferences(flatState);
+  const { isHardwareWalletAccount, isSmartTransaction } =
+    getSmartTransactionCommonParams(flatState, transactionMeta.chainId);
+
+  const isSmartTransactionAndBundleSupported =
+    isSmartTransaction && (await isSendBundleSupported(transactionMeta.chainId));
+
+  const shouldCheck7702Eligibility =
+    !isHardwareWalletAccount && !isSmartTransactionAndBundleSupported;
+
+  const is7702Supported = Boolean(
+    shouldCheck7702Eligibility &&
+      (await isRelaySupported(transactionMeta.chainId)) &&
+      transactionMeta.txParams?.to !== undefined,
+  );
+
+  const isDowngradeTransaction =
+    transactionMeta.txParams?.authorizationList?.[0]?.address ===
+    EIP_7702_REVOKE_ADDRESS;
+
+  const isMoneyAccountWithdraw =
+    transactionMeta.type === TransactionType.moneyAccountWithdraw;
+  const requiresExternalSigning =
+    isMoneyAccountWithdraw ||
+    (Boolean(transactionMeta.selectedGasFeeToken) &&
+      !transactionMeta.isGasFeeTokenIgnoredIfBalance &&
+      !isHardwareWalletAccount &&
+      !isSmartTransactionAndBundleSupported);
+
+  const sponsorshipEnabled =
+    Boolean(transactionMeta.isGasFeeSponsored) &&
+    !Boolean(gasSponsorshipOptOutByChainId?.[transactionMeta.chainId]) &&
+    (isSmartTransactionAndBundleSupported ||
+      is7702Supported ||
+      (isMoneyAccountWithdraw && requiresExternalSigning));
+
+  if (isMoneyAccountWithdraw && !sponsorshipEnabled) {
+    throw new Error('Required transaction sponsorship is unavailable');
+  }
+
+  const signingMode: 'local' | 'external' = requiresExternalSigning
+    ? 'external'
+    : 'local';
+
+  return {
+    signingMode,
+    sponsorshipEnabled,
+  };
+}
+
+function isSponsoredHook(request: TransactionControllerHookRequest) {
+  return async ({ transactionMeta }: { transactionMeta: TransactionMeta }) => {
+    const { sponsorshipEnabled } = await getTransactionApprovalDecision(
+      request,
+      transactionMeta,
+    );
+
+    return sponsorshipEnabled;
+  };
+}
+
+function shouldSignHook(request: TransactionControllerHookRequest) {
+  return async ({
+    transactionMeta,
+  }: {
+    transactionMeta: TransactionMeta;
+    isSponsored: boolean;
+  }) => {
+    const { signingMode } = await getTransactionApprovalDecision(
+      request,
+      transactionMeta,
+    );
+
+    return signingMode === 'local';
   };
 }
 

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -5,6 +5,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
 
 import {
   genUnapprovedContractInteractionConfirmation,
@@ -123,6 +124,7 @@ function runHook({
   gasFeeTokens,
   isGasFeeSponsored,
   isExternalSign,
+  isGasFeeTokenIgnoredIfBalance,
   selectedGasFeeToken,
   type,
 }: {
@@ -130,6 +132,7 @@ function runHook({
   gasFeeTokens?: GasFeeToken[];
   isGasFeeSponsored?: boolean;
   isExternalSign?: boolean;
+  isGasFeeTokenIgnoredIfBalance?: boolean;
   selectedGasFeeToken?: Hex;
   type?: TransactionType;
 } = {}) {
@@ -139,6 +142,7 @@ function runHook({
     isExternalSign,
     selectedGasFeeToken,
   }) as TransactionMeta;
+  confirmation.isGasFeeTokenIgnoredIfBalance = isGasFeeTokenIgnoredIfBalance;
   if (type) {
     confirmation.type = type;
   }
@@ -300,6 +304,35 @@ describe('useTransactionConfirm', () => {
         type: TransactionType.gasPayment,
       },
     ]);
+  });
+
+  it('preserves sponsored Smart Transaction external signing metadata', async () => {
+    useIsGaslessSupportedMock.mockReturnValue({
+      isSmartTransaction: true,
+      isSupported: true,
+      pending: false,
+    });
+    useGaslessSupportedSmartTransactionsMock.mockReturnValue({
+      isSupported: true,
+      isSmartTransaction: true,
+      pending: false,
+    });
+
+    const { onTransactionConfirm } = runHook({
+      isGasFeeSponsored: true,
+      isExternalSign: true,
+    });
+
+    await onTransactionConfirm();
+
+    expect(updateAndApproveTxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isExternalSign: true,
+        isGasFeeSponsored: true,
+      }),
+      true,
+      '',
+    );
   });
 
   it('routes hardware wallet sendBundle sends to hardware wallet signing page', async () => {
@@ -656,6 +689,7 @@ describe('useTransactionConfirm', () => {
 
     const { onTransactionConfirm } = runHook({
       gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+      isGasFeeSponsored: false,
       selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
     });
 
@@ -663,9 +697,32 @@ describe('useTransactionConfirm', () => {
 
     const actual = updateAndApproveTxMock.mock.calls[0][0];
     expect(actual.isExternalSign).toBe(true);
-    expect(actual.isGasFeeSponsored).toBe(
-      TRANSACTION_META_MOCK.isGasFeeSponsored,
-    );
+    expect(actual.isGasFeeSponsored).toBe(false);
+  });
+
+  it('preserves gas fee token balance fallback metadata', async () => {
+    useGaslessSupportedSmartTransactionsMock.mockReturnValue({
+      isSupported: true,
+      isSmartTransaction: true,
+      pending: false,
+    });
+
+    const { onTransactionConfirm } = runHook({
+      gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+      isGasFeeTokenIgnoredIfBalance: true,
+      selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+    });
+
+    await onTransactionConfirm();
+
+    const actual = updateAndApproveTxMock.mock.calls[0][0];
+    expect(actual.isGasFeeTokenIgnoredIfBalance).toBe(true);
+    expect(actual.batchTransactions).toStrictEqual([
+      expect.objectContaining({
+        to: GAS_FEE_TOKEN_MOCK.tokenAddress,
+        type: TransactionType.gasPayment,
+      }),
+    ]);
   });
 
   it('does not call handleSmartTransaction if no selected gas fee token', async () => {
@@ -692,24 +749,30 @@ describe('useTransactionConfirm', () => {
     );
   });
 
-  it('preserves isGasFeeSponsored when gasless is supported', async () => {
+  it('approves supported sponsored transactions with external signing', async () => {
     useIsGaslessSupportedMock.mockReturnValue({
       isSupported: true,
       isSmartTransaction: false,
       pending: false,
     });
 
-    const { onTransactionConfirm } = runHook({
-      gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
-      selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+    const { confirmation, onTransactionConfirm } = runHook({
+      isGasFeeSponsored: true,
+      isExternalSign: true,
     });
+    const originalConfirmation = cloneDeep(confirmation);
 
     await onTransactionConfirm();
 
-    const actual = updateAndApproveTxMock.mock.calls[0][0];
-    expect(actual.isGasFeeSponsored).toBe(
-      TRANSACTION_META_MOCK.isGasFeeSponsored,
+    expect(updateAndApproveTxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isExternalSign: true,
+        isGasFeeSponsored: true,
+      }),
+      true,
+      '',
     );
+    expect(confirmation).toStrictEqual(originalConfirmation);
   });
 
   it('sets isGasFeeSponsored to false when user opted out via 7702 flow', async () => {
@@ -776,12 +839,14 @@ describe('useTransactionConfirm', () => {
 
     const { onTransactionConfirm } = runHook({
       isGasFeeSponsored: true,
+      isExternalSign: true,
     });
 
     await onTransactionConfirm();
 
     const actual = updateAndApproveTxMock.mock.calls[0][0];
     expect(actual.isGasFeeSponsored).toBe(false);
+    expect(actual.isExternalSign).toBe(false);
   });
 
   it('clears isExternalSign when gasless is unsupported (e.g. hardware wallet on a sponsored chain)', async () => {
@@ -924,6 +989,8 @@ describe('useTransactionConfirm', () => {
 
       const { confirmation, onTransactionConfirm } = runHook({
         type: TransactionType.moneyAccountWithdraw,
+        isGasFeeSponsored: true,
+        isExternalSign: true,
       });
 
       const result = await onTransactionConfirm();

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -123,7 +123,6 @@ function runHook({
   customNonceValue,
   gasFeeTokens,
   isGasFeeSponsored,
-  isExternalSign,
   isGasFeeTokenIgnoredIfBalance,
   selectedGasFeeToken,
   type,
@@ -131,7 +130,6 @@ function runHook({
   customNonceValue?: string;
   gasFeeTokens?: GasFeeToken[];
   isGasFeeSponsored?: boolean;
-  isExternalSign?: boolean;
   isGasFeeTokenIgnoredIfBalance?: boolean;
   selectedGasFeeToken?: Hex;
   type?: TransactionType;
@@ -139,7 +137,6 @@ function runHook({
   const confirmation = genUnapprovedContractInteractionConfirmation({
     gasFeeTokens,
     isGasFeeSponsored,
-    isExternalSign,
     selectedGasFeeToken,
   }) as TransactionMeta;
   confirmation.isGasFeeTokenIgnoredIfBalance = isGasFeeTokenIgnoredIfBalance;
@@ -320,14 +317,12 @@ describe('useTransactionConfirm', () => {
 
     const { onTransactionConfirm } = runHook({
       isGasFeeSponsored: true,
-      isExternalSign: true,
     });
 
     await onTransactionConfirm();
 
     expect(updateAndApproveTxMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        isExternalSign: true,
         isGasFeeSponsored: true,
       }),
       true,
@@ -352,7 +347,6 @@ describe('useTransactionConfirm', () => {
     const { onTransactionConfirm } = runHook({
       gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
       isGasFeeSponsored: true,
-      isExternalSign: true,
       selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
       type: TransactionType.simpleSend,
     });
@@ -379,7 +373,6 @@ describe('useTransactionConfirm', () => {
                 type: TransactionType.gasPayment,
               }),
             ],
-            isExternalSign: false,
             type: TransactionType.simpleSend,
           }),
         }),
@@ -696,7 +689,7 @@ describe('useTransactionConfirm', () => {
     await onTransactionConfirm();
 
     const actual = updateAndApproveTxMock.mock.calls[0][0];
-    expect(actual.isExternalSign).toBe(true);
+    expect(actual.isExternalSign).toBeUndefined();
     expect(actual.isGasFeeSponsored).toBe(false);
   });
 
@@ -749,7 +742,7 @@ describe('useTransactionConfirm', () => {
     );
   });
 
-  it('approves supported sponsored transactions with external signing', async () => {
+  it('preserves sponsored transaction metadata without client-side external-sign hints', async () => {
     useIsGaslessSupportedMock.mockReturnValue({
       isSupported: true,
       isSmartTransaction: false,
@@ -758,7 +751,6 @@ describe('useTransactionConfirm', () => {
 
     const { confirmation, onTransactionConfirm } = runHook({
       isGasFeeSponsored: true,
-      isExternalSign: true,
     });
     const originalConfirmation = cloneDeep(confirmation);
 
@@ -766,7 +758,6 @@ describe('useTransactionConfirm', () => {
 
     expect(updateAndApproveTxMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        isExternalSign: true,
         isGasFeeSponsored: true,
       }),
       true,
@@ -795,7 +786,7 @@ describe('useTransactionConfirm', () => {
     await onTransactionConfirm();
 
     const actual = updateAndApproveTxMock.mock.calls[0][0];
-    expect(actual.isGasFeeSponsored).toBe(false);
+    expect(actual.isGasFeeSponsored).toBe(true);
   });
 
   it('sets isGasFeeSponsored to false when user opted out via smart transaction flow', async () => {
@@ -823,7 +814,7 @@ describe('useTransactionConfirm', () => {
     await onTransactionConfirm();
 
     const actual = updateAndApproveTxMock.mock.calls[0][0];
-    expect(actual.isGasFeeSponsored).toBe(false);
+    expect(actual.isGasFeeSponsored).toBe(true);
   });
 
   it('sets isGasFeeSponsored to false when user opted out without a selected gas fee token', async () => {
@@ -839,17 +830,16 @@ describe('useTransactionConfirm', () => {
 
     const { onTransactionConfirm } = runHook({
       isGasFeeSponsored: true,
-      isExternalSign: true,
     });
 
     await onTransactionConfirm();
 
     const actual = updateAndApproveTxMock.mock.calls[0][0];
-    expect(actual.isGasFeeSponsored).toBe(false);
-    expect(actual.isExternalSign).toBe(false);
+    expect(actual.isGasFeeSponsored).toBe(true);
+    expect(actual.isExternalSign).toBeUndefined();
   });
 
-  it('clears isExternalSign when gasless is unsupported (e.g. hardware wallet on a sponsored chain)', async () => {
+  it('does not add an external-sign hint when gasless is unsupported (e.g. hardware wallet on a sponsored chain)', async () => {
     useIsGaslessSupportedMock.mockReturnValue({
       isSupported: false,
       isSmartTransaction: false,
@@ -862,17 +852,16 @@ describe('useTransactionConfirm', () => {
 
     const { onTransactionConfirm } = runHook({
       isGasFeeSponsored: true,
-      isExternalSign: true,
     });
 
     await onTransactionConfirm();
 
     const actual = updateAndApproveTxMock.mock.calls[0][0];
-    expect(actual.isExternalSign).toBe(false);
-    expect(actual.isGasFeeSponsored).toBe(false);
+    expect(actual.isExternalSign).toBeUndefined();
+    expect(actual.isGasFeeSponsored).toBe(true);
   });
 
-  it('keeps isExternalSign when gasless is supported and user has not opted out', async () => {
+  it('keeps the transaction unsigned locally when gasless is supported and user has not opted out', async () => {
     useIsGaslessSupportedMock.mockReturnValue({
       isSupported: true,
       isSmartTransaction: false,
@@ -885,13 +874,12 @@ describe('useTransactionConfirm', () => {
 
     const { onTransactionConfirm } = runHook({
       isGasFeeSponsored: true,
-      isExternalSign: true,
     });
 
     await onTransactionConfirm();
 
     const actual = updateAndApproveTxMock.mock.calls[0][0];
-    expect(actual.isExternalSign).toBe(true);
+    expect(actual.isExternalSign).toBeUndefined();
   });
 
   it('returns true after successful transaction in popup environment', async () => {
@@ -990,7 +978,6 @@ describe('useTransactionConfirm', () => {
       const { confirmation, onTransactionConfirm } = runHook({
         type: TransactionType.moneyAccountWithdraw,
         isGasFeeSponsored: true,
-        isExternalSign: true,
       });
 
       const result = await onTransactionConfirm();
@@ -1061,7 +1048,7 @@ describe('useTransactionConfirm', () => {
       );
     });
 
-    it('keeps isExternalSign on sponsored money account withdraw when gasless is unsupported', async () => {
+    it('keeps the money account withdraw transaction unsigned locally when gasless is unsupported', async () => {
       useIsGaslessSupportedMock.mockReturnValue({
         isSupported: false,
         isSmartTransaction: false,
@@ -1071,18 +1058,17 @@ describe('useTransactionConfirm', () => {
       const { confirmation, onTransactionConfirm } = runHook({
         type: TransactionType.moneyAccountWithdraw,
         isGasFeeSponsored: true,
-        isExternalSign: true,
       });
       mockPrepareWithdrawTransaction.mockResolvedValue(confirmation);
 
       await onTransactionConfirm();
 
       const actual = updateAndApproveTxMock.mock.calls[0][0];
-      expect(actual.isExternalSign).toBe(true);
+      expect(actual.isExternalSign).toBeUndefined();
       expect(actual.isGasFeeSponsored).toBe(true);
     });
 
-    it('clears gas sponsorship on money account withdraw when the user opted out', async () => {
+    it('keeps money account withdraw metadata without external-sign hints when the user opted out', async () => {
       useGasSponsorshipPreferenceMock.mockReturnValue({
         isSponsorshipOptedOut: true,
         setSponsorshipOptedOut: jest.fn(),
@@ -1091,15 +1077,14 @@ describe('useTransactionConfirm', () => {
       const { confirmation, onTransactionConfirm } = runHook({
         type: TransactionType.moneyAccountWithdraw,
         isGasFeeSponsored: true,
-        isExternalSign: true,
       });
       mockPrepareWithdrawTransaction.mockResolvedValue(confirmation);
 
       await onTransactionConfirm();
 
       const actual = updateAndApproveTxMock.mock.calls[0][0];
-      expect(actual.isGasFeeSponsored).toBe(false);
-      expect(actual.isExternalSign).toBe(false);
+      expect(actual.isGasFeeSponsored).toBe(true);
+      expect(actual.isExternalSign).toBeUndefined();
     });
   });
 });

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -1,4 +1,5 @@
 import {
+  prepareTransactionForApproval,
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
@@ -94,55 +95,24 @@ export function useTransactionConfirm() {
 
     updateSwapWithQuoteDetailsIfRequired(txToApprove);
 
-    // If the gasless flow is not supported (e.g. stx is disabled by the user,
-    // or 7702 is not supported in the chain), or the user has opted out of
-    // gas sponsorship, we override the `isGasFeeSponsored` flag to `false` so
-    // the transaction meta object in state has the correct value for the
-    // transaction details on the activity list to not show as sponsored. One
-    // limitation on the activity list will be that pre-populated transactions
-    // on fresh installs will not show as sponsored even if they were because
-    // this is not easily observable onchain for all cases.
-    //
-    // Money Account withdrawals are sponsored on Monad by design (the money
-    // account has no native MON). `useIsGaslessSupported` can disagree with
-    // the 7702 publish hook; clearing the flag here made the hook skip and
-    // published the parent `execute()` instead — which mines and moves
-    // nothing when that parent is still the empty placeholder.
-    txToApprove.isGasFeeSponsored = isMoneyAccountWithdraw
-      ? Boolean(transactionMeta.isGasFeeSponsored) && !isSponsorshipOptedOut
-      : isGaslessSupported &&
-        transactionMeta.isGasFeeSponsored &&
-        !isSponsorshipOptedOut;
-
-    // Revert the controller's `isExternalSign` flag when this account cannot
-    // use an external relay — i.e. gasless is unsupported for the account/chain
-    // (such as hardware wallets, which cannot sign EIP-7702 authorization
-    // lists) — or the user has opted out of gas sponsorship. Hardware wallet
-    // sendBundle transactions are gasless but still require local signing. The
-    // TransactionController sets `isExternalSign = true` whenever
-    // `isGasFeeSponsored` is true during gas estimation, regardless of whether
-    // an external relay is actually eligible for this account. If we leave it
-    // set, the sign step is skipped (no keyring/device call) and, when no relay
-    // catches the publish, an unsigned/empty payload reaches
-    // `eth_sendRawTransaction` and is rejected by the node.
-    //
-    // Sponsored money-account withdrawals skip local signing and must stay
-    // externally signed so the 7702 relay publishes them, even when
-    // `useIsGaslessSupported` is false (same reason we keep `isGasFeeSponsored`
-    // above).
-    const shouldKeepSponsoredMoneyAccountWithdraw =
-      isMoneyAccountWithdraw &&
-      Boolean(transactionMeta.isGasFeeSponsored) &&
-      !isSponsorshipOptedOut;
-    const shouldClearExternalSign =
-      transactionMeta.isExternalSign &&
-      !shouldKeepSponsoredMoneyAccountWithdraw &&
-      (!isGaslessSupported ||
-        isSponsorshipOptedOut ||
-        shouldRedirectToHwSigningPage);
-    if (shouldClearExternalSign) {
-      txToApprove.isExternalSign = false;
-    }
+    const preparedTransaction = prepareTransactionForApproval({
+      transactionMeta: txToApprove,
+      sponsorship: {
+        available: Boolean(transactionMeta.isGasFeeSponsored),
+        supported: isGaslessSupported,
+        optedOut: isSponsorshipOptedOut,
+        required: isMoneyAccountWithdraw,
+      },
+      signing: {
+        // Money Account withdrawals require their relay even when the generic
+        // gasless eligibility hook disagrees; hardware sendBundle signs locally.
+        externalSigningSupported:
+          isMoneyAccountWithdraw ||
+          (Boolean(transactionMeta.isExternalSign) &&
+            !shouldRedirectToHwSigningPage),
+      },
+    });
+    txToApprove = preparedTransaction.transactionMeta;
 
     if (isGaslessSupportedSTX) {
       handleSmartTransaction(txToApprove);

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -1,8 +1,4 @@
-import {
-  prepareTransactionForApproval,
-  TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionMeta, TransactionType } from '@metamask/transaction-controller';
 import { cloneDeep } from 'lodash';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
@@ -12,9 +8,7 @@ import { getCustomNonceValue } from '../../../../selectors';
 import { useConfirmContext } from '../../context/confirm';
 import { useSelectedGasFeeToken } from '../../components/confirm/info/hooks/useGasFeeToken';
 import { updateAndApproveTx } from '../../../../store/actions';
-import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { useGaslessSupportedSmartTransactions } from '../gas/useGaslessSupportedSmartTransactions';
-import { useGasSponsorshipPreference } from '../gas/useGasSponsorshipPreference';
 import {
   isHardwareWalletError,
   isUserRejectedHardwareWalletError,
@@ -40,10 +34,6 @@ export function useTransactionConfirm() {
 
   const { isSupported: isGaslessSupportedSTX } =
     useGaslessSupportedSmartTransactions();
-  const { isSupported: isGaslessSupported } = useIsGaslessSupported();
-  const { isSponsorshipOptedOut } = useGasSponsorshipPreference(
-    transactionMeta?.chainId,
-  );
   const { onDappSwapCompleted, updateSwapWithQuoteDetailsIfRequired } =
     useDappSwapActions();
   const { shouldRedirectToHwSigningPage, redirectToHwSigningPage } =
@@ -71,10 +61,6 @@ export function useTransactionConfirm() {
     [selectedGasFeeToken],
   );
 
-  const handleGasless7702 = useCallback((tx: TransactionMeta) => {
-    tx.isExternalSign = true;
-  }, []);
-
   const {
     handleShieldSubscriptionApprovalTransactionAfterConfirm,
     handleShieldSubscriptionApprovalTransactionAfterConfirmErr,
@@ -95,29 +81,8 @@ export function useTransactionConfirm() {
 
     updateSwapWithQuoteDetailsIfRequired(txToApprove);
 
-    const preparedTransaction = prepareTransactionForApproval({
-      transactionMeta: txToApprove,
-      sponsorship: {
-        available: Boolean(transactionMeta.isGasFeeSponsored),
-        supported: isGaslessSupported,
-        optedOut: isSponsorshipOptedOut,
-        required: isMoneyAccountWithdraw,
-      },
-      signing: {
-        // Money Account withdrawals require their relay even when the generic
-        // gasless eligibility hook disagrees; hardware sendBundle signs locally.
-        externalSigningSupported:
-          isMoneyAccountWithdraw ||
-          (Boolean(transactionMeta.isExternalSign) &&
-            !shouldRedirectToHwSigningPage),
-      },
-    });
-    txToApprove = preparedTransaction.transactionMeta;
-
     if (isGaslessSupportedSTX) {
       handleSmartTransaction(txToApprove);
-    } else if (selectedGasFeeToken) {
-      handleGasless7702(txToApprove);
     }
 
     if (shouldRedirectToHwSigningPage) {
@@ -147,16 +112,13 @@ export function useTransactionConfirm() {
       return false;
     }
   }, [
-    handleGasless7702,
     handleSmartTransaction,
     customNonceValue,
     dispatch,
     handleShieldSubscriptionApprovalTransactionAfterConfirm,
     handleShieldSubscriptionApprovalTransactionAfterConfirmErr,
-    isGaslessSupported,
     isGaslessSupportedSTX,
     isMoneyAccountWithdraw,
-    isSponsorshipOptedOut,
     onDappSwapCompleted,
     prepareWithdrawTransaction,
     redirectToHwSigningPage,


### PR DESCRIPTION
## Related pull requests

- Core: [MetaMask/core#10109](https://github.com/MetaMask/core/pull/10109)
- Mobile: [MetaMask/metamask-mobile#35754](https://github.com/MetaMask/metamask-mobile/pull/35754)

## Description

Extension now relies on TransactionController approval-time callbacks (`isSponsored` and `shouldSign`) instead of imperatively preparing approval metadata in the confirmation screen.

The confirmation UI still owns capability discovery and all client-specific behavior: Money Account withdrawal preparation, custom nonces, swap enrichment, Shield navigation, hardware signing navigation, gas-fee-token batch construction, and `updateAndApproveTx` dispatch. The controller now derives external signing internally, so the client no longer needs to mutate `isExternalSign` before approval.

Characterization coverage was updated for sponsored Smart Transactions, gas-fee-token flows, hardware sendBundle routing, and Money Account withdrawal.

## Validation

- `npx jest --no-watchman ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts app/scripts/lib/transaction/hooks/index.test.ts`
