### PR TITLE
feat: background cleanup and toast update for BFT migration

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2013,8 +2013,14 @@
     "message": "Privacy and product updates"
   },
   "basicFunctionalityMigrationToastDescription": {
-    "message": "Third-party APIs are now part of Basic Functionality. Based on your previous preferences, this setting is enabled. Change it any time in $1",
-    "description": "$1 is the Settings > Privacy link"
+    "message": "Third-party APIs are now part of Basic Functionality. Based on your previous preferences, this setting is $1. Change it any time in $2",
+    "description": "$1 is the Basic Functionality state. $2 is the Settings > Privacy link"
+  },
+  "basicFunctionalityMigrationToastDisabled": {
+    "message": "disabled"
+  },
+  "basicFunctionalityMigrationToastEnabled": {
+    "message": "enabled"
   },
   "basicFunctionalityMigrationToastSettingsLink": {
     "message": "Settings > Privacy"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2013,8 +2013,14 @@
     "message": "Privacy and product updates"
   },
   "basicFunctionalityMigrationToastDescription": {
-    "message": "Third-party APIs are now part of Basic Functionality. Based on your previous preferences, this setting is enabled. Change it any time in $1",
-    "description": "$1 is the Settings > Privacy link"
+    "message": "Third-party APIs are now part of Basic Functionality. Based on your previous preferences, this setting is $1. Change it any time in $2",
+    "description": "$1 is the Basic Functionality state. $2 is the Settings > Privacy link"
+  },
+  "basicFunctionalityMigrationToastDisabled": {
+    "message": "disabled"
+  },
+  "basicFunctionalityMigrationToastEnabled": {
+    "message": "enabled"
   },
   "basicFunctionalityMigrationToastSettingsLink": {
     "message": "Settings > Privacy"

--- a/app/scripts/controllers/preferences-controller-method-action-types.ts
+++ b/app/scripts/controllers/preferences-controller-method-action-types.ts
@@ -53,13 +53,8 @@ export type PreferencesControllerToggleExternalServicesAction = {
 /**
  * One-time Basic Functionality consolidation when the remote FF turns on.
  * Aligns child preferences, marks the user as consolidated, and schedules
- * the modal/toast notice when needed.
- *
- * @param options - Consolidation options.
- * @param options.isSocialLogin - Whether this wallet is a social-login user.
- * @returns The landing Basic Functionality state, or `null` if already
- * consolidated (no-op). Callers should sync external-service controllers
- * via `toggleExternalServices` when a boolean is returned.
+ * the modal/toast notice when needed, then syncs external-service
+ * controllers.
  */
 export type PreferencesControllerConsolidateBasicFunctionalityAction = {
   type: `PreferencesController:consolidateBasicFunctionality`;

--- a/app/scripts/controllers/preferences-controller.test.ts
+++ b/app/scripts/controllers/preferences-controller.test.ts
@@ -52,8 +52,29 @@ const setupController = ({
     actions: [
       'AccountsController:getAccountByAddress',
       'AccountsController:setAccountName',
+      'LegacyBackgroundApiService:toggleExternalServices',
+      'OnboardingController:getState',
+      'SeedlessOnboardingController:getState',
     ],
   });
+
+  const getOnboardingState = jest.fn().mockReturnValue({
+    firstTimeFlowType: 'create',
+  });
+  const getSeedlessOnboardingState = jest.fn().mockReturnValue({});
+  const toggleExternalServices = jest.fn();
+  messenger.registerActionHandler(
+    'OnboardingController:getState',
+    getOnboardingState,
+  );
+  messenger.registerActionHandler(
+    'SeedlessOnboardingController:getState',
+    getSeedlessOnboardingState,
+  );
+  messenger.registerActionHandler(
+    'LegacyBackgroundApiService:toggleExternalServices',
+    toggleExternalServices,
+  );
 
   const controller = new PreferencesController({
     messenger: preferencesControllerMessenger,
@@ -95,6 +116,9 @@ const setupController = ({
     controller,
     messenger,
     accountsController,
+    getOnboardingState,
+    getSeedlessOnboardingState,
+    toggleExternalServices,
   };
 };
 
@@ -628,6 +652,38 @@ describe('preferences controller', () => {
     });
   });
 
+  describe('consolidateBasicFunctionality', () => {
+    it('consolidates a social-login wallet and syncs external services', () => {
+      const { controller, getSeedlessOnboardingState, toggleExternalServices } =
+        setupController({});
+      getSeedlessOnboardingState.mockReturnValue({
+        authConnection: 'google',
+      });
+
+      controller.consolidateBasicFunctionality();
+
+      expect(controller.state.useExternalServices).toBe(true);
+      expect(
+        controller.getPreferences().isBasicFunctionalityConsolidatedEnabled,
+      ).toBe(true);
+      expect(
+        controller.getPreferences().basicFunctionalityMigrationNotification,
+      ).toBe('modal');
+      expect(toggleExternalServices).toHaveBeenCalledWith(true);
+    });
+
+    it('does not sync external services when already consolidated', () => {
+      const { controller, getOnboardingState, toggleExternalServices } =
+        setupController({});
+      controller.setPreference('isBasicFunctionalityConsolidatedEnabled', true);
+
+      controller.consolidateBasicFunctionality();
+
+      expect(getOnboardingState).not.toHaveBeenCalled();
+      expect(toggleExternalServices).not.toHaveBeenCalled();
+    });
+  });
+
   describe('dismissBasicFunctionalityMigrationNotification', () => {
     it('clears a scheduled migration notification', () => {
       const { controller } = setupController({});
@@ -648,18 +704,20 @@ describe('preferences controller', () => {
     });
 
     it('does not reschedule a notice after dismiss', () => {
-      const { controller } = setupController({});
+      const { controller, getOnboardingState, toggleExternalServices } =
+        setupController({});
       controller.setPreference(
         'basicFunctionalityMigrationNotification',
         'modal',
       );
       controller.dismissBasicFunctionalityMigrationNotification();
-
-      const landingState = controller.consolidateBasicFunctionality({
-        isSocialLogin: true,
+      getOnboardingState.mockReturnValue({
+        firstTimeFlowType: 'socialCreate',
       });
 
-      expect(landingState).toBe(true);
+      controller.consolidateBasicFunctionality();
+
+      expect(toggleExternalServices).toHaveBeenCalledWith(true);
       expect(
         controller.getPreferences().basicFunctionalityMigrationNotification,
       ).toBeNull();

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -2,6 +2,7 @@ import {
   AccountsControllerGetAccountByAddressAction,
   AccountsControllerSetAccountNameAction,
 } from '@metamask/accounts-controller';
+import type { SeedlessOnboardingControllerGetStateAction } from '@metamask/seedless-onboarding-controller';
 import { Json, Hex } from '@metamask/utils';
 import {
   BaseController,
@@ -28,8 +29,11 @@ import type { Preferences } from '../../../shared/types/preferences';
 import {
   BFT_CHILD_PREFERENCES,
   getBasicFunctionalityConsolidationPlan,
+  isBasicFunctionalitySocialLoginUser,
   type BasicFunctionalityPreferenceState,
 } from '../../../shared/lib/basic-functionality-consolidation';
+import type { LegacyBackgroundApiServiceToggleExternalServicesAction } from '../services/legacy-background-api-service-method-action-types';
+import type { OnboardingControllerGetStateAction } from './onboarding';
 import { PreferencesControllerMethodActions } from './preferences-controller-method-action-types';
 
 /**
@@ -76,7 +80,10 @@ export type PreferencesControllerEvents = PreferencesControllerStateChangeEvent;
  */
 export type AllowedActions =
   | AccountsControllerGetAccountByAddressAction
-  | AccountsControllerSetAccountNameAction;
+  | AccountsControllerSetAccountNameAction
+  | LegacyBackgroundApiServiceToggleExternalServicesAction
+  | OnboardingControllerGetStateAction
+  | SeedlessOnboardingControllerGetStateAction;
 
 export type PreferencesControllerMessenger = Messenger<
   typeof controllerName,
@@ -591,22 +598,24 @@ export class PreferencesController extends BaseController<
   /**
    * One-time Basic Functionality consolidation when the remote FF turns on.
    * Aligns child preferences, marks the user as consolidated, and schedules
-   * the modal/toast notice when needed.
-   *
-   * @param options - Consolidation options.
-   * @param options.isSocialLogin - Whether this wallet is a social-login user.
-   * @returns The landing Basic Functionality state, or `null` if already
-   * consolidated (no-op). Callers should sync external-service controllers
-   * via `toggleExternalServices` when a boolean is returned.
+   * the modal/toast notice when needed, then syncs external-service
+   * controllers.
    */
-  consolidateBasicFunctionality({
-    isSocialLogin,
-  }: {
-    isSocialLogin: boolean;
-  }): boolean | null {
+  consolidateBasicFunctionality(): void {
     if (this.state.preferences.isBasicFunctionalityConsolidatedEnabled) {
-      return null;
+      return;
     }
+
+    const { firstTimeFlowType } = this.messenger.call(
+      'OnboardingController:getState',
+    );
+    const { authConnection } = this.messenger.call(
+      'SeedlessOnboardingController:getState',
+    );
+    const isSocialLogin = isBasicFunctionalitySocialLoginUser({
+      firstTimeFlowType: firstTimeFlowType ?? undefined,
+      authConnection,
+    });
 
     const preferenceState = {
       useExternalServices: this.state.useExternalServices,
@@ -633,7 +642,10 @@ export class PreferencesController extends BaseController<
         hasDismissedNotice ? null : notification;
     });
 
-    return landingState;
+    this.messenger.call(
+      'LegacyBackgroundApiService:toggleExternalServices',
+      landingState,
+    );
   }
 
   /**

--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -162,7 +162,6 @@ export function getLegacyBackgroundApiServiceMessenger(
       'PhishingController:maybeUpdateState',
       'PhishingController:testOrigin',
       'PreferencesController:toggleExternalServices',
-      'PreferencesController:consolidateBasicFunctionality',
       'SubscriptionController:getState',
       'TokenDetectionController:enable',
       'TokenDetectionController:disable',

--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -163,7 +163,6 @@ export function getLegacyBackgroundApiServiceMessenger(
       'PhishingController:testOrigin',
       'PreferencesController:toggleExternalServices',
       'PreferencesController:consolidateBasicFunctionality',
-      'PreferencesController:dismissBasicFunctionalityMigrationNotification',
       'SubscriptionController:getState',
       'TokenDetectionController:enable',
       'TokenDetectionController:disable',

--- a/app/scripts/messenger-client-init/messengers/preferences-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/preferences-controller-messenger.ts
@@ -28,6 +28,9 @@ export function getPreferencesControllerMessenger(
     actions: [
       'AccountsController:getAccountByAddress',
       'AccountsController:setAccountName',
+      'LegacyBackgroundApiService:toggleExternalServices',
+      'OnboardingController:getState',
+      'SeedlessOnboardingController:getState',
     ],
   });
   return preferencesControllerMessenger;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2925,7 +2925,7 @@ export default class MetamaskController extends EventEmitter {
       dismissBasicFunctionalityMigrationNotification:
         this.controllerMessenger.call.bind(
           this.controllerMessenger,
-          'LegacyBackgroundApiService:dismissBasicFunctionalityMigrationNotification',
+          'PreferencesController:dismissBasicFunctionalityMigrationNotification',
         ),
 
       setManageInstitutionalWallets:

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2896,7 +2896,7 @@ export default class MetamaskController extends EventEmitter {
       ),
       consolidateBasicFunctionality: this.controllerMessenger.call.bind(
         this.controllerMessenger,
-        'LegacyBackgroundApiService:consolidateBasicFunctionality',
+        'PreferencesController:consolidateBasicFunctionality',
       ),
 
       addKnownMethodData: preferencesController.addKnownMethodData.bind(

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -719,15 +719,6 @@ export type LegacyBackgroundApiServiceConsolidateBasicFunctionalityAction = {
 };
 
 /**
- * Dismisses the one-time Basic Functionality migration modal or toast.
- */
-export type LegacyBackgroundApiServiceDismissBasicFunctionalityMigrationNotificationAction =
-  {
-    type: `LegacyBackgroundApiService:dismissBasicFunctionalityMigrationNotification`;
-    handler: LegacyBackgroundApiService['dismissBasicFunctionalityMigrationNotification'];
-  };
-
-/**
  * Toggles external services on or off.
  *
  * When enabled, token detection and non-RPC gas fee APIs are started, and the
@@ -1227,7 +1218,6 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceApproveHardwareWalletTransactionAction
   | LegacyBackgroundApiServiceRejectAllPendingApprovalsAction
   | LegacyBackgroundApiServiceConsolidateBasicFunctionalityAction
-  | LegacyBackgroundApiServiceDismissBasicFunctionalityMigrationNotificationAction
   | LegacyBackgroundApiServiceToggleExternalServicesAction
   | LegacyBackgroundApiServiceAcceptPermissionsRequestAction
   | LegacyBackgroundApiServiceAttemptLedgerTransportCreationAction

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -708,17 +708,6 @@ export type LegacyBackgroundApiServiceRejectAllPendingApprovalsAction = {
 };
 
 /**
- * One-time Basic Functionality consolidation when the remote FF turns on.
- * Aligns child preferences, schedules the modal/toast notice, and syncs
- * TokenDetection / GasFee / Shield / subscription controllers when
- * consolidation actually ran.
- */
-export type LegacyBackgroundApiServiceConsolidateBasicFunctionalityAction = {
-  type: `LegacyBackgroundApiService:consolidateBasicFunctionality`;
-  handler: LegacyBackgroundApiService['consolidateBasicFunctionality'];
-};
-
-/**
  * Toggles external services on or off.
  *
  * When enabled, token detection and non-RPC gas fee APIs are started, and the
@@ -1217,7 +1206,6 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceResolvePendingApprovalAction
   | LegacyBackgroundApiServiceApproveHardwareWalletTransactionAction
   | LegacyBackgroundApiServiceRejectAllPendingApprovalsAction
-  | LegacyBackgroundApiServiceConsolidateBasicFunctionalityAction
   | LegacyBackgroundApiServiceToggleExternalServicesAction
   | LegacyBackgroundApiServiceAcceptPermissionsRequestAction
   | LegacyBackgroundApiServiceAttemptLedgerTransportCreationAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -6281,78 +6281,6 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
-  describe('consolidateBasicFunctionality', () => {
-    it('consolidates preferences for a social-login user and syncs external services', async () => {
-      await withService(async ({ rootMessenger, service }) => {
-        const consolidate = jest.fn().mockReturnValue(true);
-        const toggleExternalServices = jest.fn();
-        const toggleSpy = jest.spyOn(service, 'toggleExternalServices');
-
-        rootMessenger.registerActionHandler(
-          'OnboardingController:getState',
-          jest.fn().mockReturnValue({ firstTimeFlowType: 'socialCreate' }),
-        );
-        rootMessenger.registerActionHandler(
-          'SeedlessOnboardingController:getState',
-          jest.fn().mockReturnValue({ authConnection: 'google' }),
-        );
-        rootMessenger.registerActionHandler(
-          'PreferencesController:consolidateBasicFunctionality',
-          consolidate,
-        );
-        rootMessenger.registerActionHandler(
-          'PreferencesController:toggleExternalServices',
-          toggleExternalServices,
-        );
-        rootMessenger.registerActionHandler(
-          'SubscriptionController:getState',
-          jest.fn().mockReturnValue({ subscriptions: [] }),
-        );
-        rootMessenger.registerActionHandler(
-          'TokenDetectionController:enable',
-          jest.fn(),
-        );
-        rootMessenger.registerActionHandler(
-          'GasFeeController:enableNonRPCGasFeeApis',
-          jest.fn(),
-        );
-
-        rootMessenger.call(
-          'LegacyBackgroundApiService:consolidateBasicFunctionality',
-        );
-
-        expect(consolidate).toHaveBeenCalledWith({ isSocialLogin: true });
-        expect(toggleSpy).toHaveBeenCalledWith(true);
-        expect(toggleExternalServices).toHaveBeenCalledWith(true);
-      });
-    });
-
-    it('does not sync external services when consolidation is a no-op', async () => {
-      await withService(async ({ rootMessenger, service }) => {
-        const toggleSpy = jest.spyOn(service, 'toggleExternalServices');
-
-        rootMessenger.registerActionHandler(
-          'OnboardingController:getState',
-          jest.fn().mockReturnValue({ firstTimeFlowType: 'create' }),
-        );
-        rootMessenger.registerActionHandler(
-          'SeedlessOnboardingController:getState',
-          jest.fn().mockReturnValue({}),
-        );
-        rootMessenger.registerActionHandler(
-          'PreferencesController:consolidateBasicFunctionality',
-          jest.fn().mockReturnValue(null),
-        );
-
-        rootMessenger.call(
-          'LegacyBackgroundApiService:consolidateBasicFunctionality',
-        );
-
-        expect(toggleSpy).not.toHaveBeenCalled();
-      });
-    });
-  });
-
   describe('throwTestError', () => {
     beforeEach(() => {
       jest.useFakeTimers();
@@ -8755,7 +8683,6 @@ function getMessenger(
       'PhishingController:maybeUpdateState',
       'PhishingController:testOrigin',
       'PreferencesController:toggleExternalServices',
-      'PreferencesController:consolidateBasicFunctionality',
       'SubscriptionController:getState',
       'TokenDetectionController:enable',
       'TokenDetectionController:disable',

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -6353,24 +6353,6 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
-  describe('dismissBasicFunctionalityMigrationNotification', () => {
-    it('dismisses the notice on PreferencesController', async () => {
-      await withService(async ({ rootMessenger }) => {
-        const dismiss = jest.fn();
-        rootMessenger.registerActionHandler(
-          'PreferencesController:dismissBasicFunctionalityMigrationNotification',
-          dismiss,
-        );
-
-        rootMessenger.call(
-          'LegacyBackgroundApiService:dismissBasicFunctionalityMigrationNotification',
-        );
-
-        expect(dismiss).toHaveBeenCalledTimes(1);
-      });
-    });
-  });
-
   describe('throwTestError', () => {
     beforeEach(() => {
       jest.useFakeTimers();
@@ -8774,7 +8756,6 @@ function getMessenger(
       'PhishingController:testOrigin',
       'PreferencesController:toggleExternalServices',
       'PreferencesController:consolidateBasicFunctionality',
-      'PreferencesController:dismissBasicFunctionalityMigrationNotification',
       'SubscriptionController:getState',
       'TokenDetectionController:enable',
       'TokenDetectionController:disable',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -511,7 +511,6 @@ const MESSENGER_EXPOSED_METHODS = [
   'createNewVaultAndRestore',
   'createSeedPhraseBackup',
   'decodeTransactionData',
-  'dismissBasicFunctionalityMigrationNotification',
   'discoverAndCreateAccounts',
   'estimateGas',
   'exportAccount',
@@ -3108,15 +3107,6 @@ export class LegacyBackgroundApiService {
     if (landingState !== null) {
       this.toggleExternalServices(landingState);
     }
-  }
-
-  /**
-   * Dismisses the one-time Basic Functionality migration modal or toast.
-   */
-  dismissBasicFunctionalityMigrationNotification(): void {
-    this.#messenger.call(
-      'PreferencesController:dismissBasicFunctionalityMigrationNotification',
-    );
   }
 
   /**

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -414,7 +414,6 @@ import {
 import { isDmkFeatureEnabled } from '../../../shared/lib/hardware-wallets/feature-flags';
 import { getManifestFlags } from '../../../shared/lib/manifestFlags';
 import { getBooleanFeatureFlag } from '../../../shared/lib/remote-feature-flag-utils';
-import { isBasicFunctionalitySocialLoginUser } from '../../../shared/lib/basic-functionality-consolidation';
 import {
   LatticeKeyringV2,
   LatticeCreateAccountOptions,
@@ -505,7 +504,6 @@ const MESSENGER_EXPOSED_METHODS = [
   'checkHardwareStatus',
   'checkIsSeedlessPasswordOutdated',
   'connectHardware',
-  'consolidateBasicFunctionality',
   'createNewVaultAndGetSeedPhrase',
   'createNewVaultAndKeychain',
   'createNewVaultAndRestore',
@@ -3078,34 +3076,6 @@ export class LegacyBackgroundApiService {
           );
           break;
       }
-    }
-  }
-
-  /**
-   * One-time Basic Functionality consolidation when the remote FF turns on.
-   * Aligns child preferences, schedules the modal/toast notice, and syncs
-   * TokenDetection / GasFee / Shield / subscription controllers when
-   * consolidation actually ran.
-   */
-  consolidateBasicFunctionality(): void {
-    const { firstTimeFlowType } = this.#messenger.call(
-      'OnboardingController:getState',
-    );
-    const { authConnection } = this.#messenger.call(
-      'SeedlessOnboardingController:getState',
-    );
-    const landingState = this.#messenger.call(
-      'PreferencesController:consolidateBasicFunctionality',
-      {
-        isSocialLogin: isBasicFunctionalitySocialLoginUser({
-          firstTimeFlowType: firstTimeFlowType ?? undefined,
-          authConnection,
-        }),
-      },
-    );
-
-    if (landingState !== null) {
-      this.toggleExternalServices(landingState);
     }
   }
 

--- a/ui/components/app/basic-functionality-migration-toast/basic-functionality-migration-toast.test.tsx
+++ b/ui/components/app/basic-functionality-migration-toast/basic-functionality-migration-toast.test.tsx
@@ -54,24 +54,25 @@ describe('BasicFunctionalityMigrationToast', () => {
     jest.clearAllMocks();
   });
 
-  it.each([
-    [true, 'enabled'],
-    [false, 'disabled'],
-  ])(
-    'shows the %s Basic Functionality state',
-    (isBasicFunctionalityEnabled, expectedState) => {
-      const { getByTestId, getByText } = renderComponent({
-        isBasicFunctionalityEnabled,
-      });
+  it('shows the enabled Basic Functionality state', () => {
+    const { getByTestId } = renderComponent({
+      isBasicFunctionalityEnabled: true,
+    });
 
-      expect(
-        getByTestId('basic-functionality-migration-toast'),
-      ).toBeInTheDocument();
-      expect(
-        getByText(new RegExp(`this setting is ${expectedState}\\.`, 'u')),
-      ).toBeInTheDocument();
-    },
-  );
+    expect(
+      getByTestId('basic-functionality-migration-toast'),
+    ).toHaveTextContent('this setting is enabled.');
+  });
+
+  it('shows the disabled Basic Functionality state', () => {
+    const { getByTestId } = renderComponent({
+      isBasicFunctionalityEnabled: false,
+    });
+
+    expect(
+      getByTestId('basic-functionality-migration-toast'),
+    ).toHaveTextContent('this setting is disabled.');
+  });
 
   it('does not render when no toast is scheduled', () => {
     const { queryByTestId } = renderComponent({ notification: null });

--- a/ui/components/app/basic-functionality-migration-toast/basic-functionality-migration-toast.test.tsx
+++ b/ui/components/app/basic-functionality-migration-toast/basic-functionality-migration-toast.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import mockState from '../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { PRIVACY_ROUTE } from '../../../helpers/constants/routes';
+import { hideMigrationToast } from '../../../store/actions';
+import { BasicFunctionalityMigrationToast } from './basic-functionality-migration-toast';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../store/actions', () => ({
+  ...jest.requireActual('../../../store/actions'),
+  hideMigrationToast: jest.fn(() => jest.fn()),
+}));
+
+const mockStore = configureMockStore([thunk]);
+
+function renderComponent({
+  isBasicFunctionalityEnabled = true,
+  notification = 'toast',
+}: {
+  isBasicFunctionalityEnabled?: boolean;
+  notification?: 'modal' | 'toast' | null;
+} = {}) {
+  const store = mockStore({
+    ...mockState,
+    metamask: {
+      ...mockState.metamask,
+      useExternalServices: isBasicFunctionalityEnabled,
+      remoteFeatureFlags: {
+        ...mockState.metamask.remoteFeatureFlags,
+        extensionBasicFunctionalityToggle: true,
+      },
+      preferences: {
+        ...mockState.metamask.preferences,
+        basicFunctionalityMigrationNotification: notification,
+        basicFunctionalityMigrationNotificationDismissed: false,
+      },
+    },
+  });
+
+  return renderWithProvider(<BasicFunctionalityMigrationToast />, store);
+}
+
+describe('BasicFunctionalityMigrationToast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [true, 'enabled'],
+    [false, 'disabled'],
+  ])(
+    'shows the %s Basic Functionality state',
+    (isBasicFunctionalityEnabled, expectedState) => {
+      const { getByTestId, getByText } = renderComponent({
+        isBasicFunctionalityEnabled,
+      });
+
+      expect(
+        getByTestId('basic-functionality-migration-toast'),
+      ).toBeInTheDocument();
+      expect(
+        getByText(new RegExp(`this setting is ${expectedState}\\.`, 'u')),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it('does not render when no toast is scheduled', () => {
+    const { queryByTestId } = renderComponent({ notification: null });
+
+    expect(
+      queryByTestId('basic-functionality-migration-toast'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('dismisses and opens privacy settings from the inline link', () => {
+    const { getByTestId } = renderComponent();
+
+    fireEvent.click(getByTestId('basic-functionality-migration-settings-link'));
+
+    expect(hideMigrationToast).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(PRIVACY_ROUTE);
+  });
+
+  it('dismisses from the close button', () => {
+    const { getByRole } = renderComponent();
+
+    fireEvent.click(getByRole('button', { name: 'Close' }));
+
+    expect(hideMigrationToast).toHaveBeenCalled();
+  });
+});

--- a/ui/components/app/basic-functionality-migration-toast/basic-functionality-migration-toast.test.tsx
+++ b/ui/components/app/basic-functionality-migration-toast/basic-functionality-migration-toast.test.tsx
@@ -3,7 +3,10 @@ import { fireEvent } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import mockState from '../../../../test/data/mock-state.json';
-import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import {
+  en as messages,
+  renderWithProvider,
+} from '../../../../test/lib/render-helpers-navigate';
 import { PRIVACY_ROUTE } from '../../../helpers/constants/routes';
 import { hideMigrationToast } from '../../../store/actions';
 import { BasicFunctionalityMigrationToast } from './basic-functionality-migration-toast';
@@ -94,7 +97,11 @@ describe('BasicFunctionalityMigrationToast', () => {
   it('dismisses from the close button', () => {
     const { getByRole } = renderComponent();
 
-    fireEvent.click(getByRole('button', { name: 'Close' }));
+    fireEvent.click(
+      getByRole('button', {
+        name: messages.close.message,
+      }),
+    );
 
     expect(hideMigrationToast).toHaveBeenCalled();
   });

--- a/ui/components/app/basic-functionality-migration-toast/basic-functionality-migration-toast.tsx
+++ b/ui/components/app/basic-functionality-migration-toast/basic-functionality-migration-toast.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import {
+  Text,
+  TextButton,
+  TextButtonSize,
+  TextColor,
+  TextVariant,
+  Toast,
+} from '@metamask/design-system-react';
+import { PRIVACY_ROUTE } from '../../../helpers/constants/routes';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { getUseExternalServices } from '../../../selectors';
+import { getShouldShowBasicFunctionalityMigrationToast } from '../../../selectors/multichain/feature-flags';
+import { hideMigrationToast } from '../../../store/actions';
+import { useDispatch } from '../../../store/hooks';
+
+export function BasicFunctionalityMigrationToast() {
+  const t = useI18nContext();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const shouldShow = useSelector(getShouldShowBasicFunctionalityMigrationToast);
+  const isBasicFunctionalityEnabled = useSelector(getUseExternalServices);
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  const dismissToast = () => {
+    dispatch(hideMigrationToast());
+  };
+
+  const openPrivacySettings = () => {
+    dismissToast();
+    navigate(PRIVACY_ROUTE);
+  };
+
+  return (
+    <Toast
+      data-testid="basic-functionality-migration-toast"
+      className="relative p-3 [&>button:last-child]:absolute [&>button:last-child]:right-3 [&>button:last-child]:top-3"
+      title={t('basicFunctionalityMigrationModalTitle')}
+      titleProps={{ variant: TextVariant.BodyMd, className: 'pr-10' }}
+      description={
+        <div className="pt-0.5">
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('basicFunctionalityMigrationToastDescription', [
+              isBasicFunctionalityEnabled
+                ? t('basicFunctionalityMigrationToastEnabled')
+                : t('basicFunctionalityMigrationToastDisabled'),
+              <TextButton
+                key="basic-functionality-migration-settings-link"
+                size={TextButtonSize.BodySm}
+                className="inline-flex p-0 align-baseline"
+                data-testid="basic-functionality-migration-settings-link"
+                onClick={openPrivacySettings}
+              >
+                {t('basicFunctionalityMigrationToastSettingsLink')}
+              </TextButton>,
+            ])}
+          </Text>
+        </div>
+      }
+      closeButtonProps={{ ariaLabel: t('close') }}
+      onClose={dismissToast}
+    />
+  );
+}

--- a/ui/components/app/basic-functionality-migration-toast/basic-functionality-migration-toast.tsx
+++ b/ui/components/app/basic-functionality-migration-toast/basic-functionality-migration-toast.tsx
@@ -39,7 +39,7 @@ export function BasicFunctionalityMigrationToast() {
   return (
     <Toast
       data-testid="basic-functionality-migration-toast"
-      className="relative p-3 [&>button:last-child]:absolute [&>button:last-child]:right-3 [&>button:last-child]:top-3"
+      className="relative w-full max-w-[432px] self-center p-3 [&>button:last-child]:absolute [&>button:last-child]:right-3 [&>button:last-child]:top-3"
       title={t('basicFunctionalityMigrationModalTitle')}
       titleProps={{ variant: TextVariant.BodyMd, className: 'pr-10' }}
       description={

--- a/ui/components/app/basic-functionality-migration-toast/index.ts
+++ b/ui/components/app/basic-functionality-migration-toast/index.ts
@@ -1,0 +1,1 @@
+export { BasicFunctionalityMigrationToast } from './basic-functionality-migration-toast';

--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -15,18 +15,17 @@ import {
 import {
   DEFAULT_ROUTE,
   PERPS_ROUTE,
-  PRIVACY_ROUTE,
   REVEAL_SEED_ROUTE,
   SETTINGS_ROUTE,
   TRANSACTION_SHIELD_ROUTE,
 } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { getShouldShowBasicFunctionalityMigrationToast } from '../../../selectors/multichain/feature-flags';
-import { hideMigrationToast, toggleDefaultView } from '../../../store/actions';
+import { toggleDefaultView } from '../../../store/actions';
 import { Icon, IconName, IconSize } from '../../component-library';
 import { Toast, ToastContainer } from '../../multichain';
 import { SurveyToast } from '../../ui/survey-toast/survey-toast';
 import { StorageWriteErrorType } from '../../../../shared/constants/app-state';
+import { BasicFunctionalityMigrationToast } from '../basic-functionality-migration-toast';
 import { PerpsWithdrawToast } from '../perps/perps-withdraw-toast';
 import { ArcUsageNoticeToast } from '../arc-usage-notice-toast';
 import {
@@ -177,38 +176,6 @@ function PrivacyPolicyToast() {
           setNewPrivacyPolicyToastClickedOrClosed();
         }}
         onClose={setNewPrivacyPolicyToastClickedOrClosed}
-      />
-    )
-  );
-}
-
-function BasicFunctionalityMigrationToast() {
-  const t = useI18nContext();
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
-  const shouldShow = useSelector(getShouldShowBasicFunctionalityMigrationToast);
-
-  return (
-    shouldShow && (
-      <Toast
-        key="basic-functionality-migration-toast"
-        dataTestId="basic-functionality-migration-toast"
-        startAdornment={null}
-        text={t('basicFunctionalityMigrationModalTitle')}
-        description={t('basicFunctionalityMigrationToastDescription', [
-          <button
-            key="basic-functionality-migration-settings-link"
-            type="button"
-            onClick={() => {
-              dispatch(hideMigrationToast());
-              navigate(PRIVACY_ROUTE);
-            }}
-            className="inline h-auto min-h-0 cursor-pointer border-0 bg-transparent p-0 align-baseline text-primary-default"
-          >
-            {t('basicFunctionalityMigrationToastSettingsLink')}
-          </button>,
-        ])}
-        onClose={() => dispatch(hideMigrationToast())}
       />
     )
   );


### PR DESCRIPTION
This PR is to:
1.  address the changes requested by core platform in this [PR](https://github.com/MetaMask/metamask-extension/pull/45959)
2. Updates the Toast to use new DS component and to add enable/disable copy change

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
3. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [https://consensyssoftware.atlassian.net/browse/CEUX-1353](https://consensyssoftware.atlassian.net/browse/CEUX-1353)

## **Manual testing steps**

1. Check everything behaves same as this [PR](https://github.com/MetaMask/metamask-extension/pull/45959)
2. Toast should show enable text when BFT is enabled else disabled

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

#### Enabled

<img width="712" height="272" alt="Screenshot 2026-09-09 at 12 03 44 PM" src="https://github.com/user-attachments/assets/4bd7bed8-5f78-4425-8f9d-08086e83a577" />


#### Disabled
<img width="736" height="278" alt="Screenshot 2026-09-09 at 12 04 21 PM" src="https://github.com/user-attachments/assets/44197f95-a3ea-41e6-8e4d-4901cc6dd83e" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors privacy-related consolidation and external-service toggling across controllers; incorrect sync could leave third-party APIs or child preferences misaligned after migration.
> 
> **Overview**
> Moves **Basic Functionality (BFT) migration** orchestration out of `LegacyBackgroundApiService` into **`PreferencesController`**. `consolidateBasicFunctionality` no longer accepts `isSocialLogin` or returns a landing state; it reads onboarding/seedless state internally, applies the consolidation plan, then calls **`LegacyBackgroundApiService:toggleExternalServices`** so dependent controllers stay in sync. Public API entry points in `metamask-controller` now target **`PreferencesController:consolidateBasicFunctionality`** and **`PreferencesController:dismissBasicFunctionalityMigrationNotification`** directly.
> 
> The migration **toast** is extracted into **`BasicFunctionalityMigrationToast`** using the design-system **`Toast`**, and copy now reflects whether Basic Functionality is **enabled or disabled** via new i18n placeholders (`basicFunctionalityMigrationToastEnabled` / `Disabled`). Tests follow the move (preferences controller + new component tests; legacy service consolidation tests removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1b2076de894496dfe4ebad086aecaa38b7d842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->