### PR TITLE
feat(assets): always mark legacy assets controllers as deprecated

### DIFF
--- a/app/scripts/messenger-client-init/account-tracker-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/account-tracker-controller-init.test.ts
@@ -111,6 +111,7 @@ describe('AccountTrackerControllerInit', () => {
       isOnboarded: expect.any(Function),
       isDeprecated: expect.any(Function),
     });
+    expect(controllerMock.mock.calls[0][0].isDeprecated?.()).toBe(true);
   });
 
   it('initializes with Account API feature flag configuration', () => {

--- a/app/scripts/messenger-client-init/account-tracker-controller-init.ts
+++ b/app/scripts/messenger-client-init/account-tracker-controller-init.ts
@@ -3,7 +3,6 @@ import {
   AccountTrackerControllerMessenger,
 } from '@metamask/assets-controllers';
 import { NetworkClientId } from '@metamask/network-controller';
-import { getIsDeprecatedController } from '../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { MessengerClientInitFunction } from './types';
 import { AccountTrackerControllerInitMessenger } from './messengers';
 
@@ -53,15 +52,7 @@ export const AccountTrackerControllerInit: MessengerClientInitFunction<
       const { completedOnboarding } = onboardingController().state;
       return completedOnboarding;
     },
-    isDeprecated: () => {
-      const { remoteFeatureFlags } = initMessenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      return getIsDeprecatedController(
-        remoteFeatureFlags,
-        'AccountTrackerController',
-      );
-    },
+    isDeprecated: () => true,
   });
 
   return {

--- a/app/scripts/messenger-client-init/assets/token-rates-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/token-rates-controller-init.test.ts
@@ -103,8 +103,8 @@ describe('TokenRatesControllerInit', () => {
     TokenRatesControllerInit(requestMock);
 
     expect(tokenRatesControllerClassMock).toHaveBeenCalled();
-    expect(tokenRatesControllerClassMock.mock.calls[0][0].isDeprecated()).toBe(
-      true,
-    );
+    expect(
+      tokenRatesControllerClassMock.mock.calls[0][0].isDeprecated?.(),
+    ).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/assets/token-rates-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/token-rates-controller-init.test.ts
@@ -103,5 +103,8 @@ describe('TokenRatesControllerInit', () => {
     TokenRatesControllerInit(requestMock);
 
     expect(tokenRatesControllerClassMock).toHaveBeenCalled();
+    expect(tokenRatesControllerClassMock.mock.calls[0][0].isDeprecated()).toBe(
+      true,
+    );
   });
 });

--- a/app/scripts/messenger-client-init/assets/token-rates-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/token-rates-controller-init.ts
@@ -3,7 +3,6 @@ import {
   TokenRatesController,
   TokenRatesControllerMessenger,
 } from '@metamask/assets-controllers';
-import { getIsDeprecatedController } from '../../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { MessengerClientInitFunction } from '../types';
 import { TokenRatesControllerInitMessenger } from '../messengers/assets';
 import { previousValueComparator } from '../../lib/util';
@@ -29,15 +28,7 @@ export const TokenRatesControllerInit: MessengerClientInitFunction<
     state: persistedState.TokenRatesController,
     tokenPricesService: new CodefiTokenPricesServiceV2(),
     disabled: !preferencesState.useCurrencyRateCheck,
-    isDeprecated: () => {
-      const { remoteFeatureFlags } = initMessenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      return getIsDeprecatedController(
-        remoteFeatureFlags,
-        'TokenRatesController',
-      );
-    },
+    isDeprecated: () => true,
   });
 
   initMessenger.subscribe(

--- a/app/scripts/messenger-client-init/currency-rate-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/currency-rate-controller-init.test.ts
@@ -15,6 +15,12 @@ import { CurrencyRateControllerInit } from './currency-rate-controller-init';
 
 jest.mock('@metamask/assets-controllers', () => ({
   CurrencyRateController: class {
+    isDeprecated?: () => boolean;
+
+    constructor(options: { isDeprecated?: () => boolean }) {
+      this.isDeprecated = options.isDeprecated;
+    }
+
     // This is needed since the controller init tries to override this function.
     fetchMultiExchangeRate = jest.fn();
   },
@@ -52,5 +58,17 @@ describe('CurrencyRateControllerInit', () => {
     const { messengerClient } =
       CurrencyRateControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(CurrencyRateController);
+  });
+
+  it('marks the controller as deprecated', () => {
+    const { messengerClient } =
+      CurrencyRateControllerInit(getInitRequestMock());
+    expect(
+      (
+        messengerClient as CurrencyRateController & {
+          isDeprecated?: () => boolean;
+        }
+      ).isDeprecated?.(),
+    ).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/currency-rate-controller-init.ts
+++ b/app/scripts/messenger-client-init/currency-rate-controller-init.ts
@@ -3,7 +3,6 @@ import {
   CurrencyRateController,
   CurrencyRateMessenger,
 } from '@metamask/assets-controllers';
-import { getIsDeprecatedController } from '../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { CurrencyRateControllerInitMessenger } from './messengers';
 import { MessengerClientInitFunction } from './types';
 
@@ -30,15 +29,7 @@ export const CurrencyRateControllerInit: MessengerClientInitFunction<
     useExternalServices: () =>
       initMessenger.call('PreferencesController:getState').useExternalServices,
     tokenPricesService: new CodefiTokenPricesServiceV2(),
-    isDeprecated: () => {
-      const { remoteFeatureFlags } = initMessenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      return getIsDeprecatedController(
-        remoteFeatureFlags,
-        'CurrencyRateController',
-      );
-    },
+    isDeprecated: () => true,
   });
 
   return {

--- a/app/scripts/messenger-client-init/multichain/multichain-assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-assets-controller-init.test.ts
@@ -58,5 +58,8 @@ describe('MultichainAssetsControllerInit', () => {
       state: requestMock.persistedState.MultichainAssetsController,
       isDeprecated: expect.any(Function),
     });
+    expect(
+      MultichainAssetsControllerClassMock.mock.calls[0][0].isDeprecated(),
+    ).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/multichain/multichain-assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-assets-controller-init.test.ts
@@ -59,7 +59,7 @@ describe('MultichainAssetsControllerInit', () => {
       isDeprecated: expect.any(Function),
     });
     expect(
-      MultichainAssetsControllerClassMock.mock.calls[0][0].isDeprecated(),
+      MultichainAssetsControllerClassMock.mock.calls[0][0].isDeprecated?.(),
     ).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/multichain/multichain-assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-assets-controller-init.ts
@@ -2,7 +2,6 @@ import {
   MultichainAssetsController,
   MultichainAssetsControllerMessenger,
 } from '@metamask/assets-controllers';
-import { getIsDeprecatedController } from '../../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { MessengerClientInitFunction } from '../types';
 import { MultichainAssetsControllerInitMessenger } from '../messengers/multichain/multichain-assets-controller-messenger';
 
@@ -11,7 +10,6 @@ import { MultichainAssetsControllerInitMessenger } from '../messengers/multichai
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
- * @param request.initMessenger - The messenger to use for initialization.
  * @param request.persistedState - The persisted state of the extension.
  * @returns The initialized controller.
  */
@@ -19,19 +17,11 @@ export const MultichainAssetsControllerInit: MessengerClientInitFunction<
   MultichainAssetsController,
   MultichainAssetsControllerMessenger,
   MultichainAssetsControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, persistedState }) => {
+> = ({ controllerMessenger, persistedState }) => {
   const messengerClient = new MultichainAssetsController({
     messenger: controllerMessenger,
     state: persistedState.MultichainAssetsController,
-    isDeprecated: () => {
-      const { remoteFeatureFlags } = initMessenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      return getIsDeprecatedController(
-        remoteFeatureFlags,
-        'MultichainAssetsController',
-      );
-    },
+    isDeprecated: () => true,
   });
 
   return {

--- a/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.test.ts
@@ -58,5 +58,8 @@ describe('MultichainBalancesControllerInit', () => {
       state: requestMock.persistedState.MultichainBalancesController,
       isDeprecated: expect.any(Function),
     });
+    expect(
+      multichainBalancesControllerClassMock.mock.calls[0][0].isDeprecated(),
+    ).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.test.ts
@@ -59,7 +59,7 @@ describe('MultichainBalancesControllerInit', () => {
       isDeprecated: expect.any(Function),
     });
     expect(
-      multichainBalancesControllerClassMock.mock.calls[0][0].isDeprecated(),
+      multichainBalancesControllerClassMock.mock.calls[0][0].isDeprecated?.(),
     ).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.ts
@@ -2,7 +2,6 @@ import {
   MultichainBalancesController,
   MultichainBalancesControllerMessenger,
 } from '@metamask/assets-controllers';
-import { getIsDeprecatedController } from '../../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { MessengerClientInitFunction } from '../types';
 import { MultichainBalancesControllerInitMessenger } from '../messengers/multichain/multichain-balances-controller-messenger';
 
@@ -11,7 +10,6 @@ import { MultichainBalancesControllerInitMessenger } from '../messengers/multich
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
- * @param request.initMessenger - The messenger to use for initialization.
  * @param request.persistedState - The persisted state of the extension.
  * @returns The initialized controller.
  */
@@ -19,19 +17,11 @@ export const MultichainBalancesControllerInit: MessengerClientInitFunction<
   MultichainBalancesController,
   MultichainBalancesControllerMessenger,
   MultichainBalancesControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, persistedState }) => {
+> = ({ controllerMessenger, persistedState }) => {
   const messengerClient = new MultichainBalancesController({
     messenger: controllerMessenger,
     state: persistedState.MultichainBalancesController,
-    isDeprecated: () => {
-      const { remoteFeatureFlags } = initMessenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      return getIsDeprecatedController(
-        remoteFeatureFlags,
-        'MultichainBalancesController',
-      );
-    },
+    isDeprecated: () => true,
   });
 
   return { messengerClient };

--- a/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.test.ts
@@ -59,5 +59,8 @@ describe('MultichainAssetsRatesControllerInit', () => {
       interval: 180000,
       isDeprecated: expect.any(Function),
     });
+    expect(
+      multichainAssetsRatesControllerClassMock.mock.calls[0][0].isDeprecated(),
+    ).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.test.ts
@@ -60,7 +60,7 @@ describe('MultichainAssetsRatesControllerInit', () => {
       isDeprecated: expect.any(Function),
     });
     expect(
-      multichainAssetsRatesControllerClassMock.mock.calls[0][0].isDeprecated(),
+      multichainAssetsRatesControllerClassMock.mock.calls[0][0].isDeprecated?.(),
     ).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.ts
@@ -2,7 +2,6 @@ import {
   MultichainAssetsRatesController,
   MultichainAssetsRatesControllerMessenger,
 } from '@metamask/assets-controllers';
-import { getIsDeprecatedController } from '../../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { MessengerClientInitFunction } from '../types';
 import { MultichainAssetsRatesControllerInitMessenger } from '../messengers/multichain/multichain-assets-rates-controller-messenger';
 
@@ -11,7 +10,6 @@ import { MultichainAssetsRatesControllerInitMessenger } from '../messengers/mult
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
- * @param request.initMessenger - The messenger to use for initialization.
  * @param request.persistedState - The persisted state of the extension.
  * @returns The initialized controller.
  */
@@ -19,20 +17,12 @@ export const MultichainAssetsRatesControllerInit: MessengerClientInitFunction<
   MultichainAssetsRatesController,
   MultichainAssetsRatesControllerMessenger,
   MultichainAssetsRatesControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, persistedState }) => {
+> = ({ controllerMessenger, persistedState }) => {
   const messengerClient = new MultichainAssetsRatesController({
     messenger: controllerMessenger,
     state: persistedState.MultichainAssetsRatesController,
     interval: 1000 * 60 * 3, // 3 mins
-    isDeprecated: () => {
-      const { remoteFeatureFlags } = initMessenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      return getIsDeprecatedController(
-        remoteFeatureFlags,
-        'MultichainAssetsRatesController',
-      );
-    },
+    isDeprecated: () => true,
   });
 
   return {

--- a/app/scripts/messenger-client-init/token-balances-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-balances-controller-init.test.ts
@@ -87,5 +87,6 @@ describe('TokenBalancesControllerInit', () => {
       isOnboarded: expect.any(Function),
       isDeprecated: expect.any(Function),
     });
+    expect(controllerMock.mock.calls[0][0].isDeprecated()).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/token-balances-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-balances-controller-init.test.ts
@@ -87,6 +87,6 @@ describe('TokenBalancesControllerInit', () => {
       isOnboarded: expect.any(Function),
       isDeprecated: expect.any(Function),
     });
-    expect(controllerMock.mock.calls[0][0].isDeprecated()).toBe(true);
+    expect(controllerMock.mock.calls[0][0].isDeprecated?.()).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/token-balances-controller-init.ts
+++ b/app/scripts/messenger-client-init/token-balances-controller-init.ts
@@ -2,7 +2,6 @@ import {
   TokenBalancesController,
   TokenBalancesControllerMessenger,
 } from '@metamask/assets-controllers';
-import { getIsDeprecatedController } from '../../../shared/lib/assets-unify-state/remote-feature-flag';
 import type { PreferencesControllerState } from '../controllers/preferences-controller';
 import { MessengerClientInitFunction } from './types';
 import { TokenBalancesControllerInitMessenger } from './messengers';
@@ -43,15 +42,7 @@ export const TokenBalancesControllerInit: MessengerClientInitFunction<
       );
       return completedOnboarding;
     },
-    isDeprecated: () => {
-      const { remoteFeatureFlags } = initMessenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      return getIsDeprecatedController(
-        remoteFeatureFlags,
-        'TokenBalancesController',
-      );
-    },
+    isDeprecated: () => true,
   });
 
   return {

--- a/app/scripts/messenger-client-init/token-detection-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-detection-controller-init.test.ts
@@ -53,6 +53,6 @@ describe('TokenDetectionControllerInit', () => {
       tokenListService: expect.any(Object),
       isDeprecated: expect.any(Function),
     });
-    expect(controllerMock.mock.calls[0][0].isDeprecated()).toBe(true);
+    expect(controllerMock.mock.calls[0][0].isDeprecated?.()).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/token-detection-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-detection-controller-init.test.ts
@@ -53,5 +53,6 @@ describe('TokenDetectionControllerInit', () => {
       tokenListService: expect.any(Object),
       isDeprecated: expect.any(Function),
     });
+    expect(controllerMock.mock.calls[0][0].isDeprecated()).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/token-detection-controller-init.ts
+++ b/app/scripts/messenger-client-init/token-detection-controller-init.ts
@@ -6,7 +6,6 @@ import type {
   MetaMetricsEventOptions,
   MetaMetricsEventPayload,
 } from '../../../shared/constants/metametrics';
-import { getIsDeprecatedController } from '../../../shared/lib/assets-unify-state/remote-feature-flag';
 import type { PreferencesControllerState } from '../controllers/preferences-controller';
 import { createEventBuilder, trackEvent } from '../controllers/analytics';
 import { MessengerClientInitFunction } from './types';
@@ -79,15 +78,7 @@ export const TokenDetectionControllerInit: MessengerClientInitFunction<
       );
     },
     tokenListService,
-    isDeprecated: () => {
-      const { remoteFeatureFlags } = initMessenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      return getIsDeprecatedController(
-        remoteFeatureFlags,
-        'TokenDetectionController',
-      );
-    },
+    isDeprecated: () => true,
   });
 
   return {

--- a/app/scripts/messenger-client-init/token-list-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-list-controller-init.test.ts
@@ -102,6 +102,6 @@ describe('TokenListControllerInit', () => {
       chainId: '0x1',
       isDeprecated: expect.any(Function),
     });
-    expect(controllerMock.mock.calls[0][0].isDeprecated()).toBe(true);
+    expect(controllerMock.mock.calls[0][0].isDeprecated?.()).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/token-list-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-list-controller-init.test.ts
@@ -102,5 +102,6 @@ describe('TokenListControllerInit', () => {
       chainId: '0x1',
       isDeprecated: expect.any(Function),
     });
+    expect(controllerMock.mock.calls[0][0].isDeprecated()).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/token-list-controller-init.ts
+++ b/app/scripts/messenger-client-init/token-list-controller-init.ts
@@ -2,7 +2,6 @@ import {
   TokenListController,
   TokenListControllerMessenger,
 } from '@metamask/assets-controllers';
-import { getIsDeprecatedController } from '../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { MessengerClientInitFunction } from './types';
 import { TokenListControllerInitMessenger } from './messengers';
 import { getGlobalChainId } from './init-utils';
@@ -18,15 +17,7 @@ export const TokenListControllerInit: MessengerClientInitFunction<
     messenger: controllerMessenger,
     state: persistedState.TokenListController,
     chainId: getGlobalChainId(initMessenger),
-    isDeprecated: () => {
-      const { remoteFeatureFlags } = initMessenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      return getIsDeprecatedController(
-        remoteFeatureFlags,
-        'TokenListController',
-      );
-    },
+    isDeprecated: () => true,
   });
 
   // Initialize the controller to load cached token lists from storage.

