### PR TITLE
Fix some issues found in review of musd-1315

### DIFF
--- a/ui/pages/money/money-transaction-details-page.test.tsx
+++ b/ui/pages/money/money-transaction-details-page.test.tsx
@@ -318,6 +318,44 @@ describe('MoneyTransactionDetailsPage', () => {
     });
   });
 
+  it('prefers the activity list item over the raw controller transaction', () => {
+    const promoted = onchainItem({
+      ...deposited.tx,
+      id: 'promoted-child',
+      type: TransactionType.moneyAccountDeposit,
+    } as TransactionMeta);
+    const rawChild = {
+      ...promoted.tx,
+      type: TransactionType.swap,
+      metamaskPay: undefined,
+    } as TransactionMeta;
+    mockUseParams.mockReturnValue({ transactionId: promoted.id });
+    mockUseMoneyActivityItems.mockReturnValue({ items: [promoted] });
+    mockSelectTransactionById.mockReturnValue(rawChild);
+
+    renderWithLocalization(<MoneyTransactionDetailsPage />);
+
+    expect(
+      screen.getByTestId('money-transaction-details-title'),
+    ).toHaveTextContent(messages.moneyActivityDeposited.message);
+  });
+
+  it('redirects when the controller transaction is not Money activity and is absent from the list', () => {
+    mockUseMoneyActivityItems.mockReturnValue({ items: [] });
+    mockSelectTransactionById.mockReturnValue({
+      ...deposited.tx,
+      type: TransactionType.swap,
+      metamaskPay: undefined,
+    } as TransactionMeta);
+
+    renderWithLocalization(<MoneyTransactionDetailsPage />);
+
+    expect(screen.getByTestId('navigate')).toHaveAttribute(
+      'data-to',
+      MONEY_ACTIVITY_ROUTE,
+    );
+  });
+
   it('resolves a live transaction from TransactionController instead of the paged feed', () => {
     mockUseMoneyActivityItems.mockReturnValue({ items: [] });
     mockSelectTransactionById.mockReturnValue(deposited.tx);

--- a/ui/pages/money/money-transaction-details-page.tsx
+++ b/ui/pages/money/money-transaction-details-page.tsx
@@ -98,19 +98,22 @@ export function MoneyTransactionDetailsPage() {
   }, [transactionId]);
 
   const item = useMemo(() => {
-    if (controllerTx) {
-      const moneyAddress = availability.isAvailable
-        ? availability.address
-        : undefined;
-      if (!isVisibleMoneyActivityTransaction(controllerTx, moneyAddress)) {
-        return undefined;
-      }
-      return onchainItem(controllerTx);
-    }
-    return items.find(
+    const listItem = items.find(
       (candidate) =>
         candidate.kind === 'onchain' && candidate.id === transactionId,
     );
+    if (listItem) {
+      return listItem;
+    }
+    if (!controllerTx) {
+      return undefined;
+    }
+    const moneyAddress = availability.isAvailable
+      ? availability.address
+      : undefined;
+    return isVisibleMoneyActivityTransaction(controllerTx, moneyAddress)
+      ? onchainItem(controllerTx)
+      : undefined;
   }, [availability, controllerTx, items, transactionId]);
   const fromAddress =
     item?.kind === 'onchain' ? item.tx.txParams.from : undefined;

--- a/ui/pages/money/utils/classify-money-activity.test.ts
+++ b/ui/pages/money/utils/classify-money-activity.test.ts
@@ -9,7 +9,9 @@ import { MUSD_TOKEN_ADDRESS } from '../../../components/app/musd/constants';
 import {
   classifyMoneyActivity,
   getMoneyActivityStatus,
+  isEphemeralFailedTransaction,
   isIncomingMoneyActivityKind,
+  isOnChainRevertedTransaction,
   moneyActivityKindToIcon,
   moneyActivityLabelKey,
   type MoneyActivityKind,
@@ -64,6 +66,76 @@ describe('getMoneyActivityStatus', () => {
         }),
       ),
     ).toBe('failed');
+  });
+});
+
+describe('isOnChainRevertedTransaction', () => {
+  it('detects the OnChainFailureError TransactionController records on revert', () => {
+    expect(
+      isOnChainRevertedTransaction(
+        makeTx({
+          status: TransactionStatus.failed,
+          error: {
+            name: 'OnChainFailureError',
+            message: 'Transaction failed on-chain: slippage',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects a decoded revert receipt', () => {
+    expect(
+      isOnChainRevertedTransaction(
+        makeTx({
+          status: TransactionStatus.failed,
+          revert: { receipt: { message: 'slippage', data: '0x' } },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('treats a local RPC failure as not reverted', () => {
+    expect(
+      isOnChainRevertedTransaction(
+        makeTx({
+          status: TransactionStatus.failed,
+          error: { name: 'Error', message: 'Relay execute: 500' },
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isEphemeralFailedTransaction', () => {
+  it('is true for a failed tx with no on-chain signal', () => {
+    expect(
+      isEphemeralFailedTransaction(
+        makeTx({
+          status: TransactionStatus.failed,
+          error: { name: 'Error', message: 'Relay execute: 500' },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is false for an on-chain revert reported via error name', () => {
+    expect(
+      isEphemeralFailedTransaction(
+        makeTx({
+          status: TransactionStatus.failed,
+          error: { name: 'OnChainFailureError', message: 'reverted' },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is false for non-failed statuses', () => {
+    expect(
+      isEphemeralFailedTransaction(
+        makeTx({ status: TransactionStatus.confirmed }),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -126,6 +198,48 @@ describe('classifyMoneyActivity', () => {
       expect(classifyMoneyActivity(makeTx({ type }))).toBe('sent');
     },
   );
+
+  it('classifies a Pay-funded contract interaction as sent', () => {
+    expect(
+      classifyMoneyActivity(
+        makeTx({
+          type: TransactionType.contractInteraction,
+          metamaskPay: { tokenAddress: MUSD_TOKEN_ADDRESS, chainId: '0x8f' },
+        }),
+      ),
+    ).toBe('sent');
+  });
+
+  it('classifies a Perps deposit funded from the Money Account as sent', () => {
+    expect(
+      classifyMoneyActivity(
+        makeTx({
+          type: TransactionType.perpsDeposit,
+          metamaskPay: { tokenAddress: MUSD_TOKEN_ADDRESS, chainId: '0x8f' },
+        }),
+      ),
+    ).toBe('sent');
+  });
+
+  it('classifies a Perps withdraw landing in the Money Account as deposited', () => {
+    expect(
+      classifyMoneyActivity(
+        makeTx({
+          type: TransactionType.batch,
+          nestedTransactions: [{ type: TransactionType.perpsWithdraw }],
+          metamaskPay: { tokenAddress: MUSD_TOKEN_ADDRESS, chainId: '0x8f' },
+        }),
+      ),
+    ).toBe('deposited');
+  });
+
+  it('classifies an unknown type without Pay metadata as received', () => {
+    expect(
+      classifyMoneyActivity(
+        makeTx({ type: TransactionType.contractInteraction }),
+      ),
+    ).toBe('received');
+  });
 
   it('classifies a nested moneyAccountDeposit on a contract-interaction parent as a deposit', () => {
     expect(

--- a/ui/pages/money/utils/classify-money-activity.ts
+++ b/ui/pages/money/utils/classify-money-activity.ts
@@ -5,6 +5,10 @@ import {
 } from '@metamask/transaction-controller';
 import { IconName } from '@metamask/design-system-react';
 import { isMusdToken } from '../../../components/app/musd/constants';
+import {
+  isPerpsPredictMoneyDeposit,
+  isPerpsPredictMoneyWithdraw,
+} from '../../../helpers/money/money-transaction-guards';
 import type {
   MoneyActivityTitleKey,
   MoneyActivityTransactionMeta,
@@ -16,24 +20,28 @@ export type MoneyActivityKind = 'deposited' | 'received' | 'converted' | 'sent';
 
 const ON_CHAIN_REVERT_RECEIPT_STATUS = '0x0';
 const ON_CHAIN_SUCCESS_RECEIPT_STATUSES = new Set(['0x1', '0x01']);
+const ON_CHAIN_FAILURE_ERROR_NAME = 'OnChainFailureError';
 
 function receiptStatus(tx: TransactionMeta): string | undefined {
-  const status = tx.txReceipt?.status;
-  return typeof status === 'string' || typeof status === 'number'
-    ? String(status)
-    : undefined;
+  return tx.txReceipt?.status?.toLowerCase();
 }
 
 /**
- * True when the transaction reverted on-chain. Wallet activity uses the same
- * `txReceipt.status === '0x0'` check; TransactionController `failed` alone
- * can also mean a local RPC/relayer error that never consumed a nonce.
+ * True when the transaction reverted on-chain. TransactionController only
+ * stores `txReceipt` on confirmation; a reverted receipt is reported by
+ * marking the tx `failed` with an `OnChainFailureError` and, when the revert
+ * could be decoded, `revert.receipt`. `failed` alone can also mean a local
+ * RPC/relayer error that never consumed a nonce.
  *
  * @param tx - Transaction metadata.
- * @returns Whether the receipt reports an on-chain revert.
+ * @returns Whether the transaction reverted on-chain.
  */
 export function isOnChainRevertedTransaction(tx: TransactionMeta): boolean {
-  return receiptStatus(tx) === ON_CHAIN_REVERT_RECEIPT_STATUS;
+  return (
+    receiptStatus(tx) === ON_CHAIN_REVERT_RECEIPT_STATUS ||
+    tx.error?.name === ON_CHAIN_FAILURE_ERROR_NAME ||
+    tx.revert?.receipt !== undefined
+  );
 }
 
 /**
@@ -48,10 +56,10 @@ export function isEphemeralFailedTransaction(tx: TransactionMeta): boolean {
   if (tx.status !== TransactionStatus.failed) {
     return false;
   }
-  const status = receiptStatus(tx);
-  if (status === ON_CHAIN_REVERT_RECEIPT_STATUS) {
+  if (isOnChainRevertedTransaction(tx)) {
     return false;
   }
+  const status = receiptStatus(tx);
   if (status && ON_CHAIN_SUCCESS_RECEIPT_STATUSES.has(status)) {
     return false;
   }
@@ -134,6 +142,13 @@ export function classifyMoneyActivity(tx: TransactionMeta): MoneyActivityKind {
     return 'deposited';
   }
 
+  if (isPerpsPredictMoneyWithdraw(tx)) {
+    return 'deposited';
+  }
+  if (isPerpsPredictMoneyDeposit(tx)) {
+    return 'sent';
+  }
+
   switch (type) {
     case TransactionType.moneyAccountDeposit:
       if (isFiatDeposit(tx) || isMusdPayToken(tx)) {
@@ -148,7 +163,8 @@ export function classifyMoneyActivity(tx: TransactionMeta): MoneyActivityKind {
     case TransactionType.simpleSend:
       return 'sent';
     default:
-      return 'received';
+      // Any other Pay-funded tx is the Money Account paying mUSD out.
+      return tx.metamaskPay ? 'sent' : 'received';
   }
 }
 

--- a/ui/pages/money/utils/money-account-transactions.test.ts
+++ b/ui/pages/money/utils/money-account-transactions.test.ts
@@ -13,6 +13,7 @@ import {
 
 const MONEY_ADDRESS = '0x00000000000000000000000000000000000000aa';
 const OTHER_ADDRESS = '0x00000000000000000000000000000000000000bb';
+const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 
 function padAddress(address: string): string {
   return address.slice(2).toLowerCase().padStart(64, '0');
@@ -158,11 +159,33 @@ describe('isVisibleMoneyActivityTransaction', () => {
         makeTx({
           type: TransactionType.moneyAccountDeposit,
           status: TransactionStatus.failed,
-          txReceipt: { status: '0x0' },
+          error: {
+            name: 'OnChainFailureError',
+            message: 'Transaction failed on-chain',
+          },
         }),
         MONEY_ADDRESS,
       ),
     ).toBe(true);
+  });
+
+  it('excludes a local mUSD transfer to the Money Account that failed before broadcast', () => {
+    expect(
+      isVisibleMoneyActivityTransaction(
+        makeTx({
+          type: TransactionType.tokenMethodTransfer,
+          status: TransactionStatus.failed,
+          error: { name: 'Error', message: 'nonce too low' },
+          txParams: {
+            from: OTHER_ADDRESS,
+            to: MUSD_TOKEN_ADDRESS,
+            data: transferCalldata(MONEY_ADDRESS, 1_000_000n),
+            value: '0x0',
+          },
+        }),
+        MONEY_ADDRESS,
+      ),
+    ).toBe(false);
   });
 
   it('includes a confirmed Pay transaction signed from the Money Account', () => {
@@ -229,5 +252,65 @@ describe('filterMoneyAccountTransactions', () => {
     ).toStrictEqual([
       { ...paySource, type: TransactionType.moneyAccountDeposit },
     ]);
+  });
+
+  it('promotes only the newest child and carries the parent pay metadata', () => {
+    const metamaskPay = { tokenAddress: USDC_ADDRESS, chainId: '0x1' };
+    const requiredAssets = [{ address: MUSD_TOKEN_ADDRESS, amount: '0xf4240' }];
+    const deposit = makeTx({
+      id: 'deposit',
+      time: 1,
+      type: TransactionType.moneyAccountDeposit,
+      status: TransactionStatus.failed,
+      metamaskPay,
+      requiredAssets,
+      requiredTransactionIds: ['swap', 'vault'],
+    });
+    const swap = makeTx({
+      id: 'swap',
+      time: 2,
+      type: TransactionType.swap,
+      txParams: { from: OTHER_ADDRESS, to: OTHER_ADDRESS, value: '0x0' },
+    });
+    const vault = makeTx({
+      id: 'vault',
+      time: 3,
+      type: TransactionType.batch,
+      txParams: { from: OTHER_ADDRESS, to: OTHER_ADDRESS, value: '0x0' },
+    });
+
+    expect(
+      filterMoneyAccountTransactions([deposit, swap, vault], MONEY_ADDRESS),
+    ).toStrictEqual([
+      {
+        ...vault,
+        type: TransactionType.moneyAccountDeposit,
+        metamaskPay,
+        requiredAssets,
+      },
+    ]);
+  });
+
+  it('does not promote children of a parent that reverted on-chain', () => {
+    const deposit = makeTx({
+      id: 'deposit',
+      time: 1,
+      type: TransactionType.moneyAccountDeposit,
+      status: TransactionStatus.failed,
+      error: { name: 'OnChainFailureError', message: 'reverted' },
+      requiredTransactionIds: ['swap'],
+    });
+    const swap = makeTx({
+      id: 'swap',
+      time: 2,
+      type: TransactionType.swap,
+      txParams: { from: OTHER_ADDRESS, to: OTHER_ADDRESS, value: '0x0' },
+    });
+
+    expect(
+      filterMoneyAccountTransactions([deposit, swap], MONEY_ADDRESS).map(
+        (tx) => tx.id,
+      ),
+    ).toStrictEqual(['deposit']);
   });
 });

--- a/ui/pages/money/utils/money-account-transactions.ts
+++ b/ui/pages/money/utils/money-account-transactions.ts
@@ -85,14 +85,13 @@ export function isVisibleMoneyActivityTransaction(
     return false;
   }
 
-  if (!hasVisibleStatus(tx)) {
+  if (!hasVisibleStatus(tx) || isEphemeralFailedTransaction(tx)) {
     return false;
   }
 
   if (
     tx.metamaskPay &&
-    isEqualCaseInsensitive(tx.txParams?.from ?? '', moneyAddress) &&
-    !isEphemeralFailedTransaction(tx)
+    isEqualCaseInsensitive(tx.txParams?.from ?? '', moneyAddress)
   ) {
     return true;
   }
@@ -122,11 +121,41 @@ export function isVisibleMoneyActivityTransaction(
 }
 
 /**
+ * Presents a confirmed Pay child as its failed Money parent's row: the
+ * parent's type, pay metadata and committed mUSD amount, the child's id,
+ * hash, status and time.
+ *
+ * @param child - Confirmed required/batch child of the parent.
+ * @param parent - Ephemerally failed Money Pay parent.
+ * @returns The child re-typed as a Money deposit/withdraw row.
+ */
+function promoteChildToParentRow(
+  child: TransactionMeta,
+  parent: TransactionMeta,
+): TransactionMeta {
+  const promoted: TransactionMeta = {
+    ...child,
+    type: moneyPayTypeFromParent(parent),
+  };
+  const metamaskPay = parent.metamaskPay ?? child.metamaskPay;
+  if (metamaskPay) {
+    promoted.metamaskPay = metamaskPay;
+  }
+  const requiredAssets = parent.requiredAssets ?? child.requiredAssets;
+  if (requiredAssets) {
+    promoted.requiredAssets = requiredAssets;
+  }
+  return promoted;
+}
+
+/**
  * Filters and newest-first sorts Money activity transactions.
  *
  * When a Money Pay row failed locally (no on-chain revert) and Pay confirmed
- * a required source tx instead, that confirmed tx is shown with the parent's
- * deposit/withdraw type so Home does not render a $0 "failed" placeholder.
+ * its required source txs instead, the newest confirmed child is shown as a
+ * single row with the parent's deposit/withdraw type and pay metadata so Home
+ * renders one real deposit rather than a $0 "failed" placeholder or one row
+ * per source leg.
  *
  * @param transactions - Non-replaced TransactionController rows.
  * @param moneyAddress - Checksummed Money Account address, when known.
@@ -150,29 +179,43 @@ export function filterMoneyAccountTransactions(
     }
   }
 
-  return transactions
-    .flatMap((tx) => {
-      if (isVisibleMoneyActivityTransaction(tx, moneyAddress)) {
-        return [tx];
-      }
+  const visible: TransactionMeta[] = [];
+  const promotedChildByParentId = new Map<
+    string,
+    { child: TransactionMeta; parent: TransactionMeta }
+  >();
 
-      const parent =
-        parentByRequiredId.get(tx.id) ??
-        (tx.batchId
-          ? parentByBatchId.get(tx.batchId.toLowerCase())
-          : undefined);
-      if (
-        parent &&
-        parent.id !== tx.id &&
-        hasVisibleStatus(tx) &&
-        !isEphemeralFailedTransaction(tx)
-      ) {
-        return [{ ...tx, type: moneyPayTypeFromParent(parent) }];
-      }
+  for (const tx of transactions) {
+    if (isVisibleMoneyActivityTransaction(tx, moneyAddress)) {
+      visible.push(tx);
+      continue;
+    }
 
-      return [];
-    })
-    .sort((left, right) => (right.time ?? 0) - (left.time ?? 0));
+    const parent =
+      parentByRequiredId.get(tx.id) ??
+      (tx.batchId ? parentByBatchId.get(tx.batchId.toLowerCase()) : undefined);
+    if (
+      !parent ||
+      parent.id === tx.id ||
+      !hasVisibleStatus(tx) ||
+      isEphemeralFailedTransaction(tx)
+    ) {
+      continue;
+    }
+
+    const current = promotedChildByParentId.get(parent.id);
+    if (!current || (tx.time ?? 0) > (current.child.time ?? 0)) {
+      promotedChildByParentId.set(parent.id, { child: tx, parent });
+    }
+  }
+
+  const promoted = [...promotedChildByParentId.values()].map(
+    ({ child, parent }) => promoteChildToParentRow(child, parent),
+  );
+
+  return [...visible, ...promoted].sort(
+    (left, right) => (right.time ?? 0) - (left.time ?? 0),
+  );
 }
 
 export function splitMoneyAccountTransactions(


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes a couple of issues identified in the musd-1315 branch
- On chain failed/reverted transactions would be hidden. A revert is now recognised by the controller's OnChainFailureError error name or a decoded. Reverted Money Pay deposits and withdraws show as Failed instead of vanishing.
  - Prevent a possible case where pay deposits would be misclassified as sends by the UI
  - Details page resolves the item from the activity list first and only falls back to the raw controller tx. Promoted rows now open instead of bouncing back to the list.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Money activity filtering, promotion, and classification logic that drives what users see for Pay and Perps flows; mistakes could hide real failures or mis-label amounts.
> 
> **Overview**
> Fixes Money activity and details behavior when Pay transactions fail locally vs revert on-chain, and when deposit flows promote a confirmed child over an ephemeral parent.
> 
> **On-chain reverts stay visible.** `isOnChainRevertedTransaction` now treats `OnChainFailureError`, decoded `revert.receipt`, and receipt `0x0` as reverts (not only receipt status). Reverted Pay rows remain in the feed as **Failed** instead of disappearing; purely local RPC/relayer failures stay hidden via `isEphemeralFailedTransaction`, including failed mUSD transfers that never broadcast.
> 
> **Pay deposit rows consolidate.** `filterMoneyAccountTransactions` picks the **newest** confirmed required/batch child for each ephemerally failed parent, merges parent **type**, `metamaskPay`, and `requiredAssets` onto that child, and skips promotion when the parent actually reverted on-chain.
> 
> **Labels and details.** `classifyMoneyActivity` adds Perps deposit/withdraw rules and treats other Pay-funded types as **sent** (avoiding mis-labeling deposits as sends). The transaction details page resolves the **activity list item first**, then falls back to the controller tx—so promoted rows open with deposit copy instead of redirecting to the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9393737ba2ee76a2efec6d4176f4c2322bb68115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->