### PR TITLE
refactor(bridge): migrate amount inputs to MMDS TextField

### DIFF
--- a/ui/pages/bridge/__snapshots__/index.test.tsx.snap
+++ b/ui/pages/bridge/__snapshots__/index.test.tsx.snap
@@ -78,14 +78,11 @@ exports[`Bridge renders the component with initial props 1`] = `
               class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
             >
               <div
-                class="mm-box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--truncate amount-input mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
-                style="flex: 1; min-width: 0;"
+                class="items-center rounded-lg border bg-default transition-colors h-10 pl-0 pr-0 border-default amount-input flex min-w-0 flex-1"
               >
                 <input
-                  autocomplete="off"
-                  class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-text--text-align-start mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+                  class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-4 pr-4 truncate text-left"
                   data-testid="from-amount"
-                  focused="true"
                   placeholder="0"
                   style="font-weight: 400; font-size: 40px; transition: font-size 0.1s; padding: 0px;"
                   type="text"
@@ -190,15 +187,13 @@ exports[`Bridge renders the component with initial props 1`] = `
                 class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
               >
                 <div
-                  class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate amount-input mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
-                  style="flex: 1; min-width: 0; opacity: 1;"
+                  class="items-center rounded-lg border bg-default transition-colors h-10 pl-0 pr-0 cursor-not-allowed border-muted opacity-50 amount-input flex min-w-0 flex-1 amount-input"
+                  style="opacity: 1;"
                 >
                   <input
-                    autocomplete="off"
-                    class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-text--text-align-start mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+                    class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-4 pr-4 truncate text-left"
                     data-testid="to-amount"
                     disabled=""
