### PR TITLE
refactor(assets): use isNativeCaipAssetId for native asset checks

### DIFF
--- a/app/scripts/controllers/static-assets-controller.ts
+++ b/app/scripts/controllers/static-assets-controller.ts
@@ -19,7 +19,10 @@ import type {
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 
 import fetchWithCache from '../../../shared/lib/fetch-with-cache';
-import { toAssetId } from '../../../shared/lib/asset-utils';
+import {
+  toAssetId,
+  isNativeCaipAssetId,
+} from '../../../shared/lib/asset-utils';
 
 const CONTROLLER = 'StaticAssetsController' as const;
 
@@ -436,7 +439,7 @@ export class StaticAssetsController extends StaticIntervalPollingController<{
           const asset = parseCaipAssetType(topAsset.assetId);
           if (
             // skip slip44 tokens.
-            asset.assetNamespace === 'slip44' ||
+            isNativeCaipAssetId(topAsset.assetId as CaipAssetType) ||
             // skip zero address tokens.
             asset.assetReference ===
               '0x0000000000000000000000000000000000000000' ||

--- a/shared/lib/activity/fiat.ts
+++ b/shared/lib/activity/fiat.ts
@@ -1,6 +1,7 @@
 import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
 import type { CaipAssetType, Hex } from '@metamask/utils';
 import { NATIVE_TOKEN_ADDRESS } from '../../constants/transaction';
+import { isNativeCaipAssetId } from '../asset-utils';
 import { formatUnits } from '../unit';
 import type { Token } from '../multichain/types';
 import type { TokenAmount } from './types';
@@ -104,7 +105,7 @@ export function getTokenAddressForMarketRates(
       return assetReference.toLowerCase();
     }
 
-    if (assetNamespace === 'slip44' || assetNamespace === 'native') {
+    if (isNativeCaipAssetId(assetId) || assetNamespace === 'native') {
       return NATIVE_TOKEN_ADDRESS;
     }
   } catch {

--- a/shared/lib/asset-conversion-rates.ts
+++ b/shared/lib/asset-conversion-rates.ts
@@ -2,6 +2,8 @@ import { CaipAssetType, parseCaipAssetType } from '@metamask/utils';
 import { MultichainAssetsRatesControllerState } from '@metamask/assets-controllers';
 import { AssetConversion, FungibleAssetMarketData } from '@metamask/snaps-sdk';
 
+import { isNativeCaipAssetId } from './asset-utils';
+
 type AssetsRatesState = {
   metamask: MultichainAssetsRatesControllerState;
 };
@@ -22,10 +24,13 @@ export function getConversionRatesForNativeAsset({
 
   Object.entries(conversionRates).forEach(
     ([caip19Identifier, conversionRate]) => {
-      const { assetNamespace, chainId: caipChainId } = parseCaipAssetType(
+      const { chainId: caipChainId } = parseCaipAssetType(
         caip19Identifier as CaipAssetType,
       );
-      if (assetNamespace === 'slip44' && caipChainId === chainId) {
+      if (
+        isNativeCaipAssetId(caip19Identifier as CaipAssetType) &&
+        caipChainId === chainId
+      ) {
         conversionRateResult = conversionRate;
       }
     },

--- a/shared/lib/asset-route.ts
+++ b/shared/lib/asset-route.ts
@@ -7,7 +7,7 @@ import {
   parseCaipAssetType,
 } from '@metamask/utils';
 
-import { isEvmChainId } from './asset-utils';
+import { isEvmChainId, isNativeCaipAssetId } from './asset-utils';
 
 export const ASSET_ROUTE = '/asset';
 
@@ -97,7 +97,7 @@ export const resolveAssetRouteLookup = (
     const parsed = parseCaipAssetType(decodedAsset);
 
     if (isEvmChainId(parsed.chainId)) {
-      const isNative = parsed.assetNamespace === 'slip44';
+      const isNative = isNativeCaipAssetId(decodedAsset);
 
       return {
         ...processed,

--- a/shared/lib/token-search/convert-search-result.ts
+++ b/shared/lib/token-search/convert-search-result.ts
@@ -6,6 +6,7 @@ import {
 } from '@metamask/utils';
 import { isNativeAddress } from '@metamask/bridge-controller';
 
+import { isNativeCaipAssetId } from '../asset-utils';
 import { type TokenSearchResult } from './token-search-api';
 
 /**
@@ -56,7 +57,8 @@ export const convertSearchResultToImportPayload = (
   }
 
   const isNative =
-    assetNamespace === 'slip44' || (isEvm && isNativeAddress(assetReference));
+    isNativeCaipAssetId(result.assetId as CaipAssetType) ||
+    (isEvm && isNativeAddress(assetReference));
 
   return {
     assetId: result.assetId as CaipAssetType,

--- a/ui/hooks/useConvertToFiat.ts
+++ b/ui/hooks/useConvertToFiat.ts
@@ -4,6 +4,7 @@ import { isNonEvmChainId } from '@metamask/bridge-controller';
 import {
   type CaipChainId,
   type Hex,
+  isCaipAssetType,
   parseCaipAssetType,
 } from '@metamask/utils';
 import {
@@ -119,22 +120,20 @@ function fiatFromCurrencyOrMarketRates(
   humanAmount: string,
   quantity: number,
 ): number | undefined {
-  if (!token.assetId) {
+  if (!token.assetId || !isCaipAssetType(token.assetId)) {
     return undefined;
   }
 
+  const assetId = token.assetId;
+
   try {
-    const { chain } = parseCaipAssetType(
-      token.assetId as `${string}:${string}/${string}:${string}`,
-    );
+    const { chain } = parseCaipAssetType(assetId);
 
     // Non-EVM natives only (slip44). Symbol match is unsafe for SPL/etc.
     // tokens that reuse native tickers.
     if (
       chain.namespace !== 'eip155' &&
-      isNativeCaipAssetId(
-        token.assetId as `${string}:${string}/${string}:${string}`,
-      ) &&
+      isNativeCaipAssetId(assetId) &&
       token.symbol
     ) {
       const rate = getPositiveRate(

--- a/ui/hooks/useConvertToFiat.ts
+++ b/ui/hooks/useConvertToFiat.ts
@@ -17,6 +17,7 @@ import {
   type MultichainNetworks,
 } from '../../shared/constants/multichain/networks';
 import { decimalToPrefixedHex } from '../../shared/lib/conversion.utils';
+import { isNativeCaipAssetId } from '../../shared/lib/asset-utils';
 import { getCurrencyRates } from '../ducks/metamask/metamask';
 import { selectMarketRates } from '../selectors/activity';
 import { getAssetsPrice, getAssetsRates } from '../selectors/assets';
@@ -123,7 +124,7 @@ function fiatFromCurrencyOrMarketRates(
   }
 
   try {
-    const { chain, assetNamespace } = parseCaipAssetType(
+    const { chain } = parseCaipAssetType(
       token.assetId as `${string}:${string}/${string}:${string}`,
     );
 
@@ -131,7 +132,9 @@ function fiatFromCurrencyOrMarketRates(
     // tokens that reuse native tickers.
     if (
       chain.namespace !== 'eip155' &&
-      assetNamespace === 'slip44' &&
+      isNativeCaipAssetId(
+        token.assetId as `${string}:${string}/${string}:${string}`,
+      ) &&
       token.symbol
     ) {
       const rate = getPositiveRate(

--- a/ui/hooks/useConvertToFiat.ts
+++ b/ui/hooks/useConvertToFiat.ts
@@ -7,6 +7,7 @@ import {
   isCaipAssetType,
   parseCaipAssetType,
 } from '@metamask/utils';
+import { isNativeCaipAssetId } from '#shared/lib/asset-utils';
 import {
   calculateFiatFromMarketRates,
   getHumanReadableTokenAmount,
@@ -18,7 +19,6 @@ import {
   type MultichainNetworks,
 } from '../../shared/constants/multichain/networks';
 import { decimalToPrefixedHex } from '../../shared/lib/conversion.utils';
-import { isNativeCaipAssetId } from '../../shared/lib/asset-utils';
 import { getCurrencyRates } from '../ducks/metamask/metamask';
 import { selectMarketRates } from '../selectors/activity';
 import { getAssetsPrice, getAssetsRates } from '../selectors/assets';
@@ -120,11 +120,11 @@ function fiatFromCurrencyOrMarketRates(
   humanAmount: string,
   quantity: number,
 ): number | undefined {
-  if (!token.assetId || !isCaipAssetType(token.assetId)) {
+  const { assetId } = token;
+
+  if (!assetId || !isCaipAssetType(assetId)) {
     return undefined;
   }
-
-  const assetId = token.assetId;
 
   try {
     const { chain } = parseCaipAssetType(assetId);

--- a/ui/hooks/useMultichainBalances.ts
+++ b/ui/hooks/useMultichainBalances.ts
@@ -9,7 +9,10 @@ import { SolScope, BtcScope, TrxScope } from '@metamask/keyring-api';
 import { type InternalAccount } from '@metamask/keyring-internal-api';
 import { BigNumber } from 'bignumber.js';
 import { AssetType } from '../../shared/constants/transaction';
-import { isNativeCaipAssetId, isTronSpecialAsset  } from '../../shared/lib/asset-utils';
+import {
+  isNativeCaipAssetId,
+  isTronSpecialAsset,
+} from '../../shared/lib/asset-utils';
 import {
   getAccountAssets,
   getAssetsMetadata,

--- a/ui/hooks/useMultichainBalances.ts
+++ b/ui/hooks/useMultichainBalances.ts
@@ -9,8 +9,7 @@ import { SolScope, BtcScope, TrxScope } from '@metamask/keyring-api';
 import { type InternalAccount } from '@metamask/keyring-internal-api';
 import { BigNumber } from 'bignumber.js';
 import { AssetType } from '../../shared/constants/transaction';
-import { SLIP44_ASSET_NAMESPACE } from '../../shared/constants/multichain/assets';
-import { isTronSpecialAsset } from '../../shared/lib/asset-utils';
+import { isNativeCaipAssetId, isTronSpecialAsset  } from '../../shared/lib/asset-utils';
 import {
   getAccountAssets,
   getAssetsMetadata,
@@ -62,7 +61,7 @@ const useNonEvmAssetsWithBalances = (
           symbol: assetMetadataById[caipAssetId]?.symbol ?? '',
           assetId: caipAssetId,
           address: assetReference,
-          isNative: assetNamespace === SLIP44_ASSET_NAMESPACE,
+          isNative: isNativeCaipAssetId(caipAssetId),
           string: balancesByAssetId[caipAssetId]?.amount ?? '0',
           balance: balancesByAssetId[caipAssetId]?.amount ?? '0',
           decimals: assetMetadataById[caipAssetId]?.units[0]?.decimals,

--- a/ui/pages/asset/security-trust/useSecurityTrustPageData.ts
+++ b/ui/pages/asset/security-trust/useSecurityTrustPageData.ts
@@ -7,6 +7,7 @@ import {
 import { useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/lib/selectors/networks';
+import { isNativeCaipAssetId } from '../../../../shared/lib/asset-utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTokenSecurityData } from '../../../hooks/useTokenSecurityData';
 import { getUseExternalServices } from '../../../selectors';
@@ -68,10 +69,10 @@ export const useSecurityTrustPageData = () => {
     }
 
     try {
-      const { assetReference, assetNamespace } = parseCaipAssetType(assetId);
+      const { assetReference } = parseCaipAssetType(assetId);
       return {
         address: assetReference,
-        isNative: assetNamespace === 'slip44',
+        isNative: isNativeCaipAssetId(assetId),
       };
     } catch {
       return null;

--- a/ui/pages/asset/security-trust/useSecurityTrustPageData.ts
+++ b/ui/pages/asset/security-trust/useSecurityTrustPageData.ts
@@ -6,8 +6,8 @@ import {
 } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
+import { isNativeCaipAssetId } from '#shared/lib/asset-utils';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/lib/selectors/networks';
-import { isNativeCaipAssetId } from '../../../../shared/lib/asset-utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTokenSecurityData } from '../../../hooks/useTokenSecurityData';
 import { getUseExternalServices } from '../../../selectors';

--- a/ui/pages/defi/components/utils/map-defi-protocol-details-position-v2.ts
+++ b/ui/pages/defi/components/utils/map-defi-protocol-details-position-v2.ts
@@ -8,7 +8,10 @@ import {
   type DeFiUnderlyingPosition,
 } from '@metamask/assets-controllers';
 import { decimalToPrefixedHex } from '../../../../../shared/lib/conversion.utils';
-import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
+import {
+  isEvmChainId,
+  isNativeCaipAssetId,
+} from '../../../../../shared/lib/asset-utils';
 import { toChecksumHexAddress } from '../../../../../shared/lib/hexstring-utils';
 import type { TokenWithFiatAmount } from '../../../../components/app/assets/types';
 
@@ -44,7 +47,7 @@ function toTokenCellAddress(
   );
   const hexChainId = toTokenCellChainId(position.chainId) as Hex;
 
-  if (assetNamespace === 'slip44') {
+  if (isNativeCaipAssetId(position.assetId)) {
     return getNativeTokenAddress(hexChainId);
   }
 
@@ -79,8 +82,7 @@ function getNormalizedBalance(position: DeFiUnderlyingPosition): number {
 export function mapDefiProtocolDetailsPositionV2ToToken(
   position: DeFiUnderlyingPosition,
 ): TokenWithFiatAmount {
-  const { assetNamespace } = parseCaipAssetType(position.assetId);
-  const isNative = assetNamespace === 'slip44';
+  const isNative = isNativeCaipAssetId(position.assetId);
   const normalizedBalance = getNormalizedBalance(position);
 
   return {

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -66,7 +66,11 @@ import {
   getCurrentCurrency,
 } from '../ducks/metamask/metamask';
 import { findAssetByAddress } from '../pages/asset/util';
-import { isEvmChainId, toAssetId } from '../../shared/lib/asset-utils';
+import {
+  isEvmChainId,
+  isNativeCaipAssetId,
+  toAssetId,
+} from '../../shared/lib/asset-utils';
 import type { ResolvedAssetRoute } from '../../shared/lib/asset-route';
 import { isEmptyHexString } from '../../shared/lib/hexstring-utils';
 import { isZeroAmount } from '../helpers/utils/number-utils';
@@ -479,8 +483,8 @@ export const getMultiChainAssets = createSelector(
 
     const allAssets: TokenWithFiatAmount[] = [];
     assetIds.forEach((assetId: CaipAssetId) => {
-      const { chainId, assetNamespace } = parseCaipAssetType(assetId);
-      const isNative = assetNamespace === 'slip44';
+      const { chainId } = parseCaipAssetType(assetId);
+      const isNative = isNativeCaipAssetId(assetId);
       const balance = balances?.[assetId] || { amount: '0', unit: '' };
       const rate = assetRates?.[assetId]?.rate;
 
@@ -718,8 +722,10 @@ export const getMultichainNativeAssetType = createSelector(
   (selectedAccount, accountAssets, currentNetwork) => {
     const assetTypes = accountAssets?.[selectedAccount.id] || [];
     const nativeAssetType = assetTypes.find((assetType) => {
-      const { chainId, assetNamespace } = parseCaipAssetType(assetType);
-      return chainId === currentNetwork.chainId && assetNamespace === 'slip44';
+      const { chainId } = parseCaipAssetType(assetType);
+      return (
+        chainId === currentNetwork.chainId && isNativeCaipAssetId(assetType)
+      );
     });
 
     return nativeAssetType;
@@ -1824,7 +1830,6 @@ export const getFungibleAssetForRoute = (
     try {
       const assetsByGroup = getAssetsBySelectedAccountGroup(state);
       const chainIdsToTry = getChainIdsForAssetRouteLookup(chainId, assetId);
-      const { assetNamespace } = parseCaipAssetType(assetId);
 
       for (const id of chainIdsToTry) {
         const match = assetsByGroup[id as string]?.find((item) =>
@@ -1835,7 +1840,7 @@ export const getFungibleAssetForRoute = (
         }
       }
 
-      if (assetNamespace === 'slip44') {
+      if (isNativeCaipAssetId(assetId)) {
         for (const id of chainIdsToTry) {
           const nativeAsset = assetsByGroup[id as string]?.find(
             (item) => item.isNative,
@@ -1855,7 +1860,7 @@ export const getFungibleAssetForRoute = (
       }
 
       // Native assets may be keyed by zero address while the route uses slip44.
-      if (assetNamespace === 'slip44') {
+      if (isNativeCaipAssetId(assetId)) {
         const nativeFlatMatch = Object.values(assetsByGroup)
           .flat()
           .find(


### PR DESCRIPTION

## **Description**

Replace inline `assetNamespace === 'slip44'` / `SLIP44_ASSET_NAMESPACE` checks with the  `isNativeCaipAssetId` helper

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open native token asset pages (e.g. ETH on Mainnet) and confirm routing/details still load.
2. Verify token search import treats native tokens correctly.
3. Confirm DeFi position cells still show native token balances/addresses.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<div><a href="https://cursor.com/agents/bc-53df1d2e-9d38-4278-b381-e5793bacdec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53df1d2e-9d38-4278-b381-e5793bacdec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor across many read paths; native detection remains slip44-based via the shared helper, with slightly safer parsing guards.
> 
> **Overview**
> Replaces scattered **`assetNamespace === 'slip44'`** / **`SLIP44_ASSET_NAMESPACE`** checks with the shared **`isNativeCaipAssetId`** helper across static top-assets ingestion, fiat/market-rate lookup, asset routing, token search import, multichain balances, asset selectors, DeFi position mapping, and security-trust page metadata.
> 
> Behavior stays aligned with treating slip44 CAIP ids as native, but detection now goes through one path that **safely returns false** when a CAIP asset id cannot be parsed. **`useConvertToFiat`** also bails early unless the token’s **`assetId`** is a valid CAIP asset type before applying native-specific currency-rate logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79befbdc0baee58c557e89b901288e03b5614d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->