### PR TITLE
style(perps): polish home, market list, and detail typography

### DIFF
--- a/ui/components/app/perps/order-card/order-card.tsx
+++ b/ui/components/app/perps/order-card/order-card.tsx
@@ -116,7 +116,7 @@ export const OrderCard = ({
       {/* Token Logo */}
       <PerpsTokenLogo
         symbol={order.symbol}
-        size={AvatarTokenSize.Md}
+        size={AvatarTokenSize.Lg}
         className="shrink-0"
       />
       {/* Left side: Symbol info and size */}

--- a/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.tsx
+++ b/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.tsx
@@ -195,58 +195,52 @@ const PerpsMarketBalanceActions = ({
       {/* Action Buttons */}
       {showActionButtons && (
         <Box
-          flexDirection={BoxFlexDirection.Column}
+          flexDirection={BoxFlexDirection.Row}
           gap={3}
           marginTop={4}
           style={{ width: '100%' }}
         >
           {/*
-            Withdraw is hidden when there's nothing to withdraw: at $0 balance
-            it's a dead-end action, so Add funds becomes the single full-width
-            primary CTA. Once funded, both buttons share the row 50/50.
+            The secondary slot next to Add funds depends on funding state:
+            Withdraw is a dead-end at $0 balance, so unfunded accounts get the
+            educational Learn more entry point there instead. Either way both
+            buttons share the row 50/50.
           */}
-          <Box flexDirection={BoxFlexDirection.Row} gap={3}>
-            {accountValue > 0 && (
-              <Button
-                variant={ButtonVariant.Secondary}
-                size={ButtonSize.Lg}
-                onClick={handleWithdraw}
-                style={{ flex: 1 }}
-                data-testid="perps-balance-actions-withdraw"
-              >
-                {t('perpsWithdraw')}
-              </Button>
-            )}
-
-            <Button
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Lg}
-              isLoading={isAddFundsLoading}
-              onClick={handleAddFunds}
-              disabled={isAddFundsLoading}
-              style={{ flex: 1 }}
-              data-testid="perps-balance-actions-add-funds"
-            >
-              {t('perpsAddFunds')}
-            </Button>
-          </Box>
-
-          {/*
-            Learn more is only shown to accounts that haven't been funded yet;
-            it's an educational entry point into the tutorial modal and would
-            be redundant clutter once the user has a balance.
-          */}
-          {accountValue === 0 && onLearnMore && (
+          {accountValue > 0 ? (
             <Button
               variant={ButtonVariant.Secondary}
               size={ButtonSize.Lg}
-              onClick={handleLearnMore}
-              style={{ width: '100%' }}
-              data-testid="perps-balance-actions-learn-more"
+              onClick={handleWithdraw}
+              style={{ flex: 1 }}
+              data-testid="perps-balance-actions-withdraw"
             >
-              {t('perpsLearnMore')}
+              {t('perpsWithdraw')}
             </Button>
+          ) : (
+            onLearnMore && (
+              <Button
+                variant={ButtonVariant.Secondary}
+                size={ButtonSize.Lg}
+                onClick={handleLearnMore}
+                style={{ flex: 1 }}
+                data-testid="perps-balance-actions-learn-more"
+              >
+                {t('perpsLearnMore')}
+              </Button>
+            )
           )}
+
+          <Button
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            isLoading={isAddFundsLoading}
+            onClick={handleAddFunds}
+            disabled={isAddFundsLoading}
+            style={{ flex: 1 }}
+            data-testid="perps-balance-actions-add-funds"
+          >
+            {t('perpsAddFunds')}
+          </Button>
         </Box>
       )}
       {geoBlockModal}

--- a/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.tsx
+++ b/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.tsx
@@ -119,22 +119,22 @@ export const PerpsMarketRecentActivity = ({
       {hasTransactions ? (
         <ButtonBase
           onClick={handleSeeAll}
-          className="w-full flex flex-row justify-between items-center px-4 py-2 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
+          className="w-auto self-start h-auto justify-start gap-1 bg-transparent px-4 pt-4 rounded-none hover:bg-transparent active:bg-transparent"
           data-testid="perps-market-detail-view-all-activity"
           aria-label={`${t('perpsRecentActivity')}, ${t('perpsSeeAll')}`}
         >
-          <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Medium}>
+          <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
             {t('perpsRecentActivity')}
           </Text>
           <Icon
             name={IconName.ArrowRight}
-            size={IconSize.Sm}
+            size={IconSize.Md}
             color={IconColor.IconAlternative}
           />
         </ButtonBase>
       ) : (
-        <Box paddingLeft={4} paddingRight={4} paddingTop={2} paddingBottom={2}>
-          <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Medium}>
+        <Box paddingLeft={4} paddingRight={4} paddingTop={4} paddingBottom={2}>
+          <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
             {t('perpsRecentActivity')}
           </Text>
         </Box>

--- a/ui/components/app/perps/perps-positions-orders/perps-positions-orders.tsx
+++ b/ui/components/app/perps/perps-positions-orders/perps-positions-orders.tsx
@@ -117,7 +117,12 @@ export const PerpsPositionsOrders = ({
               justifyContent={BoxJustifyContent.Between}
               alignItems={BoxAlignItems.Center}
             >
-              <Text fontWeight={FontWeight.Medium}>{t('perpsPositions')}</Text>
+              <Text
+                variant={TextVariant.HeadingMd}
+                fontWeight={FontWeight.Bold}
+              >
+                {t('perpsPositions')}
+              </Text>
               <ButtonBase
                 size={ButtonBaseSize.Sm}
                 disabled={isCloseAllPending || !onCloseAllPositions}

--- a/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
+++ b/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import {
   Box,
   BoxFlexDirection,
-  BoxJustifyContent,
-  BoxAlignItems,
   Text,
   TextVariant,
   TextColor,
@@ -70,17 +68,8 @@ export const PerpsRecentActivity = ({
         gap={2}
         data-testid="perps-recent-activity-loading"
       >
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          justifyContent={BoxJustifyContent.Between}
-          alignItems={BoxAlignItems.Center}
-          paddingLeft={4}
-          paddingRight={4}
-          paddingTop={3}
-          paddingBottom={3}
-        >
-          <Skeleton className="h-5 w-36 rounded" />
-          <Skeleton className="h-4 w-14 rounded" />
+        <Box paddingLeft={4} paddingTop={4}>
+          <Skeleton className="h-6 w-36 rounded" />
         </Box>
         <Box flexDirection={BoxFlexDirection.Column}>
           {[1, 2, 3].map((cardIndex) => (
@@ -98,16 +87,10 @@ export const PerpsRecentActivity = ({
         gap={2}
         data-testid="perps-recent-activity-empty"
       >
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          justifyContent={BoxJustifyContent.Between}
-          alignItems={BoxAlignItems.Center}
-          paddingLeft={4}
-          paddingRight={4}
-          paddingTop={3}
-          paddingBottom={3}
-        >
-          <Text fontWeight={FontWeight.Medium}>{t('perpsRecentActivity')}</Text>
+        <Box paddingLeft={4} paddingTop={4} paddingBottom={2}>
+          <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
+            {t('perpsRecentActivity')}
+          </Text>
         </Box>
         <Box paddingLeft={4} paddingRight={4} paddingBottom={4}>
           <Text

--- a/ui/components/app/perps/perps-section-header/perps-section-header.tsx
+++ b/ui/components/app/perps/perps-section-header/perps-section-header.tsx
@@ -7,6 +7,7 @@ import {
   IconName,
   IconSize,
   Text,
+  TextVariant,
 } from '@metamask/design-system-react';
 
 export type PerpsSectionHeaderProps = {
@@ -17,8 +18,8 @@ export type PerpsSectionHeaderProps = {
 };
 
 /**
- * Clickable section header on the Perps tab: label, right-pointing arrow,
- * hover and pressed states.
+ * Clickable section header on the Perps tab: heading with the chevron
+ * tucked directly after the title, matching Top movers.
  *
  * `ButtonBase` stands in for the SectionHeader primitive the design system
  * lacks, and supplies the button role and keyboard activation.
@@ -36,15 +37,17 @@ export const PerpsSectionHeader = ({
   'aria-label': ariaLabel,
 }: PerpsSectionHeaderProps) => (
   <ButtonBase
-    className="w-full flex flex-row justify-between items-center px-4 py-3 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
+    className="w-auto self-start h-auto justify-start gap-1 bg-transparent px-4 pt-4 rounded-none hover:bg-transparent active:bg-transparent"
     onClick={onClick}
     data-testid={dataTestId}
     aria-label={ariaLabel}
   >
-    <Text fontWeight={FontWeight.Medium}>{label}</Text>
+    <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
+      {label}
+    </Text>
     <Icon
       name={IconName.ArrowRight}
-      size={IconSize.Sm}
+      size={IconSize.Md}
       color={IconColor.IconAlternative}
     />
   </ButtonBase>

--- a/ui/components/app/perps/perps-skeletons/perps-card-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-card-skeleton.tsx
@@ -19,8 +19,8 @@ export const PerpsCardSkeleton = () => {
       gap={4}
       data-testid="perps-card-skeleton"
     >
-      {/* Token Logo Skeleton - matches AvatarTokenSize.Md (32px) */}
-      <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+      {/* Token Logo Skeleton - matches AvatarTokenSize.Lg (40px) */}
+      <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
 
       {/* Left side: Symbol and info */}
       <Box

--- a/ui/components/app/perps/perps-skeletons/perps-home-card-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-home-card-skeleton.tsx
@@ -19,8 +19,8 @@ export const PerpsHomeCardSkeleton = () => {
       gap={4}
       data-testid="perps-home-card-skeleton"
     >
-      {/* Token Logo Skeleton - matches AvatarTokenSize.Md (32px) */}
-      <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+      {/* Token Logo Skeleton - matches AvatarTokenSize.Lg (40px) */}
+      <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
 
       {/* Left side: Symbol and info */}
       <Box

--- a/ui/components/app/perps/position-card/position-card.tsx
+++ b/ui/components/app/perps/position-card/position-card.tsx
@@ -103,7 +103,7 @@ export const PositionCard = ({
       {/* Token Logo */}
       <PerpsTokenLogo
         symbol={position.symbol}
-        size={AvatarTokenSize.Md}
+        size={AvatarTokenSize.Lg}
         className="shrink-0"
       />
 

--- a/ui/components/app/perps/transaction-card/transaction-card.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.tsx
@@ -168,7 +168,7 @@ export const TransactionCard = ({
     <>
       <PerpsTokenLogo
         symbol={transaction.symbol}
-        size={AvatarTokenSize.Md}
+        size={AvatarTokenSize.Lg}
         className="shrink-0"
       />
 

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -700,7 +700,7 @@ export const UpdateTPSLModalContent = ({
               className={
                 isSaving
                   ? 'flex-1 py-1.5 rounded-lg bg-muted text-center opacity-50 cursor-not-allowed pointer-events-none'
-                  : 'flex-1 py-1.5 rounded-lg bg-background-default cursor-pointer text-center hover:bg-muted-hover active:bg-muted-pressed border border-muted transition-colors duration-150'
+                  : 'flex-1 py-1.5 rounded-lg cursor-pointer text-center hover:bg-muted-hover active:bg-muted-pressed border border-muted transition-colors duration-150'
               }
             >
               <Text
@@ -842,7 +842,7 @@ export const UpdateTPSLModalContent = ({
               className={
                 isSaving
                   ? 'flex-1 py-1.5 rounded-lg bg-muted text-center opacity-50 cursor-not-allowed pointer-events-none'
-                  : 'flex-1 py-1.5 rounded-lg bg-background-default cursor-pointer text-center hover:bg-muted-hover active:bg-muted-pressed border border-muted transition-colors duration-150'
+                  : 'flex-1 py-1.5 rounded-lg cursor-pointer text-center hover:bg-muted-hover active:bg-muted-pressed border border-muted transition-colors duration-150'
               }
             >
               <Text

--- a/ui/pages/perps/market-list/components/search-input/search-input.tsx
+++ b/ui/pages/perps/market-list/components/search-input/search-input.tsx
@@ -59,7 +59,7 @@ export const SearchInput = ({
       }
       onChange={(event) => onChange(event.target.value)}
       placeholder={t('perpsSearchMarkets')}
-      size={TextFieldSize.Md}
+      size={TextFieldSize.Lg}
       value={value}
     />
   );

--- a/ui/pages/perps/market-list/index.tsx
+++ b/ui/pages/perps/market-list/index.tsx
@@ -13,6 +13,7 @@ import {
   BoxAlignItems,
   BoxJustifyContent,
   Text,
+  TextAlign,
   TextVariant,
   FontWeight,
   Icon,
@@ -682,10 +683,10 @@ export const MarketListView = () => {
     >
       {/* Header */}
       <Box
-        className="border-b border-border-muted px-4 py-3"
+        className="px-4 py-3"
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
-        gap={3}
+        justifyContent={BoxJustifyContent.Between}
       >
         <ButtonBase
           onClick={handleBack}
@@ -699,12 +700,20 @@ export const MarketListView = () => {
             color={IconColor.IconDefault}
           />
         </ButtonBase>
-        <Text fontWeight={FontWeight.Medium}>{t('perpsMarkets')}</Text>
+        <Text
+          variant={TextVariant.HeadingSm}
+          fontWeight={FontWeight.Bold}
+          textAlign={TextAlign.Center}
+          className="flex-1"
+        >
+          {t('perpsMarkets')}
+        </Text>
+        <Box className="w-8" />
       </Box>
 
       {/* Search Row */}
       <Box
-        className="border-b border-border-muted px-4 py-3"
+        className="px-4 py-3"
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
       >
@@ -720,7 +729,7 @@ export const MarketListView = () => {
       {/* Filter and Sort Row - Hidden when searching */}
       {!searchQuery.trim() && (
         <Box
-          className="border-b border-border-muted px-4 py-3 flex-wrap"
+          className="px-4 py-3 flex-wrap"
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
           justifyContent={BoxJustifyContent.Start}

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -1144,7 +1144,7 @@ const PerpsMarketDetailPage = () => {
           </Box>
 
           {/* Token Logo */}
-          <PerpsTokenLogo symbol={market.symbol} size={AvatarTokenSize.Md} />
+          <PerpsTokenLogo symbol={market.symbol} size={AvatarTokenSize.Lg} />
 
           {/* Market identity: full name + leverage + chevron, ticker-collateral perp */}
           <Box
@@ -1157,7 +1157,7 @@ const PerpsMarketDetailPage = () => {
               gap={1}
             >
               <Text
-                variant={TextVariant.HeadingMd}
+                variant={TextVariant.HeadingSm}
                 className="truncate"
                 data-testid="perps-market-detail-name"
               >
@@ -1321,8 +1321,8 @@ const PerpsMarketDetailPage = () => {
           <Box paddingLeft={4} paddingRight={4}>
             <Box paddingBottom={2}>
               <Text
-                variant={TextVariant.HeadingSm}
-                fontWeight={FontWeight.Medium}
+                variant={TextVariant.HeadingMd}
+                fontWeight={FontWeight.Bold}
               >
                 {t('perpsPosition')}
               </Text>
@@ -1541,8 +1541,8 @@ const PerpsMarketDetailPage = () => {
               {/* Details Section */}
               <Box paddingTop={4} paddingBottom={2}>
                 <Text
-                  variant={TextVariant.HeadingSm}
-                  fontWeight={FontWeight.Medium}
+                  variant={TextVariant.HeadingMd}
+                  fontWeight={FontWeight.Bold}
                 >
                   {t('perpsDetails')}
                 </Text>
@@ -1674,8 +1674,8 @@ const PerpsMarketDetailPage = () => {
               data-testid="perps-orders-section-header"
             >
               <Text
-                variant={TextVariant.HeadingSm}
-                fontWeight={FontWeight.Medium}
+                variant={TextVariant.HeadingMd}
+                fontWeight={FontWeight.Bold}
               >
                 {t('perpsOrders')}
               </Text>
@@ -1704,10 +1704,7 @@ const PerpsMarketDetailPage = () => {
             paddingBottom={2}
             data-testid="perps-stats-section-header"
           >
-            <Text
-              variant={TextVariant.HeadingSm}
-              fontWeight={FontWeight.Medium}
-            >
+            <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
               {t('perpsStats')}
             </Text>
           </Box>


### PR DESCRIPTION
## **Description**

Perps home, market list, and market detail still used older chrome (row borders, medium token avatars, medium-weight section titles, and a stacked Learn more CTA). This PR brings those surfaces closer to the current design.

**Reason:** Visual inconsistency with the rest of Perps and with the intended Markets / home layout.

**Solution:**
- Drop muted bottom borders on the Markets header, search, and filter rows; center the Markets title.
- Use `HeadingMd` / bold section titles with the chevron tucked next to the label (home, recent activity, market detail).
- Bump token logos and matching skeletons from `AvatarTokenSize.Md` to `Lg`.
- Place Learn more beside Add funds when the account is unfunded; keep Withdraw + Add funds when funded.
- Use the large search field on Markets; drop extra default backgrounds on TP/SL percentage chips.

## **Changelog**

CHANGELOG entry: Polished Perps home, markets list, and market detail typography, spacing, and action-button layout.

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Open the extension and go to the Perps tab (home).
2. Confirm section titles (Top movers, Positions, Recent activity) are bold headings with the chevron immediately after the title, not full-width.
3. With $0 balance, confirm Learn more and Add funds sit side by side. After funding, confirm Withdraw and Add funds sit side by side.
4. Open Markets. Confirm there are no divider lines under the header, search, or Watchlist/Volume row, and that search is the large pill field.
5. Open a market detail page. Confirm larger token logo, bold section headings (Position, Details, Orders, Stats, Recent activity).
6. Open Update TP/SL and confirm percentage chips still look correct without an extra default fill.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->


### **Before**

https://github.com/user-attachments/assets/409a5e9b-d5dd-4720-a245-f93a5d435847



### **After**

https://github.com/user-attachments/assets/6e9895f0-4b67-4e5f-bed7-acb396025b7d



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->

Made with [Cursor](https://cursor.com)