### PR TITLE
fix(confirmations): make From account selector keyboard accessible

### DIFF
--- a/ui/pages/confirmations/components/rows/from-account-row/from-account-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/from-account-row/from-account-row.test.tsx
@@ -144,6 +144,16 @@ describe('FromAccountRow', () => {
     );
   });
 
+  it('exposes the from account pill as an accessible button', () => {
+    const store = createStore();
+    renderWithProvider(<FromAccountRow />, store);
+
+    const accountSelector = screen.getByTestId('from-account-pill');
+
+    expect(accountSelector.tagName).toBe('BUTTON');
+    expect(accountSelector).toHaveAccessibleName('From Wallet 1 Account 1');
+  });
+
   it('does not render a divider by default', () => {
     const store = createStore();
     renderWithProvider(<FromAccountRow />, store);

--- a/ui/pages/confirmations/components/rows/from-account-row/from-account-row.tsx
+++ b/ui/pages/confirmations/components/rows/from-account-row/from-account-row.tsx
@@ -118,6 +118,7 @@ export function FromAccountRow({
   }
 
   const label = fromWalletName ? `${t('from')} ${fromWalletName}` : t('from');
+  const accountName = fromName ?? shortenAddress(from);
 
   return (
     <>
@@ -129,24 +130,30 @@ export function FromAccountRow({
         rowVariant={variant}
       >
         <Box
-          data-testid="from-account-pill"
-          onClick={openModal}
+          asChild
           alignItems={BoxAlignItems.Center}
           gap={1}
-          className="inline-flex cursor-pointer"
+          className="inline-flex min-w-0"
         >
-          <PreferredAvatar
-            address={toChecksumHexAddress(from)}
-            size={AvatarAccountSize.Xs}
-          />
-          <Text data-testid="from-account-name">
-            {fromName ?? shortenAddress(from)}
-          </Text>
-          <Icon
-            data-testid="from-account-arrow"
-            name={IconName.ArrowDown}
-            size={IconSize.Sm}
-          />
+          <button
+            type="button"
+            data-testid="from-account-pill"
+            onClick={openModal}
+            aria-label={`${label} ${accountName}`}
+            className="inline-flex min-w-0 cursor-pointer items-center border-0 bg-transparent p-0 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          >
+            <PreferredAvatar
+              address={toChecksumHexAddress(from)}
+              size={AvatarAccountSize.Xs}
+            />
+            <Text data-testid="from-account-name">{accountName}</Text>
+            <Icon
+              data-testid="from-account-arrow"
+              name={IconName.ArrowDown}
+              size={IconSize.Sm}
+              aria-hidden
+            />
+          </button>
         </Box>
       </ConfirmInfoAlertRow>
 


### PR DESCRIPTION
## **Description**

Make the transaction confirmation “From” account selector keyboard operable.

`FromAccountRow` currently opens the funding-account selection modal from a clickable `Box`. Because the element is not a native interactive control, it is not keyboard focusable or activatable.

This change follows the existing account-picker pattern used elsewhere in the confirmation UI:

- renders the selector as a native `<button>` through `Box asChild`
- provides an explicit accessible name
- marks the dropdown chevron as decorative
- adds visible keyboard focus styling
- adds regression coverage for the button semantics and accessible name

There is no intended visual or transaction-behavior change.

## **Changelog**

CHANGELOG entry: Fixed keyboard access to the funding-account selector in transaction confirmations

## **Related issues**

Fixes: #46208

## **Manual testing steps**

1. Open a transaction confirmation that allows the “From” account to be changed.
2. Navigate through the confirmation using Tab.
3. Verify that the displayed funding-account selector receives keyboard focus.
4. Press Enter and verify that the account-selection modal opens.
5. Close the modal and repeat using Space.
6. Verify that mouse interaction continues to open the same modal.
7. Verify that changing the funding account continues to behave as before.

## **Screenshots/Recordings**

### **Before**

Keyboard focus skips the “From” account selector.

### **After**

The “From” account selector is keyboard focusable and opens the existing account-selection modal with native button interaction.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.