### PR TITLE
fix(storage): request strict IndexedDB durability for backup writes

### DIFF
--- a/app/scripts/migrations/223.ts
+++ b/app/scripts/migrations/223.ts
@@ -71,7 +71,10 @@ export const migrate = (async (versionedData, _changedKeys) => {
     return;
   }
 
-  const database = new IndexedDBStore();
+  // This migration deletes the source data from `storage.local` right after
+  // writing it to IndexedDB, so the write has to be durable before the delete
+  // runs. It is a one-time write, so strict durability costs nothing here.
+  const database = new IndexedDBStore({ strictDurability: true });
   try {
     await database.open(
       STORAGE_SERVICE_INDEXED_DB_NAME,

--- a/shared/lib/stores/indexeddb-store.test.ts
+++ b/shared/lib/stores/indexeddb-store.test.ts
@@ -149,4 +149,141 @@ describe('IndexedDBStore', () => {
       await expect(db.remove(['key'])).rejects.toThrow('Database is not open');
     });
   });
+
+  describe('reset', () => {
+    it('clears all stored values', async () => {
+      await db.open(dbName, dbVersion);
+      await db.set({ key1: 'value1', key2: 'value2' });
+      await db.reset();
+      expect(await db.get(['key1', 'key2'])).toStrictEqual([
+        undefined,
+        undefined,
+      ]);
+    });
+
+    it('throws when database is not open', async () => {
+      await expect(db.reset()).rejects.toThrow('Database is not open');
+    });
+  });
+
+  describe('readwrite durability', () => {
+    const STRICT_READWRITE = ['store', 'readwrite', { durability: 'strict' }];
+    const DEFAULT_READWRITE = ['store', 'readwrite'];
+
+    it('requests strict durability for set, remove, and reset when enabled', async () => {
+      db = new IndexedDBStore({ strictDurability: true });
+      await db.open(dbName, dbVersion);
+      const transactionSpy = jest.spyOn(IDBDatabase.prototype, 'transaction');
+
+      await db.set({ key: 'value' });
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(transactionSpy.mock.calls[0]).toStrictEqual(STRICT_READWRITE);
+
+      transactionSpy.mockClear();
+      await db.remove(['key']);
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(transactionSpy.mock.calls[0]).toStrictEqual(STRICT_READWRITE);
+
+      transactionSpy.mockClear();
+      await db.reset();
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(transactionSpy.mock.calls[0]).toStrictEqual(STRICT_READWRITE);
+    });
+
+    it('does not request durability for set, remove, and reset by default', async () => {
+      await db.open(dbName, dbVersion);
+      const transactionSpy = jest.spyOn(IDBDatabase.prototype, 'transaction');
+
+      await db.set({ key: 'value' });
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(transactionSpy.mock.calls[0]).toStrictEqual(DEFAULT_READWRITE);
+
+      transactionSpy.mockClear();
+      await db.remove(['key']);
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(transactionSpy.mock.calls[0]).toStrictEqual(DEFAULT_READWRITE);
+
+      transactionSpy.mockClear();
+      await db.reset();
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(transactionSpy.mock.calls[0]).toStrictEqual(DEFAULT_READWRITE);
+    });
+
+    it('does not request durability for readonly transactions', async () => {
+      db = new IndexedDBStore({ strictDurability: true });
+      await db.open(dbName, dbVersion);
+      await db.set({ 'prefix:key': 'value' });
+      const transactionSpy = jest.spyOn(IDBDatabase.prototype, 'transaction');
+
+      await db.get(['prefix:key']);
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(transactionSpy.mock.calls[0]).toStrictEqual(['store', 'readonly']);
+
+      transactionSpy.mockClear();
+      await db.getKeys('prefix:');
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(transactionSpy.mock.calls[0]).toStrictEqual(['store', 'readonly']);
+    });
+
+    it('writes succeed even though fake-indexeddb ignores the durability option', async () => {
+      // All tests in this file run against `fake-indexeddb` (imported at the
+      // top). Its `transaction(storeNames, mode)` signature only accepts two
+      // arguments and silently drops the third `{ durability }` options bag.
+      // This makes it a real stand-in for an engine that does not support the
+      // durability option: the extra argument is ignored (not rejected), and
+      // the write must still land.
+      db = new IndexedDBStore({ strictDurability: true });
+      await db.open(dbName, dbVersion);
+
+      await db.set({ key: 'value' });
+      expect(await db.get(['key'])).toStrictEqual(['value']);
+
+      await db.remove(['key']);
+      expect(await db.get(['key'])).toStrictEqual([undefined]);
+    });
+
+    it('rejects when the transaction aborts while committing', async () => {
+      db = new IndexedDBStore({ strictDurability: true });
+      await db.open(dbName, dbVersion);
+
+      const realTransaction = IDBDatabase.prototype.transaction;
+      jest
+        .spyOn(IDBDatabase.prototype, 'transaction')
+        .mockImplementation(function (this: IDBDatabase, ...args) {
+          const tx = realTransaction.apply(this, args);
+          const realObjectStore = tx.objectStore.bind(tx);
+          tx.objectStore = (name: string) => {
+            const store = realObjectStore(name);
+            const realPut = store.put.bind(store);
+            store.put = (value: unknown, key: IDBValidKey) => {
+              const request = realPut(value, key);
+              // Abort only once the request has succeeded, so that the request
+              // has already left the transaction's request list and no `error`
+              // event is fired - which is what a failed commit looks like.
+              request.addEventListener('success', () => tx.abort());
+              return request;
+            };
+            return store;
+          };
+          return tx;
+        });
+
+      await expect(db.set({ key: 'value' })).rejects.toThrow(
+        'IndexedDB transaction aborted',
+      );
+    });
+
+    it('rejects when opening the transaction throws', async () => {
+      await db.open(dbName, dbVersion);
+      jest
+        .spyOn(IDBDatabase.prototype, 'transaction')
+        .mockImplementation(() => {
+          throw new Error('transaction failed');
+        });
+
+      await expect(db.set({ key: 'value' })).rejects.toThrow(
+        'transaction failed',
+      );
+    });
+  });
 });

