### PR TITLE
feat(perps): add discovery CTA to the spot asset page

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7472,6 +7472,14 @@
   "perpsDisclaimer": {
     "message": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Powered by Hyperliquid. Price chart powered by TradingView."
   },
+  "perpsDiscoveryBannerSubtitle": {
+    "message": "Multiply your P&L up to $1",
+    "description": "$1 is the maximum leverage available for the matching Perps market, for example '40x'."
+  },
+  "perpsDiscoveryBannerTitle": {
+    "message": "Trade $1 perps",
+    "description": "$1 is the spot asset symbol, for example 'ETH'."
+  },
   "perpsEmptyDescription": {
     "message": "Trade perpetuals with leverage. Open your first position to get started."
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7472,6 +7472,14 @@
   "perpsDisclaimer": {
     "message": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Powered by Hyperliquid. Price chart powered by TradingView."
   },
+  "perpsDiscoveryBannerSubtitle": {
+    "message": "Multiply your P&L up to $1",
+    "description": "$1 is the maximum leverage available for the matching Perps market, for example '40x'."
+  },
+  "perpsDiscoveryBannerTitle": {
+    "message": "Trade $1 perps",
+    "description": "$1 is the spot asset symbol, for example 'ETH'."
+  },
   "perpsEmptyDescription": {
     "message": "Trade perpetuals with leverage. Open your first position to get started."
   },

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -568,6 +568,59 @@ describe('AssetPage', () => {
     expect(swapButton).not.toBeDisabled();
   });
 
+  it('renders the Perps discovery banner below the token action buttons', () => {
+    const { getByTestId } = renderWithProvider(
+      <AssetPage
+        asset={{
+          ...token,
+          symbol: 'ETH',
+          aggregators: ['metamask', 'coinGecko'],
+        }}
+        optionsButton={null}
+      />,
+      configureMockStore([thunk])({
+        ...mockStore,
+        metamask: {
+          ...mockStore.metamask,
+          activeProvider: 'hyperliquid',
+          isTestnet: false,
+          cachedMarketDataByProvider: {
+            'hyperliquid:mainnet': {
+              data: [
+                {
+                  symbol: 'ETH',
+                  name: 'Ethereum',
+                  maxLeverage: '40x',
+                  price: '$4,000',
+                  change24h: '$100',
+                  change24hPercent: '2.5%',
+                  volume: '$1B',
+                },
+              ],
+              timestamp: 0,
+            },
+          },
+          cachedUserDataByProvider: {
+            'hyperliquid:mainnet': {
+              positions: [],
+              orders: [],
+              accountState: null,
+              timestamp: 0,
+              address: selectedAccountAddress,
+            },
+          },
+        },
+      }),
+    );
+
+    const swapButton = getByTestId('token-overview-swap');
+    const banner = getByTestId('perps-discovery-banner');
+
+    expect(swapButton.compareDocumentPosition(banner)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
   it('should render the network name', async () => {
     const mockedStore = configureMockStore([thunk])(mockStore);
 

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -107,6 +107,7 @@ import { AssetActivateCard } from './asset-activation-card';
 import { SpendableBalanceSection } from './spendable-balance-section';
 import { TronDailyResources } from './tron-daily-resources';
 import { MusdPositionSection } from './musd-position-section';
+import { PerpsDiscoveryBanner } from './perps-discovery-banner';
 import {
   AssetPageSecurityTrustBanner,
   AssetPageSecurityTrustHeaderBadge,
@@ -481,6 +482,7 @@ const AssetPage = ({
               isMarketClosed={isMarketClosed}
             />
           ) : null}
+          <PerpsDiscoveryBanner asset={updatedAsset} />
           {isMarketClosed && tokenAsset ? (
             <Box marginTop={4}>
               <MarketClosedActionButton onClick={handleOpenMarketClosedModal} />

--- a/ui/pages/asset/components/perps-discovery-banner.test.tsx
+++ b/ui/pages/asset/components/perps-discovery-banner.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { fireEvent } from '@testing-library/react';
+import { AssetType } from '../../../../shared/constants/transaction';
+import { PERPS_MARKET_DETAIL_ROUTE } from '../../../helpers/constants/routes';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import type { Asset } from '../types/asset';
+import { PerpsDiscoveryBanner } from './perps-discovery-banner';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const market = {
+  symbol: 'ETH',
+  name: 'Ethereum',
+  maxLeverage: '40x',
+  price: '$4,000',
+  change24h: '$100',
+  change24hPercent: '2.5%',
+  volume: '$1B',
+};
+
+const token: Asset = {
+  type: AssetType.token,
+  chainId: '0x1',
+  address: '0x1234567890123456789012345678901234567890',
+  symbol: 'ETH',
+  decimals: 18,
+  image: '',
+  aggregators: ['metamask', 'coinGecko'],
+};
+
+function getStore({
+  useExternalServices = true,
+  markets = [market],
+  positions = [],
+}: {
+  useExternalServices?: boolean;
+  markets?: (typeof market)[];
+  positions?: { symbol: string }[];
+} = {}) {
+  return configureMockStore()({
+    metamask: {
+      useExternalServices,
+      activeProvider: 'hyperliquid',
+      isTestnet: false,
+      cachedMarketDataByProvider: {
+        'hyperliquid:mainnet': {
+          data: markets,
+          timestamp: 0,
+        },
+      },
+      cachedUserDataByProvider: {
+        'hyperliquid:mainnet': {
+          positions,
+          orders: [],
+          accountState: null,
+          timestamp: 0,
+          address: '0x123',
+        },
+      },
+    },
+  });
+}
+
+describe('PerpsDiscoveryBanner', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders for a trustworthy asset with a matching Perps market', () => {
+    const { getByTestId, getByText } = renderWithProvider(
+      <PerpsDiscoveryBanner asset={token} />,
+      getStore(),
+    );
+
+    expect(getByTestId('perps-discovery-banner')).toBeInTheDocument();
+    expect(getByText('Trade ETH perps')).toBeInTheDocument();
+    expect(getByText('Multiply your P&L up to 40x')).toBeInTheDocument();
+    expect(getByTestId('perps-discovery-banner')).toHaveAttribute(
+      'aria-label',
+      'Trade ETH perps Multiply your P&L up to 40x',
+    );
+  });
+
+  it('does not render without a matching Perps market', () => {
+    const { queryByTestId } = renderWithProvider(
+      <PerpsDiscoveryBanner asset={token} />,
+      getStore({ markets: [] }),
+    );
+
+    expect(queryByTestId('perps-discovery-banner')).not.toBeInTheDocument();
+  });
+
+  it('does not render when Basic Functionality is off', () => {
+    const { queryByTestId } = renderWithProvider(
+      <PerpsDiscoveryBanner asset={token} />,
+      getStore({ useExternalServices: false }),
+    );
+
+    expect(queryByTestId('perps-discovery-banner')).not.toBeInTheDocument();
+  });
+
+  it('does not render when the user holds a position in the market', () => {
+    const { queryByTestId } = renderWithProvider(
+      <PerpsDiscoveryBanner asset={token} />,
+      getStore({ positions: [{ symbol: 'ETH' }] }),
+    );
+
+    expect(queryByTestId('perps-discovery-banner')).not.toBeInTheDocument();
+  });
+
+  it('does not render for an untrusted token', () => {
+    const { queryByTestId } = renderWithProvider(
+      <PerpsDiscoveryBanner asset={{ ...token, aggregators: [] }} />,
+      getStore(),
+    );
+
+    expect(queryByTestId('perps-discovery-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders for a native asset without token aggregators', () => {
+    const { getByTestId } = renderWithProvider(
+      <PerpsDiscoveryBanner
+        asset={{
+          type: AssetType.native,
+          chainId: '0x1',
+          symbol: 'ETH',
+          decimals: 18,
+          image: '',
+          isOriginalNativeSymbol: true,
+        }}
+      />,
+      getStore(),
+    );
+
+    expect(getByTestId('perps-discovery-banner')).toBeInTheDocument();
+  });
+
+  it('opens the matching Perps detail page', () => {
+    const { getByTestId } = renderWithProvider(
+      <PerpsDiscoveryBanner asset={token} />,
+      getStore(),
+    );
+
+    fireEvent.click(getByTestId('perps-discovery-banner'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `${PERPS_MARKET_DETAIL_ROUTE}/ETH`,
+    );
+  });
+});

--- a/ui/pages/asset/components/perps-discovery-banner.tsx
+++ b/ui/pages/asset/components/perps-discovery-banner.tsx
@@ -1,0 +1,110 @@
+import React, { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  ButtonBase,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { PERPS_MARKET_DETAIL_ROUTE } from '../../../helpers/constants/routes';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { getUseExternalServices } from '../../../selectors';
+import {
+  type PerpsState,
+  selectPerpsMarketForAsset,
+  selectPerpsPositionForMarket,
+} from '../../../selectors/perps-controller';
+import { AssetType } from '../../../../shared/constants/transaction';
+import type { Asset } from '../types/asset';
+
+const PERPS_MIN_AGGREGATORS_FOR_TRUST = 2;
+
+type PerpsDiscoveryBannerProps = {
+  asset: Asset;
+};
+
+/**
+ * Promotes the Perps market matching a trustworthy spot asset.
+ *
+ * @param options0 - Component props.
+ * @param options0.asset - Spot asset shown on the asset page.
+ * @returns The discovery banner when the asset is eligible, otherwise null.
+ */
+export const PerpsDiscoveryBanner = ({ asset }: PerpsDiscoveryBannerProps) => {
+  const t = useI18nContext();
+  const navigate = useNavigate();
+  const isBasicFunctionalityEnabled = useSelector(getUseExternalServices);
+  const selectMarket = useMemo(
+    () => (state: PerpsState) => selectPerpsMarketForAsset(state, asset.symbol),
+    [asset.symbol],
+  );
+  const market = useSelector(selectMarket);
+  const selectPosition = useMemo(
+    () => (state: PerpsState) =>
+      market ? selectPerpsPositionForMarket(state, market.symbol) : null,
+    [market],
+  );
+  const position = useSelector(selectPosition);
+  const isTrustworthy =
+    asset.type === AssetType.native ||
+    (asset.aggregators?.length ?? 0) >= PERPS_MIN_AGGREGATORS_FOR_TRUST;
+
+  const handleClick = useCallback(() => {
+    if (!market) {
+      return;
+    }
+    navigate(
+      `${PERPS_MARKET_DETAIL_ROUTE}/${encodeURIComponent(market.symbol)}`,
+    );
+  }, [market, navigate]);
+
+  if (!isBasicFunctionalityEnabled || !market || position || !isTrustworthy) {
+    return null;
+  }
+
+  const title = t('perpsDiscoveryBannerTitle', [asset.symbol]);
+  const subtitle = t('perpsDiscoveryBannerSubtitle', [market.maxLeverage]);
+
+  return (
+    <ButtonBase
+      isFullWidth
+      className="mt-2 h-auto justify-start rounded-lg bg-muted px-4 py-4 text-left hover:bg-muted-hover active:bg-muted-pressed"
+      onClick={handleClick}
+      aria-label={`${title} ${subtitle}`}
+      data-testid="perps-discovery-banner"
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={3}
+      >
+        <Box
+          backgroundColor={BoxBackgroundColor.BackgroundDefault}
+          className="rounded-full"
+          padding={2}
+        >
+          <Icon
+            name={IconName.TrendUp}
+            size={IconSize.Md}
+            color={IconColor.IconAlternative}
+          />
+        </Box>
+        <Box flexDirection={BoxFlexDirection.Column} className="min-w-0">
+          <Text variant={TextVariant.BodyMd}>{title}</Text>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {subtitle}
+          </Text>
+        </Box>
+      </Box>
+    </ButtonBase>
+  );
+};

--- a/ui/selectors/perps-controller.test.ts
+++ b/ui/selectors/perps-controller.test.ts
@@ -26,6 +26,8 @@ import {
   selectPerpsCachedPositions,
   selectPerpsCachedOrders,
   selectPerpsCachedAccountState,
+  selectPerpsMarketForAsset,
+  selectPerpsPositionForMarket,
   selectPerpsPerpsBalances,
   selectPerpsMarketFilterPreferences,
   selectPerpsShouldShowDepositToast,
@@ -604,7 +606,7 @@ describe('perps-controller selectors', () => {
           buildState({
             activeProvider: 'hyperliquid',
             cachedMarketDataByProvider: {
-              hyperliquid: { data, timestamp: 0 },
+              'hyperliquid:mainnet': { data, timestamp: 0 },
             },
           }),
         ),
@@ -637,7 +639,7 @@ describe('perps-controller selectors', () => {
           buildState({
             activeProvider: 'hyperliquid',
             cachedUserDataByProvider: {
-              hyperliquid: {
+              'hyperliquid:mainnet': {
                 positions,
                 orders: [],
                 accountState: null,
@@ -682,7 +684,7 @@ describe('perps-controller selectors', () => {
           buildState({
             activeProvider: 'hyperliquid',
             cachedUserDataByProvider: {
-              hyperliquid: {
+              'hyperliquid:mainnet': {
                 positions: [],
                 orders,
                 accountState: null,
@@ -727,7 +729,7 @@ describe('perps-controller selectors', () => {
           buildState({
             activeProvider: 'hyperliquid',
             cachedUserDataByProvider: {
-              hyperliquid: {
+              'hyperliquid:mainnet': {
                 positions: [],
                 orders: [],
                 accountState: account,
@@ -761,6 +763,73 @@ describe('perps-controller selectors', () => {
 
     it('defaults to null', () => {
       expect(selectPerpsCachedAccountState(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectPerpsMarketForAsset', () => {
+    it('returns the market matching the asset symbol', () => {
+      const market = {
+        symbol: 'ETH',
+        name: 'Ethereum',
+        maxLeverage: '40x',
+        price: '$4,000',
+        change24h: '$100',
+        change24hPercent: '2.5%',
+        volume: '$1B',
+      };
+      const state = buildState({
+        cachedMarketDataByProvider: {
+          'hyperliquid:mainnet': { data: [market], timestamp: 0 },
+        },
+      });
+
+      expect(selectPerpsMarketForAsset(state, 'eth')).toBe(market);
+    });
+
+    it('matches a HIP-3 market by its display symbol', () => {
+      const market = {
+        symbol: 'xyz:TSLA',
+        name: 'Tesla',
+        maxLeverage: '10x',
+        price: '$300',
+        change24h: '$5',
+        change24hPercent: '1.7%',
+        volume: '$10M',
+      };
+      const state = buildState({
+        cachedMarketDataByProvider: {
+          'hyperliquid:mainnet': { data: [market], timestamp: 0 },
+        },
+      });
+
+      expect(selectPerpsMarketForAsset(state, 'TSLA')).toBe(market);
+    });
+
+    it('returns null when no market matches the asset symbol', () => {
+      expect(selectPerpsMarketForAsset(buildState(), 'ETH')).toBeNull();
+    });
+  });
+
+  describe('selectPerpsPositionForMarket', () => {
+    it('returns the position matching the raw market symbol', () => {
+      const position = { symbol: 'xyz:TSLA' };
+      const state = buildState({
+        cachedUserDataByProvider: {
+          'hyperliquid:mainnet': {
+            positions: [position],
+            orders: [],
+            accountState: null,
+            timestamp: 0,
+            address: '0x123',
+          },
+        },
+      });
+
+      expect(selectPerpsPositionForMarket(state, 'XYZ:tsla')).toBe(position);
+    });
+
+    it('returns null when no position matches the market', () => {
+      expect(selectPerpsPositionForMarket(buildState(), 'ETH')).toBeNull();
     });
   });
 

--- a/ui/selectors/perps-controller.ts
+++ b/ui/selectors/perps-controller.ts
@@ -7,7 +7,10 @@ import {
 import {
   type PerpsControllerState,
   DEFAULT_PRO_LAYOUT_PREFERENCES,
+  getPerpsDisplaySymbol,
+  type PerpsMarketData,
   type ProLayoutPreferences,
+  type Position,
 } from '@metamask/perps-controller';
 
 /**
@@ -185,25 +188,89 @@ export const selectPerpsLastError = (state: PerpsState) =>
 export const selectPerpsSelectedPaymentToken = (state: PerpsState) =>
   state.metamask.selectedPaymentToken ?? null;
 
-export const selectPerpsCachedMarketData = (state: PerpsState) => {
+const selectPerpsCacheKey = (state: PerpsState) => {
   const provider = selectPerpsActiveProvider(state);
-  return state.metamask.cachedMarketDataByProvider?.[provider]?.data ?? null;
+  const network = selectPerpsIsTestnet(state) ? 'testnet' : 'mainnet';
+  return `${provider}:${network}`;
+};
+
+export const selectPerpsCachedMarketData = (state: PerpsState) => {
+  const cacheKey = selectPerpsCacheKey(state);
+  const provider = selectPerpsActiveProvider(state);
+  return (
+    state.metamask.cachedMarketDataByProvider?.[cacheKey]?.data ??
+    state.metamask.cachedMarketDataByProvider?.[provider]?.data ??
+    null
+  );
 };
 
 export const selectPerpsCachedPositions = (state: PerpsState) => {
+  const cacheKey = selectPerpsCacheKey(state);
   const provider = selectPerpsActiveProvider(state);
-  return state.metamask.cachedUserDataByProvider?.[provider]?.positions ?? null;
+  return (
+    state.metamask.cachedUserDataByProvider?.[cacheKey]?.positions ??
+    state.metamask.cachedUserDataByProvider?.[provider]?.positions ??
+    null
+  );
 };
 
 export const selectPerpsCachedOrders = (state: PerpsState) => {
+  const cacheKey = selectPerpsCacheKey(state);
   const provider = selectPerpsActiveProvider(state);
-  return state.metamask.cachedUserDataByProvider?.[provider]?.orders ?? null;
+  return (
+    state.metamask.cachedUserDataByProvider?.[cacheKey]?.orders ??
+    state.metamask.cachedUserDataByProvider?.[provider]?.orders ??
+    null
+  );
 };
 
 export const selectPerpsCachedAccountState = (state: PerpsState) => {
+  const cacheKey = selectPerpsCacheKey(state);
   const provider = selectPerpsActiveProvider(state);
   return (
-    state.metamask.cachedUserDataByProvider?.[provider]?.accountState ?? null
+    state.metamask.cachedUserDataByProvider?.[cacheKey]?.accountState ??
+    state.metamask.cachedUserDataByProvider?.[provider]?.accountState ??
+    null
+  );
+};
+
+/**
+ * Finds a Perps market matching a spot asset symbol.
+ *
+ * @param state - Perps controller state.
+ * @param assetSymbol - Spot asset symbol.
+ * @returns The matching market, or null when none is cached.
+ */
+export const selectPerpsMarketForAsset = (
+  state: PerpsState,
+  assetSymbol: string,
+): PerpsMarketData | null => {
+  const normalizedAssetSymbol = assetSymbol.toUpperCase();
+  return (
+    selectPerpsCachedMarketData(state)?.find(
+      (market) =>
+        getPerpsDisplaySymbol(market.symbol).toUpperCase() ===
+        normalizedAssetSymbol,
+    ) ?? null
+  );
+};
+
+/**
+ * Finds an open position for a Perps market.
+ *
+ * @param state - Perps controller state.
+ * @param marketSymbol - Raw Perps market symbol.
+ * @returns The matching position, or null when none is cached.
+ */
+export const selectPerpsPositionForMarket = (
+  state: PerpsState,
+  marketSymbol: string,
+): Position | null => {
+  const normalizedMarketSymbol = marketSymbol.toUpperCase();
+  return (
+    selectPerpsCachedPositions(state)?.find(
+      (position) => position.symbol.toUpperCase() === normalizedMarketSymbol,
+    ) ?? null
   );
 };
 


### PR DESCRIPTION
## **Description**

The Extension spot asset page had no Perps entry point. Mobile's lower-prominence discovery banner converts well (about 2.1x the traffic of full long/short buttons at a comparable rate), so this ports that banner only.

When a spot asset has a matching Perps market, Basic Functionality is on, the token is trustworthy (native or listed on at least two aggregators), and the user has no open position in that market, the page now shows a banner under the Buy/Send/Swap row. Tapping it opens that market's Perps detail page.

Market/position lookup uses cached Perps controller state (`provider:network` keys, with a provider-only fallback). Long/short action buttons and Mobile's existing-position card are out of scope.

Jira: [TAT-3849](https://consensyssoftware.atlassian.net/browse/TAT-3849)

## **Changelog**

CHANGELOG entry: Added a Perps discovery banner on the spot asset page that opens the matching Perps market

## **Related issues**

Fixes: [TAT-3849](https://consensyssoftware.atlassian.net/browse/TAT-3849)

## **Manual testing steps**

Feature: Perps discovery banner on the spot asset page

Scenario: Matching Perps market with no open position
Given Basic Functionality is on
And a spot asset whose symbol matches a cached Perps market (for example ETH)
And the asset is native or listed on at least two aggregators
And the user has no open position in that market
When I open that asset's token details page
Then a discovery banner appears below the Buy/Send/Swap buttons
And the banner title is "Trade {symbol} perps"
When I tap the banner
Then I land on that market's Perps detail page

Scenario: No matching market or Basic Functionality off
Given no cached Perps market matches the asset
Or Basic Functionality is off
When I open the spot asset page
Then the discovery banner is not shown

Scenario: Existing position
Given the user already holds a position in the matching Perps market
When I open the spot asset page
Then the discovery banner is not shown
And no extra position card is shown

## **Screenshots/Recordings**

### **Before**

No Perps CTA on the spot asset page.

### **After**

Please attach a screenshot of the asset page with the discovery banner under the token action buttons, and one of navigation to Perps market details after tap.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-3849]: https://consensyssoftware.atlassian.net/browse/TAT-3849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TAT-3849]: https://consensyssoftware.atlassian.net/browse/TAT-3849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