### PR TITLE
feat: [MUSD-1322] fix various money account issues identified in design review

### DIFF
--- a/ui/components/app/money/money-account-balance/money-account-balance.tsx
+++ b/ui/components/app/money/money-account-balance/money-account-balance.tsx
@@ -150,7 +150,7 @@ export const MoneyAccountBalance = () => {
         </Box>
         <Box
           flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
+          alignItems={BoxAlignItems.Baseline}
           gap={2}
         >
           {isLoading ? (
@@ -159,6 +159,9 @@ export const MoneyAccountBalance = () => {
             <Skeleton
               height={32}
               width={100}
+              // A skeleton has no baseline of its own, so it is centred rather
+              // than left to baseline-align against the APY beside it.
+              className="self-center"
               data-testid={MONEY_ACCOUNT_BALANCE_SKELETON_TEST_ID}
             />
           ) : (

--- a/ui/pages/money/constants/urls.ts
+++ b/ui/pages/money/constants/urls.ts
@@ -1,0 +1,5 @@
+/**
+ * Money marketing page, the same destination mobile's "Learn more" opens.
+ */
+export const MONEY_LANDING_URL =
+  'https://metamask.io/money?utm_source=extension';

--- a/ui/pages/money/money-home-page.test.tsx
+++ b/ui/pages/money/money-home-page.test.tsx
@@ -211,17 +211,30 @@ describe('MoneyHomePage', () => {
   it('keeps groundwork actions other than the transfer entry points inert', () => {
     renderWithLocalization(<MoneyHomePage />);
 
-    const transferLabels = [
+    const activeLabels = [
       messages.moneyAdd.message,
       messages.addFunds.message,
       messages.moneySend.message,
+      messages.moneyLearnMore.message,
     ];
     screen.getAllByRole('button').forEach((button) => {
-      if (transferLabels.includes(button.textContent ?? '')) {
+      if (activeLabels.includes(button.textContent ?? '')) {
         expect(button).toBeEnabled();
       } else {
         expect(button).toBeDisabled();
       }
+    });
+  });
+
+  it('opens the Money landing page from Learn more', () => {
+    global.platform.openTab = jest.fn();
+
+    renderWithLocalization(<MoneyHomePage />);
+
+    fireEvent.click(screen.getByTestId('money-learn-more'));
+
+    expect(global.platform.openTab).toHaveBeenCalledWith({
+      url: 'https://metamask.io/money?utm_source=extension',
     });
   });
 

--- a/ui/pages/money/money-home-page.test.tsx
+++ b/ui/pages/money/money-home-page.test.tsx
@@ -26,6 +26,18 @@ const mockSelectMoneyEarningSectionEnabled = jest.mocked(
 );
 const mockGetPrivacyMode = jest.mocked(getPrivacyMode);
 
+const DEPOSIT_TOKEN = {
+  address: '0x0000000000000000000000000000000000000001',
+  chainId: '0x1',
+  decimals: 6,
+  image: 'usdc.png',
+  moneyFiatAmountUsd: 12,
+  secondary: '$12.00',
+  symbol: 'USDC',
+  title: 'USD Coin',
+  tokenFiatAmount: 12,
+};
+
 const interestResponse = (value: string) => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interest_earned_usd: value,
@@ -138,6 +150,11 @@ describe('MoneyHomePage', () => {
   });
 
   it('renders the full empty-state composition with a live zero balance', () => {
+    mockUseMoneyDepositTokens.mockReturnValue({
+      tokens: [DEPOSIT_TOKEN],
+      isNoFeeToken: () => false,
+    });
+
     renderWithLocalization(<MoneyHomePage />);
 
     expect(screen.getByTestId('money-home-page')).toBeInTheDocument();
@@ -282,7 +299,6 @@ describe('MoneyHomePage', () => {
       totalFiatRaw: '3475.45',
       vaultApyQuery: { isLoading: false },
     });
-
     renderWithLocalization(<MoneyHomePage />);
 
     expect(screen.getByTestId('money-balance')).toHaveTextContent('$3,475.45');
@@ -299,10 +315,6 @@ describe('MoneyHomePage', () => {
       screen.getByTestId('money-position-lifetime-value'),
     ).toHaveTextContent('+$56.78');
     expect(screen.getByTestId('money-activity-list')).toBeInTheDocument();
-    expect(screen.getByTestId('money-potential-earnings')).toBeInTheDocument();
-    expect(
-      screen.getByText(messages.moneyEarnOnCrypto.message),
-    ).toBeInTheDocument();
     expect(
       screen.getByTestId('money-condensed-info-cards'),
     ).toBeInTheDocument();
@@ -528,6 +540,10 @@ describe('MoneyHomePage', () => {
       totalFiatRaw: '10',
       vaultApyQuery: { isLoading: false },
     });
+    mockUseMoneyDepositTokens.mockReturnValue({
+      tokens: [DEPOSIT_TOKEN],
+      isNoFeeToken: () => false,
+    });
 
     renderWithLocalization(<MoneyHomePage />);
 
@@ -645,21 +661,26 @@ describe('MoneyHomePage', () => {
     ).toBeInTheDocument();
   });
 
+  it('hides the earn-on-your-crypto section when no assets are eligible', () => {
+    mockUseMoneyDepositTokens.mockReturnValue({
+      tokens: [],
+      isNoFeeToken: () => false,
+    });
+
+    renderWithLocalization(<MoneyHomePage />);
+
+    expect(screen.queryByTestId('money-potential-earnings')).toBeNull();
+    expect(
+      screen.queryByText(messages.moneyEarnOnCrypto.message),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(messages.moneyBenefits.message),
+    ).toBeInTheDocument();
+  });
+
   it('previews eligible wallet assets using their existing balances', () => {
     mockUseMoneyDepositTokens.mockReturnValue({
-      tokens: [
-        {
-          address: '0x0000000000000000000000000000000000000001',
-          chainId: '0x1',
-          decimals: 6,
-          image: 'usdc.png',
-          moneyFiatAmountUsd: 12,
-          secondary: '$12.00',
-          symbol: 'USDC',
-          title: 'USD Coin',
-          tokenFiatAmount: 12,
-        },
-      ],
+      tokens: [DEPOSIT_TOKEN],
       isNoFeeToken: () => true,
     });
 
@@ -687,19 +708,7 @@ describe('MoneyHomePage', () => {
       vaultApyQuery: { isLoading: false },
     });
     mockUseMoneyDepositTokens.mockReturnValue({
-      tokens: [
-        {
-          address: '0x0000000000000000000000000000000000000001',
-          chainId: '0x1',
-          decimals: 6,
-          image: 'usdc.png',
-          moneyFiatAmountUsd: 12,
-          secondary: '$12.00',
-          symbol: 'USDC',
-          title: 'USD Coin',
-          tokenFiatAmount: 12,
-        },
-      ],
+      tokens: [DEPOSIT_TOKEN],
       isNoFeeToken: () => true,
     });
 

--- a/ui/pages/money/money-home-page.tsx
+++ b/ui/pages/money/money-home-page.tsx
@@ -195,14 +195,19 @@ export function MoneyHomePage() {
       ? t('moneyBalanceUnavailable')
       : totalFiatFormatted;
   const apyDisplay = apyPercentFormatted;
-  const earnOnYourCryptoSection = (
-    <MoneyPotentialEarnings
-      tokens={depositTokens}
-      apyDecimal={apyDecimal}
-      isNoFeeToken={isNoFeeToken}
-      privacyMode={privacyMode}
-    />
-  );
+
+  const earnOnYourCryptoSection =
+    depositTokens.length > 0 ? (
+      <>
+        <MoneyPotentialEarnings
+          tokens={depositTokens}
+          apyDecimal={apyDecimal}
+          isNoFeeToken={isNoFeeToken}
+          privacyMode={privacyMode}
+        />
+        <MoneySectionDivider />
+      </>
+    ) : null;
 
   return (
     <main
@@ -332,7 +337,6 @@ export function MoneyHomePage() {
             />
             <MoneySectionDivider />
             {earnOnYourCryptoSection}
-            <MoneySectionDivider />
             <MoneyCondensedInfoCards />
           </>
         ) : (
@@ -378,7 +382,6 @@ export function MoneyHomePage() {
             <MoneySectionDivider />
             {earnOnYourCryptoSection}
 
-            <MoneySectionDivider />
             <section className="px-4 py-3">
               <Text
                 variant={TextVariant.HeadingMd}

--- a/ui/pages/money/money-home-page.tsx
+++ b/ui/pages/money/money-home-page.tsx
@@ -32,6 +32,7 @@ import { useMoneyActivityItemClick } from '../../hooks/money/use-money-activity-
 import { moneyFormatUsd } from '../../helpers/money/format';
 import { selectMoneyEarningSectionEnabled } from '../../selectors/money/money-account-feature-flags';
 import { getPrivacyMode } from '../../selectors/selectors';
+import { MONEY_LANDING_URL } from './constants/urls';
 import { MoneyActivityList } from './components/money-activity-list';
 import { MoneyCondensedInfoCards } from './components/money-condensed-info-cards';
 import { MoneyPotentialEarnings } from './components/money-potential-earnings';
@@ -166,6 +167,9 @@ export function MoneyHomePage() {
   }, [initiateDeposit]);
   const { initiateWithdrawal, isLoading: isWithdrawalLoading } =
     useMoneyAccountWithdrawal();
+  const handleLearnMore = useCallback(() => {
+    global.platform.openTab({ url: MONEY_LANDING_URL });
+  }, []);
   const handleSend = useCallback(() => {
     initiateWithdrawal().catch((error) =>
       console.error('Failed to initiate money account withdrawal', error),
@@ -411,8 +415,9 @@ export function MoneyHomePage() {
               </ul>
               <Button
                 variant={ButtonVariant.Secondary}
-                disabled
                 className="mt-4 w-full"
+                onClick={handleLearnMore}
+                data-testid="money-learn-more"
               >
                 {t('moneyLearnMore')}
               </Button>

--- a/ui/pages/money/money-home-page.tsx
+++ b/ui/pages/money/money-home-page.tsx
@@ -220,7 +220,7 @@ export function MoneyHomePage() {
         />
       </header>
 
-      <div className="flex flex-col gap-2 px-4 pt-2 sm:items-center">
+      <div className="flex flex-col items-center gap-2 px-4 pt-2">
         <div className="flex w-full max-w-[784px] flex-col gap-1 sm:items-center">
           <Text
             variant={TextVariant.DisplayLg}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR addresses a few points that we found in our design review



1. bottom aligning the APY with the balance
<img width="199" height="48" alt="image" src="https://github.com/user-attachments/assets/2d0110fa-0092-4d76-ac22-fb6f2218175a" />

2. Center the money CTAs whenever the sidebar is wider than the elements themselves (previously they were left aligned at some breakpoints)
<img width="574" height="710" alt="Screenshot 2026-09-07 at 11 20 21" src="https://github.com/user-attachments/assets/cbec67b4-b170-4390-9abd-c5f60f7b21e1" />

3. Hide earn on your cryto for users with no stabelcoins - the screenshot for this one is a bit unimpressive, because it’s just showing something not being there.. You get the idea.
<img width="600" height="623" alt="image" src="https://github.com/user-attachments/assets/683cb47b-d94c-4114-806e-481004ac92bc" />

4. Make the 'learn more' link the money landing page lead somewhere. No screenshot for this one. Just give it a go

Some other issues were identified in the design review, which are more involved and will have separate tickets created for them.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
4. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix various design issues related to the money account

## **Related issues**

Fixes: MUSD-1322

## **Manual testing steps**
N/A

## **Screenshots/Recordings**
See the description section above
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout and marketing deep-link only; no auth, balances, or transaction logic changes.
> 
> **Overview**
> Addresses **Money** design-review feedback: layout, conditional content, and a working **Learn more** CTA.
> 
> On the **account overview** balance row, the amount and APY line up on a **baseline** instead of vertical center; the loading skeleton stays visually centered so it does not misalign with the APY text.
> 
> On **Money home**, the hero/action block is **centered** at all widths. **Earn on your crypto** (`MoneyPotentialEarnings`) renders only when `useMoneyDepositTokens` returns at least one token, with section dividers adjusted so empty wallets do not get an orphan divider. The benefits **Learn more** button is enabled and opens `MONEY_LANDING_URL` (`metamask.io/money?utm_source=extension`) via `global.platform.openTab`, matching mobile.
> 
> Tests add a shared deposit-token fixture, cover the landing-page click, the hidden earn section when `tokens` is empty, and update funded/empty expectations accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c4c2927053dc6e9858111b302a0e66efcd07c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->