-                    focused="false"
                     placeholder="0"
                     readonly=""
                     style="font-weight: 400; font-size: 40px; transition: font-size 0.1s; padding: 0px;"

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-transaction-settings-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-transaction-settings-modal.test.tsx.snap
@@ -105,13 +105,11 @@ exports[`BridgeTransactionSettingsModal should render the component, with initia
               </span>
             </button>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--truncate mm-box--padding-right-4 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted mm-box--border-width-1 box--border-style-solid"
+              class="inline-flex items-center border bg-default transition-colors h-10 pl-0 pr-4 border-default w-[94px] rounded-xl outline-none"
             >
               <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+                class="rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-4 pr-2 truncate w-full"
                 data-testid="bridge__tx-settings-modal-custom-input"
-                focused="true"
                 type="text"
                 value=""
               />

--- a/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
@@ -13,14 +13,11 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
         class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--truncate amount-input mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
-          style="flex: 1; min-width: 0;"
+          class="items-center rounded-lg border bg-default transition-colors h-10 pl-0 pr-0 border-default amount-input flex min-w-0 flex-1"
         >
           <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-text--text-align-start mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+            class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-4 pr-4 truncate text-left"
             data-testid="from-amount"
-            focused="true"
             placeholder="0"
             style="font-weight: 400; font-size: 40px; transition: font-size 0.1s; padding: 0px;"
             type="text"
@@ -125,15 +122,13 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
           class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
         >
           <div
-            class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate amount-input mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
-            style="flex: 1; min-width: 0; opacity: 1;"
+            class="items-center rounded-lg border bg-default transition-colors h-10 pl-0 pr-0 cursor-not-allowed border-muted opacity-50 amount-input flex min-w-0 flex-1 amount-input"
+            style="opacity: 1;"
           >
             <input
-              autocomplete="off"
-              class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-text--text-align-start mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+              class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-4 pr-4 truncate text-left"
               data-testid="to-amount"
               disabled=""
-              focused="false"
               placeholder="0"
               readonly=""
               style="font-weight: 400; font-size: 40px; transition: font-size 0.1s; padding: 0px;"
@@ -244,14 +239,11 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
         class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--truncate amount-input mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
-          style="flex: 1; min-width: 0;"
+          class="items-center rounded-lg border bg-default transition-colors h-10 pl-0 pr-0 border-default amount-input flex min-w-0 flex-1"
         >
           <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-text--text-align-start mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+            class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-4 pr-4 truncate text-left"
             data-testid="from-amount"
-            focused="true"
             placeholder="0"
             style="font-weight: 400; font-size: 40px; transition: font-size 0.1s; padding: 0px;"
             type="text"
@@ -356,15 +348,13 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
           class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
         >
           <div
-            class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate amount-input mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
-            style="flex: 1; min-width: 0; opacity: 1;"
+            class="items-center rounded-lg border bg-default transition-colors h-10 pl-0 pr-0 cursor-not-allowed border-muted opacity-50 amount-input flex min-w-0 flex-1 amount-input"
+            style="opacity: 1;"
           >
             <input
-              autocomplete="off"
-              class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-text--text-align-start mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+              class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-4 pr-4 truncate text-left"
               data-testid="to-amount"
               disabled=""
-              focused="false"
               placeholder="0"
               readonly=""
               style="font-weight: 400; font-size: 40px; transition: font-size 0.1s; padding: 0px;"

--- a/ui/pages/bridge/prepare/bridge-input-group.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.test.tsx
@@ -139,7 +139,7 @@ const InputGroup = ({
       token={getFromToken(mockState)}
       buttonProps={{ testId: ASSET_PICKER_BUTTON_TEST_ID }}
       amountFieldProps={{
-        testId: 'from-amount',
+        'data-testid': 'from-amount',
         autoFocus: true,
         value: '1',
       }}
@@ -310,7 +310,7 @@ describe('BridgeInputGroup', () => {
         <InputGroup
           mockState={mockState}
           amountFieldProps={{
-            testId: 'from-amount',
+            'data-testid': 'from-amount',
             autoFocus: true,
             value: '12',
           }}
@@ -340,11 +340,11 @@ describe('BridgeInputGroup', () => {
         isDestination: true,
         showAmountSkeleton: true,
         amountFieldProps: {
-          testId: 'to-amount',
+          'data-testid': 'to-amount',
           autoFocus: false,
           value: '0',
-          readOnly: true,
-          disabled: true,
+          isReadOnly: true,
+          isDisabled: true,
           className: 'amount-input',
         },
       },

--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -11,12 +11,10 @@ import {
 } from '@metamask/bridge-controller';
 import { getAccountLink } from '@metamask/etherscan-link';
 import { parseCaipAssetType } from '@metamask/utils';
-import { Skeleton } from '@metamask/design-system-react';
+import { Skeleton, TextField, twMerge } from '@metamask/design-system-react';
 import {
   IconName,
   Text,
-  TextField,
-  TextFieldType,
   ButtonLink,
 } from '../../../components/component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -95,9 +93,11 @@ export const BridgeInputGroup = ({
   onAmountChange?: (value: string) => void;
   token: BridgeToken;
   buttonProps: { testId: string };
-  amountFieldProps: Pick<
+  amountFieldProps: {
+    'data-testid': string;
+  } & Pick<
     React.ComponentProps<typeof TextField>,
-    'testId' | 'autoFocus' | 'value' | 'readOnly' | 'disabled' | 'className'
+    'autoFocus' | 'value' | 'isReadOnly' | 'isDisabled' | 'className'
   >;
   onMaxButtonClick?: (value: string) => void;
   onBlockExplorerClick?: (token: BridgeToken) => void;
@@ -138,8 +138,16 @@ export const BridgeInputGroup = ({
     : undefined;
   const balanceAmount = useSelector(getFromTokenBalance);
 
-  const isAmountReadOnly =
-    amountFieldProps?.readOnly || amountFieldProps?.disabled;
+  const {
+    'data-testid': amountTestId,
+    className: amountClassName,
+    isReadOnly,
+    isDisabled,
+    value: amountValue,
+    ...restAmountFieldProps
+  } = amountFieldProps;
+
+  const isAmountReadOnly = Boolean(isReadOnly || isDisabled);
   const shouldShowAmountSkeleton = Boolean(
     showAmountSkeleton && isAmountReadOnly,
   );
@@ -161,7 +169,7 @@ export const BridgeInputGroup = ({
   }, [locale, balanceAmount, token.symbol]);
 
   const inputFontSize = useMemo(() => {
-    const len = (amountFieldProps?.value ?? '').toString().length;
+    const len = (amountValue ?? '').toString().length;
     if (len <= 10) {
       return 40;
     }
@@ -175,14 +183,14 @@ export const BridgeInputGroup = ({
       return 25;
     }
     return 20;
-  }, [amountFieldProps?.value]);
+  }, [amountValue]);
 
   useEffect(() => {
     const hasAmountInputPrefixChanged =
       previousHasAmountInputPrefix.current !== hasAmountInputPrefix;
 
     if (!isAmountReadOnly && inputRef.current) {
-      inputRef.current.value = amountFieldProps?.value?.toString() ?? '';
+      inputRef.current.value = amountValue?.toString() ?? '';
       inputRef.current.focus();
       if (hasAmountInputPrefixChanged) {
         inputRef.current.setSelectionRange(
@@ -193,7 +201,7 @@ export const BridgeInputGroup = ({
     }
 
     previousHasAmountInputPrefix.current = hasAmountInputPrefix;
-  }, [amountFieldProps?.value, hasAmountInputPrefix, isAmountReadOnly, token]);
+  }, [amountValue, hasAmountInputPrefix, isAmountReadOnly, token]);
 
   useEffect(() => {
     return () => {
@@ -223,7 +231,7 @@ export const BridgeInputGroup = ({
           <Skeleton
             width={128}
             height={40}
-            data-testid={`${amountFieldProps.testId}-loading-skeleton`}
+            data-testid={`${amountTestId}-loading-skeleton`}
             style={{ flex: 1, minWidth: 0 }}
           />
         ) : (
@@ -243,8 +251,8 @@ export const BridgeInputGroup = ({
               ) : undefined
             }
             inputProps={{
-              disableStateStyles: true,
-              textAlign: TextAlign.Start,
+              'data-testid': amountTestId,
+              className: 'text-left',
               style: {
                 fontWeight: 400,
                 fontSize: inputFontSize,
@@ -253,23 +261,21 @@ export const BridgeInputGroup = ({
               },
             }}
             style={{
-              flex: 1,
-              minWidth: 0,
-              opacity:
-                isAmountReadOnly && amountFieldProps?.value ? 1 : undefined,
+              opacity: isAmountReadOnly && amountValue ? 1 : undefined,
             }}
-            display={Display.Flex}
+            className={twMerge(
+              'amount-input flex min-w-0 flex-1',
+              amountClassName,
+            )}
             inputRef={inputRef}
-            type={TextFieldType.Text}
-            className="amount-input"
+            isReadOnly={isReadOnly}
+            isDisabled={isDisabled}
+            value={amountValue?.toString() ?? ''}
             placeholder="0"
             onKeyPress={(e?: React.KeyboardEvent<HTMLDivElement>) => {
               if (e) {
                 // Only allow numbers and at most one decimal point
-                if (
-                  e.key === '.' &&
-                  amountFieldProps.value?.toString().includes('.')
-                ) {
+                if (e.key === '.' && amountValue?.toString().includes('.')) {
                   e.preventDefault();
                 } else if (!/^[\d.]{1}$/u.test(e.key)) {
                   e.preventDefault();
@@ -289,7 +295,7 @@ export const BridgeInputGroup = ({
               const cleanedValue = sanitizeAmountInput(e.target.value);
               onAmountChange?.(cleanedValue ?? '');
             }}
-            {...amountFieldProps}
+            {...restAmountFieldProps}
           />
         )}
         <SelectedAssetButton

--- a/ui/pages/bridge/prepare/bridge-transaction-settings-modal.tsx
+++ b/ui/pages/bridge/prepare/bridge-transaction-settings-modal.tsx
@@ -4,6 +4,7 @@ import {
   BannerAlert,
   BannerAlertSeverity,
   Box,
+  TextField,
 } from '@metamask/design-system-react';
 import {
   Button,
@@ -16,17 +17,12 @@ import {
   ModalOverlay,
   PopoverPosition,
   Text,
-  TextField,
-  TextFieldType,
-  TextFieldSize,
 } from '../../../components/component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   BlockSize,
-  BorderColor,
   JustifyContent,
   TextVariant,
-  BorderRadius,
 } from '../../../helpers/constants/design-system';
 import {
   getIsSolanaSwap,
@@ -221,11 +217,11 @@ export const BridgeTransactionSettingsModal = ({
             )}
             {showCustomInput && (
               <TextField
-                size={TextFieldSize.Md}
-                borderColor={BorderColor.borderMuted}
-                testId="bridge__tx-settings-modal-custom-input"
-                borderRadius={BorderRadius.XL}
-                type={TextFieldType.Text}
+                className="w-[94px] rounded-xl outline-none"
+                inputProps={{
+                  'data-testid': 'bridge__tx-settings-modal-custom-input',
+                  className: 'w-full',
+                }}
                 value={inputValue}
                 onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
                   handleCustomSlippage(e, e.clipboardData.getData('text'));

--- a/ui/pages/bridge/prepare/index.scss
+++ b/ui/pages/bridge/prepare/index.scss
@@ -4,16 +4,8 @@
   flex: 1;
   min-height: 100%;
 
-  .mm-text-field {
-    background-color: inherit;
-
-    &--focused {
-      outline: none;
-    }
-  }
-
   .defined {
-    & > .mm-input--disabled,
+    & > input:disabled,
     p {
       opacity: 1;
     }
@@ -134,19 +126,6 @@
   .mm-button-secondary {
     &:hover {
       background-color: var(--color-background-default-hover);
-    }
-  }
-
-  .mm-text-field {
-    width: 94px;
-
-    &--focused,
-    &:focus-visible {
-      outline: none;
-    }
-
-    input {
-      width: 100%;
     }
   }
 }

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -466,7 +466,7 @@ const PrepareBridgePage = ({
               : undefined
           }
           amountFieldProps={{
-            testId: 'from-amount',
+            'data-testid': 'from-amount',
             autoFocus: true,
             value: sourceInputAmount.amount,
           }}
@@ -606,9 +606,9 @@ const PrepareBridgePage = ({
               isDestinationFiatPrimary ? getCurrencySymbol(currency) : undefined
             }
             amountFieldProps={{
-              testId: 'to-amount',
-              readOnly: true,
-              disabled: true,
+              'data-testid': 'to-amount',
+              isReadOnly: true,
+              isDisabled: true,
               value: destinationAmount,
               autoFocus: false,
               className: destinationTokenAmount


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Migrates the bridge amount and custom slippage inputs from the deprecated extension `TextField` to `TextField` from `@metamask/design-system-react`. Legacy style props and SCSS overrides are replaced with Tailwind classes, MMDS boolean props, and native input test IDs while preserving dynamic amount sizing and filtering.

This follows the [MMDS TextField extension migration guide](https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/MIGRATION.md#textfield-component).

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Unlock the extension and open the Swap/Bridge page.
2. Enter a source amount and verify invalid characters are rejected and responsive font sizing remains correct.
3. Open transaction settings, choose custom slippage, and verify the field and validation remain correct.

## **Screenshots/Recordings**

### **Before**

[Bridge amount inputs before migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Fworkspace%2Ftest-artifacts%2Fscreenshots%2Ftextfield-bridge-amount-before-1789006262613.png)

[Bridge custom slippage before migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Fworkspace%2Ftest-artifacts%2Fscreenshots%2Ftextfield-bridge-settings-before-1789006279201.png)

### **After**

[Bridge amount inputs after migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Ftmp%2Ftextfield-perps-verify%2Ftest-artifacts%2Fscreenshots%2Ftextfield-bridge-amount-after-1789007730780.png)

[Bridge custom slippage after migration](https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6/artifacts?path=%2Ftmp%2Ftextfield-perps-verify%2Ftest-artifacts%2Fscreenshots%2Ftextfield-bridge-settings-after-1789007780786.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63e66029-e417-482e-8ec0-6b7052b85fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63e66029-e417-482e-8ec0-6b7052b85fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