--- a/shared/lib/stores/indexeddb-store.ts
+++ b/shared/lib/stores/indexeddb-store.ts
@@ -107,18 +107,6 @@ export class IndexedDBStore {
       request.onerror = () => {
         reject(request.error);
       };
-      // Fires when this version-change request is blocked by another open
-      // connection to the same database. Without this handler the promise
-      // hangs silently until the other connection closes.
-      // See https://developer.mozilla.org/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event
-      request.onblocked = () => {
-        reject(
-          new DOMException(
-            `IndexedDB open "${name}" blocked by another connection`,
-            'AbortError',
-          ),
-        );
-      };
     });
   }
 

--- a/shared/lib/stores/indexeddb-store.ts
+++ b/shared/lib/stores/indexeddb-store.ts
@@ -7,15 +7,79 @@ function transactionPromise(tx: IDBTransaction): Promise<void> {
   return new Promise((resolve, reject) => {
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
+    // `abort` has to be handled separately from `error`. When a transaction
+    // fails while *committing* - a failed flush to disk, or quota exhaustion at
+    // commit time - every request has already completed and been removed from
+    // the transaction's request list, so no `error` event is fired at any
+    // request and none bubbles up to the transaction. Only `abort` fires.
+    // Requesting strict durability is what makes those commit failures
+    // observable, so without this handler the promise would never settle.
+    // `tx.error` is `null` for an explicitly aborted transaction, hence the
+    // fallback error.
+    tx.onabort = () =>
+      reject(
+        tx.error ??
+          new DOMException('IndexedDB transaction aborted', 'AbortError'),
+      );
   });
 }
 
