### PR TITLE
ci: retries no longer ignore the e2e-quality-gate

### DIFF
--- a/.github/scripts/classify-failures.mts
+++ b/.github/scripts/classify-failures.mts
@@ -49,6 +49,7 @@
 
 import { appendFileSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
@@ -61,6 +62,11 @@ import {
   RETRY_CI_LABEL_MAX_ATTEMPT,
   type RetryBudgetDecision,
 } from './shared/retry-budget.mts';
+import {
+  E2E_QUALITY_GATE_FAILURE_ANNOTATION_TITLE,
+  hasE2eQualityGateFailure,
+} from './shared/e2e-quality-gate.mts';
+import { partitionRetryableBlockerCascadeJobs } from './shared/failure-classification.mts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -73,6 +79,7 @@ interface Job {
 }
 
 interface Annotation {
+  annotation_level?: 'notice' | 'warning' | 'failure';
   message?: string;
   title?: string;
   path?: string;
@@ -296,13 +303,27 @@ function getFailedJobs(): Job[] {
   return jobs.filter((j) => j.conclusion === 'failure');
 }
 
-function getAnnotations(jobId: number): Annotation[] {
+function getAnnotations(jobId: number): {
+  annotations: Annotation[];
+  available: boolean;
+} {
   try {
-    return JSON.parse(
-      ghApi(`${repoApi}/check-runs/${jobId}/annotations`),
-    ) as Annotation[];
+    const raw = ghApi(`${repoApi}/check-runs/${jobId}/annotations`, {
+      paginate: true,
+      jq: '.[]',
+    });
+    const annotations: Annotation[] = [];
+    for (const line of raw.split('\n')) {
+      if (!line) continue;
+      try {
+        annotations.push(JSON.parse(line) as Annotation);
+      } catch {
+        console.warn(`Skipping malformed annotation JSON for job ${jobId}`);
+      }
+    }
+    return { annotations, available: true };
   } catch {
-    return [];
+    return { annotations: [], available: false };
   }
 }
 
@@ -310,7 +331,28 @@ const LOG_TAIL_LINES = 500;
 
 function getJobLogs(jobId: number): string {
   try {
-    const full = ghApi(`${repoApi}/actions/jobs/${jobId}/logs`);
+    // The raw job-log API can make gh reject GitHub Actions' ANSI-bearing
+    // response. `gh run view` is the CLI-supported per-job log path.
+    const full = execFileSync(
+      'gh',
+      [
+        'run',
+        'view',
+        MAIN_RUN_ID,
+        '--repo',
+        REPO,
+        '--log',
+        '--job',
+        String(jobId),
+      ],
+      {
+        encoding: 'utf8',
+        // Disable CLI color without removing runner output used below to
+        // classify transient failures.
+        env: { ...process.env, NO_COLOR: '1' },
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
     // Only search the tail — error summaries appear at the end and this
     // avoids false positives from earlier benign output.
     const lines = full.split('\n');
@@ -356,6 +398,34 @@ function classifyJob(job: Job): JobClassification {
   }
 
   if (category === 'alwaysRetryable') {
+    const annotationResult = getAnnotations(jobId);
+    if (!annotationResult.available) {
+      // E2E jobs are normally retryable, but absent annotation evidence must
+      // fail closed so an unavailable API cannot bypass a terminal gate.
+      return {
+        jobName,
+        jobId,
+        category,
+        jobRetryable: false,
+        reason: 'Could not verify E2E quality-gate annotations',
+        unmatched,
+        deterministic: true,
+      };
+    }
+
+    if (hasE2eQualityGateFailure(annotationResult.annotations)) {
+      return {
+        jobName,
+        jobId,
+        category,
+        jobRetryable: false,
+        reason: 'Changed or new E2E test failed its quality gate',
+        errorSnippet: E2E_QUALITY_GATE_FAILURE_ANNOTATION_TITLE,
+        unmatched,
+        deterministic: true,
+      };
+    }
+
     return {
       jobName,
       jobId,
@@ -378,7 +448,7 @@ function classifyJob(job: Job): JobClassification {
   }
 
   // retryableOnTransientError: check annotations, then logs
-  const annotations = getAnnotations(jobId);
+  const { annotations } = getAnnotations(jobId);
   const annotationText = annotations
     .map((a) => `${a.message ?? ''} ${a.title ?? ''}`)
     .join('\n');
@@ -517,6 +587,48 @@ function classifyJob(job: Job): JobClassification {
   };
 }
 
+function resolvePrNumber(): string {
+  if (WORKFLOW_EVENT === 'pull_request' && PR_NUMBER_FROM_EVENT) {
+    return PR_NUMBER_FROM_EVENT;
+  }
+  const match = HEAD_BRANCH.match(/gh-readonly-queue\/[^/]+\/pr-(\d+)-/);
+  if (WORKFLOW_EVENT === 'merge_group' && match) {
+    return match[1];
+  }
+  return '';
+}
+
+function resolveTargetBranch(prNum: string): {
+  targetBranch: string;
+  verified: boolean;
+} {
+  const mergeQueueBranch = HEAD_BRANCH.match(/^gh-readonly-queue\/([^/]+)\//);
+  if (WORKFLOW_EVENT === 'merge_group' && mergeQueueBranch) {
+    return { targetBranch: mergeQueueBranch[1], verified: true };
+  }
+
+  if (WORKFLOW_EVENT !== 'pull_request' || !prNum) {
+    return { targetBranch: HEAD_BRANCH, verified: true };
+  }
+
+  try {
+    // workflow_run does not reliably expose the originating PR base, so query
+    // it directly before applying the stricter direct-to-main E2E policy.
+    const pullRequest = JSON.parse(ghApi(`${repoApi}/pulls/${prNum}`)) as {
+      base?: { ref?: string };
+    };
+    if (pullRequest.base?.ref) {
+      return { targetBranch: pullRequest.base.ref, verified: true };
+    }
+  } catch {
+    console.warn(
+      `Could not resolve the target branch for PR #${prNum}; requiring retry-ci for E2E failures.`,
+    );
+  }
+
+  return { targetBranch: '', verified: false };
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -568,7 +680,7 @@ if (WORKFLOW_CONCLUSION === 'cancelled' && Number(ATTEMPT) > 1) {
 
   const Sentry = initSentry();
   if (Sentry) {
-    const branch = resolveTargetBranch();
+    const branch = resolveTargetBranch(resolvePrNumber()).targetBranch;
     const prNum = resolvePrNumber();
     Sentry.logger.info('Triage and Retry System: cancelled', {
       'ci.targetBranch': branch,
@@ -698,6 +810,13 @@ if (failedJobs.length === 0) {
 
 console.log(`Found ${failedJobs.length} failed job(s):\n`);
 
+const prNumber = resolvePrNumber();
+const { targetBranch, verified: isTargetBranchVerified } =
+  resolveTargetBranch(prNumber);
+const requiresRetryCiForE2e =
+  WORKFLOW_EVENT === 'pull_request' &&
+  (!isTargetBranchVerified || targetBranch === 'main');
+
 // Partition into blockers and non-blockers. If any blocker fails
 // non-transiently, stop early and tag all remaining jobs as cascade.
 const isBlocker = (name: string) => blockerRegexes.some((re) => re.test(name));
@@ -748,8 +867,26 @@ if (blockedBy) {
   console.log(
     `\n  ♻️  Blocker(s) retryable — tagging ${otherJobs.length} downstream job(s) as cascade.\n`,
   );
+  const { jobsToClassify: alwaysRetryableJobs, jobsToCascade: cascadeJobs } =
+    partitionRetryableBlockerCascadeJobs({
+      jobs: otherJobs,
+      getCategory: (jobName) => matchCategory(jobName).category,
+    });
+
+  // A structured quality-gate annotation is deterministic evidence that a
+  // changed/new E2E test failed. It must still veto a retry when an unrelated
+  // blocker is retryable, so inspect E2E jobs before cascading the rest.
+  for (const job of alwaysRetryableJobs) {
+    console.log(`  Classifying after retryable blocker: ${job.name}`);
+    const result = classifyJob(job);
+    classifications.push(result);
+    console.log(
+      `    → ${result.jobRetryable ? '✅ retryable' : '❌ non-retryable'}: ${result.reason}`,
+    );
+  }
+
   tagCascade(
-    otherJobs,
+    cascadeJobs,
     true,
     `Cascade — will resolve when blocker retries (${blockerNames})`,
   );
@@ -772,36 +909,8 @@ const isRetryable =
 console.log(`\nDecision: is-retryable=${isRetryable}`);
 
 // ---------------------------------------------------------------------------
-// Resolve originating PR and check for retry-ci label
+// Resolve retry authorization
 // ---------------------------------------------------------------------------
-
-function resolvePrNumber(): string {
-  if (WORKFLOW_EVENT === 'pull_request' && PR_NUMBER_FROM_EVENT) {
-    return PR_NUMBER_FROM_EVENT;
-  }
-  const match = HEAD_BRANCH.match(/gh-readonly-queue\/[^/]+\/pr-(\d+)-/);
-  if (WORKFLOW_EVENT === 'merge_group' && match) {
-    return match[1];
-  }
-  return '';
-}
-
-/**
- * Resolves the target branch name from HEAD_BRANCH.
- *
- * For merge_group events HEAD_BRANCH is the temporary merge queue branch,
- * e.g. `gh-readonly-queue/main/pr-12345-abc123`. Extract the target branch
- * (`main`) so the dashboard field shows something meaningful.
- *
- * For push and pull_request events HEAD_BRANCH is already the real name.
- */
-function resolveTargetBranch(): string {
-  const match = HEAD_BRANCH.match(/^gh-readonly-queue\/([^/]+)\//);
-  if (WORKFLOW_EVENT === 'merge_group' && match) {
-    return match[1];
-  }
-  return HEAD_BRANCH;
-}
 
 function checkRetryLabel(prNum: string): boolean {
   if (!prNum) return false;
@@ -816,17 +925,29 @@ function checkRetryLabel(prNum: string): boolean {
   }
 }
 
-const prNumber = resolvePrNumber();
-const targetBranch = resolveTargetBranch();
 const hasPR = Boolean(prNumber);
+const retryContext = hasPR
+  ? 'pr'
+  : WORKFLOW_EVENT === 'push' && HEAD_BRANCH.startsWith('release/')
+    ? 'release-push'
+    : 'observation';
 const hasRetryLabel = checkRetryLabel(prNumber);
+const hasMainTargetE2eFailure =
+  requiresRetryCiForE2e &&
+  classifications.some((job) => job.jobName.startsWith('e2e-'));
+// Reducing the automatic ceiling to the current attempt makes this first
+// direct-to-main E2E failure label-funded without introducing another retry
+// flow. Non-main PRs and merge groups retain the default ceiling.
 const retryBudget = getRetryBudget({
   attempt: ATTEMPT,
-  hasPr: hasPR,
+  context: retryContext,
   hasRetryLabel,
   isRetryable,
+  automaticRetryLimit: hasMainTargetE2eFailure
+    ? 1
+    : DEFAULT_RETRY_MAX_ATTEMPT,
 });
-const atMaxAttempts = retryBudget.atRetryLimit;
+const atRetryCiLimit = retryBudget.labelRetryLimitReached;
 const willRetry = retryBudget.willRetry;
 
 // The retry decision depends on the classification result, whether the run
@@ -834,6 +955,7 @@ const willRetry = retryBudget.willRetry;
 //
 //   isRetryable    — did classification determine all failures are retryable?
 //   hasPR          — is there an originating PR? (false for push events)
+//   retryContext   — PRs and release pushes can retry; other events observe
 //   retryBudget    — default retries through attempt 2, retry-ci through attempt 4
 //
 // Attempt 1 retries automatically. Attempts 2 and 3 require retry-ci and
@@ -851,8 +973,21 @@ function resolveDecision(
   hasLabel: boolean,
   budget: RetryBudgetDecision,
   pr: string,
+  hasMainTargetE2eFailure: boolean,
 ): { key: string; label: string } {
+  // Keep the direct-to-main E2E exception ahead of generic budget messages so
+  // reviewers see the required retry-ci action instead of a vague limit note.
   if (retryable) {
+    if (
+      hasPr &&
+      hasMainTargetE2eFailure &&
+      budget.automaticRetryLimitReached &&
+      !hasLabel
+    )
+      return {
+        key: 'e2e-retry-ci-required',
+        label: `⏸️ Retryable E2E failure targeting main requires retry-ci on PR #${pr}`,
+      };
     if (hasPr && budget.willRetry && budget.retryMode === 'automatic')
       return {
         key: 'will-retry',
@@ -863,25 +998,30 @@ function resolveDecision(
         key: 'will-retry',
         label: `♻️ Will retry (retry-ci label present; attempt ${budget.attemptNumber} of ${RETRY_CI_LABEL_MAX_ATTEMPT})`,
       };
-    if (hasPr && budget.atRetryLimit && budget.retryLimitSource === 'retry-ci')
+    if (hasPr && budget.labelRetryLimitReached)
       return {
         key: 'max-attempts-reached',
-        label: `🛑 Retryable, but attempt ${budget.attemptNumber} reached the retry-ci limit of ${budget.retryLimit}`,
+        label: `🛑 Retryable, but attempt ${budget.attemptNumber} reached the retry-ci limit of ${budget.labelRetryLimit}`,
       };
-    if (hasPr && budget.atRetryLimit)
+    if (hasPr && budget.automaticRetryLimitReached)
       return {
         key: 'retryable-no-label',
-        label: `⏸️ Retryable, but the default retry budget ended at attempt ${budget.retryLimit}`,
-      };
-    if (hasPr && budget.usedRetryCiBudget)
-      return {
-        key: 'retryable-retry-ci-consumed',
-        label: `⏸️ Retryable, but retry-ci was consumed by an earlier retry; add it again to retry attempt ${budget.attemptNumber + 1}`,
+        label: `⏸️ Retryable, but the automatic retry budget ended at attempt ${budget.automaticRetryLimit}`,
       };
     if (hasPr)
       return {
         key: 'retryable-no-label',
         label: `⏸️ Retryable, but no retry-ci label on PR #${pr}`,
+      };
+    if (budget.willRetry && budget.retryMode === 'automatic')
+      return {
+        key: 'will-retry',
+        label: `♻️ Will retry automatically (default retry budget: attempt ${budget.attemptNumber} of ${DEFAULT_RETRY_MAX_ATTEMPT})`,
+      };
+    if (budget.automaticRetryLimitReached)
+      return {
+        key: 'retryable-no-pr',
+        label: `⏸️ Retryable, but the automatic retry budget ended at attempt ${budget.automaticRetryLimit}`,
       };
     return {
       key: 'retryable-no-pr',
@@ -900,7 +1040,10 @@ function resolveDecision(
     };
   return {
     key: 'not-retryable-no-pr',
-    label: '❌ Non-retryable, no originating PR (observation only)',
+    label:
+      retryContext === 'release-push'
+        ? '❌ Non-retryable release push'
+        : '❌ Non-retryable, no originating PR (observation only)',
   };
 }
 const { key: decision, label: decisionLabel } = resolveDecision(
@@ -909,17 +1052,20 @@ const { key: decision, label: decisionLabel } = resolveDecision(
   hasRetryLabel,
   retryBudget,
   prNumber,
+  hasMainTargetE2eFailure,
 );
 
-if (atMaxAttempts && hasPR && isRetryable) {
+if (atRetryCiLimit && isRetryable) {
   console.log(
-    `PR #${prNumber}: attempt ${retryBudget.attemptNumber} reached the ${retryBudget.retryLimitSource} retry limit (${retryBudget.retryLimit}) — will not retry`,
+    `${hasPR ? `PR #${prNumber}` : `Release branch ${HEAD_BRANCH}`}: attempt ${retryBudget.attemptNumber} reached the retry-ci limit (${retryBudget.labelRetryLimit}) — will not retry`,
   );
 } else {
   console.log(
     prNumber
       ? `PR #${prNumber}: retry-ci label ${hasRetryLabel ? 'present' : 'absent'}, retry-mode=${retryBudget.retryMode} → will-retry=${willRetry}`
-      : `No originating PR for event '${WORKFLOW_EVENT}' → will-retry=false`,
+      : retryContext === 'release-push'
+        ? `Release branch ${HEAD_BRANCH}: retry-mode=${retryBudget.retryMode} → will-retry=${willRetry}`
+        : `No originating PR for event '${WORKFLOW_EVENT}' → will-retry=false`,
   );
 }
 
@@ -948,8 +1094,10 @@ if (atMaxAttempts && hasPR && isRetryable) {
 // posted one.
 if (WORKFLOW_EVENT === 'merge_group' && !willRetry) {
   const headSha = getRunHeadSha();
-  const description = atMaxAttempts
-    ? `Retry limit reached (attempt ${retryBudget.attemptNumber} of ${retryBudget.retryLimit})`
+  const description = retryBudget.labelRetryLimitReached
+    ? `Retry-ci limit reached (attempt ${retryBudget.attemptNumber} of ${retryBudget.labelRetryLimit})`
+    : retryBudget.automaticRetryLimitReached
+      ? `Automatic retry limit reached (attempt ${retryBudget.attemptNumber} of ${retryBudget.automaticRetryLimit})`
     : isRetryable
       ? 'Retryable failures, but no retry budget available'
       : 'Non-retryable failures detected';
@@ -981,7 +1129,10 @@ if (GITHUB_OUTPUT) {
       `will-retry=${willRetry}`,
       `consume-retry-label=${retryBudget.consumeRetryLabel}`,
       `retry-mode=${retryBudget.retryMode}`,
-      `retry-limit=${retryBudget.retryLimit}`,
+      `automatic-retry-limit=${retryBudget.automaticRetryLimit}`,
+      `automatic-retry-limit-reached=${retryBudget.automaticRetryLimitReached}`,
+      `label-retry-limit=${retryBudget.labelRetryLimit}`,
+      `label-retry-limit-reached=${retryBudget.labelRetryLimitReached}`,
       `pr-number=${prNumber}`,
     ].join('\n') + '\n',
   );
@@ -1000,7 +1151,7 @@ const reportLines = [
   `**Run:** [${MAIN_RUN_ID}](${mainRunUrl})${ATTEMPT ? ` (attempt ${ATTEMPT})` : ''}`,
   `**Classification:** ${isRetryable ? '✅ All failures retryable' : '❌ Non-retryable failures detected'}`,
   `**Retry:** ${decisionLabel}`,
-  `**Retry mode:** ${retryBudget.retryMode} (limit ${retryBudget.retryLimit}, ${retryBudget.retryLimitSource})`,
+  `**Retry mode:** ${retryBudget.retryMode} (automatic limit ${retryBudget.automaticRetryLimit}; retry-ci limit ${retryBudget.labelRetryLimit})`,
   `**Failed jobs:** ${failedJobs.length}`,
   ``,
   `| Job | Category | Job Retryable | Reason |`,
@@ -1020,10 +1171,10 @@ if (unmatchedJobs.length > 0) {
   );
 }
 
-if (atMaxAttempts && isRetryable && hasPR) {
+if (retryBudget.labelRetryLimitReached && isRetryable && hasPR) {
   reportLines.push(
     ``,
-    `> 🛑 **Retry limit reached** — attempt ${retryBudget.attemptNumber} of ${retryBudget.retryLimit}. The failures look retryable, but no more automatic retries will be attempted for this run.`,
+    `> 🛑 **Retry-ci limit reached** — attempt ${retryBudget.attemptNumber} of ${retryBudget.labelRetryLimit}. The failures look retryable, but no further retries will be attempted for this run.`,
   );
 }
 
@@ -1125,8 +1276,12 @@ if (Sentry) {
     'ci.retry.date': new Date().toISOString().slice(0, 10),
     'ci.retry.decision': decision,
     'ci.retry.mode': retryBudget.retryMode,
-    'ci.retry.limit': String(retryBudget.retryLimit),
-    'ci.retry.limitSource': retryBudget.retryLimitSource,
+    'ci.retry.automaticLimit': String(retryBudget.automaticRetryLimit),
+    'ci.retry.automaticLimitReached': String(
+      retryBudget.automaticRetryLimitReached,
+    ),
+    'ci.retry.labelLimit': String(retryBudget.labelRetryLimit),
+    'ci.retry.labelLimitReached': String(retryBudget.labelRetryLimitReached),
     'ci.retry.consumeRetryLabel': String(retryBudget.consumeRetryLabel),
     'ci.retry.runId': MAIN_RUN_ID,
     'ci.retry.attempt': ATTEMPT || 'unknown',

--- a/.github/scripts/emit-e2e-quality-gate-annotations.mts
+++ b/.github/scripts/emit-e2e-quality-gate-annotations.mts
@@ -1,0 +1,46 @@
+import { extractTestResults } from './extract-test-results.mts';
+import {
+  E2E_QUALITY_GATE_FAILURE_ANNOTATION_TITLE,
+  E2E_QUALITY_GATE_FAILURE_ANNOTATION_MESSAGE,
+  escapeWorkflowCommandData,
+  escapeWorkflowCommandProperty,
+  getE2eQualityGateFailurePaths,
+} from './shared/e2e-quality-gate.mts';
+import {
+  readChangedAndFilterE2eChangedFiles,
+  shouldE2eQualityGateBeSkipped,
+} from '../../test/e2e/changedFilesUtil.js';
+
+async function main(): Promise<void> {
+  if (shouldE2eQualityGateBeSkipped()) {
+    // Skipping the gate deliberately leaves an E2E failure eligible for the
+    // ordinary retry policy; do not emit its terminal marker in this case.
+    console.log('E2E quality gate is skipped; no annotations emitted.');
+    return;
+  }
+
+  const { failed } = await extractTestResults('test/test-results/e2e');
+  // Selenium and Playwright use different changed-file filters, but a failed
+  // changed/new test from either runner has the same terminal retry policy.
+  const changedOrNewTests = [
+    ...readChangedAndFilterE2eChangedFiles(),
+    ...readChangedAndFilterE2eChangedFiles({ playwrightOnly: true }),
+  ];
+  const failedQualityGateTests = getE2eQualityGateFailurePaths({
+    changedOrNewTests,
+    failedTests: failed,
+  });
+
+  for (const testPath of failedQualityGateTests) {
+    // Downstream triage trusts this structured annotation, rather than JUnit
+    // or free-form logs, to identify a terminal changed/new E2E failure.
+    console.log(
+      `::error title=${escapeWorkflowCommandProperty(E2E_QUALITY_GATE_FAILURE_ANNOTATION_TITLE)},file=${escapeWorkflowCommandProperty(testPath)},line=1::${escapeWorkflowCommandData(E2E_QUALITY_GATE_FAILURE_ANNOTATION_MESSAGE)}`,
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/.github/scripts/shared/e2e-quality-gate.mts
+++ b/.github/scripts/shared/e2e-quality-gate.mts
@@ -1,0 +1,53 @@
+export const E2E_QUALITY_GATE_FAILURE_ANNOTATION_TITLE =
+  'E2E quality gate failed';
+
+export const E2E_QUALITY_GATE_FAILURE_ANNOTATION_MESSAGE =
+  'This changed or new E2E test failed. CI will not retry it automatically; review the failure output and fix the test before rerunning CI.';
+
+export type CheckAnnotation = {
+  title?: string;
+};
+
+// Workflow-command properties use commas and colons as separators. Encode
+// those along with percent and line breaks so a test path cannot modify the
+// annotation metadata or inject a second command.
+export function escapeWorkflowCommandProperty(value: string): string {
+  return value
+    .replace(/%/gu, '%25')
+    .replace(/\r/gu, '%0D')
+    .replace(/\n/gu, '%0A')
+    .replace(/:/gu, '%3A')
+    .replace(/,/gu, '%2C');
+}
+
+// Command data starts after `::`, so only percent and line breaks are control
+// characters here; colons and commas remain readable in the annotation text.
+export function escapeWorkflowCommandData(value: string): string {
+  return value
+    .replace(/%/gu, '%25')
+    .replace(/\r/gu, '%0D')
+    .replace(/\n/gu, '%0A');
+}
+
+export function getE2eQualityGateFailurePaths({
+  changedOrNewTests,
+  failedTests,
+}: {
+  changedOrNewTests: string[];
+  failedTests: string[];
+}): string[] {
+  const failedTestPaths = new Set(failedTests);
+  return changedOrNewTests.filter((testPath) => failedTestPaths.has(testPath));
+}
+
+export function hasE2eQualityGateFailure(
+  annotations: CheckAnnotation[],
+): boolean {
+  // This exact title is the producer-consumer contract between the E2E job,
+  // triage, and CI status gate. Never infer terminal status from arbitrary
+  // test output that happens to resemble a quality-gate failure.
+  return annotations.some(
+    (annotation) =>
+      annotation.title === E2E_QUALITY_GATE_FAILURE_ANNOTATION_TITLE,
+  );
+}

--- a/.github/scripts/shared/e2e-quality-gate.test.mts
+++ b/.github/scripts/shared/e2e-quality-gate.test.mts
@@ -1,0 +1,72 @@
+import {
+  E2E_QUALITY_GATE_FAILURE_ANNOTATION_TITLE,
+  E2E_QUALITY_GATE_FAILURE_ANNOTATION_MESSAGE,
+  escapeWorkflowCommandData,
+  escapeWorkflowCommandProperty,
+  getE2eQualityGateFailurePaths,
+  hasE2eQualityGateFailure,
+} from './e2e-quality-gate.mts';
+
+describe('E2E quality gate failures', () => {
+  it('returns only changed or new tests that actually failed', () => {
+    expect(
+      getE2eQualityGateFailurePaths({
+        changedOrNewTests: [
+          'test/e2e/tests/changed.spec.ts',
+          'test/e2e/tests/passed.spec.ts',
+        ],
+        failedTests: [
+          'test/e2e/tests/changed.spec.ts',
+          'test/e2e/tests/ordinary.spec.ts',
+        ],
+      }),
+    ).toStrictEqual(['test/e2e/tests/changed.spec.ts']);
+  });
+
+  it('does not signal failures when the quality gate is skipped', () => {
+    expect(
+      getE2eQualityGateFailurePaths({
+        changedOrNewTests: [],
+        failedTests: ['test/e2e/tests/changed.spec.ts'],
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it('detects the exact quality-gate annotation title', () => {
+    expect(
+      hasE2eQualityGateFailure(
+        [{ title: E2E_QUALITY_GATE_FAILURE_ANNOTATION_TITLE }],
+      ),
+    ).toBe(true);
+  });
+
+  it('explains why the test failure is terminal', () => {
+    expect(E2E_QUALITY_GATE_FAILURE_ANNOTATION_MESSAGE).toBe(
+      'This changed or new E2E test failed. CI will not retry it automatically; review the failure output and fix the test before rerunning CI.',
+    );
+  });
+
+  it('does not match arbitrary annotation text', () => {
+    // Only the emitter's exact title can make an E2E failure terminal; test
+    // output that looks similar must not be able to spoof that decision.
+    expect(
+      hasE2eQualityGateFailure([
+        { title: 'E2E quality gate failure: test/e2e/tests/changed.spec.ts' },
+        { title: 'Ordinary E2E failure' },
+      ]),
+    ).toBe(false);
+  });
+
+  it('escapes workflow-command properties', () => {
+    // These are command-syntax boundaries, not display-formatting cases.
+    expect(
+      escapeWorkflowCommandProperty('test%,:\r\n::error title=injected'),
+    ).toBe('test%25%2C%3A%0D%0A%3A%3Aerror title=injected');
+  });
+
+  it('escapes workflow-command data', () => {
+    expect(escapeWorkflowCommandData('message%\r\n::error')).toBe(
+      'message%25%0D%0A::error',
+    );
+  });
+});

--- a/.github/scripts/shared/failure-classification.mts
+++ b/.github/scripts/shared/failure-classification.mts
@@ -1,0 +1,34 @@
+export type FailureCategory = "alwaysRetryable" | "retryableOnTransientError" | "optional";
+
+export type FailureJob = {
+  name: string;
+};
+
+export function partitionRetryableBlockerCascadeJobs<JobType extends FailureJob>({
+  jobs,
+  getCategory,
+}: {
+  jobs: JobType[];
+  getCategory: (jobName: string) => FailureCategory;
+}): {
+  jobsToClassify: JobType[];
+  jobsToCascade: JobType[];
+} {
+  return jobs.reduce<{
+    jobsToClassify: JobType[];
+    jobsToCascade: JobType[];
+  }>(
+    (partition, job) => {
+      // E2E jobs normally retry after a transient blocker, but a structured
+      // quality-gate annotation can veto that retry. Keep them inspectable;
+      // cascade-classify only jobs that cannot contain that terminal signal.
+      if (getCategory(job.name) === "alwaysRetryable") {
+        partition.jobsToClassify.push(job);
+      } else {
+        partition.jobsToCascade.push(job);
+      }
+      return partition;
+    },
+    { jobsToClassify: [], jobsToCascade: [] },
+  );
+}

--- a/.github/scripts/shared/failure-classification.test.mts
+++ b/.github/scripts/shared/failure-classification.test.mts
@@ -1,0 +1,31 @@
+import { partitionRetryableBlockerCascadeJobs } from "./failure-classification.mts";
+
+describe("partitionRetryableBlockerCascadeJobs", () => {
+  it("classifies E2E jobs without losing their concrete type", () => {
+    // A retryable blocker cascades ordinary downstream jobs, but E2E jobs
+    // remain inspectable because a quality-gate annotation can veto retry.
+    const jobs = [
+      { id: 1, name: "e2e-chrome", conclusion: "failure" },
+      {
+        id: 2,
+        name: "ci-status-gate / CI status gate (controls all-jobs-pass)",
+        conclusion: "failure",
+      },
+      { id: 3, name: "build-dist-webpack", conclusion: "failure" },
+    ];
+
+    const result = partitionRetryableBlockerCascadeJobs({
+      jobs,
+      getCategory: (jobName) => {
+        if (jobName.startsWith("e2e-")) return "alwaysRetryable";
+        if (jobName.startsWith("ci-status-gate")) return "optional";
+        return "retryableOnTransientError";
+      },
+    });
+
+    expect(result.jobsToClassify).toStrictEqual([jobs[0]]);
+    expect(result.jobsToClassify[0].id).toBe(1);
+    expect(result.jobsToCascade).toStrictEqual([jobs[1], jobs[2]]);
+    expect(result.jobsToCascade[0].conclusion).toBe("failure");
+  });
+});

--- a/.github/scripts/shared/merge-queue-entry.mts
+++ b/.github/scripts/shared/merge-queue-entry.mts
@@ -78,6 +78,8 @@ export async function verifyMergeQueueRetry({
   refExists,
   ...entryOptions
 }: VerifyMergeQueueRetryOptions): Promise<MergeQueueEntryVerification> {
+  // First confirm the PR still resolves to the failed synthetic SHA, then
+  // check its temporary ref immediately before authorizing the rerun.
   const entryVerification = await verifyMergeQueueEntry(entryOptions);
   if (entryVerification.state !== 'current') {
     // The ref has no bearing once the entry itself is confirmed stale or the

--- a/.github/scripts/shared/retry-budget.mts
+++ b/.github/scripts/shared/retry-budget.mts
@@ -4,39 +4,41 @@
  * checkout, but this module is the source of truth for triage decisions.
  *
  * Attempts are one-indexed GitHub Actions run attempts. A retry is allowed
- * only before the selected limit: attempt 1 can create attempt 2; a retry-ci
- * label can additionally authorize attempts 2 -> 3 and 3 -> 4.
+ * only before its configured limit: attempt 1 can create attempt 2; a
+ * retry-ci label can additionally authorize attempts 2 -> 3 and 3 -> 4.
  */
 export const DEFAULT_RETRY_MAX_ATTEMPT = 2;
 export const RETRY_CI_LABEL_MAX_ATTEMPT = 4;
 
 export type RetryMode = 'automatic' | 'label' | 'none';
-export type RetryLimitSource = 'default' | 'retry-ci';
+export type RetryContext = 'pr' | 'release-push' | 'observation';
 
 export interface RetryBudgetInput {
   /** GitHub Actions run_attempt from the failed Main workflow. */
   attempt: number | string;
-  /** Whether this run can be associated with an originating PR. */
-  hasPr: boolean;
+  /** Identifies whether the event can use a retry budget. */
+  context: RetryContext;
   /** Whether the originating PR currently has the retry-ci label. */
   hasRetryLabel: boolean;
   /** Whether all non-optional failed jobs were classified as retryable. */
   isRetryable: boolean;
+  /** Last attempt that can automatically create a retry. */
+  automaticRetryLimit?: number;
 }
 
 export interface RetryBudgetDecision {
   /** Sanitized one-indexed attempt number used for all policy comparisons. */
   attemptNumber: number;
-  /** True only for retryable PR failures that have exhausted their budget. */
-  atRetryLimit: boolean;
+  /** Last attempt that can automatically create a retry. */
+  automaticRetryLimit: number;
+  /** Whether the automatic retry allowance is exhausted. */
+  automaticRetryLimitReached: boolean;
   /** True only when this retry spends the retry-ci label authorization. */
   consumeRetryLabel: boolean;
-  /** Last permitted attempt for the selected retry budget. */
-  retryLimit: number;
-  /** Explains whether the default or retry-ci limit was selected. */
-  retryLimitSource: RetryLimitSource;
-  /** True when this run could only have been reached with retry-ci funding. */
-  usedRetryCiBudget: boolean;
+  /** Last attempt that can create a retry using retry-ci. */
+  labelRetryLimit: number;
+  /** Whether the retry-ci retry allowance is exhausted. */
+  labelRetryLimitReached: boolean;
   /** Distinguishes automatic, label-funded, and terminal decisions. */
   retryMode: RetryMode;
   /** Whether triage should call gh run rerun --failed. */
@@ -58,45 +60,45 @@ export function parseAttempt(attempt: number | string): number {
 
 export function getRetryBudget({
   attempt,
-  hasPr,
+  context,
   hasRetryLabel,
   isRetryable,
+  automaticRetryLimit = DEFAULT_RETRY_MAX_ATTEMPT,
 }: RetryBudgetInput): RetryBudgetDecision {
+  const labelRetryLimit = RETRY_CI_LABEL_MAX_ATTEMPT;
   const attemptNumber = parseAttempt(attempt);
-  // Attempts above the default ceiling can only be created by a prior
-  // retry-ci-funded rerun. The label is removed after that rerun succeeds,
-  // so preserve the selected ceiling for later reporting and terminal status.
-  const usedRetryCiBudget = attemptNumber > DEFAULT_RETRY_MAX_ATTEMPT;
-  const retryLimit = hasRetryLabel || usedRetryCiBudget
-    ? RETRY_CI_LABEL_MAX_ATTEMPT
-    : DEFAULT_RETRY_MAX_ATTEMPT;
-  const retryLimitSource: RetryLimitSource = hasRetryLabel || usedRetryCiBudget
-    ? 'retry-ci'
-    : 'default';
-  // Pushes and other runs without an originating PR are observation-only.
-  // A retry also requires a retryable classification and a current label for
-  // retries beyond the automatic attempt 1 -> 2 transition.
-  const willRetry =
+  const isPullRequest = context === 'pr';
+  const canRetry = context === 'pr' || context === 'release-push';
+  // Evaluate the budgets independently. A retry-ci label must not be consumed
+  // while the default automatic retry is still available.
+  const automaticRetryLimitReached = attemptNumber >= automaticRetryLimit;
+  const labelRetryLimitReached =
+    // The label limit is meaningful only for PRs, but remains an absolute
+    // attempt ceiling after a label-funded retry removes the label.
+    isPullRequest && attemptNumber >= labelRetryLimit;
+  const canAutomaticallyRetry =
     isRetryable &&
-    hasPr &&
-    attemptNumber < retryLimit &&
-    (attemptNumber < DEFAULT_RETRY_MAX_ATTEMPT || hasRetryLabel);
-  const retryMode: RetryMode = !willRetry
-    ? 'none'
-    : attemptNumber < DEFAULT_RETRY_MAX_ATTEMPT
-      ? 'automatic'
-      : 'label';
+    canRetry &&
+    !automaticRetryLimitReached;
+  const canRetryWithLabel =
+    isRetryable &&
+    isPullRequest &&
+    hasRetryLabel &&
+    !labelRetryLimitReached;
+  const retryMode: RetryMode = canAutomaticallyRetry
+    ? 'automatic'
+    : canRetryWithLabel
+      ? 'label'
+      : 'none';
 
   return {
     attemptNumber,
-    // Do not call a non-retryable failure "at limit"; that distinction drives
-    // the human-readable classifier report and terminal status description.
-    atRetryLimit: isRetryable && hasPr && attemptNumber >= retryLimit,
+    automaticRetryLimit,
+    automaticRetryLimitReached,
     consumeRetryLabel: retryMode === 'label',
-    retryLimit,
-    retryLimitSource,
+    labelRetryLimit,
+    labelRetryLimitReached,
     retryMode,
-    usedRetryCiBudget,
-    willRetry,
+    willRetry: retryMode !== 'none',
   };
 }

--- a/.github/scripts/shared/retry-budget.test.mts
+++ b/.github/scripts/shared/retry-budget.test.mts
@@ -18,18 +18,18 @@ describe('getRetryBudget', () => {
     expect(
       getRetryBudget({
         attempt: 1,
-        hasPr: true,
+        context: 'pr',
         hasRetryLabel: false,
         isRetryable: true,
       }),
     ).toStrictEqual({
       attemptNumber: 1,
-      atRetryLimit: false,
+      automaticRetryLimit: 2,
+      automaticRetryLimitReached: false,
       consumeRetryLabel: false,
-      retryLimit: 2,
-      retryLimitSource: 'default',
+      labelRetryLimit: 4,
+      labelRetryLimitReached: false,
       retryMode: 'automatic',
-      usedRetryCiBudget: false,
       willRetry: true,
     });
   });
@@ -37,7 +37,7 @@ describe('getRetryBudget', () => {
   it('does not consume retry-ci when attempt 1 is inside the default budget', () => {
     const decision = getRetryBudget({
       attempt: 1,
-      hasPr: true,
+      context: 'pr',
       hasRetryLabel: true,
       isRetryable: true,
     });
@@ -47,16 +47,54 @@ describe('getRetryBudget', () => {
     expect(decision.willRetry).toBe(true);
   });
 
-  it('stops at attempt 2 without retry-ci', () => {
+  it('requires retry-ci before retrying a main-targeting PR E2E failure', () => {
+    // A limit of one means attempt one has no automatic rerun available; the
+    // same retry can proceed only through the ordinary retry-ci budget.
+    const withoutLabel = getRetryBudget({
+      attempt: 1,
+      context: 'pr',
+      hasRetryLabel: false,
+      isRetryable: true,
+      automaticRetryLimit: 1,
+    });
+    const withLabel = getRetryBudget({
+      attempt: 1,
+      context: 'pr',
+      hasRetryLabel: true,
+      isRetryable: true,
+      automaticRetryLimit: 1,
+    });
+
+    expect(withoutLabel.willRetry).toBe(false);
+    expect(withoutLabel.retryMode).toBe('none');
+    expect(withLabel.willRetry).toBe(true);
+    expect(withLabel.retryMode).toBe('label');
+    expect(withLabel.consumeRetryLabel).toBe(true);
+  });
+
+  it('keeps the automatic retry for non-E2E failures on a main-targeting PR', () => {
     const decision = getRetryBudget({
-      attempt: 2,
-      hasPr: true,
+      attempt: 1,
+      context: 'pr',
       hasRetryLabel: false,
       isRetryable: true,
     });
 
-    expect(decision.atRetryLimit).toBe(true);
-    expect(decision.retryLimit).toBe(2);
+    expect(decision.willRetry).toBe(true);
+    expect(decision.retryMode).toBe('automatic');
+    expect(decision.consumeRetryLabel).toBe(false);
+  });
+
+  it('stops at attempt 2 without retry-ci', () => {
+    const decision = getRetryBudget({
+      attempt: 2,
+      context: 'pr',
+      hasRetryLabel: false,
+      isRetryable: true,
+    });
+
+    expect(decision.automaticRetryLimitReached).toBe(true);
+    expect(decision.labelRetryLimitReached).toBe(false);
     expect(decision.retryMode).toBe('none');
     expect(decision.willRetry).toBe(false);
   });
@@ -65,14 +103,13 @@ describe('getRetryBudget', () => {
     for (const attempt of [2, 3]) {
       const decision = getRetryBudget({
         attempt,
-        hasPr: true,
+        context: 'pr',
         hasRetryLabel: true,
         isRetryable: true,
       });
 
       expect(decision.consumeRetryLabel).toBe(true);
-      expect(decision.retryLimit).toBe(4);
-      expect(decision.retryLimitSource).toBe('retry-ci');
+      expect(decision.labelRetryLimit).toBe(4);
       expect(decision.retryMode).toBe('label');
       expect(decision.willRetry).toBe(true);
     }
@@ -81,59 +118,56 @@ describe('getRetryBudget', () => {
   it('stops at attempt 4 even with retry-ci', () => {
     const decision = getRetryBudget({
       attempt: 4,
-      hasPr: true,
+      context: 'pr',
       hasRetryLabel: true,
       isRetryable: true,
     });
 
-    expect(decision.atRetryLimit).toBe(true);
-    expect(decision.retryLimit).toBe(4);
+    expect(decision.automaticRetryLimitReached).toBe(true);
+    expect(decision.labelRetryLimitReached).toBe(true);
     expect(decision.retryMode).toBe('none');
-    expect(decision.usedRetryCiBudget).toBe(true);
     expect(decision.willRetry).toBe(false);
   });
 
   it('preserves the retry-ci ceiling after the label-funded retry consumes the label', () => {
+    // Removing retry-ci authorizes no further retries, but must not erase the
+    // fixed attempt-four ceiling used for terminal reporting.
     const decision = getRetryBudget({
       attempt: 3,
-      hasPr: true,
+      context: 'pr',
       hasRetryLabel: false,
       isRetryable: true,
     });
 
-    expect(decision.atRetryLimit).toBe(false);
-    expect(decision.retryLimit).toBe(4);
-    expect(decision.retryLimitSource).toBe('retry-ci');
+    expect(decision.automaticRetryLimitReached).toBe(true);
+    expect(decision.labelRetryLimitReached).toBe(false);
     expect(decision.retryMode).toBe('none');
-    expect(decision.usedRetryCiBudget).toBe(true);
     expect(decision.willRetry).toBe(false);
   });
 
   it('reports the retry-ci ceiling at attempt 4 after the label was consumed', () => {
     const decision = getRetryBudget({
       attempt: 4,
-      hasPr: true,
+      context: 'pr',
       hasRetryLabel: false,
       isRetryable: true,
     });
 
-    expect(decision.atRetryLimit).toBe(true);
-    expect(decision.retryLimit).toBe(4);
-    expect(decision.retryLimitSource).toBe('retry-ci');
+    expect(decision.automaticRetryLimitReached).toBe(true);
+    expect(decision.labelRetryLimitReached).toBe(true);
     expect(decision.retryMode).toBe('none');
-    expect(decision.usedRetryCiBudget).toBe(true);
     expect(decision.willRetry).toBe(false);
   });
 
   it('does not retry non-retryable failures', () => {
     const decision = getRetryBudget({
       attempt: 1,
-      hasPr: true,
+      context: 'pr',
       hasRetryLabel: true,
       isRetryable: false,
     });
 
-    expect(decision.atRetryLimit).toBe(false);
+    expect(decision.automaticRetryLimitReached).toBe(false);
     expect(decision.retryMode).toBe('none');
     expect(decision.willRetry).toBe(false);
   });
@@ -141,13 +175,54 @@ describe('getRetryBudget', () => {
   it('does not retry runs without an originating PR', () => {
     const decision = getRetryBudget({
       attempt: 1,
-      hasPr: false,
+      context: 'observation',
       hasRetryLabel: false,
       isRetryable: true,
     });
 
-    expect(decision.atRetryLimit).toBe(false);
+    expect(decision.automaticRetryLimitReached).toBe(false);
     expect(decision.retryMode).toBe('none');
+    expect(decision.willRetry).toBe(false);
+  });
+
+  it('automatically retries release branch pushes without a PR', () => {
+    const decision = getRetryBudget({
+      attempt: 1,
+      context: 'release-push',
+      hasRetryLabel: false,
+      isRetryable: true,
+    });
+
+    expect(decision.automaticRetryLimitReached).toBe(false);
+    expect(decision.consumeRetryLabel).toBe(false);
+    expect(decision.automaticRetryLimit).toBe(2);
+    expect(decision.retryMode).toBe('automatic');
+    expect(decision.willRetry).toBe(true);
+  });
+
+  it('stops release branch pushes at the automatic retry limit', () => {
+    const decision = getRetryBudget({
+      attempt: 2,
+      context: 'release-push',
+      hasRetryLabel: false,
+      isRetryable: true,
+    });
+
+    expect(decision.automaticRetryLimitReached).toBe(true);
+    expect(decision.labelRetryLimitReached).toBe(false);
+    expect(decision.retryMode).toBe('none');
+    expect(decision.willRetry).toBe(false);
+  });
+
+  it('keeps release pushes terminal after attempt 2', () => {
+    const decision = getRetryBudget({
+      attempt: 3,
+      context: 'release-push',
+      hasRetryLabel: true,
+      isRetryable: true,
+    });
+
+    expect(decision.automaticRetryLimitReached).toBe(true);
     expect(decision.willRetry).toBe(false);
   });
 });

--- a/.github/scripts/verify-merge-queue-entry.mts
+++ b/.github/scripts/verify-merge-queue-entry.mts
@@ -105,6 +105,7 @@ const verification = await verifyMergeQueueRetry({
         (error as { stderr?: unknown }).stderr ?? '',
       );
       if (stderr.includes('HTTP 404')) {
+        // Only GitHub's explicit absence response proves the ref is gone.
         return false;
       }
 

--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -57,6 +57,12 @@ jobs:
             let allPassed = true;
             let onlyCancelled = true;
             const errors = [];
+            const directMainE2eFailure =
+              context.payload.pull_request?.base?.ref === 'main'
+              && Object.entries(needs).some(
+                ([job, { result }]) =>
+                  job.startsWith('e2e-') && result === 'failure',
+              );
 
             for (const [job, { result }] of Object.entries(needs)) {
               if (!result) {
@@ -79,12 +85,104 @@ jobs:
               onlyCancelled = false;
             }
 
+            // This mirrors the producer constant. The reusable workflow has
+            // no checkout, so it cannot import the TypeScript helper itself.
+            const annotationTitle = 'E2E quality gate failed';
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: process.env.RUN_ID,
+                per_page: 100,
+              },
+            );
+            const qualityGateFailures = [];
+
+            // Inspect every failed job and every annotation page: any shard's
+            // terminal marker is enough to withhold automatic retry.
+            for (const job of jobs) {
+              if (job.conclusion !== 'failure') {
+                continue;
+              }
+
+              const annotations = await github.paginate(
+                github.rest.checks.listAnnotations,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  check_run_id: job.id,
+                  per_page: 100,
+                },
+              );
+              for (const annotation of annotations) {
+                if (annotation.title === annotationTitle) {
+                  qualityGateFailures.push(annotation);
+                }
+              }
+            }
+
+            if (qualityGateFailures.length > 0) {
+              // Paths stay as list items so one policy statement can cover
+              // any number of changed/new tests without repeating its prose.
+              const failedTests = qualityGateFailures.map(
+                ({ path }) => path,
+              );
+              core.setOutput('hasE2eQualityGateFailure', 'true');
+              errors.push(
+                `E2E quality gate failed; automatic retry withheld for: ${failedTests.join(', ')}`,
+              );
+              allPassed = false;
+              onlyCancelled = false;
+              await core.summary
+                .addHeading('E2E quality gate failed')
+                .addRaw('Automatic retry withheld for:')
+                .addList(failedTests)
+                .write();
+            }
+
+            if (qualityGateFailures.length > 0 || directMainE2eFailure) {
+              // Prefer the changed/new test reason when both policies apply
+              // to the same run because retry-ci cannot override that gate.
+              core.setOutput(
+                'e2eRetryWithheldDescription',
+                qualityGateFailures.length > 0
+                  ? "There's a failure in changed/new E2E tests, so we shouldn't be retrying this"
+                  : 'A PR to main with an E2E failure requires the retry-ci label to retry',
+              );
+            }
+
             // Three-state result: success, cancelled (all failures are cancellations), failure
             const checkResult = allPassed ? 'success' : (onlyCancelled ? 'cancelled' : 'failure');
             core.setOutput('checkResult', checkResult);
 
             for (const msg of errors) core.error(msg);
             core.setOutput('errors', errors.join('\n'));
+
+      - name: Post E2E retry-withheld status
+        # This commit-level status is visible in the PR list even when the
+        # regular All jobs pass status is deferred for merge-queue triage. It
+        # uses one context for both automatic-retry withholding policies.
+        if: >-
+          ${{
+            steps.check.outputs.e2eRetryWithheldDescription != '' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+          }}
+        uses: actions/github-script@v8
+        env:
+          E2E_RETRY_WITHHELD_DESCRIPTION: ${{ steps.check.outputs.e2eRetryWithheldDescription }}
+        with:
+          script: |
+            // One visible status covers both reasons automatic E2E retry can
+            // be withheld; the description tells reviewers which one applied.
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_COMMIT_HASH,
+              state: 'failure',
+              context: 'E2E retry withheld',
+              description: process.env.E2E_RETRY_WITHHELD_DESCRIPTION,
+            });
 
       # ── Retry gate (merge queue only) ──────────────────────────────
       #
@@ -394,15 +492,7 @@ jobs:
 
       - name: Fail job if checks failed
         if: ${{ steps.check.outputs.checkResult == 'failure' || steps.check.outputs.checkResult == 'cancelled' }}
-        env:
-          ERRORS: ${{ steps.check.outputs.errors }}
-        run: |
-          # Re-emit each error from the `check` step so they appear in this
-          # step's annotations (users land here, not on the `check` step).
-          while IFS= read -r line; do
-            [[ -n "$line" ]] && echo "::error::$line"
-          done <<< "$ERRORS"
-          exit 1
+        run: exit 1
 
       # This reporting method has probably been superseded by the Sentry logging, and may be removed later.
       - name: Log merge group failure

--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -57,12 +57,13 @@ jobs:
             let allPassed = true;
             let onlyCancelled = true;
             const errors = [];
+            const hasFailedE2eJob = Object.entries(needs).some(
+              ([job, { result }]) =>
+                job.startsWith('e2e-') && result === 'failure',
+            );
             const directMainE2eFailure =
               context.payload.pull_request?.base?.ref === 'main'
-              && Object.entries(needs).some(
-                ([job, { result }]) =>
-                  job.startsWith('e2e-') && result === 'failure',
-              );
+              && hasFailedE2eJob;
 
             for (const [job, { result }] of Object.entries(needs)) {
               if (!result) {
@@ -85,39 +86,45 @@ jobs:
               onlyCancelled = false;
             }
 
-            // This mirrors the producer constant. The reusable workflow has
-            // no checkout, so it cannot import the TypeScript helper itself.
-            const annotationTitle = 'E2E quality gate failed';
-            const jobs = await github.paginate(
-              github.rest.actions.listJobsForWorkflowRun,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: process.env.RUN_ID,
-                per_page: 100,
-              },
-            );
             const qualityGateFailures = [];
 
-            // Inspect every failed job and every annotation page: any shard's
-            // terminal marker is enough to withhold automatic retry.
-            for (const job of jobs) {
-              if (job.conclusion !== 'failure') {
-                continue;
-              }
-
-              const annotations = await github.paginate(
-                github.rest.checks.listAnnotations,
+            // Quality-gate annotations are only emitted by failed E2E jobs.
+            // Skipping this API work for other runs prevents a transient API
+            // error from changing an otherwise-green status gate to failure.
+            if (hasFailedE2eJob) {
+              // This mirrors the producer constant. The reusable workflow has
+              // no checkout, so it cannot import the TypeScript helper itself.
+              const annotationTitle = 'E2E quality gate failed';
+              const jobs = await github.paginate(
+                github.rest.actions.listJobsForWorkflowRun,
                 {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  check_run_id: job.id,
+                  run_id: process.env.RUN_ID,
                   per_page: 100,
                 },
               );
-              for (const annotation of annotations) {
-                if (annotation.title === annotationTitle) {
-                  qualityGateFailures.push(annotation);
+
+              // Inspect every failed job and every annotation page: any
+              // shard's terminal marker is enough to withhold automatic retry.
+              for (const job of jobs) {
+                if (job.conclusion !== 'failure') {
+                  continue;
+                }
+
+                const annotations = await github.paginate(
+                  github.rest.checks.listAnnotations,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    check_run_id: job.id,
+                    per_page: 100,
+                  },
+                );
+                for (const annotation of annotations) {
+                  if (annotation.title === annotationTitle) {
+                    qualityGateFailures.push(annotation);
+                  }
                 }
               }
             }
@@ -159,29 +166,27 @@ jobs:
             for (const msg of errors) core.error(msg);
             core.setOutput('errors', errors.join('\n'));
 
-      - name: Post E2E retry-withheld status
+      - name: Update E2E retry-withheld status
         # This commit-level status is visible in the PR list even when the
         # regular All jobs pass status is deferred for merge-queue triage. It
         # uses one context for both automatic-retry withholding policies.
-        if: >-
-          ${{
-            steps.check.outputs.e2eRetryWithheldDescription != '' &&
-            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-          }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@v8
         env:
           E2E_RETRY_WITHHELD_DESCRIPTION: ${{ steps.check.outputs.e2eRetryWithheldDescription }}
         with:
           script: |
-            // One visible status covers both reasons automatic E2E retry can
-            // be withheld; the description tells reviewers which one applied.
+            // Reusing the same context changes a previous failure to success
+            // when retry-ci recovers this SHA on a later workflow attempt.
+            const retryWithheldDescription =
+              process.env.E2E_RETRY_WITHHELD_DESCRIPTION;
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: process.env.HEAD_COMMIT_HASH,
-              state: 'failure',
+              state: retryWithheldDescription ? 'failure' : 'success',
               context: 'E2E retry withheld',
-              description: process.env.E2E_RETRY_WITHHELD_DESCRIPTION,
+              description: retryWithheldDescription || 'Automatic retry is available',
             });
 
       # ── Retry gate (merge queue only) ──────────────────────────────

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -24,7 +24,8 @@ jobs:
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
-      fail-fast: ${{ github.event_name == 'merge_group' }}
+      # Keep all shards running for complete failure and artifact reporting.
+      fail-fast: false
       matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-chrome-webpack'] }}
     with:
       test-suite-name: test-e2e-chrome-webpack
@@ -56,7 +57,8 @@ jobs:
   test-e2e-chrome-flask-webpack:
     uses: ./.github/workflows/run-e2e.yml
     strategy:
-      fail-fast: ${{ github.event_name == 'merge_group' }}
+      # Keep all shards running for complete failure and artifact reporting.
+      fail-fast: false
       matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-chrome-flask-webpack'] }}
     with:
       test-suite-name: test-e2e-chrome-flask-webpack
@@ -103,7 +105,8 @@ jobs:
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
-      fail-fast: ${{ github.event_name == 'merge_group' }}
+      # Keep all shards running for complete failure and artifact reporting.
+      fail-fast: false
       matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-chrome-playwright'] }}
     with:
       test-suite-name: test-e2e-chrome-playwright

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -24,7 +24,8 @@ jobs:
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
-      fail-fast: ${{ github.event_name == 'merge_group' }}
+      # Keep all shards running for complete failure and artifact reporting.
+      fail-fast: false
       matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-firefox-webpack'] }}
     with:
       test-suite-name: test-e2e-firefox-webpack
@@ -38,7 +39,8 @@ jobs:
   test-e2e-firefox-flask-webpack:
     uses: ./.github/workflows/run-e2e.yml
     strategy:
-      fail-fast: ${{ github.event_name == 'merge_group' }}
+      # Keep all shards running for complete failure and artifact reporting.
+      fail-fast: false
       matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-firefox-flask-webpack'] }}
     with:
       test-suite-name: test-e2e-firefox-flask-webpack
@@ -65,7 +67,8 @@ jobs:
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
-      fail-fast: ${{ github.event_name == 'merge_group' }}
+      # Keep all shards running for complete failure and artifact reporting.
+      fail-fast: false
       matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-firefox-playwright'] }}
     with:
       test-suite-name: test-e2e-firefox-playwright

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -562,24 +562,29 @@ jobs:
           echo "Commit SHA: $HEAD_COMMIT_HASH"
 
           curl -X POST \
+            --fail-with-body \
+            --silent \
+            --show-error \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token $DISPATCH_TOKEN" \
             https://api.github.com/repos/MetaMask/extension-regression-validation-poc/dispatches \
-            -d '{
-              "event_type": "release_pr_updated",
-              "client_payload": {
-                "run_id": "'"$BUILDS_FROM_RUN"'",
-                "version": "'"$VERSION"'",
-                "branch": "'"$BRANCH"'",
-                "commit_sha": "'"$HEAD_COMMIT_HASH"'"
-              }
-            }'
+            --data-binary "$(
+              jq -n \
+                --arg run_id "$BUILDS_FROM_RUN" \
+                --arg version "$VERSION" \
+                --arg branch "$BRANCH" \
+                --arg commit_sha "$HEAD_COMMIT_HASH" \
+                '{event_type: "release_pr_updated", client_payload: {run_id: $run_id, version: $version, branch: $branch, commit_sha: $commit_sha}}'
+            )"
 
           echo "Regression validation triggered successfully"
 
   ci-status-gate:
     if: ${{ !cancelled() }}
     permissions:
+      # The reusable gate reads current-run jobs to find E2E quality-gate
+      # annotations, then posts both aggregate and terminal status contexts.
+      actions: read
       pull-requests: read
       statuses: write
       checks: read
@@ -592,6 +597,8 @@ jobs:
     # Jobs intentionally excluded:
     # - Publish jobs (not required for CI pass)
     # - Jobs that depend on ci-status-gate (e.g., log-merge-group-failure) cannot be included here
+    # E2E workflows remain direct dependencies so their failed annotations are
+    # available to the reusable gate even when another dependency is skipped.
     needs:
       - get-requirements
       - locales-changed-only

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -162,6 +162,12 @@ jobs:
           # On re-run, pass the path to previous results to run only failed tests
           PREVIOUS_RESULTS_PATH: ${{ steps.download-previous-results.outcome == 'success' && './previous-test-results/test/test-results/e2e' || '' }}
 
+      - name: Annotate changed/new E2E test failures
+        if: ${{ failure() }}
+        # Convert runner-local JUnit results into the structured marker that
+        # status gating and workflow-run triage use to withhold retries.
+        run: yarn tsx .github/scripts/emit-e2e-quality-gate-annotations.mts
+
       # Merge previous test results with current results to preserve pass/fail history across re-runs.
       # Without this, tests that passed in attempt N but were skipped in attempt N+1 would have no
       # results in the artifact, causing them to be re-run in attempt N+2.

--- a/.github/workflows/triage-and-retry-system.yml
+++ b/.github/workflows/triage-and-retry-system.yml
@@ -23,11 +23,16 @@
 #     (gh-readonly-queue/{base}/pr-{N}-{sha}).
 #
 #   - push to main/stable:
-#     Observation only — no retry (no originating PR to label).
+#     Observation only — no retry.
+#
+#   - push to release/*:
+#     Retry retryable failures once by default (attempt 1 → attempt 2).
+#     There is no PR label, so attempts 3 and 4 are unavailable.
 #
 # Reruns call `gh run rerun --failed`, which triggers a new main.yml
 # completion → workflow_run fires again. The default budget allows attempt 2;
-# retry-ci extends the budget through attempt 4. Keep these limits in sync with
+# retry-ci extends PR retries through attempt 4. Release pushes stop at attempt
+# 2 because they have no PR label. Keep these limits in sync with
 # classify-failures.mts and ci-status-gate.yml.
 #
 # Merge queue interaction:
@@ -77,7 +82,8 @@ jobs:
     #   if run.event == 'pull_request'        → run  (retry budget via PR)
     #   if run.event == 'push'
     #     and run.branch in ['main','stable'] → run  (observation only — no retry)
-    #   else                                  → skip (release/*, workflow_dispatch, etc.)
+    #     and starts with 'release/'          → run  (default retry budget, no label extension)
+    #   else                                  → skip (workflow_dispatch, etc.)
     #
     # Cancelled runs are included so that preempted retries (attempt > 1,
     # cancelled before completion) can emit a lightweight Sentry event.
@@ -90,11 +96,25 @@ jobs:
           github.event.workflow_run.event == 'merge_group'
           || github.event.workflow_run.event == 'pull_request'
           || (github.event.workflow_run.event == 'push'
-              && contains(fromJson('["main","stable"]'), github.event.workflow_run.head_branch))
+              && (contains(fromJson('["main","stable"]'), github.event.workflow_run.head_branch)
+                  || startsWith(github.event.workflow_run.head_branch, 'release/')))
         )
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      # This lock serializes triage per release branch without sharing Main's
+      # group. Sharing it would let a delayed workflow_run event replace a
+      # pending Main run. The retry step verifies the current run and branch
+      # SHA before it can rerun anything.
+      group: >-
+        ${{
+          github.event.workflow_run.event == 'push'
+          && startsWith(github.event.workflow_run.head_branch, 'release/')
+          && format('Triage-release-{0}', github.event.workflow_run.head_branch)
+          || format('Triage-{0}', github.run_id)
+        }}
+      cancel-in-progress: false
     permissions:
       actions: write
       checks: write
@@ -130,7 +150,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install Sentry SDK
-        run: npm install --no-save @sentry/node@^10.45.0
+        run: npm install --no-save @sentry/node@10.73.0
 
       - name: Get version from package.json
         run: |
@@ -149,7 +169,8 @@ jobs:
       - name: Verify current merge queue entry
         id: verify-queue-entry
         # The verifier posts a terminal failure status for stale or
-        # unverified entries; the retry step runs only for current entries.
+        # unverified entries; run it only after classification has authorized
+        # a merge-group retry so ordinary failures avoid the extra API calls.
         if: >-
           ${{
             steps.classify.outputs.will-retry == 'true'
@@ -162,6 +183,9 @@ jobs:
       # -- Retry retryable failures when a retry budget is available --
       # The classify step decides whether this is an automatic retry or a
       # retry-ci-funded retry, then outputs whether retry-ci should be consumed.
+      # Release pushes can use only the automatic attempt 1 -> 2 retry.
+      # A stale or unverified merge-queue entry is terminal: rerunning its
+      # detached synthetic SHA could interfere with a newer queue run.
       #
       # Order matters: rerun BEFORE removing the label. If the rerun API
       # call fails, the label stays on the PR — signaling that the retry
@@ -195,11 +219,44 @@ jobs:
             echo "PR #$PR head still matches failed run $HEAD_SHA"
           fi
 
+          # Release branches use branch-scoped concurrency with cancellation
+          # enabled. Only rerun while this failed SHA remains the branch head,
+          # and this is still the current failed attempt, otherwise the retry
+          # could cancel CI for a newer release commit or attempt.
+          if [[ "$WORKFLOW_EVENT" == 'push' && "$HEAD_BRANCH" == release/* ]]; then
+            if ! RUN_STATE=$(gh api "repos/$REPO/actions/runs/$MAIN_RUN_ID" --jq '[.status, .conclusion, .run_attempt, .head_sha] | @tsv' 2>/dev/null); then
+              echo "::warning::Could not verify release run $MAIN_RUN_ID — skipping retry"
+              exit 0
+            fi
+
+            IFS=$'\t' read -r CURRENT_STATUS CURRENT_CONCLUSION CURRENT_ATTEMPT CURRENT_SHA <<< "$RUN_STATE"
+            if [[ "$CURRENT_STATUS" != 'completed' || "$CURRENT_CONCLUSION" != 'failure' || "$CURRENT_ATTEMPT" != "$RUN_ATTEMPT" || "$CURRENT_SHA" != "$HEAD_SHA" ]]; then
+              echo "Release run $MAIN_RUN_ID changed since classification (status=$CURRENT_STATUS conclusion=$CURRENT_CONCLUSION attempt=$CURRENT_ATTEMPT sha=$CURRENT_SHA) — skipping stale retry"
+              exit 0
+            fi
+
+            if ! CURRENT_HEAD=$(gh api "repos/$REPO/git/ref/heads/$HEAD_BRANCH" --jq '.object.sha' 2>/dev/null); then
+              echo "::warning::Could not verify release branch $HEAD_BRANCH head — skipping retry"
+              exit 0
+            fi
+
+            if [[ "$CURRENT_HEAD" != "$HEAD_SHA" ]]; then
+              echo "Release branch $HEAD_BRANCH advanced from $HEAD_SHA to $CURRENT_HEAD — skipping stale retry"
+              exit 0
+            fi
+
+            echo "Release branch $HEAD_BRANCH head still matches failed run $HEAD_SHA"
+          fi
+
           echo "Rerunning failed jobs..."
           gh run rerun "$MAIN_RUN_ID" --failed --repo "$REPO"
           echo "Rerun triggered."
 
           if [[ "$CONSUME_RETRY_LABEL" == "true" ]]; then
+            if [[ -z "$PR" ]]; then
+              echo "::error::Cannot consume retry-ci without an originating PR"
+              exit 1
+            fi
             echo "Removing retry-ci label from PR #$PR..."
             gh pr edit "$PR" --repo "$REPO" --remove-label "retry-ci" \
               || echo "::warning::Failed to remove retry-ci label from PR #$PR — label stays"

--- a/jest.config.js
+++ b/jest.config.js
@@ -78,7 +78,7 @@ module.exports = {
   testMatch: [
     '<rootDir>/app/scripts/**/*.test.(js|ts|tsx)',
     '<rootDir>/app/offscreen/**/*.test.(js|ts|tsx)',
-    '<rootDir>/.github/scripts/**/*.test.(js|ts|mts)',
+    '<rootDir>/[.]github/scripts/**/*.test.(js|ts|mts)',
     '<rootDir>/shared/**/*.test.(js|ts|tsx)',
     '<rootDir>/ui/**/*.test.(js|ts|tsx)',
     '<rootDir>/development/**/*.test.(js|ts|tsx|mts)',


### PR DESCRIPTION
## **Description**

- **Main thing** if an E2E test fails:
  - PR run: does not automatically retry
  - Merge Queue: still automatically retries
- Now automatically retry on `release/*` push runs

- New failure summary on the Actions Run page
<img width="577" height="278" alt="image" src="https://github.com/user-attachments/assets/4a5fcecb-871b-455a-8111-b3490ed66cd0" />

- New failure message on the PR page (trying to make it more difficult to ignore when you go to rerun)
<img width="621" height="193" alt="image" src="https://github.com/user-attachments/assets/8353a5b7-a498-459f-8fe7-585728bf9aaa" />

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect merge-queue timing, commit statuses, and when CI auto-reruns—incorrect classification could block merges or retry when policy says not to, though logic is heavily tested and fail-closed on missing annotation data.
> 
> **Overview**
> CI now treats **changed or new E2E failures** as terminal for automatic retries by emitting structured `::error` annotations from failed E2E jobs and having triage, the status gate, and reporting all key off the fixed title **“E2E quality gate failed”** (with fail-closed behavior if annotations cannot be fetched).
> 
> **Triage and retry** was extended so E2E quality-gate hits are never auto-retried (including when an unrelated blocker is retryable), PRs whose base is **main** need **`retry-ci`** before any E2E failure can retry (automatic budget capped at attempt 1 for that case), and **`release/*` pushes** get one automatic retry with branch-scoped concurrency and stale-run guards. The retry budget model now separates **automatic** vs **retry-ci** limits and exposes richer workflow outputs.
> 
> The **CI status gate** scans failed E2E jobs for quality-gate annotations (when E2E failed), writes an Actions summary, and posts a visible **`E2E retry withheld`** commit status. E2E matrix jobs use **`fail-fast: false`** so every shard can emit annotations and artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb4d63722a26011da3a4576ff32274083dfd95f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->