### PR TITLE
fix(accounts): align SRP row arrow and return to account details on back

### DIFF
--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
@@ -5,6 +5,7 @@ import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import mockState from '../../../../test/data/mock-state.json';
 import configureStore from '../../../store/store';
 import {
+  MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE,
   ONBOARDING_REVIEW_SRP_ROUTE,
   REVEAL_SEED_ROUTE,
 } from '../../../helpers/constants/routes';
@@ -21,14 +22,18 @@ jest.mock('react-router-dom', () => {
 });
 
 describe('MultichainSrpBackup', () => {
-  const renderComponent = (props = {}) => {
+  const renderComponent = (props = {}, pathname = '/') => {
     const store = configureStore({
       metamask: {
         ...mockState.metamask,
       },
     });
 
-    return renderWithProvider(<MultichainSrpBackup {...props} />, store);
+    return renderWithProvider(
+      <MultichainSrpBackup {...props} />,
+      store,
+      pathname,
+    );
   };
 
   beforeEach(() => {
@@ -47,6 +52,11 @@ describe('MultichainSrpBackup', () => {
 
     const buttonElement = screen.getByTestId(srpBackupRowTestId);
     expect(buttonElement).toHaveClass('multichain-srp-backup');
+    expect(
+      screen.getByRole('button', {
+        name: messages.secretRecoveryPhrase.message,
+      }),
+    ).toBeInTheDocument();
   });
 
   it('applies custom className when provided', () => {
@@ -74,7 +84,20 @@ describe('MultichainSrpBackup', () => {
     fireEvent.click(screen.getByTestId(srpBackupRowTestId));
 
     expect(mockUseNavigate).toHaveBeenCalledWith(
-      `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`,
+      `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true&previousPage=%2F`,
+    );
+  });
+
+  it('forwards the current page to the SRP review route so the backup flow can return to it', () => {
+    const accountDetailsPage = `${MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE}?accountGroupId=entropy%3A01JKAF%2F0`;
+    renderComponent({ shouldShowBackupReminder: true }, accountDetailsPage);
+
+    fireEvent.click(screen.getByTestId(srpBackupRowTestId));
+
+    expect(mockUseNavigate).toHaveBeenCalledWith(
+      `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true&previousPage=${encodeURIComponent(
+        accountDetailsPage,
+      )}`,
     );
   });
 

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
@@ -84,13 +84,16 @@ describe('MultichainSrpBackup', () => {
     fireEvent.click(screen.getByTestId(srpBackupRowTestId));
 
     expect(mockUseNavigate).toHaveBeenCalledWith(
-      `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true&previousPage=%2F`,
+      `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`,
     );
   });
 
-  it('forwards the current page to the SRP review route so the backup flow can return to it', () => {
+  it('forwards the configured return route to the SRP review route', () => {
     const accountDetailsPage = `${MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE}?accountGroupId=entropy%3A01JKAF%2F0`;
-    renderComponent({ shouldShowBackupReminder: true }, accountDetailsPage);
+    renderComponent({
+      shouldShowBackupReminder: true,
+      backupFlowReturnRoute: accountDetailsPage,
+    });
 
     fireEvent.click(screen.getByTestId(srpBackupRowTestId));
 

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import classnames from 'clsx';
 import {
   Box,
@@ -26,32 +26,31 @@ export type MultichainSrpBackupProps = {
   shouldShowBackupReminder?: boolean;
   className?: string | Record<string, boolean>;
   keyringId?: string;
+  backupFlowReturnRoute?: string;
 };
 
 export const MultichainSrpBackup = ({
   shouldShowBackupReminder = false,
   className = '',
   keyringId,
+  backupFlowReturnRoute,
 }: MultichainSrpBackupProps) => {
   const t = useI18nContext();
   const navigate = useNavigate();
-  const { pathname, search } = useLocation();
 
   const handleSrpBackupClick = useCallback(() => {
     if (shouldShowBackupReminder) {
-      const backUpSRPParams = new URLSearchParams({
-        isFromReminder: 'true',
-        // Lets the backup flow send the user back to the page they opened it
-        // from instead of dropping them on the home page.
-        previousPage: `${pathname}${search}`,
-      });
+      const backUpSRPParams = new URLSearchParams({ isFromReminder: 'true' });
+      if (backupFlowReturnRoute) {
+        backUpSRPParams.set('previousPage', backupFlowReturnRoute);
+      }
       navigate(`${ONBOARDING_REVIEW_SRP_ROUTE}/?${backUpSRPParams.toString()}`);
     } else {
       navigate(
         keyringId ? `${REVEAL_SEED_ROUTE}/${keyringId}` : REVEAL_SEED_ROUTE,
       );
     }
-  }, [shouldShowBackupReminder, navigate, keyringId, pathname, search]);
+  }, [shouldShowBackupReminder, backupFlowReturnRoute, navigate, keyringId]);
 
   const finalClassName = classnames('multichain-srp-backup', className);
 

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import classnames from 'clsx';
 import {
   Box,
@@ -7,11 +7,11 @@ import {
   BoxBackgroundColor,
   BoxFlexDirection,
   BoxJustifyContent,
+  ButtonIcon,
+  ButtonIconSize,
   FontWeight,
-  Icon,
   IconColor,
   IconName,
-  IconSize,
   Text,
   TextColor,
   TextVariant,
@@ -35,17 +35,23 @@ export const MultichainSrpBackup = ({
 }: MultichainSrpBackupProps) => {
   const t = useI18nContext();
   const navigate = useNavigate();
+  const { pathname, search } = useLocation();
 
   const handleSrpBackupClick = useCallback(() => {
     if (shouldShowBackupReminder) {
-      const backUpSRPRoute = `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`;
-      navigate(backUpSRPRoute);
+      const backUpSRPParams = new URLSearchParams({
+        isFromReminder: 'true',
+        // Lets the backup flow send the user back to the page they opened it
+        // from instead of dropping them on the home page.
+        previousPage: `${pathname}${search}`,
+      });
+      navigate(`${ONBOARDING_REVIEW_SRP_ROUTE}/?${backUpSRPParams.toString()}`);
     } else {
       navigate(
         keyringId ? `${REVEAL_SEED_ROUTE}/${keyringId}` : REVEAL_SEED_ROUTE,
       );
     }
-  }, [shouldShowBackupReminder, navigate, keyringId]);
+  }, [shouldShowBackupReminder, navigate, keyringId, pathname, search]);
 
   const finalClassName = classnames('multichain-srp-backup', className);
 
@@ -73,7 +79,6 @@ export const MultichainSrpBackup = ({
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
-          gap={2}
         >
           <Text
             variant={TextVariant.BodyMd}
@@ -84,11 +89,14 @@ export const MultichainSrpBackup = ({
               ? t('accountDetailsSrpBackUpMessage')
               : t('srpListStateBackedUp')}
           </Text>
-          <Icon
-            name={IconName.ArrowRight}
-            size={IconSize.Sm}
-            color={IconColor.IconAlternative}
-          />
+          <Box className="ml-2">
+            <ButtonIcon
+              iconName={IconName.ArrowRight}
+              iconProps={{ color: IconColor.IconAlternative }}
+              size={ButtonIconSize.Sm}
+              ariaLabel={t('secretRecoveryPhrase')}
+            />
+          </Box>
         </Box>
       </Box>
     </>

--- a/ui/pages/multichain-accounts/multichain-account-details-page/index.scss
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/index.scss
@@ -16,10 +16,10 @@
     }
   }
 
+  /* Padding matches the other rows so the arrow icons line up. */
   &__srp-button {
     cursor: pointer;
     border: none;
-    /* Matches the padding of the other rows so the arrow icons line up. */
     padding-left: 16px;
     padding-right: 8px;
   }

--- a/ui/pages/multichain-accounts/multichain-account-details-page/index.scss
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/index.scss
@@ -19,7 +19,8 @@
   &__srp-button {
     cursor: pointer;
     border: none;
+    /* Matches the padding of the other rows so the arrow icons line up. */
     padding-left: 16px;
-    padding-right: 12px;
+    padding-right: 8px;
   }
 }

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -42,6 +42,7 @@ import {
 } from '../../../selectors/multichain-accounts/account-tree';
 import { extractWalletIdFromGroupId } from '../../../selectors/multichain-accounts/utils';
 import {
+  MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE,
   MULTICHAIN_WALLET_DETAILS_PAGE_ROUTE,
   MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE,
   MULTICHAIN_ACCOUNT_PRIVATE_KEY_LIST_PAGE_ROUTE,
@@ -310,6 +311,7 @@ export const MultichainAccountDetailsPage = () => {
               )}
               shouldShowBackupReminder={shouldShowBackupReminder}
               keyringId={keyringId}
+              backupFlowReturnRoute={`${MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE}?${searchParams.toString()}`}
             />
           ) : null}
         </Box>

--- a/ui/pages/onboarding-flow/hooks/useOnboardingSearchParams.ts
+++ b/ui/pages/onboarding-flow/hooks/useOnboardingSearchParams.ts
@@ -1,20 +1,37 @@
 import { useLocation } from 'react-router-dom';
 
 /**
- * Parses the two query-params that are threaded through every onboarding SRP
+ * Query-params starting with `//` are protocol-relative URLs, which would take
+ * the user out of the extension, so only single-slash in-app paths are honored.
+ *
+ * @param path - The candidate path read from the query-string.
+ */
+function isInAppPath(path: string) {
+  return path.startsWith('/') && !path.startsWith('//');
+}
+
+/**
+ * Parses the query-params that are threaded through every onboarding SRP
  * backup route so consuming components don't each have to repeat the
  * `new URLSearchParams(search).get(...)` boilerplate.
  *
  * Returns `isFromReminder` (truthy when the user arrived via the SRP backup
  * reminder flow), `isFromSettingsSecurity` (truthy when from the Security &
- * Privacy settings page), and `nextRouteQueryString` (pre-built query string
- * that forwards both params to the next route, empty when neither is present).
+ * Privacy settings page), `previousPage` (in-app path to return to when
+ * leaving the flow, `null` when absent or not an in-app path), and
+ * `nextRouteQueryString` (pre-built query string that forwards the params to
+ * the next route, empty when none are present).
  */
 export function useOnboardingSearchParams() {
   const { search } = useLocation();
   const searchParams = new URLSearchParams(search);
   const isFromReminder = searchParams.get('isFromReminder');
   const isFromSettingsSecurity = searchParams.get('isFromSettingsSecurity');
+  const previousPageParam = searchParams.get('previousPage');
+  const previousPage =
+    previousPageParam && isInAppPath(previousPageParam)
+      ? previousPageParam
+      : null;
 
   const forwardParams = new URLSearchParams();
   if (isFromReminder) {
@@ -23,7 +40,15 @@ export function useOnboardingSearchParams() {
   if (isFromSettingsSecurity) {
     forwardParams.set('isFromSettingsSecurity', isFromSettingsSecurity);
   }
+  if (previousPage) {
+    forwardParams.set('previousPage', previousPage);
+  }
   const nextRouteQueryString = forwardParams.toString();
 
-  return { isFromReminder, isFromSettingsSecurity, nextRouteQueryString };
+  return {
+    isFromReminder,
+    isFromSettingsSecurity,
+    previousPage,
+    nextRouteQueryString,
+  };
 }

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.test.tsx
@@ -9,6 +9,7 @@ import {
   ONBOARDING_METAMETRICS,
   ONBOARDING_REVIEW_SRP_ROUTE,
   MANAGE_WALLET_RECOVERY_ROUTE,
+  MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE,
 } from '../../../helpers/constants/routes';
 import { getSeedPhrase } from '../../../store/actions';
 import * as BrowserRuntimeUtils from '../../../../shared/lib/browser-runtime.utils';
@@ -691,6 +692,51 @@ describe('RevealRecoveryPhrase', () => {
           replace: true,
         },
       );
+    });
+
+    it('navigates to the previous page when one is provided', () => {
+      const accountDetailsPage = `${MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE}?accountGroupId=entropy%3A01JKAF%2F0`;
+      mockUseLocation.mockReturnValue({
+        search: `?isFromReminder=true&previousPage=${encodeURIComponent(
+          accountDetailsPage,
+        )}`,
+      });
+      const mockStore = configureMockStore()(mockState);
+      const { getByTestId } = renderWithProvider(
+        <RevealRecoveryPhrase
+          setSecretRecoveryPhrase={mockSetSecretRecoveryPhrase}
+        />,
+        mockStore,
+      );
+
+      const backButton = getByTestId('reveal-recovery-phrase-back-button');
+      fireEvent.click(backButton);
+
+      expect(mockUseNavigate).toHaveBeenCalledWith(accountDetailsPage, {
+        replace: true,
+      });
+    });
+
+    it('ignores a previous page that is not an in-app path', () => {
+      mockUseLocation.mockReturnValue({
+        search: `?isFromReminder=true&previousPage=${encodeURIComponent(
+          '//evil.test',
+        )}`,
+      });
+      const mockStore = configureMockStore()(mockState);
+      const { getByTestId } = renderWithProvider(
+        <RevealRecoveryPhrase
+          setSecretRecoveryPhrase={mockSetSecretRecoveryPhrase}
+        />,
+        mockStore,
+      );
+
+      const backButton = getByTestId('reveal-recovery-phrase-back-button');
+      fireEvent.click(backButton);
+
+      expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
+        replace: true,
+      });
     });
   });
 });

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.test.tsx
@@ -717,6 +717,29 @@ describe('RevealRecoveryPhrase', () => {
       });
     });
 
+    it('navigates to the default route when closing with a previous page', () => {
+      const accountDetailsPage = `${MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE}?accountGroupId=entropy%3A01JKAF%2F0`;
+      mockUseLocation.mockReturnValue({
+        search: `?isFromReminder=true&previousPage=${encodeURIComponent(
+          accountDetailsPage,
+        )}`,
+      });
+      const mockStore = configureMockStore()(mockState);
+      const { getByTestId } = renderWithProvider(
+        <RevealRecoveryPhrase
+          setSecretRecoveryPhrase={mockSetSecretRecoveryPhrase}
+        />,
+        mockStore,
+      );
+
+      const closeButton = getByTestId('reveal-recovery-phrase-close-button');
+      fireEvent.click(closeButton);
+
+      expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
+        replace: true,
+      });
+    });
+
     it('ignores a previous page that is not an in-app path', () => {
       mockUseLocation.mockReturnValue({
         search: `?isFromReminder=true&previousPage=${encodeURIComponent(

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
@@ -248,6 +248,14 @@ export default function RevealRecoveryPhrase({
     }
   }, [navigate, isFromSettingsSecurity, previousPage]);
 
+  const closeBackupFlow = useCallback(() => {
+    cancelPasskeyCeremony();
+    navigate(
+      isFromSettingsSecurity ? MANAGE_WALLET_RECOVERY_ROUTE : DEFAULT_ROUTE,
+      { replace: true },
+    );
+  }, [navigate, isFromSettingsSecurity]);
+
   return (
     <Box
       flexDirection={BoxFlexDirection.Column}
@@ -280,7 +288,7 @@ export default function RevealRecoveryPhrase({
             color={IconColor.IconDefault}
             size={ButtonIconSize.Md}
             data-testid="reveal-recovery-phrase-close-button"
-            onClick={returnToPreviousPage}
+            onClick={closeBackupFlow}
             ariaLabel={t('close')}
           />
         </Box>

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
@@ -93,7 +93,7 @@ export default function RevealRecoveryPhrase({
   const isFirefox = useIsFirefox();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
-  const { isFromSettingsSecurity, nextRouteQueryString } =
+  const { isFromSettingsSecurity, previousPage, nextRouteQueryString } =
     useOnboardingSearchParams();
   const hasSeedPhraseBackedUp = useSelector(getSeedPhraseBackedUp);
 
@@ -239,12 +239,14 @@ export default function RevealRecoveryPhrase({
 
   const returnToPreviousPage = useCallback(() => {
     cancelPasskeyCeremony();
-    if (isFromSettingsSecurity) {
+    if (previousPage) {
+      navigate(previousPage, { replace: true });
+    } else if (isFromSettingsSecurity) {
       navigate(MANAGE_WALLET_RECOVERY_ROUTE, { replace: true });
     } else {
       navigate(DEFAULT_ROUTE, { replace: true });
     }
-  }, [navigate, isFromSettingsSecurity]);
+  }, [navigate, isFromSettingsSecurity, previousPage]);
 
   return (
     <Box


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Fixes two issues on the account details page:

- Makes the Secret Recovery Phrase arrow match the other arrows.
- Returns users to account details (instead of home screen) when they click back from the SRP backup flow.

## **Changelog**

CHANGELOG entry: Fixed the Secret Recovery Phrase row arrow and back navigation on account details.

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Open an account's details page for a wallet whose SRP is not backed up.
2. Confirm the **Secret Recovery Phrase** arrow matches the other arrows.
3. Click the **Secret Recovery Phrase** row.
4. Click the back arrow in the SRP backup flow.
5. Confirm you return to the same account details page.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/ecbfdd72-75a8-4a88-ad36-685457d27a79

### **After**

https://github.com/user-attachments/assets/8a974535-918f-4a1e-a524-d3f041363a2f



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84de6d35-6a91-4e5e-be11-ac476ff283cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84de6d35-6a91-4e5e-be11-ac476ff283cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

