### PR TITLE
refactor(onboarding): migrate IPFS input to MMDS TextField

### DIFF
--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
@@ -21,10 +21,10 @@ import {
   FontWeight,
   TextButton,
   TextAlign,
+  TextField,
 } from '@metamask/design-system-react';
 import { addUrlProtocolPrefix } from '../../../../shared/lib/url-utils';
 import { useOnboardingSearchParams } from '../hooks/useOnboardingSearchParams';
-import { TextField } from '../../../components/component-library';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -615,7 +615,7 @@ export default function PrivacySettings() {
                         <Box paddingTop={2}>
                           <TextField
                             value={ipfsURL}
-                            style={{ width: '100%' }}
+                            className="w-full"
                             inputProps={{ 'data-testid': 'ipfs-input' }}
                             onChange={(e) => {
                               handleIPFSChange(e.target.value);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Migrates the custom IPFS gateway input from the deprecated extension `TextField` to `TextField` from `@metamask/design-system-react`. Replaces the inline width style with Tailwind and preserves the input test ID.

This follows the [MMDS TextField extension migration guide](https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#textfield-component).

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Start the extension and proceed to onboarding privacy settings.
2. Open **Assets**.
3. Edit the custom IPFS gateway and verify validation and layout remain correct.

## **Screenshots/Recordings**

### **Before**

[Custom IPFS gateway before migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Fworkspace%2Ftest-artifacts%2Fscreenshots%2Ftextfield-onboarding-privacy-assets-before-1789006461442.png)

### **After**

[Custom IPFS gateway after migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Ftmp%2Ftextfield-perps-verify%2Ftest-artifacts%2Fscreenshots%2Ftextfield-onboarding-privacy-assets-after-1789007567284.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63e66029-e417-482e-8ec0-6b7052b85fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

