### PR TITLE
chore(ramps): delegate Headless Buy default redirect URL to core

### DIFF
--- a/shared/lib/ramps/callback-url.ts
+++ b/shared/lib/ramps/callback-url.ts
@@ -1,27 +1,17 @@
-import { RampsEnvironment } from '@metamask/ramps-controller';
+import { getDefaultRedirectCallbackUrl } from '@metamask/ramps-controller';
 import { getRampsEnvironment } from './environment';
-
-const RAMP_CALLBACK_PATH = '/regions/fake-callback';
-
-// Production and staging serve the callback from the on-ramp-content hosts.
-// There is no `on-ramp-content.dev-api` deployment, so development uses the
-// ramps dev API host, which serves `/regions/fake-callback` directly.
-const RAMP_CALLBACK_HOST = {
-  [RampsEnvironment.Production]: 'https://on-ramp-content.api.cx.metamask.io',
-  [RampsEnvironment.Staging]: 'https://on-ramp-content.uat-api.cx.metamask.io',
-  [RampsEnvironment.Development]: 'https://on-ramp.dev-api.cx.metamask.io',
-  [RampsEnvironment.Local]: 'http://localhost:3000',
-} as const;
 
 /**
  * Builds the redirect URL handed to providers when a quote is requested, and
  * matched against tab navigations to detect the end of a hosted checkout.
  *
- * Lives in `shared` so both the UI (quote redirectUrl) and the background
- * checkout watcher can agree on the same host.
+ * Delegates to `@metamask/ramps-controller`'s `getDefaultRedirectCallbackUrl`
+ * so the callback host map has a single source of truth in core instead of
+ * being duplicated here. Lives in `shared` so both the UI (quote redirectUrl)
+ * and the background checkout watcher resolve the same host.
  *
  * @returns The callback base URL for the current build's ramps environment.
  */
 export function getRampCallbackBaseUrl(): string {
-  return `${RAMP_CALLBACK_HOST[getRampsEnvironment()]}${RAMP_CALLBACK_PATH}`;
+  return getDefaultRedirectCallbackUrl(getRampsEnvironment());
 }

--- a/ui/hooks/ramps/utils/getRampCallbackBaseUrl.test.ts
+++ b/ui/hooks/ramps/utils/getRampCallbackBaseUrl.test.ts
@@ -1,4 +1,6 @@
+import { getDefaultRedirectCallbackUrl } from '@metamask/ramps-controller';
 import { ENVIRONMENT } from '../../../../shared/constants/build';
+import { getRampsEnvironment } from '../../../../shared/lib/ramps/environment';
 import { getRampCallbackBaseUrl } from './getRampCallbackBaseUrl';
 
 const PRODUCTION_CALLBACK =
@@ -64,5 +66,14 @@ describe('getRampCallbackBaseUrl', () => {
   it('returns the staging URL when METAMASK_ENVIRONMENT is unset', () => {
     delete process.env.METAMASK_ENVIRONMENT;
     expect(getRampCallbackBaseUrl()).toBe(STAGING_CALLBACK);
+  });
+
+  // The callback host map lives in `@metamask/ramps-controller`; this locks the
+  // shared helper to core's derivation so the two cannot drift apart.
+  it('delegates to core getDefaultRedirectCallbackUrl for the resolved environment', () => {
+    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.PRODUCTION;
+    expect(getRampCallbackBaseUrl()).toBe(
+      getDefaultRedirectCallbackUrl(getRampsEnvironment()),
+    );
   });
 });


### PR DESCRIPTION
## **Description**

TRAM-3840 follows TRAM-3757, which moved Headless Buy default-redirect-URL derivation into `@metamask/ramps-controller` (core, shipped in `ramps-controller` 19.0.0). The Extension already consumes `^20.2.0`, no longer injects the redirect URL via the removed `getDefaultRedirectUrl` constructor option, and already delegates `RampsService:getDefaultRedirectCallbackUrl`. The one remaining piece was `shared/lib/ramps/callback-url.ts`, which still kept its own copy of the callback host map.

This removes that duplicate: `getRampCallbackBaseUrl()` now delegates to core's exported `getDefaultRedirectCallbackUrl(getRampsEnvironment())`, giving the callback host map a single source of truth in core. No dependency bump is needed. Behaviour is unchanged; every environment (`Production`, `Staging`, `Development`) resolves to the same URL as before. Mirrors the mobile analog MetaMask/metamask-mobile#34207.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3840

## **Manual testing steps**

Non-user-facing refactor, no behaviour change. Verified via unit tests:

1. `yarn jest ui/hooks/ramps/utils/getRampCallbackBaseUrl.test.ts` - every environment still resolves to its prior callback URL, plus a new assertion that the helper equals `getDefaultRedirectCallbackUrl(getRampsEnvironment())`.
2. `yarn jest app/scripts/lib/ramps/checkout-watch.test.ts` - the background checkout watcher that matches the callback URL still passes.

## **Screenshots/Recordings**

N/A - no UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only delegation to an already-used core API with unit tests locking prior URLs; no dependency bump or intentional behavior change.
> 
> **Overview**
> Removes the **duplicate per-environment callback host map** in `shared/lib/ramps/callback-url.ts` so ramp checkout redirect URLs come from one place.
> 
> `getRampCallbackBaseUrl()` now returns `getDefaultRedirectCallbackUrl(getRampsEnvironment())` from `@metamask/ramps-controller` instead of assembling `${RAMP_CALLBACK_HOST[env]}${RAMP_CALLBACK_PATH}` locally. **Behavior is intended to stay the same** for production, staging, and development; UI quote `redirectUrl` and the background checkout watcher still use this shared helper.
> 
> Tests keep the existing per-environment URL expectations and add an assertion that the helper matches core’s `getDefaultRedirectCallbackUrl` for the resolved environment so extension and core cannot drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1594a973c87555ba32676136ce6fac4734cfbb46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->