### PR TITLE
fix(assets): skip Token API asset requests for unsupported chains

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -1778,8 +1778,10 @@ async function setupMocking(
     });
 
   // Tokens API: v2 supported networks — mocked globally so all tests work.
+  // Matches both hosts: `tokens.` (assets controllers) and `token.` (the
+  // supported-networks check that guards Token API `/assets` requests).
   await server
-    .forGet('https://tokens.api.cx.metamask.io/v2/supportedNetworks')
+    .forGet(/^https:\/\/tokens?\.api\.cx\.metamask\.io\/v2\/supportedNetworks/u)
     .always()
     .thenJson(200, {
       fullSupport: [

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -1778,10 +1778,8 @@ async function setupMocking(
     });
 
   // Tokens API: v2 supported networks — mocked globally so all tests work.
-  // Matches both hosts: `tokens.` (assets controllers) and `token.` (the
-  // supported-networks check that guards Token API `/assets` requests).
   await server
-    .forGet(/^https:\/\/tokens?\.api\.cx\.metamask\.io\/v2\/supportedNetworks/u)
+  .forGet('https://tokens.api.cx.metamask.io/v2/supportedNetworks')
     .always()
     .thenJson(200, {
       fullSupport: [

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -1779,7 +1779,7 @@ async function setupMocking(
 
   // Tokens API: v2 supported networks — mocked globally so all tests work.
   await server
-  .forGet('https://tokens.api.cx.metamask.io/v2/supportedNetworks')
+    .forGet('https://tokens.api.cx.metamask.io/v2/supportedNetworks')
     .always()
     .thenJson(200, {
       fullSupport: [

--- a/ui/hooks/token-asset/token-asset-batcher.test.ts
+++ b/ui/hooks/token-asset/token-asset-batcher.test.ts
@@ -1,18 +1,31 @@
 import { fetchTokenAssets } from '@metamask/assets-controllers';
 import type { CaipAssetType } from '@metamask/utils';
 import type { TokenAsset } from '@metamask/assets-controllers';
+import { apiClient } from '../../helpers/api-client';
 import { fetchTokenAsset } from './token-asset-batcher';
 
 jest.mock('@metamask/assets-controllers', () => ({
   fetchTokenAssets: jest.fn(),
 }));
 
+jest.mock('../../helpers/api-client', () => ({
+  apiClient: {
+    tokens: {
+      fetchTokenV2SupportedNetworks: jest.fn(),
+    },
+  },
+}));
+
 const mockFetchTokenAssets = jest.mocked(fetchTokenAssets);
+const mockFetchSupportedNetworks = jest.mocked(
+  apiClient.tokens.fetchTokenV2SupportedNetworks,
+);
 
 const usdcAssetId =
   'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CaipAssetType;
 const wethAssetId =
   'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as CaipAssetType;
+const sepoliaEthAssetId = 'eip155:11155111/slip44:60' as CaipAssetType;
 
 const createTokenAsset = (assetId: CaipAssetType): TokenAsset =>
   ({
@@ -25,6 +38,10 @@ const createTokenAsset = (assetId: CaipAssetType): TokenAsset =>
 describe('token-asset-batcher', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFetchSupportedNetworks.mockResolvedValue({
+      fullSupport: ['eip155:1'],
+      partialSupport: [],
+    });
   });
 
   it('batches concurrent fetches into one request', async () => {
@@ -51,6 +68,27 @@ describe('token-asset-batcher', () => {
     mockFetchTokenAssets.mockResolvedValue([]);
 
     await expect(fetchTokenAsset(usdcAssetId)).resolves.toBeNull();
+  });
+
+  it('resolves null without calling the API for a chain the Token API does not support', async () => {
+    await expect(fetchTokenAsset(sepoliaEthAssetId)).resolves.toBeNull();
+    expect(mockFetchTokenAssets).not.toHaveBeenCalled();
+  });
+
+  it('requests only the assets on supported chains', async () => {
+    mockFetchTokenAssets.mockResolvedValue([createTokenAsset(usdcAssetId)]);
+
+    const [usdc, sepoliaEth] = await Promise.all([
+      fetchTokenAsset(usdcAssetId),
+      fetchTokenAsset(sepoliaEthAssetId),
+    ]);
+
+    expect(mockFetchTokenAssets).toHaveBeenCalledTimes(1);
+    expect(mockFetchTokenAssets).toHaveBeenCalledWith([usdcAssetId], {
+      includeTokenSecurityData: true,
+    });
+    expect(usdc?.assetId).toBe(usdcAssetId);
+    expect(sepoliaEth).toBeNull();
   });
 
   it('resolves tokens from successful chunks when a later chunk fails', async () => {

--- a/ui/hooks/token-asset/token-asset-batcher.ts
+++ b/ui/hooks/token-asset/token-asset-batcher.ts
@@ -2,22 +2,66 @@ import {
   fetchTokenAssets,
   type TokenAsset,
 } from '@metamask/assets-controllers';
-import { isCaipAssetType, type CaipAssetType } from '@metamask/utils';
+import {
+  isCaipAssetType,
+  parseCaipAssetType,
+  type CaipAssetType,
+} from '@metamask/utils';
 import { create } from '#shared/lib/create-batcher';
 import { normalizeTokenAssetId } from '#shared/lib/asset-utils';
+import { apiClient } from '../../helpers/api-client';
 
 const tokenAssetBatchSize = 25;
 
+let supportedNetworksCache: {
+  fullSupport: string[];
+  partialSupport: string[];
+} | null = null;
+const getSupportedNetworksCached = async () => {
+  if (supportedNetworksCache) {
+    return supportedNetworksCache;
+  }
+
+  const { fullSupport, partialSupport } =
+    await apiClient.tokens.fetchTokenV2SupportedNetworks();
+  supportedNetworksCache = { fullSupport, partialSupport };
+  return supportedNetworksCache;
+};
+
+async function filterSupportedAssetIds(assetIds: CaipAssetType[]) {
+  try {
+    const { fullSupport, partialSupport } = await getSupportedNetworksCached();
+    const supportedChainIds = new Set([...fullSupport, ...partialSupport]);
+
+    return assetIds.filter(
+      (assetId) =>
+        isCaipAssetType(assetId) &&
+        supportedChainIds.has(parseCaipAssetType(assetId).chainId),
+    );
+  } catch {
+    return assetIds;
+  }
+}
+
 async function fetchTokenAssetBatch(assetIds: CaipAssetType[]) {
+  const supportedAssetIds = await filterSupportedAssetIds(assetIds);
+
+  if (supportedAssetIds.length === 0) {
+    return [];
+  }
+
   const tokens: TokenAsset[] = [];
   let chunkError: unknown;
 
   for (
     let offset = 0;
-    offset < assetIds.length;
+    offset < supportedAssetIds.length;
     offset += tokenAssetBatchSize
   ) {
-    const chunkAssetIds = assetIds.slice(offset, offset + tokenAssetBatchSize);
+    const chunkAssetIds = supportedAssetIds.slice(
+      offset,
+      offset + tokenAssetBatchSize,
+    );
 
     try {
       const chunkTokens = await fetchTokenAssets(chunkAssetIds, {

--- a/ui/hooks/token-asset/token-asset-batcher.ts
+++ b/ui/hooks/token-asset/token-asset-batcher.ts
@@ -13,19 +13,8 @@ import { apiClient } from '../../helpers/api-client';
 
 const tokenAssetBatchSize = 25;
 
-let supportedNetworksCache: {
-  fullSupport: string[];
-  partialSupport: string[];
-} | null = null;
 const getSupportedNetworksCached = async () => {
-  if (supportedNetworksCache) {
-    return supportedNetworksCache;
-  }
-
-  const { fullSupport, partialSupport } =
-    await apiClient.tokens.fetchTokenV2SupportedNetworks();
-  supportedNetworksCache = { fullSupport, partialSupport };
-  return supportedNetworksCache;
+  return await apiClient.tokens.fetchTokenV2SupportedNetworks();
 };
 
 async function filterSupportedAssetIds(assetIds: CaipAssetType[]) {

--- a/ui/hooks/token-asset/useTokenAssetQueries.test.ts
+++ b/ui/hooks/token-asset/useTokenAssetQueries.test.ts
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fetchTokenAssets } from '@metamask/assets-controllers';
 import type { CaipAssetType } from '@metamask/utils';
 import type { TokenAsset } from '@metamask/assets-controllers';
+import { apiClient } from '../../helpers/api-client';
 import { getTokenAssetQueryKey } from './token-asset-query';
 import { useTokenAssetQueries } from './useTokenAssetQueries';
 
@@ -11,7 +12,18 @@ jest.mock('@metamask/assets-controllers', () => ({
   fetchTokenAssets: jest.fn(),
 }));
 
+jest.mock('../../helpers/api-client', () => ({
+  apiClient: {
+    tokens: {
+      fetchTokenV2SupportedNetworks: jest.fn(),
+    },
+  },
+}));
+
 const mockFetchTokenAssets = jest.mocked(fetchTokenAssets);
+const mockFetchSupportedNetworks = jest.mocked(
+  apiClient.tokens.fetchTokenV2SupportedNetworks,
+);
 
 const usdcAssetId =
   'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CaipAssetType;
@@ -40,6 +52,10 @@ describe('useTokenAssetQueries', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFetchSupportedNetworks.mockResolvedValue({
+      fullSupport: ['eip155:1'],
+      partialSupport: [],
+    });
     mockFetchTokenAssets.mockResolvedValue([]);
   });
 

--- a/ui/hooks/token-asset/useTokenAssetQuery.test.ts
+++ b/ui/hooks/token-asset/useTokenAssetQuery.test.ts
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fetchTokenAssets } from '@metamask/assets-controllers';
 import type { CaipAssetType } from '@metamask/utils';
 import type { TokenAsset } from '@metamask/assets-controllers';
+import { apiClient } from '../../helpers/api-client';
 import { getTokenAssetQueryKey } from './token-asset-query';
 import { useTokenAssetQuery } from './useTokenAssetQuery';
 
@@ -11,7 +12,18 @@ jest.mock('@metamask/assets-controllers', () => ({
   fetchTokenAssets: jest.fn(),
 }));
 
+jest.mock('../../helpers/api-client', () => ({
+  apiClient: {
+    tokens: {
+      fetchTokenV2SupportedNetworks: jest.fn(),
+    },
+  },
+}));
+
 const mockFetchTokenAssets = jest.mocked(fetchTokenAssets);
+const mockFetchSupportedNetworks = jest.mocked(
+  apiClient.tokens.fetchTokenV2SupportedNetworks,
+);
 
 const usdcAssetId =
   'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CaipAssetType;
@@ -42,6 +54,10 @@ describe('useTokenAssetQuery', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFetchSupportedNetworks.mockResolvedValue({
+      fullSupport: ['eip155:1'],
+      partialSupport: [],
+    });
     mockFetchTokenAssets.mockResolvedValue([usdcToken]);
   });
 

--- a/ui/hooks/token-asset/useTokenAssetSecurityResults.test.ts
+++ b/ui/hooks/token-asset/useTokenAssetSecurityResults.test.ts
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fetchTokenAssets } from '@metamask/assets-controllers';
 import type { CaipAssetType } from '@metamask/utils';
 import type { TokenAsset } from '@metamask/assets-controllers';
+import { apiClient } from '../../helpers/api-client';
 import { getUseExternalServices } from '../../selectors';
 import { getIsSecurityTrustTdpEnabled } from '../../selectors/multichain/feature-flags';
 import { getTokenAssetQueryKey } from './token-asset-query';
@@ -11,6 +12,14 @@ import { useTokenAssetSecurityResults } from './useTokenAssetSecurityResults';
 
 jest.mock('@metamask/assets-controllers', () => ({
   fetchTokenAssets: jest.fn(),
+}));
+
+jest.mock('../../helpers/api-client', () => ({
+  apiClient: {
+    tokens: {
+      fetchTokenV2SupportedNetworks: jest.fn(),
+    },
+  },
 }));
 
 jest.mock('../../selectors', () => ({
@@ -30,6 +39,9 @@ const mockGetIsSecurityTrustTdpEnabled = jest.mocked(
   getIsSecurityTrustTdpEnabled,
 );
 const mockFetchTokenAssets = jest.mocked(fetchTokenAssets);
+const mockFetchSupportedNetworks = jest.mocked(
+  apiClient.tokens.fetchTokenV2SupportedNetworks,
+);
 
 const usdcAssetId =
   'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CaipAssetType;
@@ -58,6 +70,10 @@ describe('useTokenAssetSecurityResults', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFetchSupportedNetworks.mockResolvedValue({
+      fullSupport: ['eip155:1'],
+      partialSupport: [],
+    });
     mockGetUseExternalServices.mockReturnValue(true);
     mockGetIsSecurityTrustTdpEnabled.mockReturnValue(true);
     mockFetchTokenAssets.mockResolvedValue([]);

--- a/ui/hooks/useTokenSecurityData.test.ts
+++ b/ui/hooks/useTokenSecurityData.test.ts
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fetchTokenAssets } from '@metamask/assets-controllers';
 import type { TokenSecurityData } from '@metamask/assets-controllers';
 import type { CaipAssetType } from '@metamask/utils';
+import { apiClient } from '../helpers/api-client';
 import { getTokenAssetQueryKey } from './token-asset/token-asset-query';
 import * as tokenAssetBatcherModule from './token-asset/token-asset-batcher';
 import { useTokenSecurityData } from './useTokenSecurityData';
@@ -12,11 +13,22 @@ jest.mock('@metamask/assets-controllers', () => ({
   fetchTokenAssets: jest.fn(),
 }));
 
+jest.mock('../helpers/api-client', () => ({
+  apiClient: {
+    tokens: {
+      fetchTokenV2SupportedNetworks: jest.fn(),
+    },
+  },
+}));
+
 jest.mock('react-redux', () => ({
   useSelector: (selector: (state: unknown) => unknown) => selector({}),
 }));
 
 const mockFetchCachedTokenAssets = jest.mocked(fetchTokenAssets);
+const mockFetchSupportedNetworks = jest.mocked(
+  apiClient.tokens.fetchTokenV2SupportedNetworks,
+);
 
 const mockSecurityData: TokenSecurityData = {
   resultType: 'Verified',
@@ -69,6 +81,10 @@ const createWrapper = (queryClient: QueryClient) =>
 describe('useTokenSecurityData', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFetchSupportedNetworks.mockResolvedValue({
+      fullSupport: ['eip155:1'],
+      partialSupport: [],
+    });
   });
 
   it('returns prefetched data immediately without fetching', () => {

--- a/ui/pages/asset/hooks/useRouteAssetToken.test.ts
+++ b/ui/pages/asset/hooks/useRouteAssetToken.test.ts
@@ -4,11 +4,20 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fetchTokenAssets } from '@metamask/assets-controllers';
 import { CaipAssetType, Hex } from '@metamask/utils';
 import { getTokenAssetQueryKey } from '#ui/hooks/token-asset/token-asset-query';
+import { apiClient } from '#ui/helpers/api-client';
 import { TokenWithFiatAmount } from '../../../components/app/assets/types';
 import { getRouteAssetChainId, useRouteAssetToken } from './useRouteAssetToken';
 
 jest.mock('@metamask/assets-controllers', () => ({
   fetchTokenAssets: jest.fn(),
+}));
+
+jest.mock('#ui/helpers/api-client', () => ({
+  apiClient: {
+    tokens: {
+      fetchTokenV2SupportedNetworks: jest.fn(),
+    },
+  },
 }));
 
 jest.mock('#ui/selectors/multichain/feature-flags', () => ({
@@ -20,6 +29,9 @@ jest.mock('react-redux', () => ({
 }));
 
 const mockFetchTokenAssets = jest.mocked(fetchTokenAssets);
+const mockFetchSupportedNetworks = jest.mocked(
+  apiClient.tokens.fetchTokenV2SupportedNetworks,
+);
 
 const createWrapper = (queryClient?: QueryClient) => {
   const client =
@@ -66,6 +78,10 @@ describe('useRouteAssetToken', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFetchSupportedNetworks.mockResolvedValue({
+      fullSupport: ['eip155:1'],
+      partialSupport: [],
+    });
     mockFetchTokenAssets.mockResolvedValue([fetchedTokenAsset]);
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The trust signals work does not filter against supported networks causing this error in the network panel. This adds a small layer for checking against supported networks.

## **Changelog**

CHANGELOG entry: Fixed a network error that occurred when switching to a test network such as Sepolia

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/43753 https://consensyssoftware.atlassian.net/browse/ASSETS-3434

## **Manual testing steps**

1. Open network tools
2. Open sepolia - EXPECTED no failing requests for unsupported networks

## **Screenshots/Recordings**

### **Before**

### **After**

https://www.loom.com/share/a3a23265b36a4d8c8997aa7f3102ed47

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c968f9d9-e979-44b7-8d2c-254ee8ee2379?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c968f9d9-e979-44b7-8d2c-254ee8ee2379&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

