### PR TITLE
feat(manifest): allow metamask.com to message v2 Chrome extension

### DIFF
--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -4,7 +4,7 @@
     "value": "same-origin-allow-popups"
   },
   "externally_connectable": {
-    "matches": ["https://metamask.io/*"],
+    "matches": ["https://metamask.io/*", "https://metamask.com/*"],
     "ids": ["*"]
   },
   "minimum_chrome_version": "123"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds `https://metamask.com/*` to `externally_connectable.matches` in the v2 Chrome manifest so MetaMask web properties that move from `metamask.io` to `metamask.com` can keep messaging the extension via `chrome.runtime.sendMessage()`.

Keeps `https://metamask.io/*` during the transition window. No change to the v3 Chrome manifest (already uses wildcards) or Firefox manifests (AMO addon id must remain unchanged).

**Likely no user-facing impact today:** Chrome ships as MV3 (`app/manifest/v3/chrome.json`, which already allows `https://*/*`), and MV2 builds target Firefox (`yarn start:mv2` / `yarn dist:mv2` use `--browser firefox` and `app/manifest/v2/firefox.json`, which does not use this `externally_connectable` list). So this change updates a Chrome MV2 overlay that current production build paths do not appear to consume. Leaving it in place for ticket completeness and in case that overlay is used later, but this PR is probably a no-op for shipped Chrome and Firefox users.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [DUS-15689](https://consensyssoftware.atlassian.net/browse/DUS-15689)

## **Manual testing steps**

1. Confirm the diff only updates `app/manifest/v2/chrome.json`.
2. Confirm Chrome MV3 already allows external connection from any HTTPS origin in `app/manifest/v3/chrome.json`.
3. Confirm MV2 build commands target Firefox and do not merge this Chrome MV2 overlay into the Firefox artifact.
4. Optionally, if a Chrome MV2 build path is ever used, load that build and verify `chrome.runtime.sendMessage()` works from both `https://metamask.io` and `https://metamask.com`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[DUS-15689]: https://consensyssoftware.atlassian.net/browse/DUS-15689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