### PR TITLE
chore: scroll the deposit prompt token picker in a ScrollContainer

### DIFF
--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
@@ -70,23 +70,34 @@ jest.mock('../../../pages/confirmations/selectors/feature-flags', () => ({
   })),
 }));
 
-jest.mock('../../../pages/confirmations/components/send/asset/asset', () => ({
-  Asset: ({ onAssetSelect }: { onAssetSelect: (asset: Asset) => void }) => (
-    <button
-      data-testid="mock-asset-picker"
-      onClick={() =>
-        onAssetSelect({
-          address: '0x2222222222222222222222222222222222222222',
-          chainId: '0x1',
-          name: 'USD Coin',
-          symbol: 'USDC',
-        })
-      }
-    >
-      Mock asset picker
-    </button>
-  ),
-}));
+jest.mock('../../../pages/confirmations/components/send/asset/asset', () => {
+  const { useScrollContainer } = jest.requireActual<
+    typeof import('../../../contexts/scroll-container')
+  >('../../../contexts/scroll-container');
+
+  return {
+    Asset: ({ onAssetSelect }: { onAssetSelect: (asset: Asset) => void }) => {
+      const scrollContainerRef = useScrollContainer();
+
+      return (
+        <button
+          data-testid="mock-asset-picker"
+          data-scroll-container={scrollContainerRef ? 'present' : 'missing'}
+          onClick={() =>
+            onAssetSelect({
+              address: '0x2222222222222222222222222222222222222222',
+              chainId: '0x1',
+              name: 'USD Coin',
+              symbol: 'USDC',
+            })
+          }
+        >
+          Mock asset picker
+        </button>
+      );
+    },
+  };
+});
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -217,6 +228,19 @@ describe('HyperliquidDepositPrompt', () => {
       },
       sensitiveProperties: {},
     });
+  });
+
+  it('renders the picker inside a scroll container so the asset list virtualizes against the modal', () => {
+    renderComponent();
+
+    fireEvent.click(
+      screen.getByTestId('hyperliquid-deposit-prompt-token-select'),
+    );
+
+    expect(screen.getByTestId('mock-asset-picker')).toHaveAttribute(
+      'data-scroll-container',
+      'present',
+    );
   });
 
   it('updates the selected token when one is picked from the modal', () => {

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
@@ -70,34 +70,23 @@ jest.mock('../../../pages/confirmations/selectors/feature-flags', () => ({
   })),
 }));
 
-jest.mock('../../../pages/confirmations/components/send/asset/asset', () => {
-  const { useScrollContainer } = jest.requireActual<
-    typeof import('../../../contexts/scroll-container')
-  >('../../../contexts/scroll-container');
-
-  return {
-    Asset: ({ onAssetSelect }: { onAssetSelect: (asset: Asset) => void }) => {
-      const scrollContainerRef = useScrollContainer();
-
-      return (
-        <button
-          data-testid="mock-asset-picker"
-          data-scroll-container={scrollContainerRef ? 'present' : 'missing'}
-          onClick={() =>
-            onAssetSelect({
-              address: '0x2222222222222222222222222222222222222222',
-              chainId: '0x1',
-              name: 'USD Coin',
-              symbol: 'USDC',
-            })
-          }
-        >
-          Mock asset picker
-        </button>
-      );
-    },
-  };
-});
+jest.mock('../../../pages/confirmations/components/send/asset/asset', () => ({
+  Asset: ({ onAssetSelect }: { onAssetSelect: (asset: Asset) => void }) => (
+    <button
+      data-testid="mock-asset-picker"
+      onClick={() =>
+        onAssetSelect({
+          address: '0x2222222222222222222222222222222222222222',
+          chainId: '0x1',
+          name: 'USD Coin',
+          symbol: 'USDC',
+        })
+      }
+    >
+      Mock asset picker
+    </button>
+  ),
+}));
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -228,19 +217,6 @@ describe('HyperliquidDepositPrompt', () => {
       },
       sensitiveProperties: {},
     });
-  });
-
-  it('renders the picker inside a scroll container so the asset list virtualizes against the modal', () => {
-    renderComponent();
-
-    fireEvent.click(
-      screen.getByTestId('hyperliquid-deposit-prompt-token-select'),
-    );
-
-    expect(screen.getByTestId('mock-asset-picker')).toHaveAttribute(
-      'data-scroll-container',
-      'present',
-    );
   });
 
   it('updates the selected token when one is picked from the modal', () => {

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
@@ -23,7 +23,6 @@ import {
   IconName,
   IconSize,
   Modal,
-  ModalBody,
   ModalContent,
   ModalHeader,
   ModalOverlay,
@@ -37,6 +36,7 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { getSelectedInternalAccount } from '../../../../shared/lib/selectors/accounts';
 import { CONFIRM_TRANSACTION_ROUTE } from '../../../helpers/constants/routes';
+import { ScrollContainer } from '../../../contexts/scroll-container';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../hooks/useFiatFormatter';
 import { updateTransactionPaymentToken } from '../../../store/controller-actions/transaction-pay-controller';
@@ -379,7 +379,9 @@ export const HyperliquidDepositPrompt: React.FC<
           >
             {t('payWithModalTitle')}
           </ModalHeader>
-          <ModalBody className="overflow-auto px-0">
+          {/* The asset list virtualizes against the nearest `ScrollContainer`,
+              so this has to be the scrolling element rather than a `ModalBody`. */}
+          <ScrollContainer className="flex-1 overflow-auto">
             <Asset
               tokens={tokens}
               nfts={[]}
@@ -387,7 +389,7 @@ export const HyperliquidDepositPrompt: React.FC<
               disableMetrics
               onAssetSelect={handleTokenSelect}
             />
-          </ModalBody>
+          </ScrollContainer>
         </ModalContent>
       </Modal>
     </Box>

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
@@ -379,8 +379,6 @@ export const HyperliquidDepositPrompt: React.FC<
           >
             {t('payWithModalTitle')}
           </ModalHeader>
-          {/* The asset list virtualizes against the nearest `ScrollContainer`,
-              so this has to be the scrolling element rather than a `ModalBody`. */}
           <ScrollContainer className="flex-1 overflow-auto">
             <Asset
               tokens={tokens}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The "Pay with" token picker in the Hyperliquid deposit prompt was rendering a large amount of blank space below the token rows as the virtualizer required a scroll container rather than the existing ModalBody container.

## **Changelog**

CHANGELOG entry: Fixed blank space below the token list when choosing a token to fund a Hyperliquid deposit


## **Related issues**

Fixes:


## **Manual testing steps**

1. Open the Hyperliquid deposit prompt (sign "Enable trading" on Hyperliquid with a wallet that holds many tokens across mainnets).
2. Click the "Pay with" token row to open the token picker.
3. Scroll the token list to the bottom.
4. Verify every token renders while scrolling and that there is no blank space below the last token.
5. Verify selecting a token still closes the picker and updates the "Pay with" row, and that "Continue" starts the deposit.
6. Repeat with a wallet holding only one or two tokens and verify the modal is still sized to its content rather than stretching.


## **Screenshots/Recordings**

### **Before**

### **After**

See that the scroll bar is at the bottom of the modal and there is no blank space beneath:
<img width="368" height="597" alt="image" src="https://github.com/user-attachments/assets/7d8271e3-48b5-443b-8217-1b6afce35e9c" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78cd35fa-374f-4963-a6a3-415f4a473f01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78cd35fa-374f-4963-a6a3-415f4a473f01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

