### PR TITLE
fix(ci): scope changed-files output to pull requests

### DIFF
--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -489,24 +489,16 @@ jobs:
           filters: .github/rules/filter-rules.yml
           list-files: json
 
-      # Only pull_request events expose the file list, because AI PR risk
-      # analysis (its only consumer) runs on pull requests only. On other
-      # events dorny/paths-filter has no base SHA to diff against, so with
-      # fetch-depth: 1 it reports the entire tree as changed. A list that long
-      # exceeds GitHub's 1,048,576-byte job-output limit, which fails this job
-      # after every step has passed and takes the whole run down with it.
+      # Schedule + shallow checkout lists the whole tree; job outputs cap at 1MB.
       - name: Expose changed files for AI PR risk analysis
         id: set-changed-files
         if: ${{ env.EVENT_NAME == 'pull_request' }}
         env:
           ALL_CHANGES_FILES: ${{ steps.filter.outputs.all_changes_files }}
         run: |
-          # Filenames come from the PR, so keep them out of the script body.
           SIZE="$(printf '%s' "$ALL_CHANGES_FILES" | wc -c | tr -d ' ')"
-          # Leave headroom under the job-output limit: GitHub counts this value
-          # once as a job output and again as a workflow_call output.
           if (( SIZE > 400000 )); then
-            echo "::warning::Changed-file list is $SIZE bytes, too large to pass as a job output — skipping AI PR risk analysis"
+            echo "::warning::Changed-file list is $SIZE bytes; skipping AI PR risk analysis"
             exit 0
           fi
           echo "changed-files=$ALL_CHANGES_FILES" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -79,7 +79,8 @@ jobs:
       needs-releases: ${{ steps.set-needs-releases.outputs.needs-releases || 'false' }}
       needs-benchmarks: ${{ steps.set-needs-benchmarks.outputs.needs-benchmarks || 'false' }}
       needs-e2e: ${{ steps.set-needs-e2e.outputs.needs-e2e || 'false' }}
-      changed-files: ${{ steps.set-changed-files.outputs.changed-files || '[]' }}
+      # Schedule + shallow checkout lists the whole tree; job outputs cap at 1MB.
+      changed-files: ${{ env.EVENT_NAME == 'pull_request' && steps.filter.outputs.all_changes_files || '[]' }}
     steps:
       - name: Check pull request merge queue status
         id: check-skip-merge-queue
@@ -488,20 +489,6 @@ jobs:
         with:
           filters: .github/rules/filter-rules.yml
           list-files: json
-
-      # Schedule + shallow checkout lists the whole tree; job outputs cap at 1MB.
-      - name: Expose changed files for AI PR risk analysis
-        id: set-changed-files
-        if: ${{ env.EVENT_NAME == 'pull_request' }}
-        env:
-          ALL_CHANGES_FILES: ${{ steps.filter.outputs.all_changes_files }}
-        run: |
-          SIZE="$(printf '%s' "$ALL_CHANGES_FILES" | wc -c | tr -d ' ')"
-          if (( SIZE > 400000 )); then
-            echo "::warning::Changed-file list is $SIZE bytes; skipping AI PR risk analysis"
-            exit 0
-          fi
-          echo "changed-files=$ALL_CHANGES_FILES" >> "$GITHUB_OUTPUT"
 
       # This puts the workflow in locales-only mode, with skip-everything=true and needs-locales=true
       - name: Compute needs-locales flag

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -79,7 +79,7 @@ jobs:
       needs-releases: ${{ steps.set-needs-releases.outputs.needs-releases || 'false' }}
       needs-benchmarks: ${{ steps.set-needs-benchmarks.outputs.needs-benchmarks || 'false' }}
       needs-e2e: ${{ steps.set-needs-e2e.outputs.needs-e2e || 'false' }}
-      changed-files: ${{ steps.filter.outputs.all_changes_files }}
+      changed-files: ${{ steps.set-changed-files.outputs.changed-files || '[]' }}
     steps:
       - name: Check pull request merge queue status
         id: check-skip-merge-queue
@@ -488,6 +488,28 @@ jobs:
         with:
           filters: .github/rules/filter-rules.yml
           list-files: json
