### PR TITLE
test: capture screenshots and clean up servers on Mocha timeout

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -240,7 +240,7 @@ async function withFixtures(options, testSuite) {
     unifiedEvmAccountsApiBalances,
     virtualAuthenticator,
     isBenchmark = false,
-    testTimeout = parseInt(process.env.MOCHA_TIMEOUT, 10) || 80_000,
+    testTimeout = parseInt(process.env.MOCHA_TIMEOUT, 10) || 0,
   } = options;
 
   // Normalize localNodeOptions

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -243,6 +243,8 @@ async function withFixtures(options, testSuite) {
     testTimeout = parseInt(process.env.MOCHA_TIMEOUT, 10) || 0,
   } = options;
 
+  const fixtureStartTime = Date.now();
+
   // Normalize localNodeOptions
   const localNodeOptsNormalized = normalizeLocalNodeOptions(localNodeOptions);
 
@@ -642,7 +644,8 @@ async function withFixtures(options, testSuite) {
     // eslint-disable-next-line no-empty-function
     testPromise.catch(() => {});
 
-    const deadlineMs = testTimeout - ARTIFACT_DEADLINE_BUFFER_MS;
+    const elapsed = Date.now() - fixtureStartTime;
+    const deadlineMs = testTimeout - ARTIFACT_DEADLINE_BUFFER_MS - elapsed;
     if (deadlineMs > 0 && testTimeout > 0) {
       let deadlineTimer;
       const deadlinePromise = new Promise((_, reject) => {

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -240,6 +240,7 @@ async function withFixtures(options, testSuite) {
     unifiedEvmAccountsApiBalances,
     virtualAuthenticator,
     isBenchmark = false,
+    testTimeout = parseInt(process.env.MOCHA_TIMEOUT, 10) || 80_000,
   } = options;
 
   // Normalize localNodeOptions
@@ -616,7 +617,18 @@ async function withFixtures(options, testSuite) {
 
     console.log(`\nExecuting testcase: '${title}'\n`);
 
-    await testSuite({
+    // --- Internal deadline ---
+    // Mocha cannot cancel a running async function when its timeout fires.
+    // It simply marks the test as failed and starts the next one, which means
+    // our `catch` (screenshots) and `finally` (server cleanup) blocks never
+    // run in time.  By racing the test callback against an internal deadline
+    // that fires a few seconds BEFORE Mocha's timeout, we regain control:
+    //   1. The deadline error flows into `catch` → screenshots are captured.
+    //   2. Then `finally` runs → Anvil and other servers are cleaned up.
+    //   3. `withFixtures` settles before Mocha's timeout, so the next test
+    //      starts with a clean slate.
+    const ARTIFACT_DEADLINE_BUFFER_MS = 5_000;
+    const testPromise = testSuite({
       bundlerServer,
       contractRegistry,
       driver: effectiveDriver,
@@ -633,6 +645,34 @@ async function withFixtures(options, testSuite) {
         },
       }),
     });
+
+    // Silence the orphaned test promise if the deadline wins the race and the
+    // test callback rejects afterwards (prevents unhandled-rejection noise).
+    testPromise.catch(() => {});
+
+    const deadlineMs = testTimeout - ARTIFACT_DEADLINE_BUFFER_MS;
+    if (deadlineMs > 0 && testTimeout > 0) {
+      let deadlineTimer;
+      const deadlinePromise = new Promise((_, reject) => {
+        deadlineTimer = setTimeout(() => {
+          reject(
+            new Error(
+              `withFixtures internal deadline exceeded after ${deadlineMs}ms ` +
+                `(Mocha timeout: ${testTimeout}ms). Capturing artifacts before Mocha moves on.`,
+            ),
+          );
+        }, deadlineMs);
+      });
+
+      try {
+        await Promise.race([testPromise, deadlinePromise]);
+      } finally {
+        clearTimeout(deadlineTimer);
+      }
+    } else {
+      // --leave-running or very short timeout: no deadline, wait indefinitely
+      await testPromise;
+    }
 
     const errorsAndExceptions = driver.summarizeErrorsAndExceptions();
     if (errorsAndExceptions) {

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -617,16 +617,9 @@ async function withFixtures(options, testSuite) {
 
     console.log(`\nExecuting testcase: '${title}'\n`);
 
-    // --- Internal deadline ---
-    // Mocha cannot cancel a running async function when its timeout fires.
-    // It simply marks the test as failed and starts the next one, which means
-    // our `catch` (screenshots) and `finally` (server cleanup) blocks never
-    // run in time.  By racing the test callback against an internal deadline
-    // that fires a few seconds BEFORE Mocha's timeout, we regain control:
-    //   1. The deadline error flows into `catch` → screenshots are captured.
-    //   2. Then `finally` runs → Anvil and other servers are cleaned up.
-    //   3. `withFixtures` settles before Mocha's timeout, so the next test
-    //      starts with a clean slate.
+    // Race the test callback against a deadline that fires just before
+    // Mocha's timeout.  This lets our catch (screenshots) and finally
+    // (server cleanup) run before Mocha moves on to the next test.
     const ARTIFACT_DEADLINE_BUFFER_MS = 5_000;
     const testPromise = testSuite({
       bundlerServer,
@@ -648,6 +641,7 @@ async function withFixtures(options, testSuite) {
 
     // Silence the orphaned test promise if the deadline wins the race and the
     // test callback rejects afterwards (prevents unhandled-rejection noise).
+    // eslint-disable-next-line no-empty-function
     testPromise.catch(() => {});
 
     const deadlineMs = testTimeout - ARTIFACT_DEADLINE_BUFFER_MS;

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -617,9 +617,7 @@ async function withFixtures(options, testSuite) {
 
     console.log(`\nExecuting testcase: '${title}'\n`);
 
-    // Race the test callback against a deadline that fires just before
-    // Mocha's timeout.  This lets our catch (screenshots) and finally
-    // (server cleanup) run before Mocha moves on to the next test.
+    // This lets our catch (screenshots) and finally (server cleanup) run before Mocha moves on to the next test.
     const ARTIFACT_DEADLINE_BUFFER_MS = 5_000;
     const testPromise = testSuite({
       bundlerServer,

--- a/test/e2e/manifest-flag-mocha-hooks.ts
+++ b/test/e2e/manifest-flag-mocha-hooks.ts
@@ -60,8 +60,17 @@ process.env.ENABLE_MV3 = getManifestVersion() === 3 ? 'true' : 'false';
 
 // Global beforeEach hook to backup the manifest.json file
 if (typeof beforeEach === 'function' && process.env.SELENIUM_BROWSER) {
-  beforeEach(() => {
+  beforeEach(function () {
     console.debug('manifest-flag-mocha-hooks.ts -- beforeEach hook');
+
+    // Expose the effective Mocha timeout for the current test so that
+    // withFixtures can set an internal deadline that fires slightly
+    // before Mocha's.  this.currentTest.timeout() respects suite-level
+    // overrides (e.g. this.timeout(180_000) on a describe block).
+    const testTimeout = this.currentTest?.timeout?.() ?? 0;
+    if (testTimeout > 0) {
+      process.env.MOCHA_TIMEOUT = String(testTimeout);
+    }
 
     restoreBackupManifest();
 

--- a/test/e2e/manifest-flag-mocha-hooks.ts
+++ b/test/e2e/manifest-flag-mocha-hooks.ts
@@ -63,10 +63,8 @@ if (typeof beforeEach === 'function' && process.env.SELENIUM_BROWSER) {
   beforeEach(function () {
     console.debug('manifest-flag-mocha-hooks.ts -- beforeEach hook');
 
-    // Expose the effective Mocha timeout for the current test so that
-    // withFixtures can set an internal deadline that fires slightly
-    // before Mocha's.  this.currentTest.timeout() respects suite-level
-    // overrides (e.g. this.timeout(180_000) on a describe block).
+    // Expose the per-test Mocha timeout (including suite-level overrides)
+    // so withFixtures can set an internal deadline just before it.
     const testTimeout = this.currentTest?.timeout?.() ?? 0;
     if (testTimeout > 0) {
       process.env.MOCHA_TIMEOUT = String(testTimeout);

--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -150,11 +150,8 @@ async function main() {
       );
     }
 
-    // Expose the Mocha timeout so withFixtures can set an internal deadline
-    // that fires slightly before Mocha's, giving it time to capture
-    // screenshots and clean up servers (Anvil, etc.) before Mocha moves on.
-    // The global beforeEach hook in manifest-flag-mocha-hooks.ts updates
-    // this per-test to honour suite-level this.timeout() overrides.
+    // Used by withFixtures to set an internal deadline before Mocha's timeout.
+    // The beforeEach hook in manifest-flag-mocha-hooks.ts updates this per-test.
     process.env.MOCHA_TIMEOUT = String(testTimeoutInMilliseconds);
 
     try {

--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -150,6 +150,13 @@ async function main() {
       );
     }
 
+    // Expose the Mocha timeout so withFixtures can set an internal deadline
+    // that fires slightly before Mocha's, giving it time to capture
+    // screenshots and clean up servers (Anvil, etc.) before Mocha moves on.
+    // The global beforeEach hook in manifest-flag-mocha-hooks.ts updates
+    // this per-test to honour suite-level this.timeout() overrides.
+    process.env.MOCHA_TIMEOUT = String(testTimeoutInMilliseconds);
+
     try {
       await retry({ retries, stopAfterOneFailure }, async () => {
         const mochaArgs = [


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When an E2E test times out, Mocha cannot cancel the running `async` function, it simply marks the test as failed and starts the next one. This means the `catch` block in `withFixtures` (which captures screenshots, DOM snapshots, and app state) and the `finally` block (which shuts down Anvil, fixture servers, and the browser) never run before the next test begins.
This causes two problems:
1. **No failure artifacts** : timed-out tests produce no screenshots, DOM dumps, or state snapshots, making them very hard to debug.
2. **Cascading failures**: the next test starts before Anvil is cleaned up, hitting "Address already in use" and failing immediately.

<img width="1309" height="264" alt="image" src="https://github.com/user-attachments/assets/3a2a6e5a-49bb-426f-9f18-220ead44566a" />


Fix: add an internal deadline inside `withFixtures` that fires **5 seconds before** Mocha's timeout. The test callback is wrapped in a `Promise.race` against this deadline. When the deadline wins:

1. The deadline error flows into `catch` → `verboseReportOnFailure` captures screenshots, DOM, and state.
2. Then `finally` runs → Anvil, fixture servers, and the browser are shut down cleanly.
3. `withFixtures` settles before Mocha's timeout fires, so the next test starts with a clean slate.
The deadline is timeout-aware: a global `beforeEach` hook reads `this.currentTest.timeout()` (which respects suite-level `this.timeout()` overrides) and updates `MOCHA_TIMEOUT` per-test. Tests with `--leave-running` (timeout = 0) skip the deadline entirely.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-2399
 
## **Manual testing steps**

1. Apply the changes and build a test build: `yarn build:test`
2. Run a test known to timeout (e.g., add a long `await new Promise(r => setTimeout(r, 90_000))` inside a `withFixtures` callback)
3. Verify that after ~75s the test fails with a `withFixtures internal deadline exceeded` error
4. Verify that `test-artifacts/` contains screenshots and DOM snapshots for the failed test
5. Verify the next test in the suite starts cleanly (no "Address already in use" errors)
6. Run a test with `--leave-running` and confirm the deadline does not fire


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E harness timing and env wiring; no production or user-facing runtime behavior is affected.
> 
> **Overview**
> E2E tests that hit Mocha’s timeout used to leave the async `withFixtures` callback running, so **failure screenshots/DOM dumps and server teardown** often never ran before the next test—causing missing debug artifacts and cascading “address already in use” failures.
> 
> **`withFixtures`** now races the test callback against an **internal deadline ~5s before** the effective Mocha timeout (accounting for fixture setup time). When the deadline wins, the thrown error runs the existing **`catch`/`finally`** path so artifacts are captured and Anvil, mocks, and the browser shut down before Mocha advances. Orphaned test promise rejections are swallowed to avoid noise. **`testTimeout`** can be passed explicitly when `this.timeout()` is set inside an `it()` body.
> 
> **`run-e2e-test.js`** seeds **`MOCHA_TIMEOUT`** (default raised **80s → 85s**), and **`manifest-flag-mocha-hooks.ts`** refreshes it each test from **`this.currentTest.timeout()`** so suite overrides apply. **`--leave-running`** (timeout 0) skips the deadline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c534185f460892f6a2309c9520341b510b38e506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->