### PR TITLE
fix(settings): style activity deletion action as danger

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -168,6 +168,9 @@
   "activity": {
     "message": "Activity"
   },
+  "activityAndNonceDataDeleted": {
+    "message": "Activity and nonce data deleted"
+  },
   "activityEmptyDescription": {
     "message": "Swap your first token today."
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -168,6 +168,9 @@
   "activity": {
     "message": "Activity"
   },
+  "activityAndNonceDataDeleted": {
+    "message": "Activity and nonce data deleted"
+  },
   "activityEmptyDescription": {
     "message": "Swap your first token today."
   },

--- a/ui/pages/settings/developer-tools-tab/__snapshots__/developer-tools-tab.test.tsx.snap
+++ b/ui/pages/settings/developer-tools-tab/__snapshots__/developer-tools-tab.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`DeveloperToolsTab snapshot matches snapshot 1`] = `
     </div>
     <div>
       <button
-        class="inline-flex items-center justify-center rounded-xl font-medium overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default text-bg !bg-transparent px-4 py-0 text-left"
+        class="inline-flex items-center justify-center rounded-xl font-medium overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default text-error-default !bg-transparent px-4 py-0 text-left"
         data-testid="developer-options-delete-activity-and-nonce-data"
         role="button"
       >

--- a/ui/pages/settings/developer-tools-tab/delete-activity-item.tsx
+++ b/ui/pages/settings/developer-tools-tab/delete-activity-item.tsx
@@ -28,7 +28,7 @@ export const DeleteActivityItem = () => {
       <Button
         data-testid="developer-options-delete-activity-and-nonce-data"
         onClick={handleDeleteActivity}
-        className="text-bg !bg-transparent px-4 py-0 text-left"
+        className="text-error-default !bg-transparent px-4 py-0 text-left"
       >
         {t(DEVELOPER_TOOLS_ITEMS['delete-activity-and-nonce-data'])}
       </Button>

--- a/ui/pages/settings/developer-tools-tab/delete-activity-modal.tsx
+++ b/ui/pages/settings/developer-tools-tab/delete-activity-modal.tsx
@@ -16,6 +16,7 @@ import {
   ModalOverlay,
   ModalContent,
 } from '@metamask/design-system-react';
+import { toast } from '../../../components/ui/toast/toast';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { resetAccount } from '../../../store/actions';
 import { useDispatch } from '../../../store/hooks';
@@ -33,6 +34,7 @@ export default function DeleteActivityModal({
   const deleteActivityData = async () => {
     await dispatch(resetAccount());
     onClose();
+    toast.success(t('activityAndNonceDataDeleted'));
   };
 
   return (

--- a/ui/pages/settings/developer-tools-tab/developer-tools-tab.test.tsx
+++ b/ui/pages/settings/developer-tools-tab/developer-tools-tab.test.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import mockState from '../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { toast } from '../../../components/ui/toast/toast';
 import { setBackgroundConnection } from '../../../store/background-connection';
 import DeveloperToolsTab from './developer-tools-tab';
+
+jest.mock('../../../components/ui/toast/toast', () => ({
+  toast: {
+    success: jest.fn(),
+  },
+}));
 
 const backgroundConnectionMock = new Proxy(
   {},
@@ -27,6 +35,23 @@ describe('DeveloperToolsTab', () => {
       );
 
       expect(container).toMatchSnapshot();
+    });
+  });
+
+  it('shows a success toast after deleting activity and nonce data', async () => {
+    renderWithProvider(<DeveloperToolsTab />, mockStore);
+
+    fireEvent.click(
+      screen.getByTestId('developer-options-delete-activity-and-nonce-data'),
+    );
+    fireEvent.click(
+      screen.getByTestId('delete-activity-and-nonce-data-button'),
+    );
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        'Activity and nonce data deleted',
+      );
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Updates the Developer tools “Delete activity and nonce data” action to use the danger text color, matching other destructive actions in Settings. After deletion completes, a success toast confirms that the activity and nonce data was deleted.

## **Changelog**

CHANGELOG entry: Updated the “Delete activity and nonce data” settings action to display in red and confirm successful deletion.

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Open MetaMask and navigate to Settings → Advanced → Developer tools.
2. Verify “Delete activity and nonce data” is red.
3. Click “Delete activity and nonce data,” then confirm the deletion.
4. Verify a success toast displays “Activity and nonce data deleted.”

## **Screenshots/Recordings**

### **Before**

<img width="369" height="520" alt="Screenshot 2026-09-04 at 12 41 39 PM" src="https://github.com/user-attachments/assets/be36a8a2-53d4-430b-a506-0e13d47de135" />

### **After**
<img width="373" height="396" alt="Screenshot 2026-09-04 at 1 57 44 PM" src="https://github.com/user-attachments/assets/af1e70fc-79d2-4a4d-a513-69496c0bfab8" />

Success toast

<img width="389" height="143" alt="Screenshot 2026-09-04 at 1 57 50 PM" src="https://github.com/user-attachments/assets/744db453-fbe9-44f7-8f58-d77a17e3ceda" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a324684-ddd0-429f-b6cd-235b246645fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a324684-ddd0-429f-b6cd-235b246645fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

