### PR TITLE
test: fix flaky test Send NFT ERC1155 Wallet initiated sends ERC1155

### DIFF
--- a/test/e2e/tests/send/send-nft.spec.ts
+++ b/test/e2e/tests/send/send-nft.spec.ts
@@ -288,9 +288,11 @@ describe('Send NFT', function () {
             await new NftsTab(driver).clickNFTIconOnActivityList();
 
             const nftDetailsPage = new NFTDetailsPage(driver);
+            await nftDetailsPage.checkPageIsLoaded();
             await nftDetailsPage.clickNFTSendButton();
 
             const sendPage = new SendPage(driver);
+            await sendPage.checkSendFormIsLoaded();
             await sendPage.fillRecipient({
               recipientAddress: DEFAULT_RECIPIENT,
             });


### PR DESCRIPTION
## **Description**

The test is flaky and failing in CI as the test was trying to fill in the recipient address before it finished rendering.

`clickNFTSendButton()` was called before the NFT Details page finished rendering, and `fillRecipient()` was called before the Send page mounted, causing a 20 s timeout on CI.

Ci [logs](https://github.com/MetaMask/metamask-extension/actions/runs/34117782377/job/101730610009)

Added two waits:

- `await nftDetailsPage.checkPageIsLoaded()` waits for the NFT Details page to fully render before clicking Send.
- `await sendPage.checkSendFormIsLoaded()` waits for both the recipient and amount to be present before filling the recipient field.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1.  Chek CI


## **Screenshots/Recordings**

<img width="780" height="493" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/0af8ce04-fc8e-4d6b-ad0a-6eb9b2ca50f9" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test-only change with no production code or security impact.
> 
> **Overview**
> Fixes CI flakiness in the **wallet-initiated ERC1155 send** e2e test by waiting for UI to finish mounting before interacting with it.
> 
> The test now calls **`checkPageIsLoaded()`** on the NFT details page before **Send**, and **`checkSendFormIsLoaded()`** on the send page before filling the recipient—matching patterns already used in other send flows. This avoids racing the renderer and hitting ~20s timeouts when **Send** or the recipient field were not ready yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9928ce520b81aa8b8f45d2cdd91e2269e9083e60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->