### PR TITLE
fix(build): make SWC minify deterministic for AMO rebuilds cp-13.47.1

### DIFF
--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -103,13 +103,27 @@ export const extensionToJs = (filename: string) =>
 
 /**
  * It gets minimizers for the webpack build.
+ *
+ * SWC's native minifier is built with Rayon concurrency (`concurrent-renamer`).
+ * Under parallel asset minification that can make mangled short-names in the
+ * webpack runtime chunk scheduling-dependent, which breaks reproducible
+ * Firefox/AMO rebuilds (same symptom as https://github.com/web-infra-dev/rspack/issues/14089:
+ * identical structure, swapped single-letter identifiers like `c`/`l`). Force a single
+ * Rayon thread and disable TerserPlugin multi-process parallel so Linux CI and
+ * local reviewer rebuilds mangle the runtime the same way.
  */
 export function getMinimizers() {
   const TerserPlugin: typeof TerserPluginType = require('terser-webpack-plugin');
+  // Prefer an explicit caller override, otherwise pin to 1 for hermetic builds.
+  if (!process.env.RAYON_NUM_THREADS) {
+    process.env.RAYON_NUM_THREADS = '1';
+  }
   return [
     new TerserPlugin({
       // use SWC to minify (about 7x faster than Terser)
       minify: TerserPlugin.swcMinify,
+      // Avoid nested parallelism with SWC's concurrent renamer (see above).
+      parallel: false,
       // do not minify snow.
       exclude: /snow\.prod/u,
     }),

--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -104,25 +104,21 @@ export const extensionToJs = (filename: string) =>
 /**
  * It gets minimizers for the webpack build.
  *
- * SWC's native minifier is built with Rayon concurrency (`concurrent-renamer`).
- * Under parallel asset minification that can make mangled short-names in the
- * webpack runtime chunk scheduling-dependent, which breaks reproducible
- * Firefox/AMO rebuilds (same symptom as https://github.com/web-infra-dev/rspack/issues/14089:
- * identical structure, swapped single-letter identifiers like `c`/`l`). Force a single
- * Rayon thread and disable TerserPlugin multi-process parallel so Linux CI and
- * local reviewer rebuilds mangle the runtime the same way.
+ * TerserPlugin's default `parallel` mode uses jest-worker to spawn a minifier
+ * process per CPU core. Worker assignment is not guaranteed to be stable across
+ * runs, which can change SWC mangling frequency analysis and produce different
+ * `runtime.[contenthash].js` filenames. That breaks Firefox AMO reviewer
+ * rebuild comparisons (mtree) even when the bundles are otherwise equivalent.
+ * Disabling parallel minify keeps that step deterministic and has also been a
+ * small wall-clock win in local `yarn dist:mv2` timings.
  */
 export function getMinimizers() {
   const TerserPlugin: typeof TerserPluginType = require('terser-webpack-plugin');
-  // Prefer an explicit caller override, otherwise pin to 1 for hermetic builds.
-  if (!process.env.RAYON_NUM_THREADS) {
-    process.env.RAYON_NUM_THREADS = '1';
-  }
   return [
     new TerserPlugin({
       // use SWC to minify (about 7x faster than Terser)
       minify: TerserPlugin.swcMinify,
-      // Avoid nested parallelism with SWC's concurrent renamer (see above).
+      // Determinism (and a small local build-time win): one minifier process.
       parallel: false,
       // do not minify snow.
       exclude: /snow\.prod/u,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Context

Firefox AMO reviewer packaging rebuilds the extension from the release source archive and compares it to the published Firefox zip with `mtree` (content SHA-256). Recent Runway releases (for example `13.47.0`) failed that gate because `runtime.[contenthash].js` differed between the production build and the Linux AMO rebuild, even though the files were structurally the same and only differed in SWC short-identifier assignments. HTML files then differed only because they referenced the other runtime filename.

Related: [INFRA-3920](https://consensyssoftware.atlassian.net/browse/INFRA-3920).

### Problem

`getMinimizers()` used `TerserPlugin.swcMinify` with default `parallel` workers (`jest-worker` per CPU core). Worker assignment is not guaranteed to be stable across runs, so mangling frequency analysis can diverge and change the runtime contenthash between the production job and the AMO rebuild.

An earlier draft also set `RAYON_NUM_THREADS=1`. Review feedback and follow-up verification showed that is unnecessary for `@swc/core@1.13.3` (Node bindings use `par-iter` / chili, not Rayon).

### Solution

In `development/webpack/utils/helpers.ts`, set TerserPlugin `parallel: false` only.

Verification:

1. Ubuntu Docker AMO rebuild of published `v13.47.0` with **only** `parallel: false` matched production `runtime.5b2d7cdb8d9e504e811b.js` and `mtree` reported identical builds.
2. Local `yarn dist:mv2` timings from review also found `parallel: false` slightly faster, not slower.
3. Local `yarn dist` (Chrome MV3) A/B: `parallel: false` avg ~57.0s vs baseline ~59.0s over 3 cold runs each (also slightly faster, not slower).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: INFRA-3920

## **Manual testing steps**

1. On Linux (or Ubuntu Docker), run Firefox AMO [prepare_release.sh](https://github.com/MetaMask/firefox-bundle-script/) for a release that previously mismatched (for example `13.47.0` / `13.46.1`), with this `helpers.ts` change present in the extracted source tree before `./bundle.sh`.
2. Confirm `BUILDS ARE IDENTICAL` and that production and local `runtime.*.js` basenames match.
3. Optionally run `yarn dist:mv2` and confirm the build completes.
4. Optionally run `yarn dist` (Chrome MV3) and confirm the build completes.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[INFRA-3920]: https://consensyssoftware.atlassian.net/browse/INFRA-3920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7671c23b14cf50fc8aae67295e36dcb1d07040d5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->