### PR TITLE
chore: Bump @metamask/delegation-deployments from ^1.3.0 to ^2.0.0

### DIFF
--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -1649,7 +1649,7 @@
         "@metamask/gator-permissions-controller>@metamask/abi-utils": true,
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/gator-permissions-controller>@metamask/delegation-deployments": true,
         "@metamask/snaps-utils": true,
         "@metamask/gator-permissions-controller>@metamask/transaction-controller": true,
         "@metamask/utils": true
@@ -1929,7 +1929,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/money-account-upgrade-controller>@metamask/delegation-deployments": true,
         "@metamask/keyring-controller": true,
         "@metamask/money-account-utils": true,
         "@metamask/utils": true

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -1649,7 +1649,7 @@
         "@metamask/gator-permissions-controller>@metamask/abi-utils": true,
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/gator-permissions-controller>@metamask/delegation-deployments": true,
         "@metamask/snaps-utils": true,
         "@metamask/gator-permissions-controller>@metamask/transaction-controller": true,
         "@metamask/utils": true
@@ -1929,7 +1929,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/money-account-upgrade-controller>@metamask/delegation-deployments": true,
         "@metamask/keyring-controller": true,
         "@metamask/money-account-utils": true,
         "@metamask/utils": true

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -1649,7 +1649,7 @@
         "@metamask/gator-permissions-controller>@metamask/abi-utils": true,
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/gator-permissions-controller>@metamask/delegation-deployments": true,
         "@metamask/snaps-utils": true,
         "@metamask/gator-permissions-controller>@metamask/transaction-controller": true,
         "@metamask/utils": true
@@ -1929,7 +1929,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/money-account-upgrade-controller>@metamask/delegation-deployments": true,
         "@metamask/keyring-controller": true,
         "@metamask/money-account-utils": true,
         "@metamask/utils": true

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -1649,7 +1649,7 @@
         "@metamask/gator-permissions-controller>@metamask/abi-utils": true,
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/gator-permissions-controller>@metamask/delegation-deployments": true,
         "@metamask/snaps-utils": true,
         "@metamask/gator-permissions-controller>@metamask/transaction-controller": true,
         "@metamask/utils": true
@@ -1929,7 +1929,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/money-account-upgrade-controller>@metamask/delegation-deployments": true,
         "@metamask/keyring-controller": true,
         "@metamask/money-account-utils": true,
         "@metamask/utils": true

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -1832,7 +1832,7 @@
         "@metamask/gator-permissions-controller>@metamask/abi-utils": true,
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/gator-permissions-controller>@metamask/delegation-deployments": true,
         "@metamask/snaps-utils": true,
         "@metamask/gator-permissions-controller>@metamask/transaction-controller": true,
         "@metamask/utils": true
@@ -2112,7 +2112,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/money-account-upgrade-controller>@metamask/delegation-deployments": true,
         "@metamask/keyring-controller": true,
         "@metamask/money-account-utils": true,
         "@metamask/utils": true

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -1832,7 +1832,7 @@
         "@metamask/gator-permissions-controller>@metamask/abi-utils": true,
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/gator-permissions-controller>@metamask/delegation-deployments": true,
         "@metamask/snaps-utils": true,
         "@metamask/gator-permissions-controller>@metamask/transaction-controller": true,
         "@metamask/utils": true
@@ -2112,7 +2112,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/money-account-upgrade-controller>@metamask/delegation-deployments": true,
         "@metamask/keyring-controller": true,
         "@metamask/money-account-utils": true,
         "@metamask/utils": true

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -1832,7 +1832,7 @@
         "@metamask/gator-permissions-controller>@metamask/abi-utils": true,
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/gator-permissions-controller>@metamask/delegation-deployments": true,
         "@metamask/snaps-utils": true,
         "@metamask/gator-permissions-controller>@metamask/transaction-controller": true,
         "@metamask/utils": true
