### PR TITLE
refactor(perps): migrate order inputs to MMDS TextField

### DIFF
--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -11,19 +11,16 @@ import {
   ButtonIconSize,
   IconName,
   IconColor,
+  TextField,
+  TextFieldSize,
 } from '@metamask/design-system-react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import {
-  BorderRadius,
-  BackgroundColor,
-} from '../../../../../../helpers/constants/design-system';
 import { useFormatters } from '../../../../../../hooks/useFormatters';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { formatPositionSize } from '../../../../../../../shared/lib/perps-formatters';
 import { getPreferences } from '../../../../../../../shared/lib/selectors/preferences';
-import { TextField, TextFieldSize } from '../../../../../component-library';
 import { PerpsSlider } from '../../../perps-slider';
 import { getDisplaySymbol } from '../../../utils';
 import type { AmountInputProps } from '../../order-entry.types';
@@ -429,16 +426,13 @@ export const AmountInput = ({
         }
         onBlur={isUsdDenomination ? handleAmountBlur : handleTokenBlur}
         placeholder={isUsdDenomination ? usdPlaceholder : '0'}
-        borderRadius={BorderRadius.MD}
-        borderWidth={0}
-        backgroundColor={BackgroundColor.backgroundMuted}
-        className="w-full"
+        className="w-full rounded-lg border-0 bg-muted"
         data-testid="amount-input-field"
         autoFocus={autoFocus}
         inputRef={usdInputRef}
         inputProps={{
           inputMode: 'decimal',
-          style: { textAlign: 'right' },
+          className: 'text-right',
         }}
         startAccessory={
           <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
@@ -492,14 +486,11 @@ export const AmountInput = ({
             onChange={handlePercentInputChange}
             onFocus={handleNumericFocusSelectAll}
             onBlur={handlePercentInputBlur}
-            borderRadius={BorderRadius.MD}
-            borderWidth={0}
-            backgroundColor={BackgroundColor.backgroundMuted}
-            className="w-full"
+            className="w-full rounded-lg border-0 bg-muted"
             data-testid="balance-percent-input"
             inputProps={{
               inputMode: 'numeric',
-              style: { textAlign: 'right', paddingLeft: '8px' },
+              className: 'text-right pl-2',
             }}
             endAccessory={
               <Text

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -7,6 +7,8 @@ import {
   BoxJustifyContent,
   BoxAlignItems,
   FontWeight,
+  TextField,
+  TextFieldSize,
 } from '@metamask/design-system-react';
 import React, {
   useCallback,
@@ -21,13 +23,8 @@ import {
   PRICE_RANGES_UNIVERSAL,
 } from '../../../../../../../shared/lib/perps-formatters';
 
-import {
-  BorderRadius,
-  BackgroundColor,
-} from '../../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { usePerpsOrderFees } from '../../../../../../hooks/perps/usePerpsOrderFees';
-import { TextField, TextFieldSize } from '../../../../../component-library';
 import ToggleButton from '../../../../../ui/toggle-button';
 import type { AutoCloseSectionProps } from '../../order-entry.types';
 import { isUnsignedDecimalInput } from '../../utils';
@@ -500,10 +497,7 @@ export const AutoCloseSection = ({
                   onChange={handleTpPriceChange}
                   onBlur={handleTpPriceBlur}
                   placeholder="0.00"
-                  borderRadius={BorderRadius.MD}
-                  borderWidth={0}
-                  backgroundColor={BackgroundColor.backgroundMuted}
-                  className="w-full"
+                  className="w-full rounded-lg border-0 bg-muted"
                   data-testid="tp-price-input"
                   inputProps={{
                     inputMode: 'decimal',
@@ -528,10 +522,7 @@ export const AutoCloseSection = ({
                   onFocus={handleTpPercentFocus}
                   onBlur={handleTpPercentBlur}
                   placeholder="0"
-                  borderRadius={BorderRadius.MD}
-                  borderWidth={0}
-                  backgroundColor={BackgroundColor.backgroundMuted}
-                  className="w-full"
+                  className="w-full rounded-lg border-0 bg-muted"
                   data-testid="tp-percent-input"
                   inputProps={{
                     inputMode: 'decimal',
@@ -632,10 +623,7 @@ export const AutoCloseSection = ({
                   onChange={handleSlPriceChange}
                   onBlur={handleSlPriceBlur}
                   placeholder="0.00"
-                  borderRadius={BorderRadius.MD}
-                  borderWidth={0}
-                  backgroundColor={BackgroundColor.backgroundMuted}
-                  className="w-full"
+                  className="w-full rounded-lg border-0 bg-muted"
                   data-testid="sl-price-input"
                   inputProps={{
                     inputMode: 'decimal',
@@ -660,10 +648,7 @@ export const AutoCloseSection = ({
                   onFocus={handleSlPercentFocus}
                   onBlur={handleSlPercentBlur}
                   placeholder="0"
-                  borderRadius={BorderRadius.MD}
-                  borderWidth={0}
-                  backgroundColor={BackgroundColor.backgroundMuted}
-                  className="w-full"
+                  className="w-full rounded-lg border-0 bg-muted"
                   data-testid="sl-percent-input"
                   inputProps={{
                     inputMode: 'decimal',

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -7,8 +7,6 @@ import {
   BoxJustifyContent,
   BoxAlignItems,
   FontWeight,
-  TextField,
-  TextFieldSize,
 } from '@metamask/design-system-react';
 import React, {
   useCallback,
@@ -23,8 +21,13 @@ import {
   PRICE_RANGES_UNIVERSAL,
 } from '../../../../../../../shared/lib/perps-formatters';
 
+import {
+  BorderRadius,
+  BackgroundColor,
+} from '../../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { usePerpsOrderFees } from '../../../../../../hooks/perps/usePerpsOrderFees';
+import { TextField, TextFieldSize } from '../../../../../component-library';
 import ToggleButton from '../../../../../ui/toggle-button';
 import type { AutoCloseSectionProps } from '../../order-entry.types';
 import { isUnsignedDecimalInput } from '../../utils';
@@ -497,7 +500,10 @@ export const AutoCloseSection = ({
                   onChange={handleTpPriceChange}
                   onBlur={handleTpPriceBlur}
                   placeholder="0.00"
-                  className="w-full rounded-lg border-0 bg-muted"
+                  borderRadius={BorderRadius.MD}
+                  borderWidth={0}
+                  backgroundColor={BackgroundColor.backgroundMuted}
+                  className="w-full"
                   data-testid="tp-price-input"
                   inputProps={{
                     inputMode: 'decimal',
@@ -522,7 +528,10 @@ export const AutoCloseSection = ({
                   onFocus={handleTpPercentFocus}
                   onBlur={handleTpPercentBlur}
                   placeholder="0"
-                  className="w-full rounded-lg border-0 bg-muted"
+                  borderRadius={BorderRadius.MD}
+                  borderWidth={0}
+                  backgroundColor={BackgroundColor.backgroundMuted}
+                  className="w-full"
                   data-testid="tp-percent-input"
                   inputProps={{
                     inputMode: 'decimal',
@@ -623,7 +632,10 @@ export const AutoCloseSection = ({
                   onChange={handleSlPriceChange}
                   onBlur={handleSlPriceBlur}
                   placeholder="0.00"
-                  className="w-full rounded-lg border-0 bg-muted"
+                  borderRadius={BorderRadius.MD}
+                  borderWidth={0}
+                  backgroundColor={BackgroundColor.backgroundMuted}
+                  className="w-full"
                   data-testid="sl-price-input"
                   inputProps={{
                     inputMode: 'decimal',
@@ -648,7 +660,10 @@ export const AutoCloseSection = ({
                   onFocus={handleSlPercentFocus}
                   onBlur={handleSlPercentBlur}
                   placeholder="0"
-                  className="w-full rounded-lg border-0 bg-muted"
+                  borderRadius={BorderRadius.MD}
+                  borderWidth={0}
+                  backgroundColor={BackgroundColor.backgroundMuted}
+                  className="w-full"
                   data-testid="sl-percent-input"
                   inputProps={{
                     inputMode: 'decimal',

--- a/ui/components/app/perps/order-entry/components/leverage-slider/leverage-slider.tsx
+++ b/ui/components/app/perps/order-entry/components/leverage-slider/leverage-slider.tsx
@@ -6,16 +6,13 @@ import {
   TextColor,
   BoxFlexDirection,
   BoxAlignItems,
+  TextField,
+  TextFieldSize,
 } from '@metamask/design-system-react';
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '../../../../../../../shared/constants/perps-events';
-import { TextField, TextFieldSize } from '../../../../../component-library';
-import {
-  BorderRadius,
-  BackgroundColor,
-} from '../../../../../../helpers/constants/design-system';
 import { PerpsSlider } from '../../../perps-slider';
 import { MetaMetricsEventName } from '../../../../../../../shared/constants/metametrics';
 import { usePerpsEventTracking } from '../../../../../../hooks/perps';
@@ -160,14 +157,11 @@ export const LeverageSlider = ({
             onChange={handleInputChange}
             onBlur={handleInputBlur}
             onFocus={handleInputFocus}
-            borderRadius={BorderRadius.MD}
-            borderWidth={0}
-            backgroundColor={BackgroundColor.backgroundMuted}
-            className="w-full"
+            className="w-full rounded-lg border-0 bg-muted"
             data-testid="leverage-input"
             inputProps={{
               inputMode: 'numeric',
-              style: { textAlign: 'right' },
+              className: 'text-right',
               onKeyDown: handleInputKeyDown,
             }}
             endAccessory={


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Migrates the visually verified Perps order-entry amount, balance percentage, and leverage inputs from the deprecated extension component-library `TextField` to the MMDS implementation. Legacy style props are replaced with Tailwind utilities while preserving the existing muted, borderless appearance and stable wrapper test identifiers.

Implementation follows the [MMDS TextField extension migration guide](https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#textfield-component).

Inputs that could not be rendered in this test instance were intentionally excluded from this PR.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Open MetaMask with a funded test wallet and select **Perps**.
2. Open a market and choose **Long** or **Short**.
3. Verify the amount and balance percentage fields render and accept numeric input.
4. Verify the leverage field renders and updates with the leverage slider.

## **Screenshots/Recordings**

### **Before**

[Perps order inputs before MMDS migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Fworkspace%2Ftest-artifacts%2Fscreenshots%2Ftextfield-perps-order-entry-before-1789006135558.png)

### **After**

[Perps order inputs after MMDS migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Ftmp%2Ftextfield-perps-verify%2Ftest-artifacts%2Fscreenshots%2Ftextfield-perps-order-entry-after-1789007105396.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63e66029-e417-482e-8ec0-6b7052b85fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

