### PR TITLE
fix(websocket): prefer manifest flag over remote flag for backendWebSocketConnection

### DIFF
--- a/app/scripts/messenger-client-init/core-backend/backend-websocket-service-init.test.ts
+++ b/app/scripts/messenger-client-init/core-backend/backend-websocket-service-init.test.ts
@@ -5,6 +5,7 @@ import {
   MockAnyNamespace,
   MOCK_ANY_NAMESPACE,
 } from '@metamask/messenger';
+import { Json } from '@metamask/utils';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import {
@@ -13,16 +14,50 @@ import {
   getBackendWebSocketServiceMessenger,
   getBackendWebSocketServiceInitMessenger,
 } from '../messengers/core-backend';
+import * as manifestFlagsModule from '../../../../shared/lib/manifestFlags';
 import { BackendWebSocketServiceInit } from './backend-websocket-service-init';
 
 jest.mock('@metamask/core-backend');
 
-function getInitRequestMock(): jest.Mocked<
+type InitRequestMock = jest.Mocked<
   MessengerClientInitRequest<
     BackendWebSocketServiceMessenger,
     BackendWebSocketServiceInitMessenger
   >
-> {
+>;
+
+/**
+ * Build a `remoteFeatureFlags` object holding the given raw
+ * `backendWebSocketConnection` value, or an empty one when omitted.
+ *
+ * @param flag - The raw flag value.
+ * @returns The `remoteFeatureFlags` object.
+ */
+function remoteFeatureFlagsFor(flag?: Json): Record<string, Json> {
+  return flag === undefined ? {} : { backendWebSocketConnection: flag };
+}
+
+/**
+ * Mock the manifest flags read by the `isEnabled` callback.
+ *
+ * @param flag - The raw manifest `backendWebSocketConnection` value, or
+ * `undefined` to expose no manifest override.
+ */
+function mockManifestFlags(flag?: Json) {
+  jest
+    .spyOn(manifestFlagsModule, 'getManifestFlags')
+    .mockReturnValue({ remoteFeatureFlags: remoteFeatureFlagsFor(flag) });
+}
+
+/**
+ * Build an init request whose `RemoteFeatureFlagController:getState` action is
+ * handled by the given function.
+ *
+ * @param getState - Handler for the `RemoteFeatureFlagController:getState`
+ * action.
+ * @returns The init request mock.
+ */
+function getInitRequestMockWithState(getState: () => unknown): InitRequestMock {
   const baseMessenger = new Messenger<
     MockAnyNamespace,
     ActionConstraint,
@@ -31,31 +66,48 @@ function getInitRequestMock(): jest.Mocked<
     namespace: MOCK_ANY_NAMESPACE,
   });
 
-  // Mock RemoteFeatureFlagController:getState
   baseMessenger.registerActionHandler(
     'RemoteFeatureFlagController:getState',
-    () =>
-      ({
-        remoteFeatureFlags: {
-          backendWebSocketConnection: {
-            value: false,
-          },
-        },
-      }) as never,
+    getState as never,
   );
 
-  const requestMock = {
+  return {
     ...buildControllerInitRequestMock(),
     controllerMessenger: getBackendWebSocketServiceMessenger(baseMessenger),
     initMessenger: getBackendWebSocketServiceInitMessenger(baseMessenger),
   };
+}
 
-  return requestMock;
+/**
+ * Build an init request whose remote `backendWebSocketConnection` flag holds
+ * the given raw value.
+ *
+ * @param flag - The raw flag value, or `undefined` to omit the flag.
+ * @returns The init request mock.
+ */
+function getInitRequestMockWithRemoteFlag(flag?: Json): InitRequestMock {
+  return getInitRequestMockWithState(() => ({
+    remoteFeatureFlags: remoteFeatureFlagsFor(flag),
+  }));
+}
+
+/**
+ * Build an init request whose remote `backendWebSocketConnection` flag is
+ * disabled.
+ *
+ * @returns The init request mock.
+ */
+function getInitRequestMock(): InitRequestMock {
+  return getInitRequestMockWithRemoteFlag({ value: false });
 }
 
 describe('BackendWebSocketServiceInit', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('initializes the controller', () => {
@@ -100,8 +152,92 @@ describe('BackendWebSocketServiceInit', () => {
   });
 
   describe('isEnabled callback', () => {
-    it('returns false when feature flag is disabled', () => {
-      BackendWebSocketServiceInit(getInitRequestMock());
+    type FlagCase = {
+      description: string;
+      manifestFlag?: Json;
+      remoteFlag?: Json;
+      expected: boolean;
+    };
+
+    // The manifest override wins whenever it is present; otherwise the remote
+    // flag decides. Both sources accept a bare boolean (as resolved from the
+    // remote config) or a `{ value }` object (as used by overrides and mocks).
+    const flagCases: FlagCase[] = [
+      {
+        description: 'the remote flag is an object set to false',
+        remoteFlag: { value: false },
+        expected: false,
+      },
+      {
+        description: 'the remote flag is an object set to true',
+        remoteFlag: { value: true },
+        expected: true,
+      },
+      {
+        description: 'the remote flag is a bare true',
+        remoteFlag: true,
+        expected: true,
+      },
+      {
+        description: 'the remote flag is a bare false',
+        remoteFlag: false,
+        expected: false,
+      },
+      {
+        description: 'the remote flag is an object without a value property',
+        remoteFlag: { enabled: true },
+        expected: false,
+      },
+      {
+        description: 'the remote flag is neither an object nor a boolean',
+        remoteFlag: 'enabled',
+        expected: false,
+      },
+      {
+        description: 'the remote flag is absent',
+        remoteFlag: undefined,
+        expected: false,
+      },
+      {
+        description: 'the manifest override enables a remotely disabled flag',
+        manifestFlag: { value: true },
+        remoteFlag: { value: false },
+        expected: true,
+      },
+      {
+        description: 'the manifest override disables a remotely enabled flag',
+        manifestFlag: { value: false },
+        remoteFlag: true,
+        expected: false,
+      },
+      {
+        description: 'the manifest override is a bare boolean',
+        manifestFlag: true,
+        remoteFlag: { value: false },
+        expected: true,
+      },
+    ];
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each(flagCases)(
+      'returns $expected when $description',
+      ({ manifestFlag, remoteFlag, expected }: FlagCase) => {
+        mockManifestFlags(manifestFlag);
+
+        BackendWebSocketServiceInit(
+          getInitRequestMockWithRemoteFlag(remoteFlag),
+        );
+
+        const { isEnabled } = jest.mocked(BackendWebSocketService).mock
+          .calls[0][0];
+
+        expect(isEnabled).toBeDefined();
+        expect(isEnabled?.()).toBe(expected);
+      },
+    );
+
+    it('returns false when remoteFeatureFlags is missing', () => {
+      BackendWebSocketServiceInit(getInitRequestMockWithState(() => ({})));
 
       const { isEnabled } = jest.mocked(BackendWebSocketService).mock
         .calls[0][0];
@@ -111,202 +247,14 @@ describe('BackendWebSocketServiceInit', () => {
     });
 
     it('returns false when feature flag check fails', () => {
-      const baseMessenger = new Messenger<
-        MockAnyNamespace,
-        ActionConstraint,
-        never
-      >({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
-      baseMessenger.registerActionHandler(
-        'RemoteFeatureFlagController:getState',
-        () => {
+      BackendWebSocketServiceInit(
+        getInitRequestMockWithState(() => {
           throw new Error('Feature flag error');
-        },
+        }),
       );
-
-      const requestMock = {
-        ...buildControllerInitRequestMock(),
-        controllerMessenger: getBackendWebSocketServiceMessenger(baseMessenger),
-        initMessenger: getBackendWebSocketServiceInitMessenger(baseMessenger),
-      };
-
-      BackendWebSocketServiceInit(requestMock);
 
       const { isEnabled } = jest.mocked(BackendWebSocketService).mock
         .calls[0][0];
-
-      expect(isEnabled).toBeDefined();
-      expect(isEnabled?.()).toBe(false);
-    });
-
-    it('returns true when feature flag is enabled', () => {
-      const baseMessenger = new Messenger<
-        MockAnyNamespace,
-        ActionConstraint,
-        never
-      >({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
-      baseMessenger.registerActionHandler(
-        'RemoteFeatureFlagController:getState',
-        () =>
-          ({
-            remoteFeatureFlags: {
-              backendWebSocketConnection: {
-                value: true,
-              },
-            },
-          }) as never,
-      );
-
-      const requestMock = {
-        ...buildControllerInitRequestMock(),
-        controllerMessenger: getBackendWebSocketServiceMessenger(baseMessenger),
-        initMessenger: getBackendWebSocketServiceInitMessenger(baseMessenger),
-      };
-
-      BackendWebSocketServiceInit(requestMock);
-
-      const constructorArgs = jest.mocked(BackendWebSocketService).mock
-        .calls[0][0];
-      const { isEnabled } = constructorArgs;
-
-      expect(isEnabled).toBeDefined();
-      expect(isEnabled?.()).toBe(true);
-    });
-
-    it('returns true when feature flag resolves to a bare boolean (threshold shape)', () => {
-      const baseMessenger = new Messenger<
-        MockAnyNamespace,
-        ActionConstraint,
-        never
-      >({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
-      baseMessenger.registerActionHandler(
-        'RemoteFeatureFlagController:getState',
-        () =>
-          ({
-            remoteFeatureFlags: {
-              backendWebSocketConnection: true,
-            },
-          }) as never,
-      );
-
-      const requestMock = {
-        ...buildControllerInitRequestMock(),
-        controllerMessenger: getBackendWebSocketServiceMessenger(baseMessenger),
-        initMessenger: getBackendWebSocketServiceInitMessenger(baseMessenger),
-      };
-
-      BackendWebSocketServiceInit(requestMock);
-
-      const { isEnabled } = jest.mocked(BackendWebSocketService).mock
-        .calls[0][0];
-
-      expect(isEnabled).toBeDefined();
-      expect(isEnabled?.()).toBe(true);
-    });
-
-    it('returns false when feature flag object does not have value property', () => {
-      const baseMessenger = new Messenger<
-        MockAnyNamespace,
-        ActionConstraint,
-        never
-      >({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
-      baseMessenger.registerActionHandler(
-        'RemoteFeatureFlagController:getState',
-        () =>
-          ({
-            remoteFeatureFlags: {
-              backendWebSocketConnection: {
-                // Missing 'value' property
-                enabled: true,
-              },
-            },
-          }) as never,
-      );
-
-      const requestMock = {
-        ...buildControllerInitRequestMock(),
-        controllerMessenger: getBackendWebSocketServiceMessenger(baseMessenger),
-        initMessenger: getBackendWebSocketServiceInitMessenger(baseMessenger),
-      };
-
-      BackendWebSocketServiceInit(requestMock);
-
-      const constructorArgs = jest.mocked(BackendWebSocketService).mock
-        .calls[0][0];
-      const { isEnabled } = constructorArgs;
-
-      expect(isEnabled).toBeDefined();
-      expect(isEnabled?.()).toBe(false);
-    });
-
-    it('returns false when feature flag is not an object', () => {
-      const baseMessenger = new Messenger<
-        MockAnyNamespace,
-        ActionConstraint,
-        never
-      >({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
-      baseMessenger.registerActionHandler(
-        'RemoteFeatureFlagController:getState',
-        () =>
-          ({
-            remoteFeatureFlags: {
-              backendWebSocketConnection: 'enabled', // Not an object
-            },
-          }) as never,
-      );
-
-      const requestMock = {
-        ...buildControllerInitRequestMock(),
-        controllerMessenger: getBackendWebSocketServiceMessenger(baseMessenger),
-        initMessenger: getBackendWebSocketServiceInitMessenger(baseMessenger),
-      };
-
-      BackendWebSocketServiceInit(requestMock);
-
-      const constructorArgs = jest.mocked(BackendWebSocketService).mock
-        .calls[0][0];
-      const { isEnabled } = constructorArgs;
-
-      expect(isEnabled).toBeDefined();
-      expect(isEnabled?.()).toBe(false);
-    });
-
-    it('returns false when remoteFeatureFlags is missing', () => {
-      const baseMessenger = new Messenger<
-        MockAnyNamespace,
-        ActionConstraint,
-        never
-      >({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
-      baseMessenger.registerActionHandler(
-        'RemoteFeatureFlagController:getState',
-        () =>
-          ({
-            // Missing remoteFeatureFlags
-          }) as never,
-      );
-
-      const requestMock = {
-        ...buildControllerInitRequestMock(),
-        controllerMessenger: getBackendWebSocketServiceMessenger(baseMessenger),
-        initMessenger: getBackendWebSocketServiceInitMessenger(baseMessenger),
-      };
-
-      BackendWebSocketServiceInit(requestMock);
-
-      const constructorArgs = jest.mocked(BackendWebSocketService).mock
-        .calls[0][0];
-      const { isEnabled } = constructorArgs;
 
       expect(isEnabled).toBeDefined();
       expect(isEnabled?.()).toBe(false);
@@ -315,31 +263,14 @@ describe('BackendWebSocketServiceInit', () => {
     it('logs warning when feature flag check fails', () => {
       const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      const baseMessenger = new Messenger<
-        MockAnyNamespace,
-        ActionConstraint,
-        never
-      >({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
-      baseMessenger.registerActionHandler(
-        'RemoteFeatureFlagController:getState',
-        () => {
+      BackendWebSocketServiceInit(
+        getInitRequestMockWithState(() => {
           throw new Error('Feature flag error');
-        },
+        }),
       );
 
-      const requestMock = {
-        ...buildControllerInitRequestMock(),
-        controllerMessenger: getBackendWebSocketServiceMessenger(baseMessenger),
-        initMessenger: getBackendWebSocketServiceInitMessenger(baseMessenger),
-      };
-
-      BackendWebSocketServiceInit(requestMock);
-
-      const constructorArgs = jest.mocked(BackendWebSocketService).mock
+      const { isEnabled } = jest.mocked(BackendWebSocketService).mock
         .calls[0][0];
-      const { isEnabled } = constructorArgs;
 
       expect(isEnabled).toBeDefined();
       isEnabled?.();

--- a/app/scripts/messenger-client-init/core-backend/backend-websocket-service-init.ts
+++ b/app/scripts/messenger-client-init/core-backend/backend-websocket-service-init.ts
@@ -1,10 +1,29 @@
 import { BackendWebSocketService } from '@metamask/core-backend';
+import { Json } from '@metamask/utils';
 import { MessengerClientInitFunction } from '../types';
 import {
   BackendWebSocketServiceMessenger,
   BackendWebSocketServiceInitMessenger,
 } from '../messengers/core-backend';
 import { trace } from '../../../../shared/lib/trace';
+import { getManifestFlags } from '../../../../shared/lib/manifestFlags';
+
+/**
+ * Resolve a raw feature flag value to a boolean. The value is a boolean when
+ * resolved from the remote config, or a `{ value }` object when provided by a
+ * flag override or test mock. Handle both so `{ value: false }` is not misread
+ * as truthy.
+ *
+ * @param flag - The raw feature flag value.
+ * @returns Whether the flag is enabled.
+ */
+function resolveFlag(flag: Json | undefined): boolean {
+  if (typeof flag === 'object' && flag !== null && 'value' in flag) {
+    return Boolean(flag.value);
+  }
+
+  return typeof flag === 'boolean' ? flag : false;
+}
 
 /**
  * Initialize the Backend Platform WebSocket service with authentication support.
@@ -39,26 +58,16 @@ export const BackendWebSocketServiceInit: MessengerClientInitFunction<
     // Service will check this callback before connecting/reconnecting
     isEnabled: () => {
       try {
-        const remoteFeatureFlagState = initMessenger?.call(
+        // Client manifest flag
+        const manifestFlag =
+          getManifestFlags().remoteFeatureFlags?.backendWebSocketConnection;
+
+        // Remote feature flag
+        const remoteFlag = initMessenger?.call(
           'RemoteFeatureFlagController:getState',
-        );
-        const { backendWebSocketConnection } =
-          remoteFeatureFlagState?.remoteFeatureFlags || {};
+        )?.remoteFeatureFlags?.backendWebSocketConnection;
 
-        // The value is a boolean when resolved from the remote config, or a
-        // `{ value }` object when provided by a flag override or test mock.
-        // Handle both so `{ value: false }` is not misread as truthy.
-        if (
-          typeof backendWebSocketConnection === 'object' &&
-          backendWebSocketConnection !== null &&
-          'value' in backendWebSocketConnection
-        ) {
-          return Boolean(backendWebSocketConnection.value);
-        }
-
-        return typeof backendWebSocketConnection === 'boolean'
-          ? backendWebSocketConnection
-          : false;
+        return resolveFlag(manifestFlag ?? remoteFlag);
       } catch (error) {
         // If feature flag check fails, default to NOT connecting for safer startup
         console.warn(

--- a/test/e2e/tests/account-activity/websocket-balance-resilience.spec.ts
+++ b/test/e2e/tests/account-activity/websocket-balance-resilience.spec.ts
@@ -125,25 +125,6 @@ async function mockChain1337(mockServer: Mockttp) {
   ];
 }
 
-async function mockDisabledWebsocketBalance(mockServer: Mockttp) {
-  return [
-    ...(await mockChain1337(mockServer)),
-    await mockServer
-      .forGet('https://client-config.api.cx.metamask.io/v1/flags')
-      .always()
-      .thenCallback(() => {
-        return {
-          statusCode: 200,
-          json: [
-            {
-              backendWebSocketConnection: false,
-            },
-          ],
-        };
-      }),
-  ];
-}
-
 describe('Account Activity WebSocket Balance Resilience', function (this: Suite) {
   describe('REST Polling Fallback', function () {
     it('balance updates continue via REST polling when WebSocket disconnects', async function () {
@@ -294,13 +275,12 @@ describe('Account Activity WebSocket Balance Resilience', function (this: Suite)
       {
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
-        // At the moment, setting this flag has no effect because of this issue #42049, so we need to mock the request
         manifestFlags: {
           remoteFeatureFlags: {
             backendWebSocketConnection: { value: false },
           },
         },
-        testSpecificMock: mockDisabledWebsocketBalance,
+        testSpecificMock: mockChain1337,
       },
       async ({
         driver,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Request from https://github.com/MetaMask/metamask-extension/issues/42049
We are using the client manifest to control the WS enablement (useful for E2E testing, esp once the remote feature flag is cleaned up/removed)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #42049 https://consensyssoftware.atlassian.net/browse/ASSETS-3958

## **Manual testing steps**

1. Add a manifest override in `.manifest-overrides.json` and point `MANIFEST_OVERRIDES` at it in `.metamaskrc`:
   ```json
   { "_flags": { "remoteFeatureFlags": { "backendWebSocketConnection": { "value": false } } } }
   ```
2. Run `yarn build:test` and load `dist/chrome` as an unpacked extension.
3. Unlock the wallet and open the background service worker devtools; in the Network tab, confirm no WebSocket connection to `gateway.api.cx.metamask.io` is opened.
4. Flip the override to `{ "value": true }`, rebuild, reload the extension, and confirm the WebSocket connection is established again.
5. With no manifest override present, confirm behaviour is unchanged and follows the remote flag.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6849eda7-52a5-45a9-a2f0-491daf9fbc21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6849eda7-52a5-45a9-a2f0-491daf9fbc21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