+
+      # Only pull_request events expose the file list, because AI PR risk
+      # analysis (its only consumer) runs on pull requests only. On other
+      # events dorny/paths-filter has no base SHA to diff against, so with
+      # fetch-depth: 1 it reports the entire tree as changed. A list that long
+      # exceeds GitHub's 1,048,576-byte job-output limit, which fails this job
+      # after every step has passed and takes the whole run down with it.
+      - name: Expose changed files for AI PR risk analysis
+        id: set-changed-files
+        if: ${{ env.EVENT_NAME == 'pull_request' }}
+        env:
+          ALL_CHANGES_FILES: ${{ steps.filter.outputs.all_changes_files }}
+        run: |
+          # Filenames come from the PR, so keep them out of the script body.
+          SIZE="$(printf '%s' "$ALL_CHANGES_FILES" | wc -c | tr -d ' ')"
+          # Leave headroom under the job-output limit: GitHub counts this value
+          # once as a job output and again as a workflow_call output.
+          if (( SIZE > 400000 )); then
+            echo "::warning::Changed-file list is $SIZE bytes, too large to pass as a job output — skipping AI PR risk analysis"
+            exit 0
+          fi
+          echo "changed-files=$ALL_CHANGES_FILES" >> "$GITHUB_OUTPUT"
 
       # This puts the workflow in locales-only mode, with skip-everything=true and needs-locales=true
       - name: Compute needs-locales flag


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Reason:** Overnight `schedule` Main has failed since [#45532](https://github.com/MetaMask/metamask-extension/pull/45532) with `Job outputs exceed 1,048,576 bytes` in `get-requirements`. Every step is green; the job then fails when collecting outputs. E2E never starts, so no `test-e2e-*-report` artifacts are uploaded and the flaky test report logs "no test artifacts found".

**Cause:** #45532 exported `dorny/paths-filter` `all_changes_files` as a job output (and a `workflow_call` output) so AI PR risk analysis could consume it. On `schedule` there is no `github.event.before`, and the job checks out with `fetch-depth: 1`, so git diffs the last commit against the empty tree and reports the entire repo as changed (~10k files). That list is counted twice against GitHub's 1MB job-output cap. Push/PR Main is unaffected because those events have a real base SHA. The analyzer only runs on `pull_request`, so the list did not need to be exported on other events.

**Solution:** Export `changed-files` only for `pull_request`. Default the output to `'[]'` otherwise so the existing `main.yml` guard skips the analyzer. If a PR's own list exceeds 400KB, warn and skip analysis instead of failing all of CI.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: https://github.com/MetaMask/metamask-extension/pull/45532
Related: https://github.com/MetaMask/metamask-extension/actions/runs/34100538499

## **Manual testing steps**

### This PR

1. Open this PR's Main run.
2. Confirm **Get workflow and job requirements** succeeds (no 1MB job-output error).
3. Confirm **Expose changed files for AI PR risk analysis** ran.
4. Confirm **AI PR risk analysis** still ran.

### After merge

1. Open the next overnight scheduled Main run (`0 2-6 * * *` UTC).
2. Confirm **Expose changed files for AI PR risk analysis** was skipped and `get-requirements` succeeded.
3. Confirm E2E uploaded `test-e2e-chrome-report` / `test-e2e-firefox-report`.
4. Run **Flaky test report** (Actions → Run workflow) and confirm it finds those artifacts.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI output gating only; PR behavior for changed-files is preserved and scheduled runs avoid oversized job outputs.
> 
> **Overview**
> Fixes overnight **scheduled** Main runs failing in **Get workflow and job requirements** with GitHub’s **1MB job-output limit** after `changed-files` started re-exporting `dorny/paths-filter`’s full file list.
> 
> On **non–pull_request** events (especially **schedule** with shallow checkout), the filter can treat the **entire repo** as changed, so the JSON output blows past the cap and blocks downstream jobs (including E2E and flaky-test artifacts). The **`changed-files`** job output now returns **`all_changes_files` only when `EVENT_NAME == 'pull_request'`**; otherwise it emits **`'[]'`**, which lets **`main.yml`** skip **AI PR risk analysis** on those runs while keeping the list available for PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e553e36e2a35442ca6521b394dafd9e3ec5b7367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->