### PR TITLE
fix: used correct usdc erc-20 wrapper in all paths for swap

### DIFF
--- a/ui/components/app/assets/enablement/arc.test.ts
+++ b/ui/components/app/assets/enablement/arc.test.ts
@@ -37,6 +37,11 @@ describe('filterOutArcNativeAsset', () => {
     address: ARC_NATIVE_ADDRESS.toUpperCase(),
     isNative: true,
   };
+  const arcNativeEmptyAddress = {
+    chainId: ARC_NATIVE_HEX_CHAIN_ID,
+    address: '',
+    isNative: true,
+  };
   const arcNativeUpperAssetId = {
     chainId: ARC_NATIVE_CAIP_CHAIN_ID.toUpperCase(),
     assetId: ARC_NATIVE_ASSET_ID.toUpperCase(),
@@ -78,6 +83,12 @@ describe('filterOutArcNativeAsset', () => {
       description: 'matches the Arc native asset case-insensitively',
       assets: [arcNativeUpperAddress, arcNativeUpperAssetId],
       expected: [],
+    },
+    {
+      description:
+        'filters out the Arc native asset when the route token has an empty address',
+      assets: [arcNativeEmptyAddress, arcErc20UsdcByAddress],
+      expected: [arcErc20UsdcByAddress],
     },
     {
       description: 'keeps the Arc native address when it is on a non-Arc chain',

--- a/ui/components/app/assets/enablement/arc.ts
+++ b/ui/components/app/assets/enablement/arc.ts
@@ -1,9 +1,11 @@
-import { BridgeAsset } from '@metamask/bridge-controller';
+import { BridgeAsset, formatChainIdToCaip } from '@metamask/bridge-controller';
 import { hexToNumber, CaipAssetType } from '@metamask/utils';
 import {
   ARC_USDC_TOKEN_ADDRESS,
   CHAIN_IDS,
 } from '../../../../../shared/constants/network';
+import { BalanceAwareSwapSourceToken } from '#ui/pages/asset/utils/get-balance-aware-swap-defaults';
+import { toAssetId } from '../../../../../shared/lib/asset-utils';
 
 /**
  * Arc Chain Augmentation Module
@@ -11,8 +13,8 @@ import {
  *
  * Listed Augmentations:
  * - Arc does not show the ERC20 token in the UI, instead the ERC20 token is synced with its native token.
- * - E.g. USDC ERC20: 0x0000000000000000000000000000000000000000
- * - E.g. USDC Native: 0x3600000000000000000000000000000000000000
+ * - E.g. USDC ERC20: 0x3600000000000000000000000000000000000000
+ * - E.g. USDC Native: 0x0000000000000000000000000000000000000000
  *
  * - Exception to showing ERC20 token in the UI: Swaps/Bridge flow - as the router has been validated for this token only.
  */
@@ -27,12 +29,24 @@ export const ARC_ERC20_USDC_BRIDGE_ASSET: BridgeAsset = {
   symbol: 'USDC',
   name: 'USDC',
   address: '0x3600000000000000000000000000000000000000',
-  assetId: 'eip155:5042/erc20:0x3600000000000000000000000000000000000000',
+  assetId: ARC_ERC20_USDC_ASSET_ID,
   chainId: hexToNumber(ARC_HEX_CHAIN_ID),
   decimals: 6,
 };
 
-function isNativeArcAsset(asset: {
+/**
+ * Whether an asset represents Arc's native USDC balance.
+ *
+ * The Arc native balance is rendered in the wallet as USDC, but Swaps must use
+ * the validated ERC20 wrapper contract.
+ *
+ * @param asset - Candidate asset.
+ * @param asset.address - Asset address.
+ * @param asset.assetId - Asset CAIP-19 asset id.
+ * @param asset.chainId - Asset chain id.
+ * @returns True when the asset is Arc native USDC.
+ */
+export function isNativeArcAsset(asset: {
   address?: string;
   assetId?: string;
   chainId?: string;
@@ -44,19 +58,30 @@ function isNativeArcAsset(asset: {
   if (
     isArcChainId &&
     'address' in asset &&
-    asset.address?.toLowerCase() === ARC_NATIVE_ADDRESS
+    (asset.address === '' ||
+      asset.address?.toLowerCase() === ARC_NATIVE_ADDRESS)
   ) {
     return true;
   }
-  if (
+  return (
     isArcChainId &&
     'assetId' in asset &&
     asset.assetId?.toLowerCase() === ARC_NATIVE_ASSET_ID
-  ) {
-    return true;
-  }
+  );
+}
 
-  return false;
+/**
+ * Whether a token is Arc's ERC20 USDC wrapper used by Swaps.
+ *
+ * @param token - Token shown on the Token Detail Page.
+ * @returns True when the token is Arc wrapper USDC.
+ */
+export function isArcErc20UsdcSwapToken(
+  token: BalanceAwareSwapSourceToken,
+): boolean {
+  const assetId = toAssetId(token.address, formatChainIdToCaip(token.chainId));
+
+  return assetId === ARC_ERC20_USDC_ASSET_ID;
 }
 
 /**

--- a/ui/components/app/assets/enablement/arc.ts
+++ b/ui/components/app/assets/enablement/arc.ts
@@ -1,10 +1,10 @@
 import { BridgeAsset, formatChainIdToCaip } from '@metamask/bridge-controller';
 import { hexToNumber, CaipAssetType } from '@metamask/utils';
+import type { BalanceAwareSwapSourceToken } from '../../../../pages/asset/utils/get-balance-aware-swap-defaults';
 import {
   ARC_USDC_TOKEN_ADDRESS,
   CHAIN_IDS,
 } from '../../../../../shared/constants/network';
-import { BalanceAwareSwapSourceToken } from '#ui/pages/asset/utils/get-balance-aware-swap-defaults';
 import { toAssetId } from '../../../../../shared/lib/asset-utils';
 
 /**

--- a/ui/components/app/wallet-overview/coin-buttons.test.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.test.tsx
@@ -3,6 +3,7 @@ import { EthAccountType, EthMethod } from '@metamask/keyring-api';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
+import { ARC_ERC20_USDC_BRIDGE_ASSET } from '../assets/enablement/arc';
 import CoinButtons from './coin-buttons';
 
 jest.mock('../../../hooks/useAnalytics', () => {
@@ -140,6 +141,20 @@ describe('CoinButtons – asset page swap token', () => {
         symbol: 'ETH',
         chainId: 'eip155:1',
       }),
+    });
+  });
+
+  it('uses the Arc ERC20 USDC wrapper for the asset page native swap button', () => {
+    renderAssetPageCoinButtons('0x13b2');
+
+    expect(useBalanceAwareSwapDefaults).toHaveBeenCalledWith({
+      currentToken: {
+        symbol: ARC_ERC20_USDC_BRIDGE_ASSET.symbol,
+        address: ARC_ERC20_USDC_BRIDGE_ASSET.address,
+        chainId: 'eip155:5042',
+        decimals: ARC_ERC20_USDC_BRIDGE_ASSET.decimals,
+        name: ARC_ERC20_USDC_BRIDGE_ASSET.name,
+      },
     });
   });
 

--- a/ui/pages/asset/utils/get-balance-aware-swap-defaults.test.ts
+++ b/ui/pages/asset/utils/get-balance-aware-swap-defaults.test.ts
@@ -1,4 +1,10 @@
 import {
+  ARC_ERC20_USDC_BRIDGE_ASSET,
+  ARC_HEX_CHAIN_ID,
+  ARC_NATIVE_ASSET_ID,
+  ARC_NATIVE_CAIP_CHAIN_ID,
+} from '../../../components/app/assets/enablement/arc';
+import {
   getBalanceAwareSwapDefaults,
   hasPositiveTokenBalance,
   selectBestSwapSourceToken,
@@ -11,6 +17,7 @@ const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const POLYGON_USDC_ADDRESS = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359';
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const POLYGON_NATIVE_ADDRESS = '0x0000000000000000000000000000000000001010';
+const ARC_EURC_ADDRESS = '0xbEf5f6d51CB62b58e6A8f77868681825C6fe21c1';
 
 const currentToken: BalanceAwareSwapSourceToken = {
   address: '0x6b175474e89094c44da98b954eedeac495271d0f',
@@ -426,6 +433,130 @@ describe('getBalanceAwareSwapDefaults', () => {
     expect(result).toEqual({
       sourceToken: bitcoinToken,
     });
+  });
+
+  it('uses the Arc ERC20 USDC wrapper as from when the Arc native token has balance', () => {
+    const arcNativeToken: BalanceAwareSwapSourceToken = {
+      address: ZERO_ADDRESS,
+      chainId: ARC_HEX_CHAIN_ID,
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USDC',
+    };
+
+    const result = getBalanceAwareSwapDefaults({
+      currentToken: arcNativeToken,
+      assetsByChain: {
+        [ARC_HEX_CHAIN_ID]: [
+          {
+            assetId: ARC_NATIVE_ASSET_ID,
+            chainId: ARC_NATIVE_CAIP_CHAIN_ID,
+            address: ZERO_ADDRESS,
+            symbol: 'USDC',
+            name: 'USDC',
+            decimals: 6,
+            isNative: true,
+            balance: '100',
+            fiat: { balance: 100 },
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      sourceToken: {
+        address: ARC_ERC20_USDC_BRIDGE_ASSET.address,
+        chainId: ARC_HEX_CHAIN_ID,
+        decimals: ARC_ERC20_USDC_BRIDGE_ASSET.decimals,
+        symbol: ARC_ERC20_USDC_BRIDGE_ASSET.symbol,
+        name: ARC_ERC20_USDC_BRIDGE_ASSET.name,
+      },
+    });
+  });
+
+  it('uses the Arc ERC20 USDC wrapper as from when the Arc native token page omits the address', () => {
+    const arcNativeToken: BalanceAwareSwapSourceToken = {
+      address: '',
+      chainId: ARC_HEX_CHAIN_ID,
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USDC',
+    };
+
+    const result = getBalanceAwareSwapDefaults({
+      currentToken: arcNativeToken,
+      currentTokenBalance: '100',
+      assetsByChain: {},
+    });
+
+    expect(result.sourceToken?.address).toBe(
+      ARC_ERC20_USDC_BRIDGE_ASSET.address,
+    );
+  });
+
+  it('uses the Arc ERC20 USDC wrapper as from when the Arc native token has no balance', () => {
+    const arcNativeToken: BalanceAwareSwapSourceToken = {
+      address: ZERO_ADDRESS,
+      chainId: ARC_HEX_CHAIN_ID,
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USDC',
+    };
+
+    const result = getBalanceAwareSwapDefaults({
+      currentToken: arcNativeToken,
+      currentTokenBalance: '0',
+      assetsByChain: {
+        '0x1': [
+          userAsset({
+            assetId: USDC_ADDRESS,
+            symbol: 'USDC',
+            decimals: 6,
+            fiatBalance: 5000,
+          }),
+        ],
+      },
+    });
+
+    expect(result.sourceToken?.address).toBe(
+      ARC_ERC20_USDC_BRIDGE_ASSET.address,
+    );
+    expect(result.destTokenAssetId).toBeUndefined();
+  });
+
+  it('keeps the Arc ERC20 USDC wrapper as from when EURC is a funded same-chain token', () => {
+    const arcErc20UsdcToken: BalanceAwareSwapSourceToken = {
+      address: ARC_ERC20_USDC_BRIDGE_ASSET.address,
+      chainId: ARC_HEX_CHAIN_ID,
+      decimals: ARC_ERC20_USDC_BRIDGE_ASSET.decimals,
+      symbol: ARC_ERC20_USDC_BRIDGE_ASSET.symbol,
+      name: ARC_ERC20_USDC_BRIDGE_ASSET.name,
+    };
+
+    const result = getBalanceAwareSwapDefaults({
+      currentToken: arcErc20UsdcToken,
+      currentTokenBalance: '0',
+      assetsByChain: {
+        [ARC_HEX_CHAIN_ID]: [
+          {
+            assetId: ARC_EURC_ADDRESS,
+            address: ARC_EURC_ADDRESS,
+            chainId: ARC_HEX_CHAIN_ID,
+            symbol: 'EURC',
+            name: 'EURC',
+            decimals: 6,
+            isNative: false,
+            balance: '100',
+            fiat: { balance: 100 },
+          },
+        ],
+      },
+    });
+
+    expect(result.sourceToken?.address).toBe(
+      ARC_ERC20_USDC_BRIDGE_ASSET.address,
+    );
+    expect(result.destTokenAssetId).toBeUndefined();
   });
 
   it('sets an unfunded non-EVM native as the destination', () => {

--- a/ui/pages/asset/utils/get-balance-aware-swap-defaults.ts
+++ b/ui/pages/asset/utils/get-balance-aware-swap-defaults.ts
@@ -8,6 +8,11 @@ import {
   type CaipAssetType,
 } from '@metamask/utils';
 import { toAssetId } from '../../../../shared/lib/asset-utils';
+import {
+  ARC_ERC20_USDC_BRIDGE_ASSET,
+  isArcErc20UsdcSwapToken,
+  isNativeArcAsset,
+} from '../../../components/app/assets/enablement/arc';
 
 /**
  * Minimal token shape accepted by `openBridgeExperience` as the swap source.
@@ -105,6 +110,34 @@ function getComparableAddress(addressOrAssetId?: string): string {
 }
 
 /**
+ * Returns the Arc ERC20 wrapper when the input is Arc native USDC.
+ *
+ * @param token - Token shown on the Token Detail Page.
+ * @returns Token usable by Swaps.
+ */
+function resolveSwapToken(
+  token: BalanceAwareSwapSourceToken,
+): BalanceAwareSwapSourceToken {
+  if (
+    isNativeArcAsset({
+      address: token.address,
+      chainId: token.chainId,
+      assetId: token.address,
+    })
+  ) {
+    return {
+      address: ARC_ERC20_USDC_BRIDGE_ASSET.address,
+      chainId: token.chainId,
+      decimals: ARC_ERC20_USDC_BRIDGE_ASSET.decimals,
+      symbol: ARC_ERC20_USDC_BRIDGE_ASSET.symbol,
+      name: ARC_ERC20_USDC_BRIDGE_ASSET.name,
+    };
+  }
+
+  return token;
+}
+
+/**
  * Whether two chain ids refer to the same network.
  *
  * @param leftChainId - First chain id (hex or CAIP-2).
@@ -188,6 +221,16 @@ function hasEligibleFiatBalance(asset: BalanceAwareUserAsset): boolean {
 function toSourceToken(
   asset: ChainScopedUserAsset,
 ): BalanceAwareSwapSourceToken {
+  if (isNativeArcAsset(asset)) {
+    return {
+      address: ARC_ERC20_USDC_BRIDGE_ASSET.address,
+      chainId: asset.chainId,
+      decimals: ARC_ERC20_USDC_BRIDGE_ASSET.decimals,
+      symbol: ARC_ERC20_USDC_BRIDGE_ASSET.symbol,
+      name: ARC_ERC20_USDC_BRIDGE_ASSET.name,
+    };
+  }
+
   return {
     address: asset.address ?? asset.assetId,
     chainId: asset.chainId,
@@ -334,22 +377,33 @@ export function getBalanceAwareSwapDefaults({
   currentTokenBalance,
   assetsByChain,
 }: GetBalanceAwareSwapDefaultsParams): BalanceAwareSwapDefaults {
+  const swapCurrentToken = resolveSwapToken(currentToken);
+
+  if (
+    swapCurrentToken !== currentToken ||
+    isArcErc20UsdcSwapToken(swapCurrentToken)
+  ) {
+    return {
+      sourceToken: swapCurrentToken,
+    };
+  }
+
   if (isCurrentTokenFunded(currentToken, currentTokenBalance, assetsByChain)) {
     return {
-      sourceToken: currentToken,
+      sourceToken: swapCurrentToken,
     };
   }
 
   const bestSource = selectBestSwapSourceToken(currentToken, assetsByChain);
   if (!bestSource) {
     return {
-      sourceToken: currentToken,
+      sourceToken: swapCurrentToken,
     };
   }
 
   const destTokenAssetId = toAssetId(
-    currentToken.address,
-    formatChainIdToCaip(currentToken.chainId),
+    swapCurrentToken.address,
+    formatChainIdToCaip(swapCurrentToken.chainId),
   ) as CaipAssetType | undefined;
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Arc represents USDC as both the native asset (`0x0000000000000000000000000000000000000000`) and an ERC20 wrapper (`0x3600000000000000000000000000000000000000`).
Swaps must use the ERC20 wrapper, but opening Swaps from the native Arc asset details page at `/home.html#/asset/0x13b2/` could be `USDC` on both sides of the swap.

This change normalizes Arc native USDC to the ERC20 wrapper for swap defaults and keeps Arc wrapper USDC as the source token, even when another same-chain token has a balance.
The destination token is left unset so the Swap page applies the normal Arc default pair, resulting in `USDC -> EURC` consistently across the home Swap button, the sticky asset-page Swap button, and the asset details Swap button.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix usage of USDC as source and destination token in Swap page

## **Related issues**

Fixes: [WPN-2026](https://consensyssoftware.atlassian.net/browse/WPN-2026)

## **Manual testing steps**

1. Enable or switch to Arc network.
2. Click on the `USDC` asset.
3. Click the top `Swap` button on the asset details page.
4. Confirm the Swap page opens with `USDC` as the source token and `EURC` as the destination token.
5. Go back to `Home` and click the Swap button under the total balance.
6. Confirm the Swap page still opens with `USDC` as source and `EURC` as destination.
7. Go back to `Home` and click the Swap button at the bottom.
6. Confirm the Swap page still opens with `USDC` as source and `EURC` as destination.
8. Go back and click on the `USDC` asset
9. Click on the bottom sticky Swap button.
10. Confirm the Swap page still opens with `USDC` as source and `EURC` as destination.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[WPN-2026]: https://consensyssoftware.atlassian.net/browse/WPN-2026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes swap source/destination selection for Arc only; incorrect mapping could break or mis-route swaps on that network, but scope is limited to Arc USDC handling.
> 
> **Overview**
> Fixes Arc Swap entry points opening with **USDC on both sides** by normalizing the native Arc balance to the router-validated **ERC20 wrapper** (`0x3600…`) whenever swap defaults are computed.
> 
> **Arc enablement** exports `isNativeArcAsset` (now treats an **empty** native address like the zero address) and adds `isArcErc20UsdcSwapToken` to recognize the wrapper token.
> 
> **Balance-aware swap defaults** map native Arc USDC to the wrapper via `resolveSwapToken` / `toSourceToken`, and **short-circuit** when the current token is native or wrapper USDC so the source stays the wrapper and **no destination asset id** is set—letting the Swap UI apply the usual Arc pair (e.g. USDC → EURC) from home, asset page, and sticky Swap buttons.
> 
> Tests cover native detection, wrapper selection, and coin-button hook arguments for chain `0x13b2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e28374a4808cea1493fa2291b3c3b29cd9c02f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->