### PR TITLE
refactor(send): migrate inputs to MMDS TextField

### DIFF
--- a/ui/pages/confirmations/components/send/amount/amount.tsx
+++ b/ui/pages/confirmations/components/send/amount/amount.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { ERC721, ERC1155 } from '@metamask/controller-utils';
 
+import { TextField, TextFieldSize } from '@metamask/design-system-react';
 import {
   Box,
   ButtonIcon,
@@ -8,11 +9,8 @@ import {
   ButtonLink,
   IconName,
   Text,
-  TextField,
-  TextFieldSize,
 } from '../../../../../components/component-library';
 import {
-  BlockSize,
   Display,
   JustifyContent,
   TextColor,
@@ -159,12 +157,9 @@ export const Amount = ({
         {t('amount')}
       </Text>
       <TextField
-        error={Boolean(amountError)}
+        isError={Boolean(amountError)}
         onChange={onChange}
-        onPaste={setAmountInputMethodPasted}
-        onInput={setAmountInputMethodManual}
         placeholder="0"
-        testId="send-amount-input"
         value={amount}
         endAccessory={
           <Box display={Display.Flex}>
@@ -182,9 +177,13 @@ export const Amount = ({
             )}
           </Box>
         }
-        width={BlockSize.Full}
+        className="w-full"
         size={TextFieldSize.Lg}
-        paddingRight={3}
+        inputProps={{
+          'data-testid': 'send-amount-input',
+          onPaste: setAmountInputMethodPasted,
+          onInput: setAmountInputMethodManual,
+        }}
       />
       <Box
         display={Display.Flex}

--- a/ui/pages/confirmations/components/send/recipient-input/recipient-input.tsx
+++ b/ui/pages/confirmations/components/send/recipient-input/recipient-input.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useMemo } from 'react';
-import { AvatarAccountSize } from '@metamask/design-system-react';
+import {
+  AvatarAccountSize,
+  TextField,
+  TextFieldSize,
+} from '@metamask/design-system-react';
 
 import {
   Box,
@@ -7,12 +11,9 @@ import {
   ButtonIconSize,
   IconName,
   Text,
-  TextField,
-  TextFieldSize,
 } from '../../../../../components/component-library';
 import {
   AlignItems,
-  BlockSize,
   BorderColor,
   BorderRadius,
   Display,
@@ -152,9 +153,9 @@ export const RecipientInput = ({
         </Box>
       ) : (
         <TextField
-          error={isHardError}
+          isError={isHardError}
           // TODO: @MetaMask/design-system-engineers: This seems to be the only current use case for a TextField warning state; align on whether TextField should support warning styling (or if there’s a preferred DS pattern).
-          className={isWarning ? '!border-warning-default' : undefined}
+          className={isWarning ? 'w-full !border-warning-default' : 'w-full'}
           endAccessory={
             recipients.length > 0 ? (
               <ButtonIcon
@@ -168,12 +169,12 @@ export const RecipientInput = ({
           }
           onChange={onToChange}
           placeholder={t('recipientPlaceholderText')}
-          testId="recipient-address-input"
-          ref={recipientInputRef}
-          value={to}
-          width={BlockSize.Full}
+          inputRef={recipientInputRef}
+          value={to ?? ''}
           size={TextFieldSize.Lg}
-          paddingRight={3}
+          inputProps={{
+            'data-testid': 'recipient-address-input',
+          }}
         />
       )}
     </>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Migrates the send recipient and amount inputs from the deprecated extension `TextField` to `TextField` from `@metamask/design-system-react`. Legacy Box style props are replaced with Tailwind classes, native input handlers and test IDs are passed through `inputProps`, and the recipient ref now targets the input explicitly.

This follows the [MMDS TextField extension migration guide](https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#textfield-component).

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Unlock the extension and open the ETH send flow.
2. Enter and clear a recipient address; verify normal, warning, and error states remain correct.
3. Enter and paste an amount; verify the denomination toggle, Max action, and layout remain correct.

## **Screenshots/Recordings**

### **Before**

[Send recipient and amount fields before migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Fworkspace%2Ftest-artifacts%2Fscreenshots%2Ftextfield-confirmations-recipient-before-1789006079378.png)

### **After**

[Send recipient and amount fields after migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Ftmp%2Ftextfield-perps-verify%2Ftest-artifacts%2Fscreenshots%2Ftextfield-confirmations-recipient-after-1789007667782.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63e66029-e417-482e-8ec0-6b7052b85fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

