### PR TITLE
feat: add new hyperliquid deposit prompt metrics

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -870,6 +870,8 @@ export enum MetaMetricsEventName {
   ForceUpgradeUpdateNeededPromptViewed = 'Force Upgrade Update Needed Prompt Viewed',
   ForceUpgradeSkipped = 'Force Upgrade Skipped',
   ForceUpgradeClickedUpdateToLatestVersion = 'Force Upgrade Clicked Update to Latest Version',
+  HyperliquidDepositPromptViewed = 'Hyperliquid Deposit Prompt Viewed',
+  HyperliquidDepositPromptInteracted = 'Hyperliquid Deposit Prompt Interacted',
   ImportSecretRecoveryPhrase = 'Import Secret Recovery Phrase',
   KeyExportSelected = 'Key Export Selected',
   KeyExportRequested = 'Key Export Requested',

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
@@ -190,29 +190,13 @@ describe('HyperliquidDepositPrompt', () => {
     ).toBeEnabled();
   });
 
-  it('tracks Hyperliquid Deposit Prompt Viewed with the notification surface on render', () => {
+  it('tracks Hyperliquid Deposit Prompt Viewed on render', () => {
     renderComponent();
 
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: MetaMetricsEventName.HyperliquidDepositPromptViewed,
       properties: {
         category: MetaMetricsEventCategory.Confirmations,
-        surface: 'notification',
-      },
-      sensitiveProperties: {},
-    });
-  });
-
-  it('tracks Hyperliquid Deposit Prompt Viewed with the sidepanel surface', () => {
-    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
-
-    renderComponent();
-
-    expect(mockTrackEvent).toHaveBeenCalledWith({
-      name: MetaMetricsEventName.HyperliquidDepositPromptViewed,
-      properties: {
-        category: MetaMetricsEventCategory.Confirmations,
-        surface: 'sidepanel',
       },
       sensitiveProperties: {},
     });

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
@@ -9,6 +9,12 @@ import {
   PERPS_HOME_PAGE_ROUTE,
 } from '../../../helpers/constants/routes';
 import { PERPS_HOME_TAB_ROUTE } from '../../../hooks/perps/usePerpsHomeRoute';
+import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { updateTransactionPaymentToken } from '../../../store/controller-actions/transaction-pay-controller';
 import { useSendTokens } from '../../../pages/confirmations/hooks/send/useSendTokens';
 import {
@@ -29,6 +35,24 @@ jest.mock('../perps/hooks/usePerpsDepositConfirmation', () => ({
     isLoading: false,
     trigger: mockStartPerpsDeposit,
   }),
+}));
+
+const mockTrackEvent = jest.fn();
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
+
+jest.mock('../../../../shared/lib/environment-type', () => ({
+  getEnvironmentType: jest.fn(() => 'notification'),
 }));
 
 jest.mock('../../../store/controller-actions/transaction-pay-controller');
@@ -75,6 +99,7 @@ const mockSelectBlockedPayTokens = jest.mocked(selectBlockedPayTokens);
 const mockUpdateTransactionPaymentToken = jest.mocked(
   updateTransactionPaymentToken,
 );
+const mockGetEnvironmentType = jest.mocked(getEnvironmentType);
 
 const ETH_TOKEN: Asset = {
   accountType: 'eip155:eoa',
@@ -141,6 +166,7 @@ describe('HyperliquidDepositPrompt', () => {
       transactionId: 'transaction-id-mock',
     });
     mockUpdateTransactionPaymentToken.mockResolvedValue(undefined);
+    mockGetEnvironmentType.mockReturnValue('notification');
   });
 
   it('renders the title, logos, default token and continue button', () => {
@@ -164,6 +190,34 @@ describe('HyperliquidDepositPrompt', () => {
     ).toBeEnabled();
   });
 
+  it('tracks Hyperliquid Deposit Prompt Viewed with the notification surface on render', () => {
+    renderComponent();
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: MetaMetricsEventName.HyperliquidDepositPromptViewed,
+      properties: {
+        category: MetaMetricsEventCategory.Confirmations,
+        surface: 'notification',
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('tracks Hyperliquid Deposit Prompt Viewed with the sidepanel surface', () => {
+    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
+
+    renderComponent();
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: MetaMetricsEventName.HyperliquidDepositPromptViewed,
+      properties: {
+        category: MetaMetricsEventCategory.Confirmations,
+        surface: 'sidepanel',
+      },
+      sensitiveProperties: {},
+    });
+  });
+
   it('resolves the approval without starting a deposit when closed', () => {
     const { onActionComplete } = renderComponent();
 
@@ -171,6 +225,14 @@ describe('HyperliquidDepositPrompt', () => {
 
     expect(onActionComplete).toHaveBeenCalledWith({ action: 'dismiss' });
     expect(mockStartPerpsDeposit).not.toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: MetaMetricsEventName.HyperliquidDepositPromptInteracted,
+      properties: {
+        category: MetaMetricsEventCategory.Confirmations,
+        action: 'dismiss',
+      },
+      sensitiveProperties: {},
+    });
   });
 
   it('updates the selected token when one is picked from the modal', () => {
@@ -211,6 +273,14 @@ describe('HyperliquidDepositPrompt', () => {
       },
       { replace: true },
     );
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: MetaMetricsEventName.HyperliquidDepositPromptInteracted,
+      properties: {
+        category: MetaMetricsEventCategory.Confirmations,
+        action: 'continue',
+      },
+      sensitiveProperties: {},
+    });
   });
 
   it('defaults to the first selectable token when the largest balance is blocked', () => {
@@ -280,6 +350,11 @@ describe('HyperliquidDepositPrompt', () => {
 
     expect(onActionComplete).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: MetaMetricsEventName.HyperliquidDepositPromptInteracted,
+      }),
+    );
   });
 
   it('dismisses immediately when the signer address does not match the selected account', async () => {
@@ -291,5 +366,6 @@ describe('HyperliquidDepositPrompt', () => {
     });
 
     expect(mockStartPerpsDeposit).not.toHaveBeenCalled();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
   });
 });

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
@@ -31,12 +31,10 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
-import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { getSelectedInternalAccount } from '../../../../shared/lib/selectors/accounts';
 import { CONFIRM_TRANSACTION_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -54,15 +52,8 @@ import { useAnalytics } from '../../../hooks/useAnalytics';
 import { usePerpsDepositConfirmation } from '../perps/hooks/usePerpsDepositConfirmation';
 import type {
   HyperliquidDepositPromptProps,
-  HyperliquidDepositPromptSurface,
   HyperliquidDepositPromptAction,
 } from './hyperliquid-deposit-prompt.types';
-
-function getHyperliquidDepositPromptSurface(): HyperliquidDepositPromptSurface {
-  return getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL
-    ? 'sidepanel'
-    : 'notification';
-}
 
 /**
  * Tokens the user can fund a Hyperliquid deposit with through MetaMask Pay.
@@ -225,9 +216,6 @@ export const HyperliquidDepositPrompt: React.FC<
     trackEvent(
       createEventBuilder(MetaMetricsEventName.HyperliquidDepositPromptViewed)
         .addCategory(MetaMetricsEventCategory.Confirmations)
-        .addProperties({
-          surface: getHyperliquidDepositPromptSurface(),
-        })
         .build(),
     );
   }, [createEventBuilder, isSignerMismatch, trackEvent]);

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { TransactionType } from '@metamask/transaction-controller';
@@ -25,6 +31,12 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
+import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { getSelectedInternalAccount } from '../../../../shared/lib/selectors/accounts';
 import { CONFIRM_TRANSACTION_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -38,8 +50,19 @@ import { getAvailableTokens } from '../../../pages/confirmations/utils/transacti
 import { Asset } from '../../../pages/confirmations/components/send/asset/asset';
 import type { Asset as AssetType } from '../../../pages/confirmations/types/send';
 import { usePerpsHomeRoute } from '../../../hooks/perps/usePerpsHomeRoute';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { usePerpsDepositConfirmation } from '../perps/hooks/usePerpsDepositConfirmation';
-import type { HyperliquidDepositPromptProps } from './hyperliquid-deposit-prompt.types';
+import type {
+  HyperliquidDepositPromptProps,
+  HyperliquidDepositPromptSurface,
+  HyperliquidDepositPromptAction,
+} from './hyperliquid-deposit-prompt.types';
+
+function getHyperliquidDepositPromptSurface(): HyperliquidDepositPromptSurface {
+  return getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL
+    ? 'sidepanel'
+    : 'notification';
+}
 
 /**
  * Tokens the user can fund a Hyperliquid deposit with through MetaMask Pay.
@@ -162,18 +185,52 @@ export const HyperliquidDepositPrompt: React.FC<
   const perpsHomeRoute = usePerpsHomeRoute();
   const tokens = useHyperliquidDepositTokens();
   const currentAccount = useSelector(getSelectedInternalAccount);
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const hasTrackedView = useRef(false);
+
+  const isSignerMismatch = Boolean(
+    selectedAddress &&
+    currentAccount?.address &&
+    selectedAddress.toLowerCase() !== currentAccount.address.toLowerCase(),
+  );
+
+  const trackPromptInteracted = useCallback(
+    (action: HyperliquidDepositPromptAction) => {
+      trackEvent(
+        createEventBuilder(
+          MetaMetricsEventName.HyperliquidDepositPromptInteracted,
+        )
+          .addCategory(MetaMetricsEventCategory.Confirmations)
+          .addProperties({ action })
+          .build(),
+      );
+    },
+    [createEventBuilder, trackEvent],
+  );
 
   // Dismiss if the signer account isn't the currently selected account as
   // useSendTokens and usePerpsDepositConfirmation use the selected account.
   useEffect(() => {
-    if (
-      selectedAddress &&
-      currentAccount?.address &&
-      selectedAddress.toLowerCase() !== currentAccount.address.toLowerCase()
-    ) {
+    if (isSignerMismatch) {
       onActionComplete({ action: 'dismiss' });
     }
-  }, [selectedAddress, currentAccount?.address, onActionComplete]);
+  }, [isSignerMismatch, onActionComplete]);
+
+  useEffect(() => {
+    if (isSignerMismatch || hasTrackedView.current) {
+      return;
+    }
+
+    hasTrackedView.current = true;
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.HyperliquidDepositPromptViewed)
+        .addCategory(MetaMetricsEventCategory.Confirmations)
+        .addProperties({
+          surface: getHyperliquidDepositPromptSurface(),
+        })
+        .build(),
+    );
+  }, [createEventBuilder, isSignerMismatch, trackEvent]);
 
   // The same entry point the Perps "Add funds" button uses. It creates the
   // unapproved draft transaction that backs the Perps deposit confirmation;
@@ -194,8 +251,9 @@ export const HyperliquidDepositPrompt: React.FC<
   const displayToken = selectedToken ?? selectableTokens[0];
 
   const handleClose = useCallback(() => {
+    trackPromptInteracted('dismiss');
     onActionComplete({ action: 'dismiss' });
-  }, [onActionComplete]);
+  }, [onActionComplete, trackPromptInteracted]);
 
   const handleTokenSelect = useCallback((token: AssetType) => {
     if (token.disabled) {
@@ -246,6 +304,7 @@ export const HyperliquidDepositPrompt: React.FC<
       { replace: true },
     );
 
+    trackPromptInteracted('continue');
     onActionComplete({ action: 'continue', transactionId });
   }, [
     displayToken,
@@ -253,6 +312,7 @@ export const HyperliquidDepositPrompt: React.FC<
     onActionComplete,
     perpsHomeRoute,
     startPerpsDeposit,
+    trackPromptInteracted,
   ]);
 
   return (

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.types.ts
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.types.ts
@@ -6,3 +6,6 @@ export type HyperliquidDepositPromptProps = {
   onActionComplete: (result: HyperliquidDepositPromptResult) => void;
   selectedAddress?: string;
 };
+
+export type HyperliquidDepositPromptSurface = 'sidepanel' | 'notification';
+export type HyperliquidDepositPromptAction = 'dismiss' | 'continue';

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.types.ts
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.types.ts
@@ -7,5 +7,4 @@ export type HyperliquidDepositPromptProps = {
   selectedAddress?: string;
 };
 
-export type HyperliquidDepositPromptSurface = 'sidepanel' | 'notification';
 export type HyperliquidDepositPromptAction = 'dismiss' | 'continue';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds Hyperliquid Deposit Prompt Viewed when Hyperliquid deposit prompt is shown
Adds Hyperliquid Deposit Prompt Interacted with `action: dismiss | continue` when the Hyperliquid deposit prompt is accepted or closed

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Part fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1344?issueKey=CEUX-1344&subProduct=jira-software

## **Manual testing steps**

1. Feature flag `extensionUxHyperliquidDepositPrompt` is already true in dev
2. Ensure wallet has:
   - No existing Hyperliquid perps balance
   - Less than $10 USDC on Arbitrum
   - Some other token balance (ETH, USDC on other chains, etc.)
3. Go to app.hyperliquid.xyz
4. Click "Enable Trading" and sign the transaction in MetaMask
5. After signing, the "Fund Hyperliquid with MetaMask" prompt should appear
6. Check that `Hyperliquid Deposit Prompt Viewed` is emitted and the `environment_type` property is correct (sidepanel or notification)
8. Click Continue
9. Check that `Hyperliquid Deposit Prompt Interacted` is emitted and the `action` property is `continue`
10. Repeat steps but then close the prompt via X button
11. Check that `Hyperliquid Deposit Prompt Interacted` is emitted and the `action` property is `dismiss`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to analytics event names and non-functional tracking in the deposit prompt UI, with no impact on deposit or payment flows.
> 
> **Overview**
> Adds **MetaMetrics** instrumentation for the Hyperliquid deposit prompt so product can measure funnel engagement.
> 
> Two new events are registered in `metametrics`: **Hyperliquid Deposit Prompt Viewed** (fires once when the prompt actually renders) and **Hyperliquid Deposit Prompt Interacted** (fires on close or successful continue with an `action` of `dismiss` or `continue`, under the Confirmations category). View tracking is skipped when the signer address does not match the selected account; interaction is not sent when deposit creation fails.
> 
> The prompt component wires `useAnalytics` and a small `trackPromptInteracted` helper; signer mismatch logic is consolidated into `isSignerMismatch` for reuse in dismiss and analytics guards. Unit tests mock analytics and assert the expected events (and absence of events) for error and mismatch paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbdd55f50b89ca1d0a0355886ce6aab1c626dded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->