### PR TITLE
fix(content): replace "dapp" with "site" in extension locale strings

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3619,16 +3619,16 @@
     "message": "Disconnect all"
   },
   "disconnectAllSitesDescriptionText": {
-    "message": "This will disconnect all your accounts from all dapps. You'll need to reconnect to use them again."
+    "message": "This will disconnect all your accounts from all sites. You'll need to reconnect to use them again."
   },
   "disconnectAllSitesError": {
-    "message": "Some dapps couldn't be disconnected. Please try again."
+    "message": "Some sites couldn't be disconnected. Please try again."
   },
   "disconnectAllSitesQuestion": {
     "message": "Disconnect all?"
   },
   "disconnectAllSitesSuccess": {
-    "message": "All dapps successfully disconnected."
+    "message": "All sites successfully disconnected."
   },
   "disconnectPrompt": {
     "message": "Disconnect $1"
@@ -3637,7 +3637,7 @@
     "message": "Disconnect?"
   },
   "disconnectSiteDescriptionText": {
-    "message": "This will disconnect all your accounts from $1. You'll need to reconnect to use this dapp again.",
+    "message": "This will disconnect all your accounts from $1. You'll need to reconnect to use this site again.",
     "description": "$1 is the site hostname"
   },
   "disconnectSiteSuccess": {
@@ -10657,10 +10657,10 @@
     "message": "Smart Account"
   },
   "smartAccountRequestsFromDapps": {
-    "message": "Smart account requests from dapps"
+    "message": "Smart account requests from sites"
   },
   "smartAccountRequestsFromDappsDescriptionV2": {
-    "message": "Let dapps request smart account features for standard accounts. MetaMask will only upgrade to our audited smart account."
+    "message": "Let sites request smart account features for standard accounts. MetaMask will only upgrade to our audited smart account."
   },
   "smartAccountUpgradeBannerDescription": {
     "message": "Same address. Smarter features."


### PR DESCRIPTION
## **Description**

"dapp" is jargon per MetaMask content guidelines. Use "site" for general audiences.

Updated strings in `app/_locales/en/messages.json`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Load the extension in a browser.
2. Navigate to any screen that displays the updated strings.
3. Confirm the updated wording appears correctly with no layout regressions.

## **Screenshots/Recordings**

### **Before**

N/A — locale string changes only.

### **After**

N/A — locale string changes only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.