+type IndexedDBStoreOptions = {
+  /**
+   * Request `durability: 'strict'` for `set`, `remove` and `reset`, so those
+   * operations only resolve once the write has been flushed to disk. Defaults
+   * to `false`, which leaves the browser default in place (`relaxed` in
+   * Chromium 121+).
+   */
+  strictDurability?: boolean;
+};
+
 /**
  * Store for managing IndexedDB operations in an objectStore named `store`.
- * Used for storing backups of the critical parts of the extension state.
+ * Backs both the critical-state backup (`metamask-backup`) and the general
+ * StorageService database.
  */
 export class IndexedDBStore {
   #db: IDBDatabase | null = null;
+
+  readonly #strictDurability: boolean;
+
+  /**
+   * @param options - Store options.
+   * @param options.strictDurability - Whether writes should wait for the data
+   * to be flushed to disk before resolving. Off by default.
+   */
+  constructor({ strictDurability = false }: IndexedDBStoreOptions = {}) {
+    this.#strictDurability = strictDurability;
+  }
+
+  /**
+   * Opens a readwrite transaction on the `store` object store.
+   *
+   * When this store was constructed with `strictDurability`, the transaction
+   * requests `durability: 'strict'` so that the commit waits for the write to
+   * reach disk. Every browser version this extension supports implements the
+   * `durability` option (Chrome 83+, Firefox 126+, Safari 15+; see
+   * https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/durability#browser_compatibility),
+   * and per WebIDL an engine that did not would ignore the unknown option
+   * rather than throw — the dictionary conversion algorithm only reads
+   * declared members (see
+   * https://webidl.spec.whatwg.org/#es-dictionary), so no fallback branch
+   * is needed.
+   *
+   * @returns A readwrite IndexedDB transaction on the `store` object store.
+   */
+  #readWriteTransaction(): IDBTransaction {
+    if (!this.#db) {
+      throw new Error('Database is not open');
+    }
+    if (!this.#strictDurability) {
+      return this.#db.transaction('store', 'readwrite');
+    }
+    return this.#db.transaction('store', 'readwrite', {
+      durability: 'strict',
+    });
+  }
 
   /**
    * Opens the database, running migrations if necessary.
@@ -43,6 +107,18 @@ export class IndexedDBStore {
       request.onerror = () => {
         reject(request.error);
       };
+      // Fires when this version-change request is blocked by another open
+      // connection to the same database. Without this handler the promise
+      // hangs silently until the other connection closes.
+      // See https://developer.mozilla.org/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event
+      request.onblocked = () => {
+        reject(
+          new DOMException(
+            `IndexedDB open "${name}" blocked by another connection`,
+            'AbortError',
+          ),
+        );
+      };
     });
   }
 
@@ -52,11 +128,8 @@ export class IndexedDBStore {
    * @param values - An object containing key-value pairs to set.
    */
   async set(values: Record<string, unknown>): Promise<void> {
-    if (!this.#db) {
-      throw new Error('Database is not open');
-    }
     const keys = Object.keys(values);
-    const tx = this.#db.transaction('store', 'readwrite');
+    const tx = this.#readWriteTransaction();
     const store = tx.objectStore('store');
     for (const key of keys) {
       store.put(values[key], key);
@@ -113,10 +186,7 @@ export class IndexedDBStore {
   }
 
   async remove(keys: string[]): Promise<void> {
-    if (!this.#db) {
-      throw new Error('Database is not open');
-    }
-    const tx = this.#db.transaction('store', 'readwrite');
+    const tx = this.#readWriteTransaction();
     const store = tx.objectStore('store');
     for (const key of keys) {
       store.delete(key);
@@ -128,10 +198,7 @@ export class IndexedDBStore {
    * Resets the database by clearing all data in the 'store' object store.
    */
   async reset(): Promise<void> {
-    if (!this.#db) {
-      throw new Error('Database is not open');
-    }
-    const tx = this.#db.transaction('store', 'readwrite');
+    const tx = this.#readWriteTransaction();
     const store = tx.objectStore('store');
     store.clear();
     await transactionPromise(tx);

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -735,6 +735,32 @@ describe('PersistenceManager', () => {
     });
   });
 
+  describe('backup durability', () => {
+    it('requests strict durability for backup writes', async () => {
+      await manager.open();
+      manager.storageKind = 'data';
+      manager.setMetadata({ version: 10 });
+      mockStoreSet.mockResolvedValueOnce(undefined);
+
+      // Spy after `open()` so only the backup write itself is captured.
+      const transactionSpy = jest.spyOn(IDBDatabase.prototype, 'transaction');
+
+      const [result] = await manager.set({
+        KeyringController: {
+          vault: 'encrypted-vault',
+        },
+      } as unknown as MetaMaskStateType);
+
+      expect(result).toBe(true);
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(transactionSpy.mock.calls[0]).toStrictEqual([
+        'store',
+        'readwrite',
+        { durability: 'strict' },
+      ]);
+    });
+  });
+
   describe('persist', () => {
     it('throws if storageKind is not split', async () => {
       manager.storageKind = 'data';

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -444,7 +444,12 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
 
   async #openBackupDatabase(): Promise<void> {
     try {
-      const db = new IndexedDBStore();
+      // The backup is the recovery path for a corrupted vault, so its writes
+      // request strict durability: they must reach disk before resolving, even
+      // if the browser or the machine goes down immediately afterwards. The
+      // cost is negligible here because the write is skipped unless the
+      // serialized backup actually changed.
+      const db = new IndexedDBStore({ strictDurability: true });
       await db.open('metamask-backup', 1);
       this.#backupDb = db;
     } catch (error) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`IndexedDBStore` opened its `set`, `remove` and `reset` transactions in `readwrite` mode without a durability option, so the critical-state backup relied on the browser default — `relaxed` in Chromium 121+, which resolves the commit before the write is actually flushed to disk. A crash or power loss right after a backup write could therefore leave the `metamask-backup` database without the vault it was supposed to protect.

This PR makes strict durability an opt-in per store instance and enables it for the
two writes that need it:

- **`IndexedDBStore` gains a `strictDurability` constructor option.** When set, its `readwrite` transactions request `durability: 'strict'`, so the commit waits for the write to reach disk. It defaults to `false`, leaving the browser default in
  place. Read-only transactions are unaffected.
- **`persistence-manager.ts` enables it for the `metamask-backup` database.** This is the critical-state backup the issue is about. The cost is negligible because the write is skipped unless the serialized backup actually changed.
- **Migration 223 enables it too.** That migration writes the StorageService entries into IndexedDB and then deletes the source data from `storage.local`, so the write has to be durable before the delete runs. It is a one-time write, so strict durability costs nothing there.
- **The StorageService adapter and the e2e fixture store keep the browser default.** `IndexedDBStorageAdapter` is the steady-state controller-storage write path (Snap source code, token-list caches, debounced `BaseDataService` cache persistence); forcing an fsync on every one of those commits would undo the performance win Chromium got by defaulting to `relaxed`, and none of those writes are on the vault-recovery path.

**On the unsupported-browser fallback.** The `durability` option is supported in Chrome 83+ and Firefox 126+ ([MDN compat table](https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/durability#browser_compatibility)),
while the extension's manifests require Chrome ≥123 (`app/manifest/v{2,3}/chrome.json`) and Firefox ≥128
(`app/manifest/v{2,3}/firefox.json`), so every supported browser implements it. An engine that did not would ignore the extra argument rather than throw, because the WebIDL dictionary conversion algorithm only reads declared members ([spec §3.2.17](https://webidl.spec.whatwg.org/#es-dictionary)). No fallback branch
is therefore needed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/44741

## **Manual testing steps**

Behavior is unchanged apart from the durability request, so this is covered by unit tests rather than manual steps. To sanity-check the backup path in a build:

1. Build and load the extension, then complete onboarding so a vault exists.
2. Open the service worker devtools console and run
   `indexedDB.databases()` — confirm `metamask-backup` is present.
3. In Application → IndexedDB → `metamask-backup` → `store`, confirm the
   `KeyringController` entry holds the encrypted vault.
4. Change something that alters the backed-up state (e.g. add an account) and
   confirm the `metamask-backup` entry updates.
5. Optionally exercise vault recovery via
   `test/e2e/tests/vault-corruption/vault-corruption.spec.ts`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)