### PR TITLE
fix(confirmations): delegate `getAmountData` to `TransactionControllerInit`

### DIFF
--- a/app/scripts/wallet-init/messengers/transaction-controller-messenger.test.ts
+++ b/app/scripts/wallet-init/messengers/transaction-controller-messenger.test.ts
@@ -20,6 +20,7 @@ describe('getTransactionControllerInitMessenger', () => {
     expect(delegateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         actions: expect.arrayContaining([
+          'TransactionPayController:getAmountData',
           'TransactionPayController:getDelegationTransaction',
           'TransactionPayController:getPaymentOverrideData',
         ]),

--- a/app/scripts/wallet-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/wallet-init/messengers/transaction-controller-messenger.ts
@@ -198,6 +198,7 @@ export function getTransactionControllerInitMessenger(
       'TransactionPayController:getPaymentOverrideData',
       'TransactionPayController:getState',
       'TransactionPayController:getStrategy',
+      'TransactionPayController:getAmountData',
     ],
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Non-atomic Money Account deposits pay with a source token (for example BNB on BSC), wait for Relay to settle mUSD on the Money Account, then submit a second-leg vault batch (`approve` + teller deposit). That second leg re-encodes the nested vault calldata with the settled amount by calling `TransactionPayController:getAmountData`.

`TransactionPayPublishHook` runs on the `TransactionControllerInit` messenger. That messenger already delegated `getDelegationTransaction`, `getPaymentOverrideData`, `getState`, and `getStrategy`, but not `getAmountData`. After Relay completes, `resolveVaultDepositBatch` throws:

```
MetaMask Pay: Relay: A handler for TransactionPayController:getAmountData has not been delegated to TransactionControllerInit
```

The BSC funding transaction is already on-chain and confirmed. The parent Money Pay transaction is then marked failed locally (no on-chain revert), so Money activity hides it as an ephemeral failed row and no deposit item appears.

This change only delegates `TransactionPayController:getAmountData` on `TransactionControllerInit` (plus a unit assertion). Isolated from Money activity work so Confirmations can review the messenger wiring on its own.

## **Changelog**

CHANGELOG entry: Fixed a bug that could fail Money Account deposits after the funding transaction already succeeded

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run the extension and open Money Home with a funded EOA that can pay in BNB.
2. Add funds to the Money Account using BNB (cross-chain Relay / non-atomic deposit).
3. Confirm the Pay confirmation and wait until Relay reports the source transaction as successful on BSC.
4. Verify the second-leg vault deposit is submitted (no `getAmountData has not been delegated` error in the background stack).
5. Verify the deposit appears in Money activity instead of remaining missing / locally failed.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)