### PR TITLE
fix: normalize activity asset ids for swap history

### DIFF
--- a/ui/pages/activity/helpers.test.ts
+++ b/ui/pages/activity/helpers.test.ts
@@ -132,6 +132,7 @@ describe('activityMatchesAssetId', () => {
       type: 'receive',
       data: {
         from: '0x1',
+        to: '0x2',
         token: {
           assetId: 'eip155:5042/slip44:5042',
           direction: 'in',

--- a/ui/pages/activity/helpers.test.ts
+++ b/ui/pages/activity/helpers.test.ts
@@ -1,5 +1,6 @@
 import type { ActivityListItem } from '../../../shared/lib/activity/types';
 import {
+  activityMatchesAssetId,
   dedupeItems,
   getActivityItemIdentifier,
   getItemKey,
@@ -77,6 +78,73 @@ describe('getActivityItemIdentifier', () => {
     });
 
     expect(getActivityItemIdentifier(rampSell)).toBeUndefined();
+  });
+});
+
+describe('activityMatchesAssetId', () => {
+  it('matches equivalent EVM token asset ids with token and erc20 namespaces', () => {
+    const tokenAddress = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+    const item = makeItem({
+      timestamp: 1,
+      status: 'success',
+      type: 'swap',
+      data: {
+        from: '0x1',
+        sourceToken: {
+          assetId: `eip155:8453/token:${tokenAddress}`,
+          direction: 'out',
+        },
+      },
+    });
+
+    expect(
+      activityMatchesAssetId(
+        item,
+        `eip155:8453/erc20:${tokenAddress}` as never,
+      ),
+    ).toBe(true);
+  });
+
+  it('matches Arc ERC20 USDC wrapper activity on the Arc native USDC asset page', () => {
+    const item = makeItem({
+      timestamp: 1,
+      status: 'success',
+      type: 'swap',
+      data: {
+        from: '0x1',
+        destinationToken: {
+          assetId:
+            'eip155:5042/erc20:0x3600000000000000000000000000000000000000',
+          direction: 'in',
+        },
+      },
+    });
+
+    expect(
+      activityMatchesAssetId(item, 'eip155:5042/slip44:5042' as never),
+    ).toBe(true);
+  });
+
+  it('matches Arc native USDC activity on the Arc ERC20 USDC wrapper route', () => {
+    const item = makeItem({
+      timestamp: 1,
+      status: 'success',
+      type: 'receive',
+      data: {
+        from: '0x1',
+        token: {
+          assetId: 'eip155:5042/slip44:5042',
+          direction: 'in',
+        },
+      },
+    });
+
+    expect(
+      activityMatchesAssetId(
+        item,
+        'eip155:5042/erc20:0x3600000000000000000000000000000000000000' as never,
+      ),
+    ).toBe(true);
   });
 });
 

--- a/ui/pages/activity/helpers.ts
+++ b/ui/pages/activity/helpers.ts
@@ -6,6 +6,8 @@ import {
 import type { CaipAssetType } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import type { ActivityListItem } from '../../../shared/lib/activity/types';
+import { ARC_USDC_TOKEN_ADDRESS } from '../../../shared/constants/network';
+import { toAssetId } from '../../../shared/lib/asset-utils';
 import { isEqualCaseInsensitive } from '../../../shared/lib/string-utils';
 import { selectLocalTransactionsByHash } from '../../selectors/activity';
 import {
@@ -15,16 +17,72 @@ import {
 } from '../../components/app/transaction-status-label';
 import type { TransactionGroup } from '../../../shared/lib/multichain/types';
 import type { LocalActivityListItem } from './types';
+import { ARC_NATIVE_CAIP_CHAIN_ID } from '../../../ui/components/app/assets/enablement/arc';
 
 export type ActivityListFilter =
   | { assetId: CaipAssetType }
   | { networks: string[] };
 
+const ARC_NATIVE_USDC_ASSET_ID =
+  `${ARC_NATIVE_CAIP_CHAIN_ID}/slip44:5042` as CaipAssetType;
+const ARC_ERC20_USDC_ASSET_ID = toAssetId(
+  ARC_USDC_TOKEN_ADDRESS,
+  ARC_NATIVE_CAIP_CHAIN_ID,
+);
+
+/**
+ * Converts a CAIP asset ID to the canonical asset ID used by the asset system
+ * when possible.
+ *
+ * @param assetId - The CAIP asset ID to normalize.
+ * @returns The canonical asset ID, or the original asset ID when it cannot be normalized.
+ */
+function normalizeActivityAssetId(assetId: CaipAssetType) {
+  return toAssetId(assetId) ?? assetId;
+}
+
+/**
+ * Gets all activity asset IDs that should be considered equivalent to the
+ * given asset ID.
+ *
+ * Arc USDC can appear as the native token in wallet views and as the ERC20
+ * wrapper in swaps, so both IDs are included for either representation.
+ *
+ * @param assetId - The CAIP asset ID to resolve.
+ * @returns Equivalent asset IDs that should match the same activity rows.
+ */
+function getEquivalentActivityAssetIds(assetId: CaipAssetType) {
+  const normalizedAssetId = normalizeActivityAssetId(assetId);
+  const assetIds = [normalizedAssetId];
+
+  if (
+    ARC_ERC20_USDC_ASSET_ID &&
+    (isEqualCaseInsensitive(normalizedAssetId, ARC_NATIVE_USDC_ASSET_ID) ||
+      isEqualCaseInsensitive(normalizedAssetId, ARC_ERC20_USDC_ASSET_ID))
+  ) {
+    assetIds.push(ARC_NATIVE_USDC_ASSET_ID, ARC_ERC20_USDC_ASSET_ID);
+  }
+
+  return assetIds;
+}
+
+/**
+ * Checks whether an activity item belongs on a token details page for the
+ * given asset ID.
+ *
+ * The check compares the activity token, source token, and destination token,
+ * including equivalent asset IDs such as Arc native USDC and its ERC20 wrapper.
+ *
+ * @param item - The activity item to check.
+ * @param assetId - The token details page asset ID.
+ * @returns Whether the activity item references the given asset.
+ */
 export function activityMatchesAssetId(
   item: ActivityListItem,
   assetId: CaipAssetType,
 ) {
   const { data } = item;
+  const equivalentAssetIds = getEquivalentActivityAssetIds(assetId);
   const tokenAssetIds = [
     'token' in data ? data.token?.assetId : undefined,
     'sourceToken' in data ? data.sourceToken?.assetId : undefined,
@@ -33,7 +91,12 @@ export function activityMatchesAssetId(
 
   return tokenAssetIds.some(
     (tokenAssetId) =>
-      tokenAssetId && isEqualCaseInsensitive(tokenAssetId, assetId),
+      tokenAssetId &&
+      getEquivalentActivityAssetIds(tokenAssetId).some((equivalentAssetId) =>
+        equivalentAssetIds.some((filterAssetId) =>
+          isEqualCaseInsensitive(equivalentAssetId, filterAssetId),
+        ),
+      ),
   );
 }
 

--- a/ui/pages/activity/helpers.ts
+++ b/ui/pages/activity/helpers.ts
@@ -16,8 +16,8 @@ import {
   SIGNING_PSUEDO_STATUS,
 } from '../../components/app/transaction-status-label';
 import type { TransactionGroup } from '../../../shared/lib/multichain/types';
+import { ARC_NATIVE_CAIP_CHAIN_ID } from '../../components/app/assets/enablement/arc';
 import type { LocalActivityListItem } from './types';
-import { ARC_NATIVE_CAIP_CHAIN_ID } from '../../../ui/components/app/assets/enablement/arc';
 
 export type ActivityListFilter =
   | { assetId: CaipAssetType }

--- a/ui/pages/activity/helpers.ts
+++ b/ui/pages/activity/helpers.ts
@@ -3,7 +3,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-import type { CaipAssetType } from '@metamask/utils';
+import { isCaipAssetType, type CaipAssetType } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import type { ActivityListItem } from '../../../shared/lib/activity/types';
 import { ARC_USDC_TOKEN_ADDRESS } from '../../../shared/constants/network';
@@ -92,6 +92,7 @@ export function activityMatchesAssetId(
   return tokenAssetIds.some(
     (tokenAssetId) =>
       tokenAssetId &&
+      isCaipAssetType(tokenAssetId) &&
       getEquivalentActivityAssetIds(tokenAssetId).some((equivalentAssetId) =>
         equivalentAssetIds.some((filterAssetId) =>
           isEqualCaseInsensitive(equivalentAssetId, filterAssetId),

--- a/ui/selectors/activity.test.ts
+++ b/ui/selectors/activity.test.ts
@@ -9,12 +9,14 @@ import {
   type TransactionMeta,
 } from '@metamask/transaction-controller';
 import { MultichainNetworks } from '../../shared/constants/multichain/networks';
+import { toAssetId } from '../../shared/lib/asset-utils';
 import type { MetaMaskReduxState } from '../store/store';
 import { generateTokenCacheKey } from '../helpers/utils/token-scan';
 import mockState from '../../test/data/mock-state.json';
 import { MOCK_ACCOUNT_SOLANA_MAINNET } from '../../test/data/mock-accounts';
 import type { MultichainAccountsState } from './multichain-accounts/account-tree.types';
 import {
+  selectLocalActivityItems,
   selectLocalTransactions,
   selectNonEvmActivityItems,
   selectNonEvmTransactionsForActivity,
@@ -253,6 +255,87 @@ describe('selectNonEvmActivityItems', () => {
       token: {
         symbol: 'USDC',
         direction: 'out',
+      },
+    });
+  });
+});
+
+describe('selectLocalActivityItems', () => {
+  const selectedAddress =
+    typedMockState.metamask.internalAccounts.accounts[
+      typedMockState.metamask.internalAccounts.selectedAccount
+    ].address;
+  const eurcAddress = '0xbEf5f6d51CB62b58e6A8f77868681825C6fe21c1';
+  const usdcAddress = '0x3600000000000000000000000000000000000000';
+  const txHash =
+    '0x33e372dd70212a94910691d07b0acab26dcf1d7e919b8cf42638f025d5abffb9';
+
+  it('normalizes same-chain swap token asset ids from bridge history', () => {
+    const state = structuredClone(
+      typedMockState,
+    ) as unknown as MetaMaskReduxState & MultichainAccountsState;
+
+    state.metamask.transactions = [
+      {
+        id: 'swap-tx',
+        chainId: '0x2105',
+        networkClientId: 'base',
+        status: EvmTransactionStatus.confirmed,
+        time: 1,
+        hash: txHash,
+        type: EvmTransactionType.swap,
+        txParams: {
+          from: selectedAddress,
+          to: '0xrouter',
+          nonce: '0x1',
+          value: '0x0',
+        },
+      } as TransactionMeta,
+    ];
+    (
+      state.metamask as MetaMaskReduxState['metamask'] & {
+        txHistory: Record<string, BridgeHistoryItem>;
+      }
+    ).txHistory = {
+      'swap-tx': {
+        quote: {
+          srcChainId: 8453,
+          destChainId: 8453,
+          srcTokenAmount: '1000000',
+          destTokenAmount: '999000',
+          srcAsset: {
+            address: eurcAddress,
+            chainId: 8453,
+            symbol: 'EURC',
+            assetId: `eip155:8453/token:${eurcAddress}`,
+            decimals: 6,
+          },
+          destAsset: {
+            address: usdcAddress,
+            chainId: 8453,
+            symbol: 'USDC',
+            assetId: `eip155:8453/token:${usdcAddress}`,
+            decimals: 6,
+          },
+        },
+        status: {
+          status: StatusTypes.COMPLETE,
+          srcChain: { txHash },
+          destChain: { amount: '999000' },
+        },
+        startTime: 1,
+      } as unknown as BridgeHistoryItem,
+    };
+
+    const [activity] = selectLocalActivityItems(state);
+
+    expect(activity.type).toBe('swap');
+    expect(activity.data).toMatchObject({
+      sourceToken: {
+        assetId: toAssetId(eurcAddress, 'eip155:8453'),
+      },
+      destinationToken: {
+        assetId: toAssetId(usdcAddress, 'eip155:8453'),
       },
     });
   });

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -12,7 +12,14 @@ import {
   isEvmAccountType,
   type Transaction as KeyringTransaction,
 } from '@metamask/keyring-api';
-import { KnownCaipNamespace, toCaipChainId } from '@metamask/utils';
+import {
+  KnownCaipNamespace,
+  isCaipAssetType,
+  parseCaipAssetType,
+  toCaipChainId,
+  type CaipAssetType,
+  type CaipChainId,
+} from '@metamask/utils';
 import {
   mapKeyringTransaction,
   mapLocalTransaction,
@@ -30,7 +37,7 @@ import { NATIVE_TOKEN_ADDRESS } from '../../shared/constants/transaction';
 import type { MetaMaskReduxState } from '../store/store';
 import { getNetworkConfigurationsByChainId } from '../../shared/lib/selectors/networks';
 import { getTokensControllerAllTokens } from '../../shared/lib/selectors/assets-migration';
-import { toAssetId } from '../../shared/lib/asset-utils';
+import { isEvmChainId, toAssetId } from '../../shared/lib/asset-utils';
 import { getLocalTransactionFees } from '../../shared/lib/activity/adapters/helpers';
 import {
   getMoneyAccountTransactionType,
@@ -426,6 +433,40 @@ function patchUnit(
   };
 }
 
+/**
+ * Resolves a bridge quote asset to the canonical activity asset ID.
+ *
+ * EVM quote assets are rebuilt from their address and chain ID so persisted
+ * `token:` asset IDs match the wallet's `erc20:` asset IDs. Non-EVM asset IDs
+ * are preserved as provided by bridge history.
+ *
+ * @param asset - The source or destination asset from bridge history.
+ * @returns The canonical asset ID, or the persisted bridge asset ID as a fallback.
+ */
+function getBridgeAssetId(asset: BridgeHistoryItem['quote']['srcAsset']) {
+  if (isCaipAssetType(asset.assetId)) {
+    const { chainId } = parseCaipAssetType(asset.assetId);
+
+    if (!isEvmChainId(chainId)) {
+      return asset.assetId;
+    }
+  }
+
+  if (!asset.address || asset.chainId === undefined) {
+    return asset.assetId as CaipAssetType | undefined;
+  }
+
+  const caipChainId = toCaipChainId(
+    KnownCaipNamespace.Eip155,
+    asset.chainId.toString(),
+  ) as CaipChainId;
+
+  return (
+    toAssetId(asset.address, caipChainId) ??
+    (asset.assetId as CaipAssetType | undefined)
+  );
+}
+
 function getSwapTokens(bridgeHistoryItem?: BridgeHistoryItem) {
   if (bridgeHistoryItem === undefined) {
     return undefined;
@@ -436,14 +477,14 @@ function getSwapTokens(bridgeHistoryItem?: BridgeHistoryItem) {
   return {
     sourceToken: {
       amount: quote.srcTokenAmount,
-      assetId: quote.srcAsset.assetId,
+      assetId: getBridgeAssetId(quote.srcAsset),
       decimals: quote.srcAsset.decimals,
       direction: 'out' as const,
       symbol: quote.srcAsset.symbol,
     },
     destinationToken: {
       amount: status.destChain?.amount ?? quote.destTokenAmount,
-      assetId: quote.destAsset.assetId,
+      assetId: getBridgeAssetId(quote.destAsset),
       decimals: quote.destAsset.decimals,
       direction: 'in' as const,
       symbol: quote.destAsset.symbol,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes missing swap activity on token details pages when activity items and wallet token routes use equivalent but differently formatted asset IDs.
Same-chain swap history can persist EVM assets with token: CAIP asset IDs, while the wallet asset system uses canonical erc20: IDs.
This caused swaps to be created correctly in activity, but filtered out from the related token activity view.
The PR normalizes EVM bridge-history asset IDs before mapping swap activity, and updates token activity filtering to compare equivalent asset IDs.
It also treats Arc native `USDC` and the Arc `ERC20 USDC wrapper` as equivalent, so Arc `USDC` swap activity appears whether the token page is opened through the native asset route or the wrapper asset route.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that caused some swap activity to be missing from token details activity list

## **Related issues**

Fixes: [WPN-2023](https://consensyssoftware.atlassian.net/browse/WPN-2023)

## **Manual testing steps**

1. Perform a USDC -> EURC Swap on Arc.
2. Open the Activity list and confirm the swap appears as expected.
3. Open the Arc USDC token details page.
4. Confirm the same swap appears in the token-specific activity list.
5. Open the Arc EURC token details page.
6. Confirm the same swap appears in the token-specific activity list.
7. Perform a EURC -> USDC Swap.
8. Open the Arc EURC token details page.
9. Confirm the same swap appears in the token-specific activity list.
10. Open the Arc USDC token details page.
11. Confirm the same swap appears in the token-specific activity list.
12. Perform a ETH -> USDC Swap on Arc.
13. Open the Activity list and confirm the swap appears as expected.
14. Open the Ethereum ETH details page.
15. Confirm the same swap appears in the token-specific activity list.
16. Open the Ethereum USDC token details page.
17. Confirm the same swap appears in the token-specific activity list.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes activity asset ID resolution and token-page filtering logic; scope is limited to activity display but incorrect equivalence could show wrong rows or still hide swaps.
> 
> **Overview**
> Fixes swap rows missing from **token details activity** when bridge history and wallet routes use different CAIP asset ID formats (e.g. `token:` vs `erc20:`).
> 
> **Swap mapping:** `getBridgeAssetId` rebuilds EVM bridge quote assets from address + chain so `selectLocalActivityItems` emits canonical `erc20:` IDs; non-EVM bridge assets are unchanged.
> 
> **Token page filter:** `activityMatchesAssetId` now compares **equivalent** asset IDs (normalization via `toAssetId`, plus Arc native USDC `slip44:5042` and the Arc ERC20 USDC wrapper). Tests cover helper matching and same-chain swap normalization from bridge history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cc9d7a0658622a2ffff618eba95dda788a139e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[WPN-2023]: https://consensyssoftware.atlassian.net/browse/WPN-2023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