### PR TITLE
fix(ui): polish Money home action row spacing and icon color

### DIFF
--- a/ui/pages/money/money-home-page.tsx
+++ b/ui/pages/money/money-home-page.tsx
@@ -88,7 +88,7 @@ const MoneyActionCard = ({
       onClick={onClick}
       className="flex h-[76px] flex-1 flex-col items-center justify-center gap-0.5 rounded-xl bg-background-muted disabled:cursor-default disabled:opacity-100"
     >
-      <Icon name={icon} size={IconSize.Lg} color={IconColor.IconDefault} />
+      <Icon name={icon} size={IconSize.Lg} color={IconColor.IconAlternative} />
       <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
         {label}
       </Text>
@@ -267,7 +267,7 @@ export function MoneyHomePage() {
           </div>
         </div>
 
-        <div className="mt-2 flex w-full max-w-[389px] gap-2 py-2">
+        <div className="mt-2 flex w-full max-w-[458px] gap-3 py-2">
           <MoneyActionCard
             icon={IconName.Add}
             label={t('moneyAdd')}
@@ -283,7 +283,7 @@ export function MoneyHomePage() {
         </div>
 
         {isFunded ? null : (
-          <section className="mt-1 flex w-full max-w-[389px] flex-col gap-4 overflow-hidden rounded-2xl bg-background-muted p-4">
+          <section className="flex w-full max-w-[458px] flex-col gap-4 overflow-hidden rounded-2xl bg-background-muted p-4">
             <img
               src={MONEY_ONBOARDING_ARTWORK}
               alt=""


### PR DESCRIPTION
## **Description**

The unfunded Money home layout was tighter than the intended design: Add/Send sat in a narrower row with default-color icons, and the earn promo card had extra top margin.

This PR updates the Money home page so Add/Send use `icon-alternative`, the action row and earn promo share a 458px max width with a slightly larger gap, and the extra top margin on the earn card is removed. Horizontal padding on the balance/header content wrapper is unchanged.

## **Changelog**

CHANGELOG entry: Updated Money home Add and Send buttons to use alternative icon color and wider spacing on the unfunded layout.

## **Related issues**

<!--
Fixes:
-->

## **Manual testing steps**

1. Run the extension and open the Money home page with an unfunded mUSD balance (`$0.00`).
2. Confirm Add and Send icons use the alternative (muted) icon color, not the default icon color.
3. Confirm Add/Send and the “Earn on your balance” card are aligned at the wider 458px width, with a bit more space between the two buttons.
4. Confirm the earn promo card sits closer to the action row (no extra top margin).
5. Confirm the balance section still has horizontal padding (`px-4`).
6. Open Money home with a funded balance and confirm Add/Send still use alternative icon color and the rest of the funded layout is unchanged.

## **Screenshots/Recordings**


### **Before**

https://github.com/user-attachments/assets/d856a88b-2007-487d-92b0-b3188f746e6c



### **After**

https://github.com/user-attachments/assets/f41fd07a-8b76-4af2-b898-fc5c6a0f4500



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)