### PR TITLE
feat: add mm_pay_entry_point property to transactions coming from hyperliquid prompt

### DIFF
--- a/app/scripts/lib/transaction/metrics-builders/metamask-pay.test.ts
+++ b/app/scripts/lib/transaction/metrics-builders/metamask-pay.test.ts
@@ -177,6 +177,59 @@ describe('getMetaMaskPayProperties', () => {
     });
   });
 
+  describe('mm_pay_entry_point', () => {
+    it('includes entry point from UI metrics fragment', async () => {
+      const base = createPayRequest();
+      const request = createBuilderRequest({
+        transactionMeta: base.transactionMeta,
+        transactionMetricsRequest: {
+          ...base.transactionMetricsRequest,
+          getTransactionUIMetricsFragment: jest.fn().mockReturnValue({
+            properties: { mm_pay_entry_point: 'hyperliquid_deposit_prompt' },
+          }),
+        },
+      });
+
+      const result = await getMetaMaskPayProperties(request);
+
+      expect(result.properties.mm_pay_entry_point).toBe(
+        'hyperliquid_deposit_prompt',
+      );
+    });
+
+    it('does not include entry point when fragment has no entry point', async () => {
+      const base = createPayRequest();
+      const request = createBuilderRequest({
+        transactionMeta: base.transactionMeta,
+        transactionMetricsRequest: {
+          ...base.transactionMetricsRequest,
+          getTransactionUIMetricsFragment: jest.fn().mockReturnValue({
+            properties: {},
+          }),
+        },
+      });
+
+      const result = await getMetaMaskPayProperties(request);
+
+      expect(result.properties.mm_pay_entry_point).toBeUndefined();
+    });
+
+    it('does not include entry point when no fragment exists', async () => {
+      const base = createPayRequest();
+      const request = createBuilderRequest({
+        transactionMeta: base.transactionMeta,
+        transactionMetricsRequest: {
+          ...base.transactionMetricsRequest,
+          getTransactionUIMetricsFragment: jest.fn().mockReturnValue(undefined),
+        },
+      });
+
+      const result = await getMetaMaskPayProperties(request);
+
+      expect(result.properties.mm_pay_entry_point).toBeUndefined();
+    });
+  });
+
   describe('mm_pay_amount_input_type', () => {
     function createMusdRequest({
       flags = {},

--- a/app/scripts/lib/transaction/metrics-builders/metamask-pay.ts
+++ b/app/scripts/lib/transaction/metrics-builders/metamask-pay.ts
@@ -176,6 +176,10 @@ function addPayTypeProperties(
       transactionId,
     )?.properties;
 
+  if (fragmentProperties?.mm_pay_entry_point !== undefined) {
+    properties.mm_pay_entry_point = fragmentProperties.mm_pay_entry_point;
+  }
+
   const prefilledAmount = fragmentProperties?.mm_pay_prefilled_amount;
 
   if (prefilledAmount !== undefined) {

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
@@ -33,6 +33,11 @@ jest.mock('../perps/hooks/usePerpsDepositConfirmation', () => ({
 
 jest.mock('../../../store/controller-actions/transaction-pay-controller');
 
+jest.mock('../../../store/actions', () => ({
+  ...jest.requireActual('../../../store/actions'),
+  upsertTransactionUIMetricsFragment: jest.fn(),
+}));
+
 const mockUsePerpsHomeRoute = jest.fn(() => PERPS_HOME_PAGE_ROUTE);
 jest.mock('../../../hooks/perps/usePerpsHomeRoute', () => ({
   ...jest.requireActual('../../../hooks/perps/usePerpsHomeRoute'),

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
@@ -30,6 +30,7 @@ import { CONFIRM_TRANSACTION_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../hooks/useFiatFormatter';
 import { updateTransactionPaymentToken } from '../../../store/controller-actions/transaction-pay-controller';
+import { upsertTransactionUIMetricsFragment } from '../../../store/actions';
 import { TokenIcon } from '../../../pages/confirmations/components/token-icon/token-icon';
 import { useSendTokens } from '../../../pages/confirmations/hooks/send/useSendTokens';
 import { ConfirmationLoader } from '../../../pages/confirmations/hooks/useConfirmationNavigation';
@@ -217,6 +218,13 @@ export const HyperliquidDepositPrompt: React.FC<
     }
 
     const { transactionId } = result;
+
+    upsertTransactionUIMetricsFragment(transactionId, {
+      properties: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        mm_pay_entry_point: 'hyperliquid_deposit_prompt',
+      },
+    });
 
     if (displayToken?.address && displayToken.chainId) {
       try {


### PR DESCRIPTION
## **Description**

Adds `mm_pay_entry_point` to MM Pay transaction metrics to distinguish deposits initiated from the Hyperliquid deposit prompt vs other entry points.

When a user initiates a perps deposit from the Hyperliquid prompt, we tag the transaction's UI metrics fragment with `mm_pay_entry_point: 'hyperliquid_deposit_prompt'`. The metrics builder reads this and includes it in Transaction Added/Submitted/Finalized/Rejected events.

This is a property that already exists on mobile and is in the segment schema already.

## **Changelog**

CHANGELOG entry: null

## **Related issues**



## **Manual testing steps**

1. Feature flag `extensionUxHyperliquidDepositPrompt` is already true in dev
2. Ensure wallet has:
No existing Hyperliquid perps balance
Less than $10 USDC on Arbitrum
Some other token balance (ETH, USDC on other chains, etc.)
6. Go to app.hyperliquid.xyz
7. Click "Enable Trading" and sign the transaction in MetaMask
8. After signing, view "Fund Hyperliquid with MetaMask" prompt and choose a token and continue
9. Verify you're navigated to the Perps deposit confirmation and choose a value and submit
10. Verify transaction metrics include `mm_pay_entry_point: 'hyperliquid_deposit_prompt'`

## **Screenshots/Recordings**

### **Before**

### **After**


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or parties involved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only tagging on an existing deposit path; no changes to signing, payment selection, or transaction submission logic beyond recording a metrics property.
> 
> **Overview**
> Adds **`mm_pay_entry_point`** to MM Pay transaction analytics so deposits started from the Hyperliquid “Fund with MetaMask” prompt can be distinguished from other flows.
> 
> When a user continues from **`HyperliquidDepositPrompt`**, the UI writes `mm_pay_entry_point: 'hyperliquid_deposit_prompt'` on the transaction’s UI metrics fragment via **`upsertTransactionUIMetricsFragment`**. The MetaMask Pay metrics builder copies that value from the parent confirmation fragment onto emitted transaction events (alongside existing prefill fields), and only sets it when the fragment defines it.
> 
> Unit tests cover the metrics builder behavior (present, empty fragment, no fragment) and the prompt test suite mocks the new action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8905b7bca79193af22841294b9691d3397fce7c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->