@@ -2112,7 +2112,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/money-account-upgrade-controller>@metamask/delegation-deployments": true,
         "@metamask/keyring-controller": true,
         "@metamask/money-account-utils": true,
         "@metamask/utils": true

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -1832,7 +1832,7 @@
         "@metamask/gator-permissions-controller>@metamask/abi-utils": true,
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/gator-permissions-controller>@metamask/delegation-deployments": true,
         "@metamask/snaps-utils": true,
         "@metamask/gator-permissions-controller>@metamask/transaction-controller": true,
         "@metamask/utils": true
@@ -2112,7 +2112,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/delegation-core": true,
-        "@metamask/delegation-deployments": true,
+        "@metamask/money-account-upgrade-controller>@metamask/delegation-deployments": true,
         "@metamask/keyring-controller": true,
         "@metamask/money-account-utils": true,
         "@metamask/utils": true

--- a/package.json
+++ b/package.json
@@ -402,7 +402,7 @@
     "@metamask/core-backend": "^9.1.1",
     "@metamask/delegation-controller": "^3.0.2",
     "@metamask/delegation-core": "^2.0.0",
-    "@metamask/delegation-deployments": "^1.3.0",
+    "@metamask/delegation-deployments": "^2.0.0",
     "@metamask/design-system-react": "^0.41.0",
     "@metamask/design-system-tailwind-preset": "^0.13.0",
     "@metamask/design-tokens": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6298,10 +6298,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-deployments@npm:^1.3.0, @metamask/delegation-deployments@npm:^1.4.0":
+"@metamask/delegation-deployments@npm:^1.4.0":
   version: 1.4.0
   resolution: "@metamask/delegation-deployments@npm:1.4.0"
   checksum: 10/e5e7b83e27daec5b1b61482647d43d4b685954818ff02687e2dbe8169a4dfe199cc8d2ed444242b60425ac2e7d2cf2a5ca29f3e69936abe6a8391f578ec693bb
+  languageName: node
+  linkType: hard
+
+"@metamask/delegation-deployments@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/delegation-deployments@npm:2.0.0"
+  checksum: 10/7f2712ab5e48551880f2ce49d6bd6434b7587772b5053504b1186ae1a894313e9a30ef7ba94cceb7ee80a91c31764ca1a92aec9d8a30de925524a6314f163a7d
   languageName: node
   linkType: hard
 
@@ -31916,7 +31923,7 @@ __metadata:
     "@metamask/core-backend": "npm:^9.1.1"
     "@metamask/delegation-controller": "npm:^3.0.2"
     "@metamask/delegation-core": "npm:^2.0.0"
-    "@metamask/delegation-deployments": "npm:^1.3.0"
+    "@metamask/delegation-deployments": "npm:^2.0.0"
     "@metamask/design-system-react": "npm:^0.41.0"
     "@metamask/design-system-shared": "npm:^0.36.0"
     "@metamask/design-system-tailwind-preset": "npm:^0.13.0"


### PR DESCRIPTION
## **Description**

Bump @metamask/delegation-deployments from ^1.3.0 to ^2.0.0, bringing Robinhood chain deployments.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: @metamask/delegation-deployments from ^1.3.0 to ^2.0.0

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches delegation contract deployment data consumed by permission and account-upgrade controllers; wrong addresses would affect delegation-related transactions on supported chains.
> 
> **Overview**
> Upgrades **`@metamask/delegation-deployments`** from **^1.3.0** to **^2.0.0** in `package.json` and `yarn.lock`, resolving **2.0.0** as the extension’s direct dependency (v1.x remains in the lockfile for other transitive consumers).
> 
> Across all **LavaMoat** webpack policies (MV2/MV3 × beta/experimental/flask/main), **`@metamask/delegation-deployments`** is no longer granted as a top-level package on **`@metamask/gator-permissions-controller`** and **`@metamask/money-account-upgrade-controller`**. It is now scoped to each controller’s dependency path (e.g. `@metamask/gator-permissions-controller>@metamask/delegation-deployments`), matching how the v2 dependency graph is bundled.
> 
> Per the PR intent, **v2** adds deployment metadata (including **Robinhood chain** deployments) used by gator permissions and money-account upgrade flows that rely on `@metamask/delegation-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049521512516d27a90e2cd4d0c62856752f3c076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->