--- a/app/scripts/messenger-client-init/tokens-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/tokens-controller-init.test.ts
@@ -98,6 +98,6 @@ describe('TokensControllerInit', () => {
       tokenListService: expect.any(Object),
       isDeprecated: expect.any(Function),
     });
-    expect(controllerMock.mock.calls[0][0].isDeprecated()).toBe(true);
+    expect(controllerMock.mock.calls[0][0].isDeprecated?.()).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/tokens-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/tokens-controller-init.test.ts
@@ -98,5 +98,6 @@ describe('TokensControllerInit', () => {
       tokenListService: expect.any(Object),
       isDeprecated: expect.any(Function),
     });
+    expect(controllerMock.mock.calls[0][0].isDeprecated()).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/tokens-controller-init.ts
+++ b/app/scripts/messenger-client-init/tokens-controller-init.ts
@@ -3,7 +3,6 @@ import {
   TokensControllerMessenger,
 } from '@metamask/assets-controllers';
 import { assert } from '@metamask/utils';
-import { getIsDeprecatedController } from '../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { MessengerClientInitFunction } from './types';
 import { TokensControllerInitMessenger } from './messengers';
 import { getGlobalChainId } from './init-utils';
@@ -26,12 +25,7 @@ export const TokensControllerInit: MessengerClientInitFunction<
     provider,
     chainId: getGlobalChainId(initMessenger),
     tokenListService,
-    isDeprecated: () => {
-      const { remoteFeatureFlags } = initMessenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      return getIsDeprecatedController(remoteFeatureFlags, 'TokensController');
-    },
+    isDeprecated: () => true,
   });
 
   return {


### PR DESCRIPTION
## **Description**

Forces `isDeprecated` to always return `true` for the legacy assets controllers, instead of reading `RemoteFeatureFlagController` via `getIsDeprecatedController`.

This unblocks treating these controllers as deprecated regardless of remote flag state:

- AccountTrackerController
- TokenBalancesController
- TokensController
- TokenListController
- TokenRatesController
- CurrencyRateController
- TokenDetectionController
- MultichainAssetsController
- MultichainBalancesController
- MultichainAssetsRatesController

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Start a development build (`yarn start`) and unlock the wallet.
2. Open the homepage asset list on Mainnet and confirm tokens, native balance, and fiat values still load.
3. Open a token asset page and confirm balances and rates still display.
4. Switch to a non-EVM account/network (if available) and confirm multichain assets, balances, and rates still load.
5. Restart the extension and confirm the wallet still shows the same assets.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)