### PR TITLE
fix(confirmations): use pending tx chain balance for cancel/speed-up

### DIFF
--- a/ui/pages/confirmations/cancel-speedup/cancel-speedup.test.tsx
+++ b/ui/pages/confirmations/cancel-speedup/cancel-speedup.test.tsx
@@ -12,6 +12,7 @@ import configureStore from '../../../store/store';
 import mockEstimates from '../../../../test/data/mock-estimates.json';
 import mockState from '../../../../test/data/mock-state.json';
 import { decGWEIToHexWEI } from '../../../../shared/lib/conversion.utils';
+import { toChecksumHexAddress } from '../../../../shared/lib/hexstring-utils';
 import { getSelectedInternalAccountFromMockState } from '../../../../test/jest/mocks';
 import {
   createCancelTransaction,
@@ -62,6 +63,13 @@ jest.mock('../context/gas-fee-modal', () => ({
 const mockSelectedInternalAccount = getSelectedInternalAccountFromMockState(
   mockState as unknown as MetaMaskReduxState,
 );
+const checksummedSelectedAddress = toChecksumHexAddress(
+  mockSelectedInternalAccount.address,
+);
+const mockAccountsByChainId = mockState.metamask.accountsByChainId as Record<
+  string,
+  Record<string, { balance: string }>
+>;
 
 const MOCK_SUGGESTED_MEDIUM_MAXFEEPERGAS_DEC_GWEI =
   mockEstimates[GasEstimateTypes.feeMarket].gasFeeEstimates.medium
@@ -128,6 +136,9 @@ describe('CancelSpeedup Component', () => {
     gasLimitNoBuffer?: string;
     gasFeeEstimates?: (typeof mockEstimates)[GasEstimateTypes.feeMarket]['gasFeeEstimates'];
     balance?: string;
+    selectedAccountBalance?: string;
+    selectedChainId?: string;
+    selectedNetworkClientId?: string;
   };
 
   const BALANCE_ONE_ETH = '0xDE0B6B3A7640000';
@@ -148,42 +159,10 @@ describe('CancelSpeedup Component', () => {
       gasFeeEstimates = mockEstimates[GasEstimateTypes.feeMarket]
         .gasFeeEstimates,
       balance = BALANCE_ONE_ETH,
+      selectedAccountBalance = balance,
+      selectedChainId = '0x5',
+      selectedNetworkClientId = 'goerli',
     } = opts;
-
-    const store = configureStore({
-      appState: {
-        isLoading: false,
-      },
-      metamask: {
-        ...mockState.metamask,
-        isInitialized: true,
-        accounts: {
-          [mockSelectedInternalAccount.address]: {
-            address: mockSelectedInternalAccount.address,
-            balance,
-          },
-        },
-        accountsByChainId: {
-          ...mockState.metamask.accountsByChainId,
-          '0x5': {
-            ...mockState.metamask.accountsByChainId['0x5'],
-            [mockSelectedInternalAccount.address]: { balance },
-          },
-        },
-        preferences: {
-          showFiatInTestnets: true,
-        },
-        featureFlags: { advancedInlineGas: true },
-        gasFeeEstimates,
-        gasFeeEstimatesByChainId: {
-          ...mockState.metamask.gasFeeEstimatesByChainId,
-          '0x5': {
-            ...mockState.metamask.gasFeeEstimatesByChainId['0x5'],
-            gasFeeEstimates,
-          },
-        },
-      },
-    });
 
     const effectiveGas = gas ?? mockTransaction.txParams.gas;
     const txParams = {
@@ -200,6 +179,49 @@ describe('CancelSpeedup Component', () => {
       txParams,
       gasLimitNoBuffer: gasLimitNoBuffer ?? effectiveGas,
     } as TransactionMeta;
+
+    const store = configureStore({
+      appState: {
+        isLoading: false,
+      },
+      metamask: {
+        ...mockState.metamask,
+        isInitialized: true,
+        selectedNetworkClientId,
+        transactions: [...mockState.metamask.transactions, transaction],
+        accounts: {
+          [mockSelectedInternalAccount.address]: {
+            address: mockSelectedInternalAccount.address,
+            balance: selectedAccountBalance,
+          },
+        },
+        accountsByChainId: {
+          ...mockAccountsByChainId,
+          '0x5': {
+            ...mockAccountsByChainId['0x5'],
+            [checksummedSelectedAddress]: { balance },
+          },
+          [selectedChainId]: {
+            ...mockAccountsByChainId[selectedChainId],
+            [checksummedSelectedAddress]: {
+              balance: selectedAccountBalance,
+            },
+          },
+        },
+        preferences: {
+          showFiatInTestnets: true,
+        },
+        featureFlags: { advancedInlineGas: true },
+        gasFeeEstimates,
+        gasFeeEstimatesByChainId: {
+          ...mockState.metamask.gasFeeEstimatesByChainId,
+          '0x5': {
+            ...mockState.metamask.gasFeeEstimatesByChainId['0x5'],
+            gasFeeEstimates,
+          },
+        },
+      },
+    });
 
     return renderWithProvider(
       <CancelSpeedup
@@ -478,6 +500,24 @@ describe('CancelSpeedup Component', () => {
 
     it('keeps the confirm button enabled and labelled "Confirm" when the balance covers the gas fee', async () => {
       render({ editGasMode: EditGasModes.cancel });
+
+      const confirmButton = await screen.findByTestId(
+        'cancel-speedup-confirm-button',
+      );
+      expect(confirmButton).not.toBeDisabled();
+      expect(confirmButton).toHaveTextContent(tEn('confirm') as string);
+    });
+
+    it('uses the transaction chain balance when a different network is selected', async () => {
+      render(
+        { editGasMode: EditGasModes.cancel },
+        {
+          balance: BALANCE_ONE_ETH,
+          selectedAccountBalance: '0x1F4',
+          selectedChainId: '0x1',
+          selectedNetworkClientId: 'testNetworkConfigurationId',
+        },
+      );
 
       const confirmButton = await screen.findByTestId(
         'cancel-speedup-confirm-button',

--- a/ui/pages/confirmations/cancel-speedup/cancel-speedup.tsx
+++ b/ui/pages/confirmations/cancel-speedup/cancel-speedup.tsx
@@ -30,8 +30,8 @@ import { EditGasModes } from '../../../../shared/constants/gas';
 import { getMaximumGasTotalInHexWei } from '../../../../shared/lib/gas.utils';
 import {
   getAppIsLoading,
-  getSelectedAccount,
   getShouldShowFiat,
+  selectTransactionAvailableBalance,
 } from '../../../selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTransactionModalContext } from '../../../contexts/transaction-modal';
@@ -294,7 +294,15 @@ const CancelSpeedupModal = ({
   const t = useI18nContext();
   const isCancel = mode === EditGasModes.cancel;
 
-  const selectedAccount = useSelector(getSelectedAccount);
+  // The transaction can belong to a chain other than the selected one, so the
+  // balance must be read for the transaction's own chain and sender.
+  const transactionBalance = useSelector((state) =>
+    selectTransactionAvailableBalance(
+      state,
+      effectiveTransaction.id,
+      effectiveTransaction.chainId,
+    ),
+  );
 
   const hasEnoughBalance = isInitialGasReady
     ? isBalanceSufficient({
@@ -306,7 +314,7 @@ const CancelSpeedupModal = ({
           gasPrice: effectiveTransaction.txParams?.gasPrice,
           maxFeePerGas: effectiveTransaction.txParams?.maxFeePerGas,
         }),
-        balance: selectedAccount?.balance,
+        balance: transactionBalance,
       })
     : true;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The Cancel/Speed Up modal compared replacement gas against the currently selected network's native balance. In All Networks Activity, a pending send on chain A could be blocked as "Insufficient funds" when the wallet was selected to chain B with a lower (or zero) native balance, even though the sender had enough on the transaction chain.

This change reads the sender's native balance from `accountsByChainId` for the pending transaction's `chainId` instead of `getSelectedAccount().balance`.

## **Changelog**

CHANGELOG entry: Fixed Cancel and Speed Up showing insufficient funds when the pending transaction was on a different network than the one currently selected.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1907

Related: https://github.com/MetaMask/metamask-extension/issues/43767

## **Manual testing steps**

1. Run the extension and create a pending send on network A (low gas price, or local Anvil with mining paused).
2. Confirm the account has enough native tokens on network A to cover a cancel/speed-up gas fee.
3. Switch the selected network to network B where the same account has little or no native balance.
4. Open Activity (All popular networks) and tap Cancel on the pending send.
5. Verify Confirm stays enabled and labelled Confirm (not Insufficient funds).
6. Switch back to network A, drain native balance below the cancel gas fee, reopen Cancel, and verify Confirm is disabled with Insufficient funds.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.