### PR TITLE
feat(money): show card spend and mUSD back activity from the accounts api

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5546,6 +5546,9 @@
   "moneyActivity": {
     "message": "Activity"
   },
+  "moneyActivityCard": {
+    "message": "Card"
+  },
   "moneyActivityConversionFailed": {
     "message": "Conversion failed"
   },
@@ -5579,11 +5582,20 @@
   "moneyActivityFilterSends": {
     "message": "Sends"
   },
+  "moneyActivityLoadError": {
+    "message": "Couldn't load your activity"
+  },
+  "moneyActivityMusdBack": {
+    "message": "mUSD back"
+  },
   "moneyActivityPending": {
     "message": "Pending"
   },
   "moneyActivityPlaceholderDescription": {
     "message": "Your Money activity will appear here."
+  },
+  "moneyActivityPurchase": {
+    "message": "Purchase"
   },
   "moneyActivityReceived": {
     "message": "Received"
@@ -5593,6 +5605,12 @@
   },
   "moneyActivityReceiving": {
     "message": "Receiving"
+  },
+  "moneyActivityRefund": {
+    "message": "Refund"
+  },
+  "moneyActivityRetry": {
+    "message": "Retry"
   },
   "moneyActivitySendFailed": {
     "message": "Send failed"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5546,6 +5546,9 @@
   "moneyActivity": {
     "message": "Activity"
   },
+  "moneyActivityCard": {
+    "message": "Card"
+  },
   "moneyActivityConversionFailed": {
     "message": "Conversion failed"
   },
@@ -5579,11 +5582,20 @@
   "moneyActivityFilterSends": {
     "message": "Sends"
   },
+  "moneyActivityLoadError": {
+    "message": "Couldn't load your activity"
+  },
+  "moneyActivityMusdBack": {
+    "message": "mUSD back"
+  },
   "moneyActivityPending": {
     "message": "Pending"
   },
   "moneyActivityPlaceholderDescription": {
     "message": "Your Money activity will appear here."
+  },
+  "moneyActivityPurchase": {
+    "message": "Purchase"
   },
   "moneyActivityReceived": {
     "message": "Received"
@@ -5593,6 +5605,12 @@
   },
   "moneyActivityReceiving": {
     "message": "Receiving"
+  },
+  "moneyActivityRefund": {
+    "message": "Refund"
+  },
+  "moneyActivityRetry": {
+    "message": "Retry"
   },
   "moneyActivitySendFailed": {
     "message": "Send failed"

--- a/ui/hooks/money/use-money-account-api-activity.integration.test.tsx
+++ b/ui/hooks/money/use-money-account-api-activity.integration.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { apiClient } from '../../helpers/api-client';
+import { selectMoneyActivityMockDataEnabled } from '../../selectors/money/money-account-feature-flags';
+import { parseAccountsApiActivity } from '../../pages/money/utils/accounts-api';
+import type { AccountsApiActivity } from '../../pages/money/types/money-activity';
+import { useMoneyAccountInfo } from './useMoneyAccountInfo';
+import { useMoneyAccountApiActivity } from './use-money-account-api-activity';
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: () => unknown) => selector(),
+}));
+
+jest.mock('../../helpers/api-client', () => ({
+  apiClient: {
+    accounts: {
+      getV1AccountTransactionsQueryOptions: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../selectors/money/money-account-feature-flags', () => ({
+  selectMoneyActivityMockDataEnabled: jest.fn(),
+}));
+
+jest.mock('./useMoneyAccountInfo', () => ({
+  useMoneyAccountInfo: jest.fn(),
+}));
+
+jest.mock('../../pages/money/utils/accounts-api', () => ({
+  ...jest.requireActual('../../pages/money/utils/accounts-api'),
+  parseAccountsApiActivity: jest.fn(),
+}));
+
+const mockGetQueryOptions = jest.mocked(
+  apiClient.accounts.getV1AccountTransactionsQueryOptions,
+);
+const mockParse = jest.mocked(parseAccountsApiActivity);
+const mockUseMoneyAccountInfo = jest.mocked(useMoneyAccountInfo);
+const mockSelectMoneyActivityMockDataEnabled = jest.mocked(
+  selectMoneyActivityMockDataEnabled,
+);
+
+const ADDR_A = '0xbF4bC559f929cE3994Ba12D71d564737357bC8C2';
+const QUERY_KEY = [
+  'accounts',
+  'transactions',
+  'v1Account',
+  { address: ADDR_A },
+];
+
+const CARD: AccountsApiActivity = {
+  kind: 'card',
+  hash: '0xabc',
+  time: 1,
+  chainId: '0x8f',
+  token: { address: '0xtoken', symbol: 'mUSD', decimals: 6 },
+  amount: '5381986',
+  paidTo: '0xdef',
+};
+
+const PAGE_MOCK = {
+  data: [{ hash: '0xabc', timestamp: '2026-06-04T00:00:00.000Z' }],
+  pageInfo: { count: 1, hasNextPage: false, cursor: '' },
+};
+
+describe('useMoneyAccountApiActivity first-page fetch', () => {
+  function createWrapper() {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return function wrapperElement({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelectMoneyActivityMockDataEnabled.mockReturnValue(false);
+    mockUseMoneyAccountInfo.mockReturnValue({
+      isMoneyAccountFeatureEnabled: true,
+      hasMoneyAccount: true,
+      primaryMoneyAccount: { address: ADDR_A },
+    });
+    mockParse.mockReturnValue([CARD]);
+    mockGetQueryOptions.mockReturnValue({
+      queryKey: QUERY_KEY,
+      queryFn: jest.fn().mockResolvedValue(PAGE_MOCK),
+    } as unknown as ReturnType<typeof mockGetQueryOptions>);
+  });
+
+  it('settles the first page without deadlocking on fetchQuery', async () => {
+    const { result } = renderHook(() => useMoneyAccountApiActivity(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.pageCount).toBe(1);
+    expect(result.current.activity).toStrictEqual([CARD]);
+    expect(result.current.watermark).toBe(Number.NEGATIVE_INFINITY);
+  });
+});

--- a/ui/hooks/money/use-money-account-api-activity.test.ts
+++ b/ui/hooks/money/use-money-account-api-activity.test.ts
@@ -1,0 +1,249 @@
+import { renderHook } from '@testing-library/react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { MUSD_MONEY_ACCOUNT_CHAIN_IDS } from '@metamask/money-account-utils';
+import { apiClient } from '../../helpers/api-client';
+import { MINUTE } from '../../../shared/constants/time';
+import { selectMoneyActivityMockDataEnabled } from '../../selectors/money/money-account-feature-flags';
+import { parseAccountsApiActivity } from '../../pages/money/utils/accounts-api';
+import type { AccountsApiActivity } from '../../pages/money/types/money-activity';
+import { useMoneyAccountInfo } from './useMoneyAccountInfo';
+import { useMoneyAccountApiActivity } from './use-money-account-api-activity';
+
+jest.mock('@tanstack/react-query', () => ({
+  useInfiniteQuery: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: () => unknown) => selector(),
+}));
+
+jest.mock('../../helpers/api-client', () => ({
+  apiClient: {
+    accounts: {
+      getV1AccountTransactionsQueryOptions: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../selectors/money/money-account-feature-flags', () => ({
+  selectMoneyActivityMockDataEnabled: jest.fn(),
+}));
+
+jest.mock('./useMoneyAccountInfo', () => ({
+  useMoneyAccountInfo: jest.fn(),
+}));
+
+jest.mock('../../pages/money/utils/accounts-api', () => ({
+  ...jest.requireActual('../../pages/money/utils/accounts-api'),
+  parseAccountsApiActivity: jest.fn(),
+}));
+
+const mockUseInfiniteQuery = jest.mocked(useInfiniteQuery);
+const mockGetQueryOptions = jest.mocked(
+  apiClient.accounts.getV1AccountTransactionsQueryOptions,
+);
+const mockParse = jest.mocked(parseAccountsApiActivity);
+const mockUseMoneyAccountInfo = jest.mocked(useMoneyAccountInfo);
+const mockSelectMoneyActivityMockDataEnabled = jest.mocked(
+  selectMoneyActivityMockDataEnabled,
+);
+
+const ADDR_A = '0xbF4bC559f929cE3994Ba12D71d564737357bC8C2';
+const QUERY_OPTIONS_MOCK = {
+  queryKey: ['accounts', 'transactions', 'v1Account'],
+};
+
+const CARD: AccountsApiActivity = {
+  kind: 'card',
+  hash: '0xabc',
+  time: 1,
+  chainId: '0x8f',
+  token: { address: '0xtoken', symbol: 'mUSD', decimals: 6 },
+  amount: '5381986',
+  paidTo: '0xdef',
+};
+
+const PAGE_MOCK = {
+  data: [{ hash: '0xabc', timestamp: '2026-06-04T00:00:00.000Z' }],
+  pageInfo: { count: 1, hasNextPage: true, cursor: 'cursor-2' },
+};
+
+function mockQueryResult(
+  overrides: Partial<ReturnType<typeof useInfiniteQuery>> = {},
+) {
+  mockUseInfiniteQuery.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    isFetchingNextPage: false,
+    hasNextPage: undefined,
+    fetchNextPage: jest.fn(),
+    refetch: jest.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useInfiniteQuery>);
+}
+
+describe('useMoneyAccountApiActivity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelectMoneyActivityMockDataEnabled.mockReturnValue(false);
+    mockUseMoneyAccountInfo.mockReturnValue({
+      isMoneyAccountFeatureEnabled: true,
+      hasMoneyAccount: true,
+      primaryMoneyAccount: { address: ADDR_A },
+    });
+    mockGetQueryOptions.mockReturnValue(
+      QUERY_OPTIONS_MOCK as unknown as ReturnType<typeof mockGetQueryOptions>,
+    );
+    mockQueryResult();
+    mockParse.mockReturnValue([]);
+  });
+
+  it('composes query options from the checksummed money address on Monad', () => {
+    renderHook(() => useMoneyAccountApiActivity());
+
+    expect(mockGetQueryOptions).toHaveBeenCalledWith(ADDR_A, {
+      chainIds: MUSD_MONEY_ACCOUNT_CHAIN_IDS,
+      sortDirection: 'DESC',
+    });
+  });
+
+  it('delegates to useInfiniteQuery with a cursor-free query key', () => {
+    renderHook(() => useMoneyAccountApiActivity());
+
+    expect(mockUseInfiniteQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: QUERY_OPTIONS_MOCK.queryKey,
+        queryFn: expect.any(Function),
+        getNextPageParam: expect.any(Function),
+        enabled: true,
+        staleTime: 5 * MINUTE,
+        retry: false,
+      }),
+    );
+  });
+
+  it('disables the query when there is no money account', () => {
+    mockUseMoneyAccountInfo.mockReturnValue({
+      isMoneyAccountFeatureEnabled: true,
+      hasMoneyAccount: false,
+      primaryMoneyAccount: undefined,
+    });
+
+    renderHook(() => useMoneyAccountApiActivity());
+
+    expect(mockUseInfiniteQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('disables the query in mock-data mode', () => {
+    mockSelectMoneyActivityMockDataEnabled.mockReturnValue(true);
+
+    renderHook(() => useMoneyAccountApiActivity());
+
+    expect(mockUseInfiniteQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('queryFn fetches pages via the SDK queryFn, not fetchQuery', async () => {
+    const fetchPage = jest.fn().mockResolvedValue(PAGE_MOCK);
+    mockGetQueryOptions.mockReturnValue({
+      queryKey: QUERY_OPTIONS_MOCK.queryKey,
+      queryFn: fetchPage,
+    } as unknown as ReturnType<typeof mockGetQueryOptions>);
+    renderHook(() => useMoneyAccountApiActivity());
+    const { queryFn } = mockUseInfiniteQuery.mock.calls[0][0] as unknown as {
+      queryFn: (ctx: {
+        pageParam?: string;
+        signal?: AbortSignal;
+      }) => Promise<unknown>;
+    };
+    const { signal } = new AbortController();
+
+    await queryFn({ pageParam: 'cursor-1', signal });
+
+    expect(mockGetQueryOptions).toHaveBeenCalledWith(ADDR_A, {
+      chainIds: MUSD_MONEY_ACCOUNT_CHAIN_IDS,
+      sortDirection: 'DESC',
+      cursor: 'cursor-1',
+    });
+    expect(fetchPage).toHaveBeenCalledWith({ signal });
+  });
+
+  it('getNextPageParam returns the cursor only while more pages remain', () => {
+    renderHook(() => useMoneyAccountApiActivity());
+    const { getNextPageParam } = mockUseInfiniteQuery.mock
+      .calls[0][0] as unknown as {
+      getNextPageParam: (page: {
+        pageInfo?: { hasNextPage?: boolean; cursor?: string };
+      }) => string | undefined;
+    };
+
+    expect(getNextPageParam(PAGE_MOCK)).toBe('cursor-2');
+    expect(
+      getNextPageParam({ pageInfo: { hasNextPage: true, cursor: '' } }),
+    ).toBeUndefined();
+    expect(
+      getNextPageParam({ pageInfo: { hasNextPage: false, cursor: 'x' } }),
+    ).toBeUndefined();
+  });
+
+  it('parses and dedupes activity across pages', () => {
+    mockParse.mockReturnValue([CARD]);
+    mockQueryResult({
+      data: { pages: [PAGE_MOCK, PAGE_MOCK], pageParams: [undefined, 'c2'] },
+      hasNextPage: true,
+    });
+
+    const { result } = renderHook(() => useMoneyAccountApiActivity());
+
+    expect(result.current.activity).toStrictEqual([CARD]);
+    expect(result.current.pageCount).toBe(2);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it('opens the watermark once paging is complete', () => {
+    mockQueryResult({
+      data: { pages: [PAGE_MOCK], pageParams: [undefined] },
+      hasNextPage: false,
+    });
+
+    const { result } = renderHook(() => useMoneyAccountApiActivity());
+
+    expect(result.current.watermark).toBe(Number.NEGATIVE_INFINITY);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('does not freeze the list when fetched pages have no parseable timestamps', () => {
+    mockQueryResult({
+      data: {
+        pages: [{ data: [{ hash: '0xabc', timestamp: 'not-a-date' }] }],
+        pageParams: [undefined],
+      },
+      hasNextPage: true,
+    });
+
+    const { result } = renderHook(() => useMoneyAccountApiActivity());
+
+    expect(result.current.watermark).toBe(Number.NEGATIVE_INFINITY);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it('does not load more after an error', () => {
+    const fetchNextPage = jest.fn();
+    mockQueryResult({
+      hasNextPage: true,
+      isError: true,
+      fetchNextPage,
+    });
+
+    const { result } = renderHook(() => useMoneyAccountApiActivity());
+    result.current.loadMore();
+
+    expect(fetchNextPage).not.toHaveBeenCalled();
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.error).toBe(true);
+  });
+});

--- a/ui/hooks/money/use-money-account-api-activity.ts
+++ b/ui/hooks/money/use-money-account-api-activity.ts
@@ -1,0 +1,151 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { MUSD_MONEY_ACCOUNT_CHAIN_IDS } from '@metamask/money-account-utils';
+import type { V1AccountTransactionsResponse } from '@metamask/core-backend';
+import { apiClient } from '../../helpers/api-client';
+import { MINUTE } from '../../../shared/constants/time';
+import { selectMoneyActivityMockDataEnabled } from '../../selectors/money/money-account-feature-flags';
+import type { AccountsApiActivity } from '../../pages/money/types/money-activity';
+import {
+  DEFAULT_MONEY_CARD_ACTIVITY_CASHBACK_MULTISEND_CONTRACTS,
+  oldestRawActivityTime,
+  parseAccountsApiActivity,
+} from '../../pages/money/utils/accounts-api';
+import { useMoneyAccountInfo } from './useMoneyAccountInfo';
+
+export type UseMoneyAccountApiActivityResult = {
+  activity: AccountsApiActivity[];
+  /**
+   * Pagination watermark in epoch ms. Merged activity older than this may
+   * have un-fetched API rows that belong above it. Once paging is complete
+   * this is `Number.NEGATIVE_INFINITY`.
+   */
+  watermark: number;
+  pageCount: number;
+  hasMore: boolean;
+  loadMore: () => void;
+  isLoadingMore: boolean;
+  isLoading: boolean;
+  error: boolean;
+  refetch: () => void;
+};
+
+const EMPTY_ACTIVITY: AccountsApiActivity[] = [];
+const EMPTY_PAGES: V1AccountTransactionsResponse[] = [];
+
+const ACCOUNT_ACTIVITY_QUERY_OPTIONS = {
+  chainIds: MUSD_MONEY_ACCOUNT_CHAIN_IDS,
+  sortDirection: 'DESC' as const,
+};
+
+/**
+ * Off-device MetaMask Card activity (spends, cashback, refunds) for the
+ * Money Account, sourced from the Accounts API.
+ *
+ * @returns Parsed activity, pagination controls, and query status.
+ */
+export function useMoneyAccountApiActivity(): UseMoneyAccountApiActivityResult {
+  const { primaryMoneyAccount } = useMoneyAccountInfo();
+  const mockDataEnabled = useSelector(selectMoneyActivityMockDataEnabled);
+  const rawAddress = primaryMoneyAccount?.address;
+  const moneyAddress = rawAddress ? toChecksumHexAddress(rawAddress) : '';
+  const enabled = moneyAddress !== '' && !mockDataEnabled;
+
+  const queryOptions = apiClient.accounts.getV1AccountTransactionsQueryOptions(
+    moneyAddress,
+    ACCOUNT_ACTIVITY_QUERY_OPTIONS,
+  );
+
+  const query = useInfiniteQuery({
+    queryKey: queryOptions.queryKey,
+    initialPageParam: undefined as string | undefined,
+    // Call the SDK HTTP `queryFn` directly. `fetchV1AccountTransactions`
+    // wraps the same options in `queryClient.fetchQuery`, whose key hashes
+    // identically to this infinite query on page 1 (`cursor: undefined` is
+    // dropped by JSON.stringify). That makes the first page wait on itself.
+    queryFn: async ({
+      pageParam,
+      signal,
+    }: {
+      pageParam?: string;
+      signal?: AbortSignal;
+    }) => {
+      const { queryFn: fetchPage } =
+        apiClient.accounts.getV1AccountTransactionsQueryOptions(moneyAddress, {
+          ...ACCOUNT_ACTIVITY_QUERY_OPTIONS,
+          cursor: pageParam,
+        });
+      if (typeof fetchPage !== 'function') {
+        throw new Error('Accounts API query function is missing');
+      }
+      return fetchPage({ signal } as Parameters<typeof fetchPage>[0]);
+    },
+    getNextPageParam: (lastPage: V1AccountTransactionsResponse) =>
+      lastPage.pageInfo?.hasNextPage && lastPage.pageInfo.cursor
+        ? lastPage.pageInfo.cursor
+        : undefined,
+    enabled,
+    staleTime: 5 * MINUTE,
+    retry: false,
+  });
+
+  const pages = query.data?.pages ?? EMPTY_PAGES;
+
+  const activity = useMemo(() => {
+    if (pages.length === 0) {
+      return EMPTY_ACTIVITY;
+    }
+    const seen = new Set<string>();
+    return pages
+      .flatMap((page) =>
+        parseAccountsApiActivity(
+          page,
+          moneyAddress,
+          DEFAULT_MONEY_CARD_ACTIVITY_CASHBACK_MULTISEND_CONTRACTS,
+        ),
+      )
+      .filter((row) => {
+        const key = `${row.kind}:${row.hash.toLowerCase()}`;
+        if (seen.has(key)) {
+          return false;
+        }
+        seen.add(key);
+        return true;
+      });
+  }, [pages, moneyAddress]);
+
+  const isComplete = !enabled || query.isError || query.hasNextPage === false;
+  const watermark = useMemo(() => {
+    if (isComplete) {
+      return Number.NEGATIVE_INFINITY;
+    }
+    const oldest = oldestRawActivityTime(pages);
+    // Pages arrived but none had parseable timestamps — do not freeze the
+    // merged list behind +Infinity (`time > Infinity` is never true).
+    if (pages.length > 0 && oldest === Number.POSITIVE_INFINITY) {
+      return Number.NEGATIVE_INFINITY;
+    }
+    return oldest;
+  }, [pages, isComplete]);
+
+  const { hasNextPage, isFetchingNextPage, fetchNextPage, isError } = query;
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage && !isError) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage, isError]);
+
+  return {
+    activity,
+    watermark,
+    pageCount: pages.length,
+    hasMore: hasNextPage === true && !isError,
+    loadMore,
+    isLoadingMore: isFetchingNextPage,
+    isLoading: query.isLoading,
+    error: query.isError,
+    refetch: query.refetch,
+  };
+}

--- a/ui/hooks/money/use-money-account-api-activity.ts
+++ b/ui/hooks/money/use-money-account-api-activity.ts
@@ -116,7 +116,13 @@ export function useMoneyAccountApiActivity(): UseMoneyAccountApiActivityResult {
       });
   }, [pages, moneyAddress]);
 
-  const isComplete = !enabled || query.isError || query.hasNextPage === false;
+  // `hasNextPage` is `false` before any page has loaded, so it only means
+  // "paging finished" once data exists.
+  const isComplete =
+    !enabled ||
+    query.isError ||
+    (query.data !== undefined && !query.hasNextPage);
+
   const watermark = useMemo(() => {
     if (isComplete) {
       return Number.NEGATIVE_INFINITY;

--- a/ui/hooks/money/use-money-activity-display.ts
+++ b/ui/hooks/money/use-money-activity-display.ts
@@ -8,6 +8,7 @@ import { useI18nContext } from '../useI18nContext';
 import { selectSingleTokenByAddressAndChainId } from '../../selectors/assets';
 import type { MoneyActivityItem } from '../../pages/money/types/money-activity';
 import {
+  getAccountsApiActivityDisplayInfo,
   getMoneyActivityDisplayInfo,
   resolvePayTokenSymbol,
   type MoneyActivityTranslate,
@@ -25,8 +26,14 @@ export function useMoneyActivityDisplayInfo(
   item: MoneyActivityItem,
 ): MoneyTransactionDisplayInfo {
   const t = useI18nContext() as MoneyActivityTranslate;
-  const payTokenAddress = item.tx.metamaskPay?.tokenAddress as Hex | undefined;
-  const payTokenChainId = item.tx.metamaskPay?.chainId as Hex | undefined;
+  const payTokenAddress =
+    item.kind === 'onchain'
+      ? (item.tx.metamaskPay?.tokenAddress as Hex | undefined)
+      : undefined;
+  const payTokenChainId =
+    item.kind === 'onchain'
+      ? (item.tx.metamaskPay?.chainId as Hex | undefined)
+      : undefined;
 
   const payToken = useSelector((state) =>
     payTokenAddress && payTokenChainId && !isMusdToken(payTokenAddress)
@@ -58,6 +65,10 @@ export function useMoneyActivityDisplayInfo(
   });
 
   return useMemo(() => {
+    if (item.kind === 'accountsApi') {
+      return getAccountsApiActivityDisplayInfo(item.tx, t);
+    }
+
     const sourceTokenSymbol = resolvePayTokenSymbol(
       payTokenAddress,
       payToken?.symbol,

--- a/ui/hooks/money/use-money-activity-item-click.test.ts
+++ b/ui/hooks/money/use-money-activity-item-click.test.ts
@@ -1,7 +1,10 @@
 import { renderHook } from '@testing-library/react';
 import { getMoneyTransactionDetailsRoute } from '../../helpers/constants/routes';
 import { selectMoneyActivityDetailsEnabled } from '../../selectors/money/money-account-feature-flags';
-import { onchainItem } from '../../pages/money/types/money-activity';
+import {
+  onchainItem,
+  accountsApiItem,
+} from '../../pages/money/types/money-activity';
 import MOCK_MONEY_TRANSACTIONS from '../../pages/money/constants/mock-activity-data';
 import { useMoneyActivityItemClick } from './use-money-activity-item-click';
 
@@ -47,5 +50,27 @@ describe('useMoneyActivityItemClick', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       getMoneyTransactionDetailsRoute(item.id),
     );
+  });
+
+  it('does not navigate for Accounts API rows', () => {
+    mockSelectMoneyActivityDetailsEnabled.mockReturnValue(true);
+    const apiItem = accountsApiItem({
+      kind: 'card',
+      hash: '0xabc',
+      time: 1,
+      chainId: '0x8f',
+      token: {
+        address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+        symbol: 'mUSD',
+        decimals: 6,
+      },
+      amount: '1000000',
+      paidTo: '0xdef',
+    });
+
+    const { result } = renderHook(() => useMoneyActivityItemClick());
+    result.current?.(apiItem);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/ui/hooks/money/use-money-activity-item-click.ts
+++ b/ui/hooks/money/use-money-activity-item-click.ts
@@ -19,6 +19,9 @@ export function useMoneyActivityItemClick():
 
   const onClick = useCallback(
     (item: MoneyActivityItem) => {
+      if (item.kind !== 'onchain') {
+        return;
+      }
       navigate(getMoneyTransactionDetailsRoute(item.id));
     },
     [navigate],

--- a/ui/hooks/money/use-money-activity-items.test.ts
+++ b/ui/hooks/money/use-money-activity-items.test.ts
@@ -3,18 +3,131 @@ import {
   type TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import type { AccountsApiActivity } from '../../pages/money/types/money-activity';
 import { MoneyActivityFilter } from '../../pages/money/utils/money-activity-filters';
 import MOCK_MONEY_TRANSACTIONS from '../../pages/money/constants/mock-activity-data';
 import { useMoneyAccountTransactions } from './use-money-account-transactions';
-import { useMoneyActivityItems } from './use-money-activity-items';
+import { useMoneyAccountApiActivity } from './use-money-account-api-activity';
+import {
+  AUTO_FILL_MAX_PAGES,
+  buildMergedMoneyActivityBuckets,
+  mergeMoneyActivity,
+  useMoneyActivityItems,
+} from './use-money-activity-items';
 
 jest.mock('./use-money-account-transactions');
+jest.mock('./use-money-account-api-activity');
 
 const mockUseMoneyAccountTransactions = jest.mocked(
   useMoneyAccountTransactions,
 );
+const mockUseMoneyAccountApiActivity = jest.mocked(useMoneyAccountApiActivity);
+
+function onchainTx(
+  id: string,
+  time: number,
+  hash?: Hex,
+  type: TransactionType = TransactionType.moneyAccountDeposit,
+): TransactionMeta {
+  return {
+    id,
+    time,
+    hash,
+    type,
+    chainId: '0x8f',
+    txParams: { from: '0x1', to: '0x2', value: '0x0' },
+  } as unknown as TransactionMeta;
+}
+
+function cardTx(hash: Hex, time: number): AccountsApiActivity {
+  return {
+    kind: 'card',
+    hash,
+    time,
+    chainId: '0x8f',
+    token: { address: '0xtoken', symbol: 'mUSD', decimals: 6 },
+    amount: '1000000',
+    paidTo: '0xmerchant',
+  };
+}
+
+const deposit = onchainTx('dep', 40);
+const transfer = onchainTx(
+  'xfer',
+  30,
+  undefined,
+  TransactionType.moneyAccountWithdraw,
+);
+const onchain = {
+  all: [deposit, transfer],
+  deposits: [deposit],
+  transfers: [transfer],
+};
+
+describe('mergeMoneyActivity', () => {
+  it('drops on-chain rows whose hash is represented by the API', () => {
+    const shared = '0xCaRd' as Hex;
+    const local = onchainTx('dup', 200, shared);
+    const api = cardTx('0xcard' as Hex, 200);
+
+    expect(
+      mergeMoneyActivity([local], [api]).map((item) => item.id),
+    ).toStrictEqual(['card:0xcard']);
+  });
+
+  it('sorts by time then stable id', () => {
+    const older = onchainTx('a', 1);
+    const newer = cardTx('0xnew' as Hex, 2);
+
+    expect(
+      mergeMoneyActivity([older], [newer]).map((item) => item.id),
+    ).toStrictEqual(['card:0xnew', 'a']);
+  });
+});
+
+describe('buildMergedMoneyActivityBuckets', () => {
+  const card = cardTx('0xcard' as Hex, 200);
+  const cashback: AccountsApiActivity = {
+    ...cardTx('0xback' as Hex, 250),
+    kind: 'cashback',
+    receivedFrom: '0xrewarder',
+  };
+
+  it('keeps API rows in All only', () => {
+    const buckets = buildMergedMoneyActivityBuckets(onchain, [card, cashback]);
+    const ids = (filter: MoneyActivityFilter) =>
+      buckets[filter].map((item) => item.id);
+
+    expect(ids(MoneyActivityFilter.All)).toStrictEqual([
+      'cashback:0xback',
+      'card:0xcard',
+      'dep',
+      'xfer',
+    ]);
+    expect(ids(MoneyActivityFilter.Deposits)).toStrictEqual(['dep']);
+    expect(ids(MoneyActivityFilter.Transfers)).toStrictEqual(['xfer']);
+  });
+
+  it('withholds rows at or below the watermark', () => {
+    const buckets = buildMergedMoneyActivityBuckets(
+      onchain,
+      [card, cashback],
+      200,
+    );
+
+    expect(
+      buckets[MoneyActivityFilter.All].map((item) => item.id),
+    ).toStrictEqual(['cashback:0xback']);
+    expect(buckets[MoneyActivityFilter.Deposits]).toStrictEqual([]);
+    expect(buckets[MoneyActivityFilter.Transfers]).toStrictEqual([]);
+  });
+});
 
 describe('useMoneyActivityItems', () => {
+  const loadMore = jest.fn();
+  const refetch = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseMoneyAccountTransactions.mockReturnValue({
@@ -24,13 +137,25 @@ describe('useMoneyActivityItems', () => {
       moneyAddress: '0x1',
       mockDataEnabled: false,
     });
+    mockUseMoneyAccountApiActivity.mockReturnValue({
+      activity: [],
+      watermark: Number.NEGATIVE_INFINITY,
+      pageCount: 1,
+      hasMore: false,
+      loadMore,
+      isLoadingMore: false,
+      isLoading: false,
+      error: false,
+      refetch,
+    });
   });
 
-  it('returns empty buckets when there are no transactions', () => {
+  it('returns empty buckets when both sources are empty', () => {
     const { result } = renderHook(() => useMoneyActivityItems());
 
     expect(result.current.items).toStrictEqual([]);
     expect(result.current.buckets[MoneyActivityFilter.All]).toStrictEqual([]);
+    expect(result.current.isSettling).toBe(false);
   });
 
   it('returns mock transactions newest-first when mock data is enabled', () => {
@@ -51,7 +176,82 @@ describe('useMoneyActivityItems', () => {
     const { result } = renderHook(() => useMoneyActivityItems());
 
     expect(result.current.items[0].id).toBe('money-tx-deposited');
-    expect(result.current.mockDataEnabled).toBe(true);
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.error).toBe(false);
+    expect(result.current.isSettling).toBe(false);
+  });
+
+  it('auto-fills while the target bucket is short of the requested count', () => {
+    mockUseMoneyAccountApiActivity.mockReturnValue({
+      activity: [],
+      watermark: 1,
+      pageCount: 1,
+      hasMore: true,
+      loadMore,
+      isLoadingMore: false,
+      isLoading: false,
+      error: false,
+      refetch,
+    });
+
+    renderHook(() =>
+      useMoneyActivityItems({
+        fill: { bucket: MoneyActivityFilter.All, count: 5 },
+      }),
+    );
+
+    expect(loadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops auto-fill once the page budget is spent and the bucket has rows', () => {
+    mockUseMoneyAccountTransactions.mockReturnValue({
+      allTransactions: [onchainTx('dep', 500)],
+      deposits: [onchainTx('dep', 500)],
+      transfers: [],
+      moneyAddress: '0x1',
+      mockDataEnabled: false,
+    });
+    mockUseMoneyAccountApiActivity.mockReturnValue({
+      activity: [],
+      watermark: Number.NEGATIVE_INFINITY,
+      pageCount: AUTO_FILL_MAX_PAGES,
+      hasMore: true,
+      loadMore,
+      isLoadingMore: false,
+      isLoading: false,
+      error: false,
+      refetch,
+    });
+
+    renderHook(() =>
+      useMoneyActivityItems({
+        fill: { bucket: MoneyActivityFilter.All, count: 15 },
+      }),
+    );
+
+    expect(loadMore).not.toHaveBeenCalled();
+  });
+
+  it('keeps auto-filling past the page budget while the target bucket is empty', () => {
+    mockUseMoneyAccountApiActivity.mockReturnValue({
+      activity: [],
+      watermark: 1,
+      pageCount: AUTO_FILL_MAX_PAGES,
+      hasMore: true,
+      loadMore,
+      isLoadingMore: false,
+      isLoading: false,
+      error: false,
+      refetch,
+    });
+
+    renderHook(() =>
+      useMoneyActivityItems({
+        fill: { bucket: MoneyActivityFilter.All, count: 5 },
+      }),
+    );
+
+    expect(loadMore).toHaveBeenCalledTimes(1);
   });
 
   it('surfaces every visibility-filtered transaction on All, including Pay txs', () => {

--- a/ui/hooks/money/use-money-activity-items.ts
+++ b/ui/hooks/money/use-money-activity-items.ts
@@ -1,42 +1,180 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import {
+  accountsApiItem,
   onchainItem,
+  type AccountsApiActivity,
   type MoneyActivityItem,
 } from '../../pages/money/types/money-activity';
 import {
-  buildMoneyActivityBuckets,
   MoneyActivityFilter,
   type MoneyActivityBuckets,
 } from '../../pages/money/utils/money-activity-filters';
 import { useMoneyAccountTransactions } from './use-money-account-transactions';
+import { useMoneyAccountApiActivity } from './use-money-account-api-activity';
+
+const EMPTY_API_ACTIVITY: AccountsApiActivity[] = [];
 
 export type UseMoneyActivityItemsResult = {
   items: MoneyActivityItem[];
   buckets: MoneyActivityBuckets;
+  loadMore: () => void;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  error: boolean;
+  refetch: () => void;
+  isSettling: boolean;
   moneyAddress: string | undefined;
   mockDataEnabled: boolean;
 };
 
 /**
- * Assembles the Money activity list from local on-chain transactions,
- * bucketed by filter tab.
- *
- * @returns Filter buckets plus the Money Account address.
+ * Upper bound on pages the {@link UseMoneyActivityItemsOptions.fill}
+ * auto-fill will pull.
  */
-export function useMoneyActivityItems(): UseMoneyActivityItemsResult {
-  const { allTransactions, moneyAddress, mockDataEnabled } =
-    useMoneyAccountTransactions();
+export const AUTO_FILL_MAX_PAGES = 10;
 
-  const items = useMemo(
-    () => allTransactions.map(onchainItem),
-    [allTransactions],
+export type UseMoneyActivityItemsOptions = {
+  fill?: {
+    bucket: MoneyActivityFilter;
+    count: number;
+  };
+};
+
+function safeItems(
+  items: MoneyActivityItem[],
+  watermark: number,
+): MoneyActivityItem[] {
+  if (watermark === Number.NEGATIVE_INFINITY) {
+    return items;
+  }
+  return items.filter((item) => item.time > watermark);
+}
+
+function onchainOnly(items: MoneyActivityItem[]): MoneyActivityItem[] {
+  return items.filter((item) => item.kind === 'onchain');
+}
+
+/**
+ * Merge local on-chain Money transactions with Accounts API activity into a
+ * single source-tagged, time-descending list.
+ *
+ * @param onchainTransactions - Local TransactionController rows.
+ * @param apiActivity - Parsed Accounts API settlements.
+ * @returns Merged items, newest first, with id as a stable timestamp tiebreak.
+ */
+export function mergeMoneyActivity(
+  onchainTransactions: TransactionMeta[],
+  apiActivity: AccountsApiActivity[],
+): MoneyActivityItem[] {
+  const apiHashes = new Set(apiActivity.map((row) => row.hash.toLowerCase()));
+  const onchain = onchainTransactions
+    .filter((tx) => !(tx.hash && apiHashes.has(tx.hash.toLowerCase())))
+    .map(onchainItem);
+  return [...onchain, ...apiActivity.map(accountsApiItem)].sort(
+    (left, right) => right.time - left.time || left.id.localeCompare(right.id),
+  );
+}
+
+export function buildMergedMoneyActivityBuckets(
+  onchain: {
+    all: TransactionMeta[];
+    deposits: TransactionMeta[];
+    transfers: TransactionMeta[];
+  },
+  apiActivity: AccountsApiActivity[],
+  watermark: number = Number.NEGATIVE_INFINITY,
+): MoneyActivityBuckets {
+  return {
+    [MoneyActivityFilter.All]: safeItems(
+      mergeMoneyActivity(onchain.all, apiActivity),
+      watermark,
+    ),
+    [MoneyActivityFilter.Deposits]: onchainOnly(
+      safeItems(mergeMoneyActivity(onchain.deposits, apiActivity), watermark),
+    ),
+    [MoneyActivityFilter.Transfers]: onchainOnly(
+      safeItems(mergeMoneyActivity(onchain.transfers, apiActivity), watermark),
+    ),
+  };
+}
+
+/**
+ * Assembles the Money activity list from local on-chain transactions and
+ * Accounts API card activity, bucketed by filter tab.
+ *
+ * @param options - Optional auto-fill target for the Home preview or
+ * full-list active tab.
+ * @param options.fill
+ * @returns Buckets, pagination controls, and settling/error state.
+ */
+export function useMoneyActivityItems({
+  fill,
+}: UseMoneyActivityItemsOptions = {}): UseMoneyActivityItemsResult {
+  const {
+    allTransactions,
+    deposits,
+    transfers,
+    moneyAddress,
+    mockDataEnabled,
+  } = useMoneyAccountTransactions();
+  const {
+    activity,
+    isLoading,
+    watermark,
+    hasMore,
+    loadMore,
+    isLoadingMore,
+    pageCount,
+    error,
+    refetch,
+  } = useMoneyAccountApiActivity();
+
+  const apiActivity = mockDataEnabled ? EMPTY_API_ACTIVITY : activity;
+  const effectiveWatermark = mockDataEnabled
+    ? Number.NEGATIVE_INFINITY
+    : watermark;
+
+  const buckets = useMemo(
+    () =>
+      buildMergedMoneyActivityBuckets(
+        { all: allTransactions, deposits, transfers },
+        apiActivity,
+        effectiveWatermark,
+      ),
+    [allTransactions, deposits, transfers, apiActivity, effectiveWatermark],
   );
 
-  const buckets = useMemo(() => buildMoneyActivityBuckets(items), [items]);
+  const fillCount = buckets[fill?.bucket ?? MoneyActivityFilter.All].length;
+  // Keep paging past the screenful budget while the target bucket is still
+  // empty: otherwise the watermark can hide older on-chain rows forever
+  // after AUTO_FILL_MAX_PAGES of unrelated API history.
+  const wantsMorePages =
+    fill !== undefined &&
+    !mockDataEnabled &&
+    hasMore &&
+    fillCount < fill.count &&
+    (fillCount === 0 || pageCount < AUTO_FILL_MAX_PAGES);
+
+  useEffect(() => {
+    if (wantsMorePages && !isLoadingMore) {
+      loadMore();
+    }
+  }, [wantsMorePages, isLoadingMore, loadMore]);
+
+  const isSettling =
+    !mockDataEnabled &&
+    (isLoading || (fillCount === 0 && (wantsMorePages || isLoadingMore)));
 
   return {
     items: buckets[MoneyActivityFilter.All],
     buckets,
+    loadMore,
+    hasMore: hasMore && !mockDataEnabled,
+    isLoadingMore: isLoadingMore && !mockDataEnabled,
+    error: error && !mockDataEnabled,
+    refetch,
+    isSettling,
     moneyAddress,
     mockDataEnabled,
   };

--- a/ui/pages/money/components/money-activity-list.test.tsx
+++ b/ui/pages/money/components/money-activity-list.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, screen } from '@testing-library/react';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { renderWithLocalization } from '../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
-import { onchainItem } from '../types/money-activity';
+import { onchainItem, accountsApiItem } from '../types/money-activity';
 import type { MoneyActivityTransactionMeta } from '../constants/mock-activity-data';
 import MOCK_MONEY_TRANSACTIONS from '../constants/mock-activity-data';
 import { MoneyActivityList, MAX_PREVIEW_ITEMS } from './money-activity-list';
@@ -70,6 +70,45 @@ describe('MoneyActivityList', () => {
     expect(
       screen.queryByTestId('money-activity-view-all'),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows View all when more API pages exist even with five preview rows', () => {
+    renderWithLocalization(<MoneyActivityList items={previewItems} hasMore />);
+
+    expect(screen.getByTestId('money-activity-view-all')).toBeInTheDocument();
+  });
+
+  it('shows a settling skeleton instead of empty copy', () => {
+    renderWithLocalization(<MoneyActivityList items={[]} isSettling />);
+
+    expect(screen.getByTestId('money-activity-settling')).toBeInTheDocument();
+    expect(
+      screen.queryByText(messages.moneyActivityPlaceholderDescription.message),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not make Accounts API rows clickable', () => {
+    const onItemClick = jest.fn();
+    const apiItem = accountsApiItem({
+      kind: 'card',
+      hash: '0xabc',
+      time: 1,
+      chainId: '0x8f',
+      token: {
+        address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+        symbol: 'mUSD',
+        decimals: 6,
+      },
+      amount: '1000000',
+      paidTo: '0xdef',
+    });
+
+    renderWithLocalization(
+      <MoneyActivityList items={[apiItem]} onItemClick={onItemClick} />,
+    );
+
+    const row = screen.getByTestId(`money-activity-row-${apiItem.id}`);
+    expect(row.tagName).toBe('DIV');
   });
 
   it('masks amounts in privacy mode', () => {

--- a/ui/pages/money/components/money-activity-list.tsx
+++ b/ui/pages/money/components/money-activity-list.tsx
@@ -12,6 +12,7 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import type { MoneyActivityItem } from '../types/money-activity';
 import { MoneyActivityRow } from './money-activity-row';
+import { MoneyActivitySettlingSkeletons } from './money-activity-settling-skeletons';
 
 export const MAX_PREVIEW_ITEMS = 5;
 
@@ -20,6 +21,10 @@ export type MoneyActivityListProps = {
   privacyMode?: boolean;
   onViewAll?: () => void;
   onItemClick?: (item: MoneyActivityItem) => void;
+  /** True when more Accounts API pages exist beyond the current preview. */
+  hasMore?: boolean;
+  /** True while the preview is still filling and should not show empty copy. */
+  isSettling?: boolean;
 };
 
 export function MoneyActivityList({
@@ -27,11 +32,13 @@ export function MoneyActivityList({
   privacyMode = false,
   onViewAll,
   onItemClick,
+  hasMore = false,
+  isSettling = false,
 }: MoneyActivityListProps) {
   const t = useI18nContext();
   const previewItems = items.slice(0, MAX_PREVIEW_ITEMS);
-  const hasMoreItems = items.length > MAX_PREVIEW_ITEMS;
-  const showEmptyCopy = items.length === 0;
+  const hasMoreItems = items.length > MAX_PREVIEW_ITEMS || hasMore;
+  const showEmptyCopy = items.length === 0 && !isSettling;
 
   return (
     <section
@@ -54,14 +61,18 @@ export function MoneyActivityList({
           </Text>
         ) : null}
       </Box>
-      {previewItems.map((item) => (
-        <MoneyActivityRow
-          key={item.id}
-          item={item}
-          privacyMode={privacyMode}
-          onItemClick={onItemClick}
-        />
-      ))}
+      {isSettling && items.length === 0 ? (
+        <MoneyActivitySettlingSkeletons />
+      ) : (
+        previewItems.map((item) => (
+          <MoneyActivityRow
+            key={item.id}
+            item={item}
+            privacyMode={privacyMode}
+            onItemClick={onItemClick}
+          />
+        ))
+      )}
       {hasMoreItems ? (
         <Box paddingLeft={4} paddingRight={4} paddingTop={3} paddingBottom={3}>
           <Button

--- a/ui/pages/money/components/money-activity-retry-button.test.tsx
+++ b/ui/pages/money/components/money-activity-retry-button.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithLocalization } from '../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import { MoneyActivityRetryButton } from './money-activity-retry-button';
+
+describe('MoneyActivityRetryButton', () => {
+  it('invokes onClick', () => {
+    const onClick = jest.fn();
+    renderWithLocalization(
+      <MoneyActivityRetryButton className="mt-4" onClick={onClick} />,
+    );
+
+    fireEvent.click(screen.getByTestId('money-activity-retry'));
+    expect(screen.getByTestId('money-activity-retry')).toHaveTextContent(
+      messages.moneyActivityRetry.message,
+    );
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/pages/money/components/money-activity-retry-button.tsx
+++ b/ui/pages/money/components/money-activity-retry-button.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+
+export type MoneyActivityRetryButtonProps = {
+  className: string;
+  onClick: () => void;
+};
+
+/**
+ * Retry control for Accounts API load failures on the Money Activity page.
+ *
+ * @param options0 - Component props.
+ * @param options0.className - Spacing around the button.
+ * @param options0.onClick - Refetch handler.
+ * @returns The retry button.
+ */
+export function MoneyActivityRetryButton({
+  className,
+  onClick,
+}: MoneyActivityRetryButtonProps) {
+  const t = useI18nContext();
+
+  return (
+    <Button
+      variant={ButtonVariant.Secondary}
+      size={ButtonSize.Md}
+      className={className}
+      onClick={onClick}
+      data-testid="money-activity-retry"
+    >
+      {t('moneyActivityRetry')}
+    </Button>
+  );
+}

--- a/ui/pages/money/components/money-activity-row.test.tsx
+++ b/ui/pages/money/components/money-activity-row.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalization } from '../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import MOCK_MONEY_TRANSACTIONS from '../constants/mock-activity-data';
-import { onchainItem } from '../types/money-activity';
+import { accountsApiItem, onchainItem } from '../types/money-activity';
 import { MoneyActivityRow } from './money-activity-row';
 
 jest.mock('react-redux', () => ({
@@ -34,5 +34,31 @@ describe('MoneyActivityRow', () => {
     expect(row.tagName).toBe('BUTTON');
     fireEvent.click(row);
     expect(onItemClick).toHaveBeenCalledWith(deposited);
+  });
+
+  it('keeps Accounts API rows non-interactive even when onItemClick is set', () => {
+    const onItemClick = jest.fn();
+    const apiItem = accountsApiItem({
+      kind: 'card',
+      hash: '0xabc',
+      time: 1,
+      chainId: '0x1',
+      token: {
+        address: '0x1',
+        symbol: 'mUSD',
+        decimals: 6,
+      },
+      amount: '1000000',
+      paidTo: '0xdef',
+    });
+
+    renderWithLocalization(
+      <MoneyActivityRow item={apiItem} onItemClick={onItemClick} />,
+    );
+
+    const row = screen.getByTestId(`money-activity-row-${apiItem.id}`);
+    expect(row.tagName).toBe('DIV');
+    fireEvent.click(row);
+    expect(onItemClick).not.toHaveBeenCalled();
   });
 });

--- a/ui/pages/money/components/money-activity-row.tsx
+++ b/ui/pages/money/components/money-activity-row.tsx
@@ -19,7 +19,10 @@ import {
   TextVariant,
 } from '@metamask/design-system-react';
 import { useMoneyActivityDisplayInfo } from '../../../hooks/money/use-money-activity-display';
-import type { MoneyActivityItem } from '../types/money-activity';
+import {
+  isOnchainMoneyActivityItem,
+  type MoneyActivityItem,
+} from '../types/money-activity';
 
 export type MoneyActivityRowProps = {
   item: MoneyActivityItem;
@@ -55,7 +58,7 @@ export function MoneyActivityRow({
     isFailed,
     isIncoming: display.isIncoming,
   });
-  const isClickable = Boolean(onItemClick);
+  const isClickable = Boolean(onItemClick) && isOnchainMoneyActivityItem(item);
 
   const content = (
     <>

--- a/ui/pages/money/components/money-activity-settling-skeletons.test.tsx
+++ b/ui/pages/money/components/money-activity-settling-skeletons.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MoneyActivitySettlingSkeletons } from './money-activity-settling-skeletons';
+
+describe('MoneyActivitySettlingSkeletons', () => {
+  it('renders the settling placeholder', () => {
+    render(
+      <MoneyActivitySettlingSkeletons>
+        <div data-testid="child" />
+      </MoneyActivitySettlingSkeletons>,
+    );
+
+    expect(screen.getByTestId('money-activity-settling')).toBeInTheDocument();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/ui/pages/money/components/money-activity-settling-skeletons.tsx
+++ b/ui/pages/money/components/money-activity-settling-skeletons.tsx
@@ -1,0 +1,30 @@
+import React, { type ReactNode } from 'react';
+import { Skeleton } from '@metamask/design-system-react';
+
+export type MoneyActivitySettlingSkeletonsProps = {
+  children?: ReactNode;
+  className?: string;
+};
+
+/**
+ * Placeholder rows shown while Money activity is still filling its first page.
+ *
+ * @param options0 - Component props.
+ * @param options0.children - Optional content after the skeletons, such as a
+ * scroll sentinel.
+ * @param options0.className - Layout classes. Defaults match the Home preview.
+ * @returns Three full-width row skeletons.
+ */
+export function MoneyActivitySettlingSkeletons({
+  children,
+  className = 'flex flex-col gap-3 px-4 py-3',
+}: MoneyActivitySettlingSkeletonsProps) {
+  return (
+    <div className={className} data-testid="money-activity-settling">
+      <Skeleton className="h-12 w-full" />
+      <Skeleton className="h-12 w-full" />
+      <Skeleton className="h-12 w-full" />
+      {children}
+    </div>
+  );
+}

--- a/ui/pages/money/money-activity-page.test.tsx
+++ b/ui/pages/money/money-activity-page.test.tsx
@@ -91,6 +91,12 @@ describe('MoneyActivityPage', () => {
     mockUseMoneyActivityItems.mockReturnValue({
       items: mockItems,
       buckets: mockBuckets,
+      hasMore: false,
+      loadMore: jest.fn(),
+      isLoadingMore: false,
+      isSettling: false,
+      error: false,
+      refetch: jest.fn(),
     });
     mockUseMoneyActivityItemClick.mockReturnValue(undefined);
   });
@@ -210,6 +216,12 @@ describe('MoneyActivityPage', () => {
     mockUseMoneyActivityItems.mockReturnValue({
       items: [],
       buckets: EMPTY_MONEY_ACTIVITY_BUCKETS,
+      hasMore: false,
+      loadMore: jest.fn(),
+      isLoadingMore: false,
+      isSettling: false,
+      error: false,
+      refetch: jest.fn(),
     });
 
     renderWithLocalization(<MoneyActivityPage />);
@@ -228,6 +240,12 @@ describe('MoneyActivityPage', () => {
     mockUseMoneyActivityItems.mockReturnValue({
       items,
       buckets: buildMoneyActivityBuckets(items),
+      hasMore: false,
+      loadMore: jest.fn(),
+      isLoadingMore: false,
+      isSettling: false,
+      error: false,
+      refetch: jest.fn(),
     });
 
     renderWithLocalization(<MoneyActivityPage />);
@@ -258,5 +276,50 @@ describe('MoneyActivityPage', () => {
     expect(
       screen.getByTestId(`money-activity-row-${mockItems[0].id}`).tagName,
     ).toBe('DIV');
+  });
+
+  it('shows a settling skeleton instead of empty copy', () => {
+    mockUseMoneyActivityItems.mockReturnValue({
+      items: [],
+      buckets: EMPTY_MONEY_ACTIVITY_BUCKETS,
+      hasMore: true,
+      loadMore: jest.fn(),
+      isLoadingMore: true,
+      isSettling: true,
+      error: false,
+      refetch: jest.fn(),
+    });
+
+    renderWithLocalization(<MoneyActivityPage />);
+
+    expect(screen.getByTestId('money-activity-settling')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('money-activity-scroll-sentinel'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('money-activity-empty'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a load error and retry when the Accounts API fails with no rows', () => {
+    const refetch = jest.fn();
+    mockUseMoneyActivityItems.mockReturnValue({
+      items: [],
+      buckets: EMPTY_MONEY_ACTIVITY_BUCKETS,
+      hasMore: false,
+      loadMore: jest.fn(),
+      isLoadingMore: false,
+      isSettling: false,
+      error: true,
+      refetch,
+    });
+
+    renderWithLocalization(<MoneyActivityPage />);
+
+    expect(screen.getByTestId('money-activity-empty')).toHaveTextContent(
+      messages.moneyActivityLoadError.message,
+    );
+    fireEvent.click(screen.getByTestId('money-activity-retry'));
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/pages/money/money-activity-page.tsx
+++ b/ui/pages/money/money-activity-page.tsx
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -23,14 +24,19 @@ import {
 } from '@metamask/design-system-react';
 import { DEFAULT_ROUTE, PREVIOUS_ROUTE } from '../../helpers/constants/routes';
 import { useI18nContext } from '../../hooks/useI18nContext';
+import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
 import { useMoneyAccountAvailability } from '../../hooks/money/use-money-account-availability';
 import { useMoneyActivityItems } from '../../hooks/money/use-money-activity-items';
 import { useMoneyActivityItemClick } from '../../hooks/money/use-money-activity-item-click';
 import { getPrivacyMode } from '../../selectors/selectors';
 import { MoneyActivityRow } from './components/money-activity-row';
+import { MoneyActivityRetryButton } from './components/money-activity-retry-button';
+import { MoneyActivitySettlingSkeletons } from './components/money-activity-settling-skeletons';
 import { MoneyActivityFilter } from './utils/money-activity-filters';
 import { groupMoneyActivityItems } from './utils/group-money-activity';
 import { resetOverflowAncestorScroll } from './utils/reset-overflow-ancestor-scroll';
+
+const ACTIVITY_FILL_COUNT = 15;
 
 const FILTERS: {
   id: MoneyActivityFilter;
@@ -61,13 +67,32 @@ export function MoneyActivityPage() {
   const { availability, isLoading: isAvailabilityLoading } =
     useMoneyAccountAvailability();
   const [filter, setFilter] = useState(MoneyActivityFilter.All);
-  const { buckets } = useMoneyActivityItems();
+  const {
+    buckets,
+    hasMore,
+    loadMore,
+    isLoadingMore,
+    isSettling,
+    error,
+    refetch,
+  } = useMoneyActivityItems({
+    fill: { bucket: filter, count: ACTIVITY_FILL_COUNT },
+  });
   const handleItemClick = useMoneyActivityItemClick();
   const pageRef = useRef<HTMLDivElement>(null);
+  const [sentinelRef, isSentinelIntersecting] = useIntersectionObserver({
+    rootMargin: '400px 0px',
+  });
 
   useLayoutEffect(() => {
     resetOverflowAncestorScroll(pageRef.current);
   }, []);
+
+  useEffect(() => {
+    if (isSentinelIntersecting && hasMore) {
+      loadMore();
+    }
+  }, [isSentinelIntersecting, hasMore, loadMore]);
 
   const filteredItems = buckets[filter];
   const sections = useMemo(
@@ -78,6 +103,10 @@ export function MoneyActivityPage() {
   const handleBack = useCallback(() => {
     navigate(PREVIOUS_ROUTE);
   }, [navigate]);
+
+  const scrollSentinel = hasMore ? (
+    <div ref={sentinelRef} data-testid="money-activity-scroll-sentinel" />
+  ) : null;
 
   let body: React.ReactNode;
   if (isAvailabilityLoading) {
@@ -93,7 +122,13 @@ export function MoneyActivityPage() {
     );
   } else if (availability.isAvailable) {
     let listBody: React.ReactNode;
-    if (filteredItems.length === 0) {
+    if (isSettling) {
+      listBody = (
+        <MoneyActivitySettlingSkeletons className="flex flex-col gap-3 px-4 py-4">
+          {scrollSentinel}
+        </MoneyActivitySettlingSkeletons>
+      );
+    } else if (filteredItems.length === 0) {
       listBody = (
         <Box paddingLeft={4} paddingRight={4} paddingTop={8}>
           <Text
@@ -101,8 +136,17 @@ export function MoneyActivityPage() {
             color={TextColor.TextAlternative}
             data-testid="money-activity-empty"
           >
-            {t('moneyActivityEmpty')}
+            {t(error ? 'moneyActivityLoadError' : 'moneyActivityEmpty')}
           </Text>
+          {error ? (
+            <MoneyActivityRetryButton
+              className="mt-4"
+              onClick={() => {
+                refetch();
+              }}
+            />
+          ) : null}
+          {scrollSentinel}
         </Box>
       );
     } else {
@@ -139,6 +183,40 @@ export function MoneyActivityPage() {
               ))}
             </section>
           ))}
+          {isLoadingMore ? (
+            <Box
+              paddingLeft={4}
+              paddingRight={4}
+              paddingTop={3}
+              paddingBottom={3}
+              data-testid="money-activity-loading-more"
+            >
+              <Skeleton className="h-12 w-full" />
+            </Box>
+          ) : null}
+          {error ? (
+            <Box
+              paddingLeft={4}
+              paddingRight={4}
+              paddingTop={3}
+              paddingBottom={3}
+              data-testid="money-activity-load-error"
+            >
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
+                {t('moneyActivityLoadError')}
+              </Text>
+              <MoneyActivityRetryButton
+                className="mt-3"
+                onClick={() => {
+                  refetch();
+                }}
+              />
+            </Box>
+          ) : null}
+          {scrollSentinel}
         </>
       );
     }

--- a/ui/pages/money/money-home-page.tsx
+++ b/ui/pages/money/money-home-page.tsx
@@ -33,10 +33,14 @@ import { moneyFormatUsd } from '../../helpers/money/format';
 import { selectMoneyEarningSectionEnabled } from '../../selectors/money/money-account-feature-flags';
 import { getPrivacyMode } from '../../selectors/selectors';
 import { MONEY_LANDING_URL } from './constants/urls';
-import { MoneyActivityList } from './components/money-activity-list';
+import {
+  MoneyActivityList,
+  MAX_PREVIEW_ITEMS,
+} from './components/money-activity-list';
 import { MoneyCondensedInfoCards } from './components/money-condensed-info-cards';
 import { MoneyPotentialEarnings } from './components/money-potential-earnings';
 import { MoneyPositionPlaceholder } from './components/money-position-placeholder';
+import { MoneyActivityFilter } from './utils/money-activity-filters';
 
 const MONEY_FUNDED_BALANCE_THRESHOLD = 0.01;
 const MONEY_ONBOARDING_ARTWORK = './images/money-onboarding-stepper-step-1.png';
@@ -153,7 +157,13 @@ export function MoneyHomePage() {
   const isLifetimeEarningsLoading = sinceInceptionQuery.isLoading;
   const { tokens: depositTokens, isNoFeeToken } = useMoneyDepositTokens();
   const privacyMode = useSelector(getPrivacyMode);
-  const { items: activityItems } = useMoneyActivityItems();
+  const {
+    items: activityItems,
+    hasMore: hasMoreActivity,
+    isSettling: isActivitySettling,
+  } = useMoneyActivityItems({
+    fill: { bucket: MoneyActivityFilter.All, count: MAX_PREVIEW_ITEMS },
+  });
   const handleActivityItemClick = useMoneyActivityItemClick();
   const { initiateDeposit, isLoading: isDepositLoading } =
     useMoneyAccountDeposit();
@@ -338,6 +348,8 @@ export function MoneyHomePage() {
               privacyMode={privacyMode}
               onViewAll={handleViewAllActivity}
               onItemClick={handleActivityItemClick}
+              hasMore={hasMoreActivity}
+              isSettling={isActivitySettling}
             />
             <MoneySectionDivider />
             {earnOnYourCryptoSection}
@@ -381,6 +393,8 @@ export function MoneyHomePage() {
               privacyMode={privacyMode}
               onViewAll={handleViewAllActivity}
               onItemClick={handleActivityItemClick}
+              hasMore={hasMoreActivity}
+              isSettling={isActivitySettling}
             />
 
             <MoneySectionDivider />

--- a/ui/pages/money/types/money-activity.ts
+++ b/ui/pages/money/types/money-activity.ts
@@ -1,18 +1,91 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
 
 /**
- * One row in the Money activity list, sourced from TransactionController.
+ * Card spends, cashback, and refunds from the Accounts API. These are not
+ * created in this client, so they never reach TransactionController.
  */
-export type MoneyActivityItem = {
+type AccountsApiSettlement = {
+  /** On-chain tx hash. Combined with `kind` for the activity row id. */
+  hash: Hex;
+  /** Settlement time, epoch ms (parsed from the API's ISO timestamp). */
+  time: number;
+  chainId: Hex;
+  token: {
+    address: Hex;
+    symbol: string;
+    decimals: number;
+  };
+  /** Raw, minimal-unit amount of the settlement transfer. */
+  amount: string;
+};
+
+export type AccountsApiActivity =
+  | (AccountsApiSettlement & {
+      kind: 'card';
+      paidTo: Hex;
+    })
+  | (AccountsApiSettlement & {
+      kind: 'cashback';
+      receivedFrom: Hex;
+    })
+  | (AccountsApiSettlement & {
+      kind: 'refund';
+      receivedFrom: Hex;
+    });
+
+export type OnchainMoneyActivityItem = {
   kind: 'onchain';
   id: string;
   time: number;
   tx: TransactionMeta;
 };
 
-export const onchainItem = (tx: TransactionMeta): MoneyActivityItem => ({
+export type AccountsApiMoneyActivityItem = {
+  kind: 'accountsApi';
+  id: string;
+  time: number;
+  tx: AccountsApiActivity;
+};
+
+/**
+ * One row in the Money activity list, tagged by source.
+ */
+export type MoneyActivityItem =
+  | OnchainMoneyActivityItem
+  | AccountsApiMoneyActivityItem;
+
+export const onchainItem = (tx: TransactionMeta): OnchainMoneyActivityItem => ({
   kind: 'onchain',
   id: tx.id,
   time: tx.time ?? 0,
   tx,
 });
+
+/**
+ * Wraps an Accounts API settlement as a list item. The id is kind-qualified
+ * so a same-hash purchase and cashback cannot collide as React keys.
+ *
+ * @param tx - Parsed Accounts API activity.
+ * @returns A source-tagged activity item.
+ */
+export const accountsApiItem = (
+  tx: AccountsApiActivity,
+): AccountsApiMoneyActivityItem => ({
+  kind: 'accountsApi',
+  id: `${tx.kind}:${tx.hash}`,
+  time: tx.time,
+  tx,
+});
+
+export function isOnchainMoneyActivityItem(
+  item: MoneyActivityItem,
+): item is OnchainMoneyActivityItem {
+  return item.kind === 'onchain';
+}
+
+export function isAccountsApiMoneyActivityItem(
+  item: MoneyActivityItem,
+): item is AccountsApiMoneyActivityItem {
+  return item.kind === 'accountsApi';
+}

--- a/ui/pages/money/utils/accounts-api.test.ts
+++ b/ui/pages/money/utils/accounts-api.test.ts
@@ -1,0 +1,229 @@
+import {
+  oldestRawActivityTime,
+  parseAccountsApiActivity,
+} from './accounts-api';
+
+const MONEY_ADDRESS = '0xbF4bC559f929cE3994Ba12D71d564737357bC8C2';
+const SETTLEMENT_ADDRESS = '0x8dFE562Cbb4E93D5029f39DA26BB6B501a8d1D3e';
+const REWARDER_ADDRESS = '0xfe80eea4249a1f01095d35e0cf4f37367976a9f0';
+const CASHBACK_MULTISEND_TO = '0xC7f1b2228fbf28451c7bf791C4f610111f0f32cb';
+
+const cardPaymentRow = {
+  hash: '0x2b45bda071d8feff265c541e251a5e035e5f55270f8ad288dcd80f6740793847',
+  timestamp: '2026-06-04T11:53:51.000Z',
+  chainId: 143,
+  from: '0x1905d0a43340c81b94468e7dfa5f341ff47ae6a5',
+  to: '0x40a695a16c213afef1c87fd471fb73157b948f3f',
+  isError: false,
+  transactionType: 'METAMASK_CARD_PAYMENT',
+  valueTransfers: [
+    {
+      from: MONEY_ADDRESS.toLowerCase(),
+      to: SETTLEMENT_ADDRESS.toLowerCase(),
+      amount: '5381986',
+      decimal: 6,
+      contractAddress: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+      symbol: 'mUSD',
+    },
+  ],
+};
+
+const cashbackRow = {
+  hash: '0x9c3aa0a1f1f4a8c2d3e4f5061728394a5b6c7d8e9f00112233445566778899aa',
+  timestamp: '2026-06-04T12:10:00.000Z',
+  chainId: 143,
+  from: REWARDER_ADDRESS,
+  to: MONEY_ADDRESS.toLowerCase(),
+  isError: false,
+  transactionType: 'METAMASK_CARD_CASHBACK',
+  valueTransfers: [
+    {
+      from: REWARDER_ADDRESS,
+      to: MONEY_ADDRESS.toLowerCase(),
+      amount: '300000',
+      decimal: 6,
+      contractAddress: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+      symbol: 'mUSD',
+    },
+  ],
+};
+
+const unclassifiedCashbackRow = {
+  hash: '0x126be466696f2e3d124c97dedd7a6abd02e31883f544e92f80de732d566b9b16',
+  timestamp: '2026-06-22T21:41:12.000Z',
+  chainId: 143,
+  from: '0xb978703B01a60c7fbD4541D6c29299C65C8e61EA',
+  to: CASHBACK_MULTISEND_TO,
+  isError: false,
+  methodId: '0x0d49b711',
+  transactionType: 'GENERIC_CONTRACT_CALL',
+  valueTransfers: [
+    {
+      from: '0x21607d4c8cf71844955889890c1711655fd08d72',
+      to: MONEY_ADDRESS.toLowerCase(),
+      amount: '999454',
+      decimal: 6,
+      contractAddress: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+      symbol: 'mUSD',
+    },
+  ],
+};
+
+const inboundTopUpRow = {
+  hash: '0x1219eae581c3f3ff44cace3ec51b91c31fa15aecbff612d8bcd058128990e710',
+  timestamp: '2026-06-04T11:42:02.000Z',
+  chainId: 143,
+  from: '0xb42f812a44c22cc6b861478900401ee759ebead6',
+  to: '0xdb9b1e94b5b69df7e401ddbede43491141047db3',
+  isError: false,
+  transactionType: 'GENERIC_CONTRACT_CALL',
+  valueTransfers: [
+    {
+      from: '0xfe80eea4249a1f01095d35e0cf4f37367976a9f0',
+      to: MONEY_ADDRESS.toLowerCase(),
+      amount: '9910542',
+      decimal: 6,
+      contractAddress: '0x754704bc059f8c67012fed69bc8a327a5aafb603',
+      symbol: 'USDC',
+    },
+  ],
+};
+
+describe('parseAccountsApiActivity', () => {
+  it('maps a card payment to a card outflow keyed on the leg leaving the money account', () => {
+    const result = parseAccountsApiActivity(
+      { data: [cardPaymentRow, inboundTopUpRow] },
+      MONEY_ADDRESS,
+    );
+
+    expect(result).toStrictEqual([
+      {
+        kind: 'card',
+        hash: cardPaymentRow.hash,
+        time: Date.parse('2026-06-04T11:53:51.000Z'),
+        chainId: '0x8f',
+        token: {
+          address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+          symbol: 'mUSD',
+          decimals: 6,
+        },
+        amount: '5381986',
+        paidTo: SETTLEMENT_ADDRESS.toLowerCase(),
+      },
+    ]);
+  });
+
+  it('maps a cashback row to a cashback inflow', () => {
+    const result = parseAccountsApiActivity(
+      { data: [cashbackRow, inboundTopUpRow] },
+      MONEY_ADDRESS,
+    );
+
+    expect(result).toStrictEqual([
+      {
+        kind: 'cashback',
+        hash: cashbackRow.hash,
+        time: Date.parse('2026-06-04T12:10:00.000Z'),
+        chainId: '0x8f',
+        token: {
+          address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+          symbol: 'mUSD',
+          decimals: 6,
+        },
+        amount: '300000',
+        receivedFrom: REWARDER_ADDRESS,
+      },
+    ]);
+  });
+
+  it('maps an unclassified Baanx multisend payout to cashback', () => {
+    const result = parseAccountsApiActivity(
+      { data: [unclassifiedCashbackRow] },
+      MONEY_ADDRESS,
+    );
+
+    expect(result).toStrictEqual([
+      expect.objectContaining({
+        kind: 'cashback',
+        hash: unclassifiedCashbackRow.hash,
+        amount: '999454',
+      }),
+    ]);
+  });
+
+  it('maps a reversed card payment to a refund', () => {
+    const result = parseAccountsApiActivity(
+      {
+        data: [
+          {
+            ...cardPaymentRow,
+            valueTransfers: [
+              {
+                ...cardPaymentRow.valueTransfers[0],
+                from: SETTLEMENT_ADDRESS.toLowerCase(),
+                to: MONEY_ADDRESS.toLowerCase(),
+              },
+            ],
+          },
+        ],
+      },
+      MONEY_ADDRESS,
+    );
+
+    expect(result).toStrictEqual([
+      expect.objectContaining({
+        kind: 'refund',
+        hash: cardPaymentRow.hash,
+        amount: '5381986',
+      }),
+    ]);
+  });
+
+  it('drops rows whose chainId is not Monad', () => {
+    expect(
+      parseAccountsApiActivity(
+        {
+          data: [
+            { ...cardPaymentRow, chainId: 1 },
+            { ...cashbackRow, chainId: 1 },
+          ],
+        },
+        MONEY_ADDRESS,
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it('drops malformed rows without throwing', () => {
+    expect(
+      parseAccountsApiActivity(
+        {
+          data: [
+            { ...cardPaymentRow, valueTransfers: [] },
+            { ...cashbackRow, timestamp: 'not-a-date' },
+          ],
+        },
+        MONEY_ADDRESS,
+      ),
+    ).toStrictEqual([]);
+  });
+});
+
+describe('oldestRawActivityTime', () => {
+  const page = (...timestamps: string[]) => ({
+    data: timestamps.map((timestamp) => ({ timestamp })),
+  });
+
+  it('returns +Infinity when no pages have been fetched', () => {
+    expect(oldestRawActivityTime([])).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('returns the oldest raw timestamp across every page', () => {
+    const oldest = '2026-06-01T00:00:00.000Z';
+    expect(
+      oldestRawActivityTime([
+        page('2026-06-04T00:00:00.000Z', '2026-06-03T00:00:00.000Z'),
+        page(oldest, '2026-06-02T00:00:00.000Z'),
+      ]),
+    ).toBe(new Date(oldest).getTime());
+  });
+});

--- a/ui/pages/money/utils/accounts-api.ts
+++ b/ui/pages/money/utils/accounts-api.ts
@@ -1,0 +1,250 @@
+import type { Hex } from '@metamask/utils';
+import { toHex } from '@metamask/controller-utils';
+import {
+  isMusdOnMoneyAccountChain,
+  MUSD_MONEY_ACCOUNT_CHAIN_IDS,
+} from '@metamask/money-account-utils';
+import { isEqualCaseInsensitive } from '../../../../shared/lib/string-utils';
+import type { AccountsApiActivity } from '../types/money-activity';
+
+export const METAMASK_CARD_PAYMENT_TYPE = 'METAMASK_CARD_PAYMENT';
+export const METAMASK_CARD_CASHBACK_TYPE = 'METAMASK_CARD_CASHBACK';
+
+/**
+ * Baanx card-cashback multisend contracts observed on Monad and Linea.
+ * Temporary client-side signal until Accounts API assigns
+ * `METAMASK_CARD_CASHBACK`.
+ */
+export const DEFAULT_MONEY_CARD_ACTIVITY_CASHBACK_MULTISEND_CONTRACTS: readonly string[] =
+  [
+    '0x9dd23A4a0845f10d65D293776B792af1131c7B30',
+    '0xA90b298d05C2667dDC64e2A4e17111357c215dD2',
+    '0x40A695A16C213afEf1c87Fd471Fb73157b948f3f',
+    '0x144c1cE815Bd1Eb71678978fE8641cC4e3fd59e6',
+    '0xC7f1b2228fbf28451c7bf791C4f610111f0f32cb',
+  ];
+
+/** `multiSend` entrypoint on card-cashback payout transactions. */
+const CARD_CASHBACK_MULTISEND_METHOD_ID = '0x0d49b711';
+
+const ALLOWED_CHAIN_IDS = new Set(
+  MUSD_MONEY_ACCOUNT_CHAIN_IDS.map((chainId) => chainId.toLowerCase()),
+);
+
+type AccountsApiValueTransfer = {
+  contractAddress: string;
+  symbol: string;
+  decimal: number;
+  from: string;
+  to: string;
+  amount: string;
+};
+
+type AccountsApiTransaction = {
+  hash: string;
+  timestamp: string;
+  chainId: number;
+  from: string;
+  to: string;
+  isError?: boolean;
+  transactionType?: string;
+  methodId?: string;
+  valueTransfers?: AccountsApiValueTransfer[];
+};
+
+export type AccountsApiTransactionsResponse = {
+  data?: AccountsApiTransaction[];
+  pageInfo?: { count: number; hasNextPage: boolean; cursor?: string };
+};
+
+function outboundTransfer(
+  tx: AccountsApiTransaction,
+  moneyAddress: string,
+): AccountsApiValueTransfer | undefined {
+  return (tx.valueTransfers ?? []).find((transfer) =>
+    isEqualCaseInsensitive(transfer.from, moneyAddress),
+  );
+}
+
+function inboundMusdTransfer(
+  tx: AccountsApiTransaction,
+  moneyAddress: string,
+): AccountsApiValueTransfer | undefined {
+  const chainId = parseChainId(tx.chainId);
+  if (!chainId) {
+    return undefined;
+  }
+  return (tx.valueTransfers ?? []).find(
+    (transfer) =>
+      isEqualCaseInsensitive(transfer.to, moneyAddress) &&
+      isMusdOnMoneyAccountChain(transfer.contractAddress, chainId),
+  );
+}
+
+const AMOUNT_PATTERN = /^\d+$/u;
+
+function parseChainId(chainId: unknown): Hex | undefined {
+  if (
+    typeof chainId !== 'number' ||
+    !Number.isInteger(chainId) ||
+    chainId < 0
+  ) {
+    return undefined;
+  }
+  const hex = toHex(chainId);
+  return ALLOWED_CHAIN_IDS.has(hex.toLowerCase()) ? hex : undefined;
+}
+
+type ParsedSettlement = {
+  hash: Hex;
+  time: number;
+  chainId: Hex;
+  token: { address: Hex; symbol: string; decimals: number };
+  amount: string;
+};
+
+function parseSettlement(
+  tx: AccountsApiTransaction,
+  transfer: AccountsApiValueTransfer | undefined,
+): ParsedSettlement | undefined {
+  const time = new Date(tx.timestamp).getTime();
+  const chainId = parseChainId(tx.chainId);
+  if (
+    !tx.hash ||
+    !transfer ||
+    Number.isNaN(time) ||
+    !chainId ||
+    !Number.isInteger(transfer.decimal) ||
+    transfer.decimal < 0 ||
+    typeof transfer.amount !== 'string' ||
+    !AMOUNT_PATTERN.test(transfer.amount)
+  ) {
+    return undefined;
+  }
+  return {
+    hash: tx.hash as Hex,
+    time,
+    chainId,
+    token: {
+      address: transfer.contractAddress as Hex,
+      symbol: transfer.symbol,
+      decimals: transfer.decimal,
+    },
+    amount: transfer.amount,
+  };
+}
+
+/**
+ * Oldest raw (pre-filter) settlement time across the fetched Accounts-API
+ * pages, in epoch ms. Because pages are fetched newest-first, every API row
+ * newer than this has been seen. Merged activity older than the watermark
+ * must be withheld until more pages load.
+ *
+ * Computed from the raw rows because a row we do not render still advances
+ * how far back we have looked. Returns `Number.POSITIVE_INFINITY` when no
+ * rows have been fetched yet.
+ *
+ * @param responses - Fetched Accounts API pages.
+ * @returns Oldest parseable timestamp, or +Infinity when none.
+ */
+export function oldestRawActivityTime(
+  responses: readonly { data?: { timestamp: string }[] }[],
+): number {
+  let oldest = Number.POSITIVE_INFINITY;
+  for (const response of responses) {
+    for (const row of response.data ?? []) {
+      const time = new Date(row.timestamp).getTime();
+      if (!Number.isNaN(time) && time < oldest) {
+        oldest = time;
+      }
+    }
+  }
+  return oldest;
+}
+
+/**
+ * Parse an Accounts API page into Money activity rows (card spend, cashback,
+ * refund). Unrelated and malformed rows are dropped.
+ *
+ * @param response - One Accounts API transactions page.
+ * @param moneyAddress - Money Account address used to pick settlement legs.
+ * @param cashbackMultisendContracts - Known Baanx cashback multisend targets.
+ * @returns Parsed activity rows from this page.
+ */
+export function parseAccountsApiActivity(
+  response: AccountsApiTransactionsResponse,
+  moneyAddress: string,
+  cashbackMultisendContracts: readonly string[] = DEFAULT_MONEY_CARD_ACTIVITY_CASHBACK_MULTISEND_CONTRACTS,
+): AccountsApiActivity[] {
+  return (response.data ?? []).flatMap((tx): AccountsApiActivity[] => {
+    if (tx.transactionType === METAMASK_CARD_PAYMENT_TYPE) {
+      const outbound = outboundTransfer(tx, moneyAddress);
+      if (outbound) {
+        const parsed = parseSettlement(tx, outbound);
+        if (!parsed) {
+          return [];
+        }
+        return [{ ...parsed, kind: 'card', paidTo: outbound.to as Hex }];
+      }
+      const inbound = inboundMusdTransfer(tx, moneyAddress);
+      const parsed = parseSettlement(tx, inbound);
+      if (!parsed || !inbound) {
+        return [];
+      }
+      return [{ ...parsed, kind: 'refund', receivedFrom: inbound.from as Hex }];
+    }
+    if (isCashbackTransaction(tx, moneyAddress, cashbackMultisendContracts)) {
+      const transfer = inboundMusdTransfer(tx, moneyAddress);
+      const parsed = parseSettlement(tx, transfer);
+      if (!parsed || !transfer) {
+        return [];
+      }
+      return [
+        { ...parsed, kind: 'cashback', receivedFrom: transfer.from as Hex },
+      ];
+    }
+    return [];
+  });
+}
+
+function isCashbackMultisendTarget(
+  to: string,
+  cashbackMultisendContracts: readonly string[],
+): boolean {
+  return cashbackMultisendContracts.some((address) =>
+    isEqualCaseInsensitive(to, address),
+  );
+}
+
+function isCashbackTransaction(
+  tx: AccountsApiTransaction,
+  moneyAddress: string,
+  cashbackMultisendContracts: readonly string[],
+): boolean {
+  if (tx.isError) {
+    return false;
+  }
+  if (tx.transactionType === METAMASK_CARD_CASHBACK_TYPE) {
+    return true;
+  }
+  if (tx.transactionType === METAMASK_CARD_PAYMENT_TYPE) {
+    return false;
+  }
+  if (!parseChainId(tx.chainId)) {
+    return false;
+  }
+  if (
+    !isCashbackMultisendTarget(tx.to, cashbackMultisendContracts) ||
+    !inboundMusdTransfer(tx, moneyAddress)
+  ) {
+    return false;
+  }
+  if (
+    tx.methodId &&
+    tx.methodId.toLowerCase() !==
+      CARD_CASHBACK_MULTISEND_METHOD_ID.toLowerCase()
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/ui/pages/money/utils/group-money-activity.test.ts
+++ b/ui/pages/money/utils/group-money-activity.test.ts
@@ -3,7 +3,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { onchainItem } from '../types/money-activity';
+import { onchainItem, accountsApiItem } from '../types/money-activity';
 import {
   formatMoneyActivityDateHeader,
   getMoneyActivityDateKeyUtc,
@@ -79,6 +79,28 @@ describe('groupMoneyActivityItems', () => {
     expect(sections[0].isPending).toBeUndefined();
     expect(sections[0].title).toBe('May 10, 2026');
     expect(sections[0].data.map((item) => item.id)).toStrictEqual(['failed']);
+  });
+
+  it('keeps Accounts API rows in date sections rather than Pending', () => {
+    const apiItem = accountsApiItem({
+      kind: 'card',
+      hash: '0xabc',
+      time: Date.UTC(2026, 4, 10),
+      chainId: '0x8f',
+      token: {
+        address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+        symbol: 'mUSD',
+        decimals: 6,
+      },
+      amount: '1000000',
+      paidTo: '0xdef',
+    });
+
+    const sections = groupMoneyActivityItems([apiItem], 'Pending');
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].isPending).toBeUndefined();
+    expect(sections[0].data.map((item) => item.id)).toStrictEqual([apiItem.id]);
   });
 
   it('groups settled items by UTC day newest-first', () => {

--- a/ui/pages/money/utils/group-money-activity.ts
+++ b/ui/pages/money/utils/group-money-activity.ts
@@ -35,7 +35,9 @@ export function formatMoneyActivityDateHeader(dateKey: string): string {
 }
 
 function isPendingItem(item: MoneyActivityItem): boolean {
-  return getMoneyActivityStatus(item.tx) === 'pending';
+  return (
+    item.kind === 'onchain' && getMoneyActivityStatus(item.tx) === 'pending'
+  );
 }
 
 function groupByDate(items: MoneyActivityItem[]): MoneyActivitySection[] {

--- a/ui/pages/money/utils/money-activity-display.test.ts
+++ b/ui/pages/money/utils/money-activity-display.test.ts
@@ -9,6 +9,7 @@ import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import MOCK_MONEY_TRANSACTIONS from '../constants/mock-activity-data';
 import {
   getMoneyActivityDisplayInfo,
+  getAccountsApiActivityDisplayInfo,
   type MoneyActivityTranslate,
 } from './money-activity-display';
 
@@ -152,5 +153,36 @@ describe('getMoneyActivityDisplayInfo', () => {
 
     expect(display.primaryAmount).toBe('+2.50 mUSD');
     expect(display.fiatAmount).toBe('+$2.50');
+  });
+});
+
+describe('getAccountsApiActivityDisplayInfo', () => {
+  it('renders a card purchase as a signed outflow with a Card subtitle', () => {
+    const display = getAccountsApiActivityDisplayInfo(
+      {
+        kind: 'card',
+        hash: '0xabc',
+        time: 1,
+        chainId: '0x8f',
+        token: {
+          address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+          symbol: 'mUSD',
+          decimals: 6,
+        },
+        amount: '1500000',
+        paidTo: '0xdef',
+      },
+      t,
+    );
+
+    expect(display).toMatchObject({
+      label: messages.moneyActivityPurchase.message,
+      description: messages.moneyActivityCard.message,
+      primaryAmount: '-1.50 mUSD',
+      fiatAmount: '-$1.50',
+      isIncoming: false,
+      icon: IconName.Card,
+      status: 'confirmed',
+    });
   });
 });

--- a/ui/pages/money/utils/money-activity-display.ts
+++ b/ui/pages/money/utils/money-activity-display.ts
@@ -6,11 +6,13 @@ import {
   MUSD_TOKEN,
 } from '@metamask/money-account-utils';
 import type { IconName as IconNameType } from '@metamask/design-system-react';
+import { IconName } from '@metamask/design-system-react';
 import BigNumber from 'bignumber.js';
 import { moneyFormatUsd } from '../../../helpers/money/format';
 import { getMoneyAccountDepositAmount } from '../../../helpers/money/money-account-amounts';
 import { shortenAddress } from '../../../helpers/utils/util';
 import type { MoneyActivityTransactionMeta } from '../constants/mock-activity-data';
+import type { AccountsApiActivity } from '../types/money-activity';
 import { decodeErc20Transfer } from './erc20-transfer';
 import { ERC20_TRANSFER_TYPES } from './money-activity-filters';
 import {
@@ -290,6 +292,39 @@ export function getMoneyActivityDisplayInfo(
     isIncoming,
     icon: moneyActivityKindToIcon(kind),
     status,
+  };
+}
+
+const ACCOUNTS_API_LABEL_KEY: Record<AccountsApiActivity['kind'], string> = {
+  card: 'moneyActivityPurchase',
+  cashback: 'moneyActivityMusdBack',
+  refund: 'moneyActivityRefund',
+};
+
+/**
+ * Display strings for an Accounts API card/cashback/refund row.
+ *
+ * @param activity - Parsed Accounts API settlement.
+ * @param t - i18n translate function.
+ * @returns Label, Card subtitle, signed amounts, and confirmed status.
+ */
+export function getAccountsApiActivityDisplayInfo(
+  activity: AccountsApiActivity,
+  t: MoneyActivityTranslate,
+): MoneyTransactionDisplayInfo {
+  const isIncoming = activity.kind === 'cashback' || activity.kind === 'refund';
+  const usdValue = new BigNumber(activity.amount).dividedBy(
+    new BigNumber(10).pow(activity.token.decimals),
+  );
+
+  return {
+    label: t(ACCOUNTS_API_LABEL_KEY[activity.kind]),
+    description: t('moneyActivityCard'),
+    primaryAmount: formatMusdAmount(usdValue, isIncoming),
+    fiatAmount: formatFiatAmount(usdValue, isIncoming),
+    isIncoming,
+    icon: IconName.Card,
+    status: 'confirmed',
   };
 }
 

--- a/ui/pages/money/utils/money-activity-filters.ts
+++ b/ui/pages/money/utils/money-activity-filters.ts
@@ -7,7 +7,10 @@ import {
   isMoneyDepositTx,
   isMoneyWithdrawTx,
 } from '../../../helpers/money/money-transaction-guards';
-import { type MoneyActivityItem } from '../types/money-activity';
+import {
+  isOnchainMoneyActivityItem,
+  type MoneyActivityItem,
+} from '../types/money-activity';
 
 /**
  * Filter chips on the Money Activity page. Values match mobile; the
@@ -68,11 +71,12 @@ export function isMoneyActivityTransfer(tx: TransactionMeta): boolean {
  * Splits on-chain activity into All / Deposits / Sends buckets.
  *
  * `items` is already visibility-filtered (Money Pay deposits, sends, and
- * incoming mUSD). All keeps that full list. Deposits and Sends are narrower
- * chips; a confirmed Pay tx from the Money Account can be visible without
- * matching either chip type, and must still appear on Home / All.
+ * incoming mUSD, plus any Accounts API rows). All keeps that full list.
+ * Deposits and Sends are on-chain-only chips; a confirmed Pay tx from the
+ * Money Account can be visible without matching either chip type, and must
+ * still appear on Home / All.
  *
- * @param items - Newest-first on-chain activity items.
+ * @param items - Newest-first activity items.
  * @returns Filter buckets.
  */
 export function buildMoneyActivityBuckets(
@@ -80,11 +84,13 @@ export function buildMoneyActivityBuckets(
 ): MoneyActivityBuckets {
   return {
     [MoneyActivityFilter.All]: items,
-    [MoneyActivityFilter.Deposits]: items.filter((item) =>
-      isMoneyActivityDeposit(item.tx),
+    [MoneyActivityFilter.Deposits]: items.filter(
+      (item) =>
+        isOnchainMoneyActivityItem(item) && isMoneyActivityDeposit(item.tx),
     ),
-    [MoneyActivityFilter.Transfers]: items.filter((item) =>
-      isMoneyActivityTransfer(item.tx),
+    [MoneyActivityFilter.Transfers]: items.filter(
+      (item) =>
+        isOnchainMoneyActivityItem(item) && isMoneyActivityTransfer(item.tx),
     ),
   };
 }


### PR DESCRIPTION
## **Description**

Extension Money Home already lists on-chain deposits and sends from TransactionController (see #46105). Card spends and mUSD cashback that happened on mobile with the same SRP never reach that controller, so they would be missing from the activity list.

This change merges paginated Accounts API settlements (card purchase, mUSD back, refund) into the Money Home preview and full Activity list. Parsing ports Mobile's `parseAccountsApiActivity` heuristics, including inbound/outbound legs and Baanx cashback-multisend fallbacks. The query is disabled when basic functionality is off because `useMoneyAccountInfo` withholds the Money Account address when `getUseExternalServices` is false.

Card rows appear in All only, stay non-clickable, and use fixed USD for mUSD. A pagination watermark withholds older on-chain rows until enough API history has loaded, matching Mobile.

Depends on #46105.

## **Changelog**

CHANGELOG entry: Added MetaMask Card purchases, mUSD back, and refunds to Money Account activity

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1316

## **Manual testing steps**

1. Enable Money Account and basic functionality. Open Money Home with a Money Account that has MetaMask Card spend or cashback from mobile (same SRP).
2. Confirm the Home activity preview shows **Purchase** (card spend) and **mUSD back** rows with a Card subtitle, signed mUSD amounts, and USD fiat.
3. Open the full Activity list. Confirm All includes card and cashback rows mixed with on-chain deposits/sends, newest-first. Deposits and Sends stay on-chain only.
4. Tap a card purchase / mUSD back / refund row and confirm it does not navigate. Tap an on-chain row and confirm details still open.
5. Scroll the full list until older pages load. Confirm ordering stays newest-first and older on-chain rows appear once enough API history has loaded.
6. Turn off basic functionality and confirm the Accounts API is not called (Money Account path is unavailable).
7. With the activity mock flag enabled, confirm Home and Activity show only mock rows and do not call the live Accounts API.
8. Force an Accounts API failure (for example block the accounts request) and confirm an error plus Retry on the Activity list; Retry reloads the feed.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/contributor-docs/blob/main/docs/labeling-guidelines.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)