### PR TITLE
feat(money): wire up real apy values through money account in home screen

### DIFF
--- a/ui/components/app/money/money-account-balance/money-account-balance.test.tsx
+++ b/ui/components/app/money/money-account-balance/money-account-balance.test.tsx
@@ -12,6 +12,8 @@ import type { UseMoneyAccountInfoResult } from '../../../../hooks/money/useMoney
 import {
   MoneyAccountBalance,
   MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID,
+  MONEY_ACCOUNT_BALANCE_APY_SKELETON_TEST_ID,
+  MONEY_ACCOUNT_BALANCE_APY_TEST_ID,
   MONEY_ACCOUNT_BALANCE_INFO_TEST_ID,
   MONEY_ACCOUNT_BALANCE_LAST_KNOWN_TEST_ID,
   MONEY_ACCOUNT_BALANCE_SKELETON_TEST_ID,
@@ -44,6 +46,8 @@ type ArrangeOptions = {
   lastKnownTotalFiatFormatted?: string;
   isBalanceLoading?: boolean;
   isDepositLoading?: boolean;
+  apyPercentFormatted?: string;
+  isVaultApyLoading?: boolean;
 };
 
 /**
@@ -59,6 +63,8 @@ type ArrangeOptions = {
  * @param options.lastKnownTotalFiatFormatted - The last-known balance, if any.
  * @param options.isBalanceLoading - Whether the balance fetch is in flight.
  * @param options.isDepositLoading - Whether a deposit initiation is in flight.
+ * @param options.apyPercentFormatted - The formatted vault APY, if any.
+ * @param options.isVaultApyLoading - Whether the vault APY fetch is in flight.
  */
 const arrange = ({
   hasMoneyAccount = true,
@@ -66,6 +72,8 @@ const arrange = ({
   lastKnownTotalFiatFormatted,
   isBalanceLoading = false,
   isDepositLoading = false,
+  apyPercentFormatted,
+  isVaultApyLoading = false,
 }: ArrangeOptions = {}) => {
   mockInitiateDeposit.mockResolvedValue(undefined);
   mockUseMoneyAccountDeposit.mockReturnValue({
@@ -85,6 +93,8 @@ const arrange = ({
     totalFiatFormatted,
     lastKnownTotalFiatFormatted,
     isBalanceLoading,
+    apyPercentFormatted,
+    vaultApyQuery: { isLoading: isVaultApyLoading },
   } as UseMoneyAccountBalanceResult);
 };
 
@@ -248,5 +258,60 @@ describe('MoneyAccountBalance', () => {
       getByTestId(MONEY_ACCOUNT_BALANCE_LAST_KNOWN_TEST_ID),
     ).toHaveTextContent(tEn('moneyBalanceLastKnown'));
     expect(queryByTestId(MONEY_ACCOUNT_BALANCE_SKELETON_TEST_ID)).toBeNull();
+  });
+
+  it('renders the vault APY from the balance hook', () => {
+    arrange({
+      totalFiatFormatted: '$2,384.34',
+      apyPercentFormatted: '4.2%',
+    });
+
+    const { getByTestId } = render();
+
+    expect(getByTestId(MONEY_ACCOUNT_BALANCE_APY_TEST_ID)).toHaveTextContent(
+      tEn('moneyApy', ['4.2%']),
+    );
+  });
+
+  it('shows a skeleton while the vault APY is loading with nothing to show', () => {
+    arrange({
+      totalFiatFormatted: '$2,384.34',
+      isVaultApyLoading: true,
+    });
+
+    const { getByTestId, queryByTestId } = render();
+
+    expect(
+      getByTestId(MONEY_ACCOUNT_BALANCE_APY_SKELETON_TEST_ID),
+    ).toBeInTheDocument();
+    expect(queryByTestId(MONEY_ACCOUNT_BALANCE_APY_TEST_ID)).toBeNull();
+  });
+
+  it('shows a configured APY while the vault APY query is loading', () => {
+    arrange({
+      totalFiatFormatted: '$2,384.34',
+      apyPercentFormatted: '5%',
+      isVaultApyLoading: true,
+    });
+
+    const { getByTestId, queryByTestId } = render();
+
+    expect(getByTestId(MONEY_ACCOUNT_BALANCE_APY_TEST_ID)).toHaveTextContent(
+      tEn('moneyApy', ['5%']),
+    );
+    expect(
+      queryByTestId(MONEY_ACCOUNT_BALANCE_APY_SKELETON_TEST_ID),
+    ).toBeNull();
+  });
+
+  it('omits the APY when none is available', () => {
+    arrange({ totalFiatFormatted: '$2,384.34' });
+
+    const { queryByTestId } = render();
+
+    expect(queryByTestId(MONEY_ACCOUNT_BALANCE_APY_TEST_ID)).toBeNull();
+    expect(
+      queryByTestId(MONEY_ACCOUNT_BALANCE_APY_SKELETON_TEST_ID),
+    ).toBeNull();
   });
 });

--- a/ui/components/app/money/money-account-balance/money-account-balance.tsx
+++ b/ui/components/app/money/money-account-balance/money-account-balance.tsx
@@ -31,15 +31,13 @@ export const MONEY_ACCOUNT_BALANCE_VALUE_TEST_ID =
 export const MONEY_ACCOUNT_BALANCE_LAST_KNOWN_TEST_ID =
   'money-account-balance-last-known';
 export const MONEY_ACCOUNT_BALANCE_APY_TEST_ID = 'money-account-balance-apy';
+export const MONEY_ACCOUNT_BALANCE_APY_SKELETON_TEST_ID =
+  'money-account-balance-apy-skeleton';
 export const MONEY_ACCOUNT_BALANCE_SKELETON_TEST_ID =
   'money-account-balance-skeleton';
 export const MONEY_ACCOUNT_BALANCE_INFO_TEST_ID = 'money-account-balance-info';
 export const MONEY_ACCOUNT_BALANCE_ADD_BUTTON_TEST_ID =
   'money-account-balance-add-button';
-
-// The vault APY isn't wired up to a data source yet, so this is shown as a
-// fixed placeholder until a hook for it exists.
-const PLACEHOLDER_APY = '88%';
 
 /**
  * The Money Account balance, or nothing.
@@ -78,20 +76,34 @@ const PLACEHOLDER_APY = '88%';
  * redux tree here is not rehydrated on restart, so a reopened extension starts
  * with no fallback until the value is mirrored into controller state.
  *
+ * ## APY uses the same vault query as Money Home
+ *
+ * The rate is `apyPercentFormatted` from `useMoneyAccountBalance`, which
+ * already calls `MoneyAccountBalanceService:getVaultApy`. While that query is
+ * in flight and no override or fallback is available, a skeleton occupies the
+ * APY slot. If the query fails with nothing to show, the slot is omitted
+ * rather than inventing a rate.
+ *
  * @returns The balance row, or `null`.
  */
 export const MoneyAccountBalance = () => {
   const t = useI18nContext();
   const { privacyMode } = useSelector(getPreferences);
   const { hasMoneyAccount } = useMoneyAccountInfo();
-  const { totalFiatFormatted, lastKnownTotalFiatFormatted, isBalanceLoading } =
-    useMoneyAccountBalance();
+  const {
+    totalFiatFormatted,
+    lastKnownTotalFiatFormatted,
+    isBalanceLoading,
+    apyPercentFormatted,
+    vaultApyQuery,
+  } = useMoneyAccountBalance();
   const { initiateDeposit, isLoading: isDepositLoading } =
     useMoneyAccountDeposit();
 
   const balance = totalFiatFormatted ?? lastKnownTotalFiatFormatted;
   const isLoading = isBalanceLoading && balance === undefined;
   const isLastKnown = totalFiatFormatted === undefined && !isLoading;
+  const isApyLoading = vaultApyQuery.isLoading && !apyPercentFormatted;
 
   if (!hasMoneyAccount || (balance === undefined && !isLoading)) {
     return null;
@@ -173,18 +185,25 @@ export const MoneyAccountBalance = () => {
               {balance}
             </SensitiveText>
           )}
-          {/*
-            The vault APY isn't wired up to a data source yet, so this is
-            always shown alongside a live or last-known balance rather than
-            being gated on its own loading state.
-          */}
-          <Text
-            variant={TextVariant.BodyMd}
-            color={TextColor.SuccessDefault}
-            data-testid={MONEY_ACCOUNT_BALANCE_APY_TEST_ID}
-          >
-            {t('moneyApy', [PLACEHOLDER_APY])}
-          </Text>
+          {isApyLoading ? (
+            // 22px matches the bodyMd line-height of the APY text so the
+            // row doesn't shift when the figure arrives.
+            <Skeleton
+              height={22}
+              width={72}
+              data-testid={MONEY_ACCOUNT_BALANCE_APY_SKELETON_TEST_ID}
+            />
+          ) : (
+            apyPercentFormatted && (
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.SuccessDefault}
+                data-testid={MONEY_ACCOUNT_BALANCE_APY_TEST_ID}
+              >
+                {t('moneyApy', [apyPercentFormatted])}
+              </Text>
+            )
+          )}
         </Box>
         {isLastKnown ? (
           <Text


### PR DESCRIPTION
## **Description**

The Extension Home Money Account row showed a hardcoded placeholder APY (`88%`) even though Money Home already fetches and renders the live vault rate. That mismatch made the home card look like mock data next to a real rate on the dedicated Money screen.

This change uses the same `useMoneyAccountBalance` fields Money Home already uses (`apyPercentFormatted` from `@metamask/money-account-balance-service` `getVaultApy`, including remote override/fallback). While the vault query is in flight and no rate is available, a skeleton occupies the APY slot. If the query fails with nothing to show, the APY is omitted rather than inventing a number.

## **Changelog**

CHANGELOG entry: Fixed the Money Account APY on the home screen to show the live vault rate instead of a placeholder

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1311

## **Manual testing steps**

1. Enable Money Account and open the Extension Home screen with a Money Account available.
2. Confirm the Money balance row APY matches the rate shown on Money Home (not `88%` or any other placeholder).
3. Reload the extension and watch the home row: while the vault APY is still loading and no fallback/override is set, confirm a skeleton appears in the APY slot, then the live rate.
4. If a vault APY override or fallback is configured, confirm that rate is shown on Home even while the service query is still loading.
5. Confirm Home still hides the Money row when there is no Money Account, and that a missing APY does not hide a live or last-known balance.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/contributor-docs/blob/main/docs/labeling-guidelines.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in the Money home row with no new data fetching; behavior aligns with an existing hook used elsewhere.
> 
> **Overview**
> Replaces the hardcoded **88%** placeholder on Extension Home’s Money account balance row with **`apyPercentFormatted`** from **`useMoneyAccountBalance`**, matching Money Home’s vault rate (including override/fallback when present).
> 
> While the vault APY query is loading and no formatted rate exists yet, a **skeleton** fills the APY slot; if nothing is available after load, the APY is **hidden** instead of showing a fake number. Tests cover render, loading skeleton, showing cached/override APY during load, and omission when absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baad74fd010188b3510038072bd4311c4bbf4c10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->