### PR TITLE
fix(content): remove "please" from extension locale strings (batch 2 of 3)

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6248,7 +6248,7 @@
     "message": "You don't have any tokens yet. Search by name or address to discover popular tokens."
   },
   "noWebcamFound": {
-    "message": "Your computer's webcam was not found. Please try again."
+    "message": "Your computer's webcam was not found. Try again."
   },
   "noWebcamFoundTitle": {
     "message": "Webcam not found"
@@ -6428,7 +6428,7 @@
     "message": "Nothing to see here"
   },
   "notificationsPageErrorContent": {
-    "message": "Please, try to visit this page again."
+    "message": "Try visiting this page again."
   },
   "notificationsPageErrorTitle": {
     "message": "There has been an error"
@@ -6443,7 +6443,7 @@
     "message": "Agent wallet"
   },
   "notificationsSettingsBoxError": {
-    "message": "Something went wrong. Please try again."
+    "message": "Something went wrong. Try again."
   },
   "notificationsSettingsDeselectAll": {
     "message": "Deselect all"
@@ -6549,7 +6549,7 @@
     "message": "The IPFS gateway makes it possible to access and view data hosted by third parties. You can add a custom IPFS gateway or continue using the default."
   },
   "onboardingAdvancedPrivacyIPFSInvalid": {
-    "message": "Please enter a valid URL"
+    "message": "Enter a valid URL"
   },
   "onboardingAdvancedPrivacyIPFSTitle": {
     "message": "Add custom IPFS Gateway"
@@ -7402,7 +7402,7 @@
     "message": "Close short"
   },
   "perpsConnectionTimeout": {
-    "message": "Connection timed out. Please try again."
+    "message": "Connection timed out. Try again."
   },
   "perpsContactSupport": {
     "message": "Contact support"
@@ -7655,7 +7655,7 @@
     "message": "More"
   },
   "perpsNetworkError": {
-    "message": "A network error occurred. Please try again."
+    "message": "A network error occurred. Try again."
   },
   "perpsNoMarketsFound": {
     "message": "No markets found"
@@ -7815,7 +7815,7 @@
     "message": "Positions"
   },
   "perpsRateLimitExceeded": {
-    "message": "Too many requests. Please wait and try again."
+    "message": "Too many requests. Wait and try again."
   },
   "perpsRecentActivity": {
     "message": "Recent activity"
@@ -7865,7 +7865,7 @@
     "description": "Accessible label for the arrow button that navigates to the full activity list"
   },
   "perpsServiceUnavailable": {
-    "message": "Service temporarily unavailable. Please try again later."
+    "message": "Service temporarily unavailable. Try again later."
   },
   "perpsShort": {
     "message": "Short"
@@ -8053,7 +8053,7 @@
     "description": "Error toast text shown when adding or removing margin fails"
   },
   "perpsToastMarginAdjustmentFailedDescriptionFallback": {
-    "message": "Unable to adjust margin. Please try again.",
+    "message": "Unable to adjust margin. Try again.",
     "description": "Fallback description shown when margin adjustment fails without a usable error message."
   },
   "perpsToastMarginRemoveSuccess": {
@@ -8328,7 +8328,7 @@
     "message": "Pinned"
   },
   "pleaseConfirm": {
-    "message": "Please confirm"
+    "message": "Confirm"
   },
   "pna25ModalBlogPostLink": {
     "message": "blog post."
@@ -8551,7 +8551,7 @@
     "description": "$1 is the token symbol being purchased"
   },
   "rampsBuyWidgetError": {
-    "message": "Unable to start your purchase. Please try again."
+    "message": "Unable to start your purchase. Try again."
   },
   "rampsBuyingViaProvider": {
     "message": "Buying via $1.",
@@ -8576,7 +8576,7 @@
     "description": "Banner title on the ramps complete-buy interstitial"
   },
   "rampsEligibilityFailedDescription": {
-    "message": "Please try again, or contact support if this keeps happening."
+    "message": "Try again, or contact support if this keeps happening."
   },
   "rampsEligibilityFailedTitle": {
     "message": "We couldn’t verify your region"
@@ -8741,7 +8741,7 @@
     "message": "Select payment method"
   },
   "rampsServiceDisruptionDescription": {
-    "message": "We’re experiencing a service disruption. Please try again later."
+    "message": "We're experiencing a service disruption. Try again later."
   },
   "rampsServiceDisruptionTitle": {
     "message": "Buying is temporarily unavailable"
@@ -9036,25 +9036,25 @@
     "message": "Reward"
   },
   "rewardsAuthFailDescription": {
-    "message": "An unknown error occurred while authenticating this account with the rewards program. Please try again later."
+    "message": "An unknown error occurred while authenticating this account with the rewards program. Try again later."
   },
   "rewardsAuthFailTitle": {
     "message": "Unknown error."
   },
   "rewardsErrorMessagesAccountAlreadyRegistered": {
-    "message": "This account is already registered with another Rewards profile. Please switch account to continue."
+    "message": "This account is already registered with another Rewards profile. Switch account to continue."
   },
   "rewardsErrorMessagesFailedToClaimReward": {
-    "message": "Failed to claim reward. Please try again shortly."
+    "message": "Failed to claim reward. Try again shortly."
   },
   "rewardsErrorMessagesRequestRejected": {
     "message": "You rejected the request."
   },
   "rewardsErrorMessagesServiceNotAvailable": {
-    "message": "Service is not available at the moment. Please try again shortly."
+    "message": "Service is not available at the moment. Try again shortly."
   },
   "rewardsErrorMessagesSomethingWentWrong": {
-    "message": "Something went wrong. Please try again shortly."
+    "message": "Something went wrong. Try again shortly."
   },
   "rewardsLinkAccount": {
     "message": "Add account"
@@ -9069,7 +9069,7 @@
     "message": "Win prizes, claim perks, and discover more ways to earn—just by using MetaMask."
   },
   "rewardsOnboardingIntroGeoCheckFailedDescription": {
-    "message": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again."
+    "message": "We cannot determine if your country allows opting into the rewards program. Check your connection and try again."
   },
   "rewardsOnboardingIntroGeoCheckFailedTitle": {
     "message": "Cannot determine opt-in eligibility"
@@ -9353,7 +9353,7 @@
     "message": "Security and privacy"
   },
   "securityChangePasswordToastError": {
-    "message": "Password couldn’t be changed. Please try again."
+    "message": "Password couldn't be changed. Try again."
   },
   "securityChangePasswordToastPasskeyRenewalFailed": {
     "message": "New password saved, but $1 unlock couldn't be turned on.",
@@ -9866,13 +9866,13 @@
     "message": "Deleting draft failed"
   },
   "shieldClaimDraftDeleteFailedDescription": {
-    "message": "Unable to delete your claim draft. Please try again."
+    "message": "Unable to delete your claim draft. Try again."
   },
   "shieldClaimDraftSaveFailed": {
     "message": "Saving draft failed"
   },
   "shieldClaimDraftSaveFailedDescription": {
-    "message": "Unable to save your claim draft. Please try again."
+    "message": "Unable to save your claim draft. Try again."
   },
   "shieldClaimDraftSaved": {
     "message": "Draft saved"
@@ -9906,7 +9906,7 @@
     "description": "The $1 is the maximum file size in MB"
   },
   "shieldClaimFileUploaderHelpText": {
-    "message": "If you have any additional evidence, please upload it here."
+    "message": "If you have any additional evidence, upload it here."
   },
   "shieldClaimGroupActive": {
     "message": "Active claims"
@@ -9955,10 +9955,10 @@
     "message": "Incident details"
   },
   "shieldClaimInvalidChainId": {
-    "message": "Please enter a valid chain ID"
+    "message": "Enter a valid chain ID"
   },
   "shieldClaimInvalidEmail": {
-    "message": "Please enter a valid email address"
+    "message": "Enter a valid email address"
   },
   "shieldClaimInvalidRequired": {
     "message": "This field is required"


### PR DESCRIPTION
## **Description**

Per MetaMask content guidelines: UI strings shouldn't ask for favors. Use direct imperative language instead.

Updated strings in `app/_locales/en/messages.json`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Load the extension in a browser.
2. Navigate to any screen that displays the updated strings.
3. Confirm the updated wording appears correctly with no layout regressions.

## **Screenshots/Recordings**

### **Before**

N/A — locale string changes only.

### **After**

N/A — locale string changes only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.