### PR TITLE
fix(content): replace "&" with "and" in extension locale strings

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7697,7 +7697,7 @@
     "description": "Order book buy-side depth percentage label. $1 is the buy percentage."
   },
   "perpsOrderBookConfigTitle": {
-    "message": "Listed by & Group by"
+    "message": "Listed by and Group by"
   },
   "perpsOrderBookConnectionError": {
     "message": "Order book connection lost"
@@ -9363,7 +9363,7 @@
     "message": "New password saved"
   },
   "securityDefaultSettingsSocialLogin": {
-    "message": "Security & privacy"
+    "message": "Security and privacy"
   },
   "securityDescription": {
     "message": "Reduce your chances of joining unsafe networks and protect your accounts"


### PR DESCRIPTION
## **Description**

Per MetaMask content guidelines: spell out "and" — never use "&" in user-facing strings.

Updated strings in `app/_locales/en/messages.json`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Load the extension in a browser.
2. Navigate to any screen that displays the updated strings.
3. Confirm the updated wording appears correctly with no layout regressions.

## **Screenshots/Recordings**

### **Before**

N/A — locale string changes only.

### **After**

N/A — locale string changes only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.