### PR TITLE
chore: rename hyperliquid deposit prompt interacted property

### DIFF
--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
@@ -218,7 +218,8 @@ describe('HyperliquidDepositPrompt', () => {
       name: MetaMetricsEventName.HyperliquidDepositPromptInteracted,
       properties: {
         category: MetaMetricsEventCategory.Confirmations,
-        action: 'dismiss',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        interaction_type: 'dismiss',
       },
       sensitiveProperties: {},
     });
@@ -266,7 +267,8 @@ describe('HyperliquidDepositPrompt', () => {
       name: MetaMetricsEventName.HyperliquidDepositPromptInteracted,
       properties: {
         category: MetaMetricsEventCategory.Confirmations,
-        action: 'continue',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        interaction_type: 'continue',
       },
       sensitiveProperties: {},
     });

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
@@ -204,7 +204,10 @@ export const HyperliquidDepositPrompt: React.FC<
           MetaMetricsEventName.HyperliquidDepositPromptInteracted,
         )
           .addCategory(MetaMetricsEventCategory.Confirmations)
-          .addProperties({ action })
+          .addProperties({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            interaction_type: action,
+          })
           .build(),
       );
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Change `action` to be `interaction_type` as written in the segment schema.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics property rename only; no user-facing or deposit flow behavior changes.
> 
> **Overview**
> Aligns **Hyperliquid Deposit Prompt Interacted** MetaMetrics payloads with the Segment schema by sending **`interaction_type`** (values `dismiss` / `continue`) instead of **`action`**.
> 
> The change is limited to `trackPromptInteracted` in the Hyperliquid deposit prompt and the unit tests that assert those tracking calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099c700f0058bf068fffc8b70d123bc6f54e807b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->