### PR TITLE
test: fix flaky tests `Reset Wallet`

### DIFF
--- a/test/e2e/page-objects/pages/onboarding/onboarding-metrics-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/onboarding-metrics-page.ts
@@ -79,12 +79,16 @@ class OnboardingMetricsPage {
    * Ensures the "Participate in MetaMetrics" checkbox is unchecked.
    * If it is already unchecked (e.g. state restored from a previous session
    * during vault recovery), the click is skipped to avoid toggling it back on.
+   *
+   * We check for the *checked* state (the default) rather than the unchecked
+   * state so the lookup succeeds instantly in the common case.
    */
   async ensureParticipateInMetaMetricsIsUnchecked(): Promise<void> {
-    const isAlreadyUnchecked = await this.driver.isElementPresent(
-      this.participateUnchecked,
+    const isCurrentlyChecked = await this.driver.isElementPresentAndVisible(
+      this.participateChecked,
+      1000,
     );
-    if (!isAlreadyUnchecked) {
+    if (isCurrentlyChecked) {
       await this.driver.clickElement(this.dataParticipateInMetaMetricsCheckbox);
       await this.driver.waitForSelector(this.participateUnchecked);
     }

--- a/test/e2e/tests/reset-wallet/reset-wallet.spec.ts
+++ b/test/e2e/tests/reset-wallet/reset-wallet.spec.ts
@@ -37,15 +37,8 @@ describe('Reset Wallet - ', function () {
         await loginPage.resetWalletFromForgotPassword();
 
         // Complete onboarding again with SRP create.
-        // needNavigateToNewPage must be false: the wallet reset is async —
-        // `resetWalletFromForgotPassword` resolves as soon as the modal
-        // closes, but the background `resetWallet` RPC is still in flight.
-        // A full-page `driver.navigate()` at this point would reload
-        // home.html before the reset finishes, so the app shows the home
-        // page instead of redirecting to onboarding.
-        // With `false`, the flow waits for the onboarding welcome page to
-        // appear naturally once the background reset completes and the React
-        // Router navigates to DEFAULT_ROUTE.
+        // `resetWalletFromForgotPassword` resolves as soon as the modal closes, but the background `resetWallet` RPC is still in flight.
+        // So we just wait for the onboarding welcome page to appear naturally once the background reset completes, instead of navigating.
         await completeCreateNewWalletOnboardingFlow({
           driver,
           skipSRPBackup: true,
@@ -85,7 +78,6 @@ describe('Reset Wallet - ', function () {
         await loginPage.resetWalletFromForgotPassword();
 
         // Complete onboarding again by importing SRP.
-        // See the first test for why needNavigateToNewPage must be false.
         await completeImportSRPOnboardingFlow({
           driver,
           needNavigateToNewPage: false,

--- a/test/e2e/tests/reset-wallet/reset-wallet.spec.ts
+++ b/test/e2e/tests/reset-wallet/reset-wallet.spec.ts
@@ -36,10 +36,20 @@ describe('Reset Wallet - ', function () {
         // Reset wallet via forgot password -> "I don't know my Recovery Phrase"
         await loginPage.resetWalletFromForgotPassword();
 
-        // Complete onboarding again with SRP create
+        // Complete onboarding again with SRP create.
+        // needNavigateToNewPage must be false: the wallet reset is async —
+        // `resetWalletFromForgotPassword` resolves as soon as the modal
+        // closes, but the background `resetWallet` RPC is still in flight.
+        // A full-page `driver.navigate()` at this point would reload
+        // home.html before the reset finishes, so the app shows the home
+        // page instead of redirecting to onboarding.
+        // With `false`, the flow waits for the onboarding welcome page to
+        // appear naturally once the background reset completes and the React
+        // Router navigates to DEFAULT_ROUTE.
         await completeCreateNewWalletOnboardingFlow({
           driver,
           skipSRPBackup: true,
+          needNavigateToNewPage: false,
         });
 
         await homePage.checkPageIsLoaded();
@@ -74,8 +84,12 @@ describe('Reset Wallet - ', function () {
         // Reset wallet via forgot password -> "I don't know my Recovery Phrase"
         await loginPage.resetWalletFromForgotPassword();
 
-        // Complete onboarding again by importing SRP
-        await completeImportSRPOnboardingFlow({ driver });
+        // Complete onboarding again by importing SRP.
+        // See the first test for why needNavigateToNewPage must be false.
+        await completeImportSRPOnboardingFlow({
+          driver,
+          needNavigateToNewPage: false,
+        });
 
         await homePage.headerNavbar.checkPageIsLoaded();
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The flakiness is a race condition between the async wallet reset and the test's driver.navigate() call.
The chain of events:

1. resetWalletFromForgotPassword() clicks the "Reset wallet" button in the modal
2. The handler (handleResetWalletConfirm) calls onClose() first (line 65 of reset-password-modal.tsx), closing the modal immediately
3. The test's clickElementAndWaitToDisappear resolves because the button is gone from the DOM
4. But the actual wallet reset (await dispatch(resetWalletAction()) on line 67) hasn't happened yet — it's an async background RPC
5. The test immediately calls completeCreateNewWalletOnboardingFlow → driver.navigate() → full page reload of home.html
6. This reload destroys the React context (so the navigate(DEFAULT_ROUTE) on line 72 never executes)
7. If the background resetWallet hasn't finished, completedOnboarding is still true → the home page loads instead of redirecting to onboarding
8. The test waits forever for [data-testid="parent-selector-onboarding-welcome"] → 80s timeout


Fix: Both test cases now pass `needNavigateToNewPage: false` to the onboarding flow that runs after resetWalletFromForgotPassword(). This prevents the full page reload that races with the async reset, and instead lets the startOnboardingPage.checkLoginPageIsLoaded() wait (up to 20s) for the onboarding welcome page to appear naturally through the React Router navigation that fires after the background reset completes.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to e2e page objects and specs; no production wallet or auth behavior is modified.
> 
> **Overview**
> Addresses **Reset Wallet** e2e flakiness caused by a race: after forgot-password reset, the modal closes before the async `resetWallet` RPC finishes, and the default onboarding helper’s full `driver.navigate()` reload could land on home instead of onboarding.
> 
> Both reset-wallet specs now pass **`needNavigateToNewPage: false`** into the post-reset create-wallet and import-SRP flows so they wait for the welcome onboarding screen via existing checks instead of forcing a navigation.
> 
> **`ensureParticipateInMetaMetricsIsUnchecked`** on the metrics page object now probes the **checked** (default) state with **`isElementPresentAndVisible`** and a short timeout, then clicks only when checked—so the common path resolves quickly and restored-session unchecked state is not accidentally toggled on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bdcb69c67a7ec44ba032cdedc7423bb9712e533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->