### PR TITLE
refactor(accounts): migrate recovery inputs to MMDS TextField

### DIFF
--- a/ui/components/app/srp-input-import/srp-input-import.scss
+++ b/ui/components/app/srp-input-import/srp-input-import.scss
@@ -23,24 +23,6 @@
 
   &__words-list {
     grid-template-columns: repeat(3, 1fr);
-    // SRP_OVERRIDE: custom text field style
-    .mm-text-field {
-      padding-inline-start: 8px;
-      border-radius: 8px;
-    }
-
-    .mm-text-field:not(.mm-text-field--error) {
-      border-color: var(--color-border-muted);
-    }
-    // SRP_OVERRIDE: custom text field style
-    .mm-text-field.mm-text-field--focused {
-      outline: 5px auto var(--color-primary-default);
-    }
-    // SRP_OVERRIDE: custom text field style
-    .mm-input {
-      padding-inline-end: 8px;
-      padding-inline-start: 4px;
-    }
   }
 
   &__word-index {
@@ -56,4 +38,3 @@
     height: 40px;
   }
 }
-

--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -15,9 +15,9 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
   BoxBackgroundColor,
+  TextField,
+  TextFieldType,
 } from '@metamask/design-system-react';
-import { TextField, TextFieldType } from '../../component-library';
-import { BackgroundColor } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   ENVIRONMENT_TYPE_SIDEPANEL,
@@ -365,17 +365,33 @@ export default function SrpInputImport({
                 {draftSrp.map((word, index) => {
                   return (
                     <TextField
+                      inputRef={(el) => {
+                        if (el) {
+                          srpRefs.current[word.id] = el;
+                        }
+                      }}
                       inputProps={{
-                        ref: (el) => {
-                          if (el) {
-                            srpRefs.current[word.id] = el;
+                        'data-testid': `import-srp__srp-word-${index}`,
+                        onKeyDown: (
+                          e: React.KeyboardEvent<HTMLInputElement>,
+                        ) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            if (word.word.trim() !== '') {
+                              nextWord(word.id);
+                            }
+                          } else if (
+                            e.key === 'Backspace' &&
+                            word.word.length === 0
+                          ) {
+                            e.preventDefault();
+                            deleteWord(word.id);
                           }
                         },
                       }}
-                      backgroundColor={BackgroundColor.backgroundMuted}
-                      testId={`import-srp__srp-word-${index}`}
+                      className="w-full bg-muted"
                       key={word.id}
-                      error={
+                      isError={
                         !word.active &&
                         misSpelledWordsList().includes(word.word)
                       }
@@ -397,20 +413,6 @@ export default function SrpInputImport({
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                         handleChange(word.id, e.target.value)
                       }
-                      onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          if (word.word.trim() !== '') {
-                            nextWord(word.id);
-                          }
-                        } else if (
-                          e.key === 'Backspace' &&
-                          word.word.length === 0
-                        ) {
-                          e.preventDefault();
-                          deleteWord(word.id);
-                        }
-                      }}
                       onFocus={() => {
                         onWordFocus(word.id);
                       }}

--- a/ui/pages/keychains/password-prompt.tsx
+++ b/ui/pages/keychains/password-prompt.tsx
@@ -6,16 +6,15 @@ import {
   ButtonIcon,
   IconName,
   IconColor,
-} from '@metamask/design-system-react';
-import {
-  Label,
   TextField,
   TextFieldSize,
   TextFieldType,
+} from '@metamask/design-system-react';
+import {
+  Label,
   HelpText,
   HelpTextSeverity,
 } from '../../components/component-library';
-import { BlockSize } from '../../helpers/constants/design-system';
 import { useI18nContext } from '../../hooks/useI18nContext';
 
 type PasswordPromptProps = {
@@ -60,8 +59,8 @@ export function PasswordPrompt({
           size={TextFieldSize.Lg}
           value={password}
           onChange={(event) => onPasswordChange(event.target.value)}
-          error={Boolean(error)}
-          width={BlockSize.Full}
+          isError={Boolean(error)}
+          className="w-full"
           endAccessory={
             <ButtonIcon
               type="button"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Migrates the reveal-recovery password and SRP import inputs from the deprecated extension `TextField` to `TextField` from `@metamask/design-system-react`. It replaces legacy SCSS overrides with MMDS defaults and Tailwind utilities, moves native handlers and test IDs to the inner input, and preserves keyboard navigation and password visibility behavior.

This follows the [MMDS TextField extension migration guide](https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#textfield-component).

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Unlock the extension, open account details, and choose to reveal the Secret Recovery Phrase.
2. Complete the security quiz and verify password entry, visibility toggle, invalid-password state, and submission remain correct.
3. Open **Add a wallet** and choose **Import a wallet**.
4. Enter a 12-word phrase and verify focus, Enter/Space navigation, deletion, validation, and masking remain correct.

## **Screenshots/Recordings**

### **Before**

[Recovery password field before migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Fworkspace%2Ftest-artifacts%2Fscreenshots%2Ftextfield-account-password-prompt-before-1789006621525.png)

[SRP import fields before migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Fworkspace%2Ftest-artifacts%2Fscreenshots%2Ftextfield-account-import-srp-words-before-1789006402693.png)

### **After**

[Recovery password field after migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Ftmp%2Ftextfield-perps-verify%2Ftest-artifacts%2Fscreenshots%2Ftextfield-account-password-prompt-after-1789007993788.png)

[SRP import fields after migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Ftmp%2Ftextfield-perps-verify%2Ftest-artifacts%2Fscreenshots%2Ftextfield-account-import-srp-words-after-1789008135410.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63e66029-e417-482e-8ec0-6b7052b85fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

