### PR TITLE
test: fix flaky test `Empty Buy Banner Displayed event is sent when the balance empty state is shown after onboarding`

### DIFF
--- a/test/e2e/tests/metrics/empty-buy-banner-displayed.spec.ts
+++ b/test/e2e/tests/metrics/empty-buy-banner-displayed.spec.ts
@@ -57,19 +57,22 @@ describe('Empty Buy Banner Displayed event', function () {
         await homePage.checkBalanceEmptyStateIsDisplayed();
 
         const events = await getEventPayloads(driver, mockedEndpoints);
-        assert.equal(events.length, 1);
+        // On Chrome with sidepanel enabled, both sidepanel.html and home.html
+        // render BalanceEmptyState after onboarding, so we may receive 1 or 2
+        // events depending on timing (one per window, each with a different
+        // environment_type: 'sidepanel' or 'fullscreen').
+        assert.ok(events.length >= 1, 'Expected at least one event');
         assert.equal(events[0].event, 'Empty Buy Banner Displayed');
 
-        const expectedEnvironmentType = (await isSidePanelEnabled())
-          ? 'sidepanel'
-          : 'fullscreen';
+        const sidePanelEnabled = await isSidePanelEnabled();
         const {
           profile_id: _profileId,
           canonical_profile_id: _canonicalProfileId,
-          ...eventProperties
+          environment_type: actualEnvironmentType,
+          ...restEventProperties
         } = events[0].properties;
 
-        assert.deepStrictEqual(eventProperties, {
+        assert.deepStrictEqual(restEventProperties, {
           category: 'Navigation',
           locale: 'en',
           referrer: 'metamask',
@@ -77,10 +80,19 @@ describe('Empty Buy Banner Displayed event', function () {
           // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
           // eslint-disable-next-line @typescript-eslint/naming-convention
           chain_id: '0x1',
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          environment_type: expectedEnvironmentType,
         });
+
+        if (sidePanelEnabled) {
+          assert.ok(
+            actualEnvironmentType === 'sidepanel' ||
+              actualEnvironmentType === 'fullscreen',
+            `Expected environment_type to be 'sidepanel' or 'fullscreen' ` +
+              `when sidepanel is enabled (both windows fire the event), ` +
+              `but got '${actualEnvironmentType}'`,
+          );
+        } else {
+          assert.equal(actualEnvironmentType, 'fullscreen');
+        }
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky as sometimes we get different properties for the environment type in the EMpty Buy banner metric event.
The reason is because on Chrome, both side panel and full screen render the component and trigger the event independently, leading to have 2 competing events. Whichever event arrives in the mock server first, is the one asserted, meaning we have undeterministic results for that property.
When the fullscreen event wins the race, the test fais.

<img width="1246" height="296" alt="image" src="https://github.com/user-attachments/assets/2c7c284f-4738-47a9-b1e6-83b6a43ae1c4" />


Fix:

- Changed events.length === 1 to events.length >= 1 to account for potentially receiving events from both windows.
- Extracted environment_type from the deep-equal assertion and validated it separately — accepting either 'sidepanel' or 'fullscreen' on Chrome, since both are legitimate in this dual-window scenario.
- 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<img width="1826" height="894" alt="image" src="https://github.com/user-attachments/assets/c0adb664-cc40-4746-8f78-2c23de54e42c" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion changes with no production or analytics pipeline behavior modified.
> 
> **Overview**
> Fixes flaky e2e coverage for the **Empty Buy Banner Displayed** metric after onboarding on Chrome when the side panel is enabled.
> 
> The spec no longer requires exactly one Segment batch event or a single fixed `environment_type`. It accepts **at least one** event because both `sidepanel.html` and `home.html` can mount the balance empty state and emit the track independently. Non-`environment_type` properties are still checked with `deepStrictEqual`; `environment_type` is asserted separately as **`sidepanel` or `fullscreen`** when the side panel is on, and **`fullscreen`** when it is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb2bb097f575f7ce1065ec570599da460e2b925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->