### PR TITLE
test: fix flaky test Personal Sign copied tooltip

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/accountDetailsModal.ts
+++ b/test/e2e/page-objects/pages/confirmations/accountDetailsModal.ts
@@ -79,11 +79,24 @@ class AccountDetailsModal extends Confirmation {
   }
 
   async clickAddressCopyButton() {
+    await this.driver.waitForElementToStopMoving(this.addressCopyButton);
     await this.driver.clickElement(this.addressCopyButton);
   }
 
   async waitForAddressCopied() {
-    await this.driver.waitForSelector(this.addressCopiedButton);
+    await this.driver.waitUntil(
+      async () => {
+        const copyButton = await this.driver.findElement(
+          this.addressCopyButton,
+        );
+        await this.driver.hoverElement(copyButton);
+        return await this.driver.isElementPresentAndVisible(
+          this.addressCopiedButton,
+          500,
+        );
+      },
+      { timeout: 20000, interval: 200 },
+    );
   }
 }
 

--- a/test/e2e/page-objects/pages/confirmations/accountDetailsModal.ts
+++ b/test/e2e/page-objects/pages/confirmations/accountDetailsModal.ts
@@ -95,7 +95,7 @@ class AccountDetailsModal extends Confirmation {
           500,
         );
       },
-      { timeout: 20000, interval: 200 },
+      { timeout: 5000, interval: 200 },
     );
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark this as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Stabilizes Personal Sign confirmation copy-address by waiting for the copy button to stop moving, then hovering so the "Copied." tooltip is actually on screen.

**Root cause:**

- The test logs in, opens the test dapp, and starts a Personal Sign request.
- That opens the confirmation dialog. The test then opens the account details modal from the header.
- Next it clicks the account address copy button and waits for a div whose text is "Copied."
- "Copied." only exists while the copy tooltip is open. A Selenium click does not always keep the mouse over the button, so the tooltip never appears.
- The copy button can also still be moving after the modal opens, so the click does not always register. The wait then times out after about 20 seconds.

**Solution:**

- Wait until the copy button stops moving before clicking it, so the click lands on a stable control.
- After the click, hover the copy button and keep waiting for the same "Copied." div, so the tooltip is on screen when the test looks for that text.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Start a test build with `yarn start:test`.
2. Run:

```bash
SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/confirmations/signatures/personal-sign.spec.ts --debug --leave-running
```

3. Confirm the Personal Sign confirmation opens, the account details modal copy action shows "Copied.", and the test pastes the address into the dapp before confirming.


## **Screenshots/Recordings**

<img height="350" alt="image" src="https://github.com/user-attachments/assets/22c4ef0c-6759-4e40-93b9-d8c1066bca3a" />


### **Before**

### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test the code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2e page-object timing only; no production or wallet logic changes.
> 
> **Overview**
> Fixes flaky Personal Sign e2e coverage around copying the account address from the confirmation **account details** modal.
> 
> **`clickAddressCopyButton`** now waits for the copy control to stop moving before clicking, so clicks land on a stable target after the modal opens.
> 
> **`waitForAddressCopied`** no longer only waits for the "Copied." selector. It polls (5s timeout, 200ms interval): find the copy button, **hover** it, then assert the copied tooltip is present and visible—matching behavior where Selenium clicks do not keep the pointer over the button and the tooltip only shows on hover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3cb0f30624028b45c7305f1dff53bf8618c61a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->