### PR TITLE
feat: [musd-1323] implement money kebab menu

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5677,6 +5677,9 @@
   "moneyBenefits": {
     "message": "Benefits"
   },
+  "moneyContactSupport": {
+    "message": "Contact support"
+  },
   "moneyEarnApyTitle": {
     "message": "Earn up to $1 APY"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5677,6 +5677,9 @@
   "moneyBenefits": {
     "message": "Benefits"
   },
+  "moneyContactSupport": {
+    "message": "Contact support"
+  },
   "moneyEarnApyTitle": {
     "message": "Earn up to $1 APY"
   },

--- a/ui/pages/money/components/money-more-menu.test.tsx
+++ b/ui/pages/money/components/money-more-menu.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithLocalization } from '../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import { MONEY_LANDING_URL } from '../constants/urls';
+import { MoneyMoreMenu } from './money-more-menu';
+
+jest.mock(
+  '../../../components/app/modals/visit-support-data-consent-modal',
+  () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+      isOpen ? (
+        <button
+          type="button"
+          data-testid="support-consent-modal"
+          onClick={onClose}
+        />
+      ) : null,
+  }),
+);
+
+const openMenu = () => {
+  fireEvent.click(screen.getByTestId('money-more-menu-button'));
+};
+
+describe('MoneyMoreMenu', () => {
+  beforeEach(() => {
+    global.platform.openTab = jest.fn();
+  });
+
+  it('renders a closed menu button', () => {
+    renderWithLocalization(<MoneyMoreMenu />);
+
+    expect(
+      screen.getByRole('button', { name: messages.moneyMoreOptions.message }),
+    ).toBeEnabled();
+    expect(screen.queryByTestId('money-more-menu')).not.toBeInTheDocument();
+  });
+
+  it('shows the options when the button is clicked', () => {
+    renderWithLocalization(<MoneyMoreMenu />);
+
+    openMenu();
+
+    expect(screen.getByTestId('money-more-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('money-more-menu-how-it-works')).toBeDisabled();
+    expect(
+      screen.getByTestId('money-more-menu-how-it-works'),
+    ).toHaveTextContent(messages.moneyHowItWorks.message);
+    expect(screen.getByTestId('money-more-menu-benefits')).toHaveTextContent(
+      messages.moneyBenefits.message,
+    );
+    expect(
+      screen.getByTestId('money-more-menu-contact-support'),
+    ).toHaveTextContent(messages.moneyContactSupport.message);
+  });
+
+  it('opens the money landing page and closes when benefits is clicked', () => {
+    renderWithLocalization(<MoneyMoreMenu />);
+
+    openMenu();
+    fireEvent.click(screen.getByTestId('money-more-menu-benefits'));
+
+    expect(global.platform.openTab).toHaveBeenCalledWith({
+      url: MONEY_LANDING_URL,
+    });
+    expect(screen.queryByTestId('money-more-menu')).not.toBeInTheDocument();
+  });
+
+  it('opens the support consent modal when contact support is clicked', () => {
+    renderWithLocalization(<MoneyMoreMenu />);
+
+    openMenu();
+    fireEvent.click(screen.getByTestId('money-more-menu-contact-support'));
+
+    expect(screen.queryByTestId('money-more-menu')).not.toBeInTheDocument();
+    expect(screen.getByTestId('support-consent-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('support-consent-modal'));
+
+    expect(
+      screen.queryByTestId('support-consent-modal'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('closes the menu on escape', () => {
+    renderWithLocalization(<MoneyMoreMenu />);
+
+    openMenu();
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByTestId('money-more-menu')).not.toBeInTheDocument();
+  });
+});

--- a/ui/pages/money/components/money-more-menu.test.tsx
+++ b/ui/pages/money/components/money-more-menu.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalization } from '../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { MONEY_LANDING_URL } from '../constants/urls';
@@ -21,8 +21,10 @@ jest.mock(
   }),
 );
 
-const openMenu = () => {
-  fireEvent.click(screen.getByTestId('money-more-menu-button'));
+const openMenu = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('money-more-menu-button'));
+  });
 };
 
 describe('MoneyMoreMenu', () => {
@@ -39,10 +41,10 @@ describe('MoneyMoreMenu', () => {
     expect(screen.queryByTestId('money-more-menu')).not.toBeInTheDocument();
   });
 
-  it('shows the options when the button is clicked', () => {
+  it('shows the options when the button is clicked', async () => {
     renderWithLocalization(<MoneyMoreMenu />);
 
-    openMenu();
+    await openMenu();
 
     expect(screen.getByTestId('money-more-menu')).toBeInTheDocument();
     expect(screen.getByTestId('money-more-menu-how-it-works')).toBeDisabled();
@@ -57,10 +59,10 @@ describe('MoneyMoreMenu', () => {
     ).toHaveTextContent(messages.moneyContactSupport.message);
   });
 
-  it('opens the money landing page and closes when benefits is clicked', () => {
+  it('opens the money landing page and closes when benefits is clicked', async () => {
     renderWithLocalization(<MoneyMoreMenu />);
 
-    openMenu();
+    await openMenu();
     fireEvent.click(screen.getByTestId('money-more-menu-benefits'));
 
     expect(global.platform.openTab).toHaveBeenCalledWith({
@@ -69,10 +71,10 @@ describe('MoneyMoreMenu', () => {
     expect(screen.queryByTestId('money-more-menu')).not.toBeInTheDocument();
   });
 
-  it('opens the support consent modal when contact support is clicked', () => {
+  it('opens the support consent modal when contact support is clicked', async () => {
     renderWithLocalization(<MoneyMoreMenu />);
 
-    openMenu();
+    await openMenu();
     fireEvent.click(screen.getByTestId('money-more-menu-contact-support'));
 
     expect(screen.queryByTestId('money-more-menu')).not.toBeInTheDocument();
@@ -85,10 +87,10 @@ describe('MoneyMoreMenu', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('closes the menu on escape', () => {
+  it('closes the menu on escape', async () => {
     renderWithLocalization(<MoneyMoreMenu />);
 
-    openMenu();
+    await openMenu();
     fireEvent.keyDown(document, { key: 'Escape' });
 
     expect(screen.queryByTestId('money-more-menu')).not.toBeInTheDocument();

--- a/ui/pages/money/components/money-more-menu.tsx
+++ b/ui/pages/money/components/money-more-menu.tsx
@@ -1,0 +1,129 @@
+import React, { useCallback, useState } from 'react';
+import {
+  ButtonIcon,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+import {
+  Popover,
+  PopoverPosition,
+  PopoverRole,
+} from '../../../components/component-library';
+import VisitSupportDataConsentModal from '../../../components/app/modals/visit-support-data-consent-modal';
+import { useBoolean } from '../../../hooks/useBoolean';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { MONEY_LANDING_URL } from '../constants/urls';
+
+type MenuOption = {
+  key: string;
+  icon: IconName;
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+};
+
+export function MoneyMoreMenu() {
+  const t = useI18nContext();
+  const [anchorElement, setAnchorElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const {
+    value: isMenuOpen,
+    toggle: toggleMenu,
+    setFalse: closeMenu,
+  } = useBoolean();
+  const {
+    value: isSupportModalOpen,
+    setTrue: openSupportModal,
+    setFalse: closeSupportModal,
+  } = useBoolean();
+
+  const handleBenefits = useCallback(() => {
+    closeMenu();
+    global.platform.openTab({ url: MONEY_LANDING_URL });
+  }, [closeMenu]);
+
+  const handleContactSupport = useCallback(() => {
+    closeMenu();
+    openSupportModal();
+  }, [closeMenu, openSupportModal]);
+
+  const options: MenuOption[] = [
+    {
+      key: 'how-it-works',
+      icon: IconName.Book,
+      label: t('moneyHowItWorks'),
+      disabled: true,
+    },
+    {
+      key: 'benefits',
+      icon: IconName.Export,
+      label: t('moneyBenefits'),
+      onClick: handleBenefits,
+    },
+    {
+      key: 'contact-support',
+      icon: IconName.Sms,
+      label: t('moneyContactSupport'),
+      onClick: handleContactSupport,
+    },
+  ];
+
+  return (
+    <div ref={setAnchorElement}>
+      <ButtonIcon
+        iconName={IconName.MoreVertical}
+        ariaLabel={t('moneyMoreOptions')}
+        onClick={toggleMenu}
+        data-testid="money-more-menu-button"
+      />
+      <Popover
+        referenceElement={anchorElement}
+        isOpen={isMenuOpen}
+        isPortal
+        role={PopoverRole.Dialog}
+        position={PopoverPosition.BottomEnd}
+        preventOverflow
+        flip
+        padding={0}
+        className="min-w-[220px] rounded-lg z-[1050]"
+        onClickOutside={closeMenu}
+        onPressEscKey={closeMenu}
+        data-testid="money-more-menu"
+      >
+        <div className="flex flex-col py-2">
+          {options.map(({ key, icon, label, onClick, disabled }) => (
+            <button
+              key={key}
+              type="button"
+              disabled={disabled}
+              onClick={onClick}
+              className="flex w-full items-center gap-4 px-4 py-3 text-left hover:bg-hover active:bg-pressed disabled:cursor-default disabled:opacity-50 disabled:hover:bg-transparent"
+              data-testid={`money-more-menu-${key}`}
+            >
+              <Icon
+                name={icon}
+                size={IconSize.Md}
+                color={IconColor.IconDefault}
+              />
+              <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+                {label}
+              </Text>
+            </button>
+          ))}
+        </div>
+      </Popover>
+      {isSupportModalOpen ? (
+        <VisitSupportDataConsentModal
+          isOpen={isSupportModalOpen}
+          onClose={closeSupportModal}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/ui/pages/money/money-home-page.test.tsx
+++ b/ui/pages/money/money-home-page.test.tsx
@@ -243,9 +243,14 @@ describe('MoneyHomePage', () => {
       messages.addFunds.message,
       messages.moneySend.message,
       messages.moneyLearnMore.message,
+      messages.moneyMoreOptions.message,
     ];
     screen.getAllByRole('button').forEach((button) => {
-      if (activeLabels.includes(button.textContent ?? '')) {
+      if (
+        activeLabels.includes(
+          button.textContent || (button.getAttribute('aria-label') ?? ''),
+        )
+      ) {
         expect(button).toBeEnabled();
       } else {
         expect(button).toBeDisabled();
@@ -367,8 +372,12 @@ describe('MoneyHomePage', () => {
     expect(screen.getByTestId('money-add-button')).toBeEnabled();
     screen.getAllByRole('button').forEach((button) => {
       if (
-        [messages.moneyAdd.message, messages.moneySend.message].includes(
-          button.textContent ?? '',
+        [
+          messages.moneyAdd.message,
+          messages.moneySend.message,
+          messages.moneyMoreOptions.message,
+        ].includes(
+          button.textContent || (button.getAttribute('aria-label') ?? ''),
         )
       ) {
         expect(button).toBeEnabled();

--- a/ui/pages/money/money-home-page.tsx
+++ b/ui/pages/money/money-home-page.tsx
@@ -6,7 +6,6 @@ import {
   BannerAlert,
   BannerAlertSeverity,
   Button,
-  ButtonIcon,
   ButtonVariant,
   FontWeight,
   Icon,
@@ -41,6 +40,7 @@ import {
   MAX_PREVIEW_ITEMS,
 } from './components/money-activity-list';
 import { MoneyCondensedInfoCards } from './components/money-condensed-info-cards';
+import { MoneyMoreMenu } from './components/money-more-menu';
 import { MoneyPotentialEarnings } from './components/money-potential-earnings';
 import { MoneyPositionPlaceholder } from './components/money-position-placeholder';
 import { MoneyActivityFilter } from './utils/money-activity-filters';
@@ -245,11 +245,7 @@ export function MoneyHomePage() {
           <Text variant={TextVariant.HeadingLg} fontWeight={FontWeight.Bold}>
             {t('money')}
           </Text>
-          <ButtonIcon
-            iconName={IconName.MoreVertical}
-            ariaLabel={t('moneyMoreOptions')}
-            disabled
-          />
+          <MoneyMoreMenu />
         </header>
 
         {isBalanceFetchError ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This adds money 'kebab menu' to replace a previously inert placeholder.
The two menu items that are merely doc links are fully working.
The ”How it works” link is intended to lead to a currently unimplemented page in the extension client, so it is left disabled for now.
We don’t currently have real designs for this, so I freestyled. We will most likely do another pass once a designer reviews it.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: implement money kebab menu

## **Related issues**

Fixes: MUSD-1323

## **Manual testing steps**

1. Go to money home
2. Click the kebab menu
3. Click the links, observe that they take you somewhere.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
<img width="414" height="264" alt="Screenshot 2026-09-08 at 18 02 00" src="https://github.com/user-attachments/assets/4a279e7a-9246-4f36-a38c-395025c4f6ac" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change reusing existing support consent modal and external landing URL; no auth, balance, or transfer logic changes.
> 
> **Overview**
> Replaces the **disabled** “more options” icon on the Money home header with a working **`MoneyMoreMenu`** popover.
> 
> The menu exposes three entries: **How it works** (shown but **disabled** until an in-extension destination exists), **Benefits** (opens the existing Money landing URL in a new tab and closes the menu), and **Contact support** (closes the menu and opens the existing **`VisitSupportDataConsentModal`**). A new **`moneyContactSupport`** locale string backs the support label.
> 
> Home page tests are updated so the more-options control counts as an **enabled** action (matching **`aria-label`**, not only visible text). New unit tests cover menu open/close, Benefits navigation, support modal flow, and Escape handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b91c750d900012aca376e604cf62856b9cc0e6a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->