### PR TITLE
fix(confirmations): show one loader for money account deposit prefill

### DIFF
--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -114,6 +114,7 @@ const DEFAULT_CUSTOM_AMOUNT_HOOK_RETURN = {
   isDepositPrefillLoading: false,
   isDepositPrefilled: false,
   isInputChanged: false,
+  isQuoteDerivedAmountLoading: false,
   updatePendingAmount: jest.fn(),
   updatePendingAmountPercentage: jest.fn(),
 };
@@ -363,6 +364,18 @@ describe('CustomAmountInfo', () => {
 
     expect(getByTestId('custom-amount')).toHaveTextContent('123');
     expect(queryByTestId('custom-amount-skeleton')).not.toBeInTheDocument();
+  });
+
+  it('shows amount skeleton while the quote the amount comes from is loading', () => {
+    const { getByTestId, queryByTestId } = render({
+      customAmountHookReturn: {
+        ...DEFAULT_CUSTOM_AMOUNT_HOOK_RETURN,
+        isQuoteDerivedAmountLoading: true,
+      },
+    });
+
+    expect(getByTestId('custom-amount-skeleton')).toBeInTheDocument();
+    expect(queryByTestId('custom-amount')).not.toBeInTheDocument();
   });
 
   it('renders amount details under the amount input', () => {

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -169,6 +169,7 @@ export const CustomAmountInfo = React.memo(
       hasAmount,
       hasInput,
       isDepositPrefillLoading,
+      isQuoteDerivedAmountLoading,
       updatePendingAmount,
       updatePendingAmountPercentage,
     } = useTransactionCustomAmount({
@@ -196,8 +197,11 @@ export const CustomAmountInfo = React.memo(
     );
 
     // Show amount skeleton while deposit prefill recomputes (e.g. token or
-    // account change) so the field does not briefly flash "0".
-    const showAmountLoader = isDepositPrefillLoading && !hasAccountNoFunds;
+    // account change) so the field does not briefly flash "0", and while a
+    // quote the displayed amount comes from is still loading.
+    const showAmountLoader =
+      (isDepositPrefillLoading && !hasAccountNoFunds) ||
+      isQuoteDerivedAmountLoading;
 
     if (!currentConfirmation || isAwaitingRequiredToken) {
       return (

--- a/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
+++ b/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
@@ -148,6 +148,7 @@ function setupDefaultMocks({
       isDepositPrefillLoading: false,
       isDepositPrefilled: false,
       isInputChanged: false,
+      isQuoteDerivedAmountLoading: false,
       updatePendingAmount: jest.fn(),
       updatePendingAmountPercentage: jest.fn(),
     });

--- a/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
+++ b/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
@@ -3,18 +3,7 @@ import { screen } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
-import {
-  useIsTransactionPayLoading,
-  useTransactionPayIsMaxAmount,
-} from '../../../hooks/pay/useTransactionPayData';
 import { CustomAmount, CustomAmountSkeleton } from './custom-amount';
-
-jest.mock('../../../hooks/pay/useTransactionPayData');
-
-const mockUseTransactionPayIsMaxAmount = jest.mocked(
-  useTransactionPayIsMaxAmount,
-);
-const mockUseIsTransactionPayLoading = jest.mocked(useIsTransactionPayLoading);
 
 const mockStore = configureStore([thunk]);
 
@@ -27,8 +16,6 @@ const getMockState = (currentCurrency = 'usd') => ({
 describe('CustomAmount', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockUseTransactionPayIsMaxAmount.mockReturnValue(false);
-    mockUseIsTransactionPayLoading.mockReturnValue(false);
   });
 
   it('renders amount', () => {
@@ -64,39 +51,6 @@ describe('CustomAmount', () => {
     renderWithProvider(<CustomAmount amountFiat="123.45" isLoading />, store);
 
     expect(screen.getByTestId('custom-amount-skeleton')).toBeInTheDocument();
-  });
-
-  it('renders skeleton when max amount and quotes are loading', () => {
-    mockUseTransactionPayIsMaxAmount.mockReturnValue(true);
-    mockUseIsTransactionPayLoading.mockReturnValue(true);
-
-    const store = mockStore(getMockState());
-
-    renderWithProvider(<CustomAmount amountFiat="123.45" />, store);
-
-    expect(screen.getByTestId('custom-amount-skeleton')).toBeInTheDocument();
-  });
-
-  it('renders amount when max amount but quotes are not loading', () => {
-    mockUseTransactionPayIsMaxAmount.mockReturnValue(true);
-    mockUseIsTransactionPayLoading.mockReturnValue(false);
-
-    const store = mockStore(getMockState());
-
-    renderWithProvider(<CustomAmount amountFiat="123.45" />, store);
-
-    expect(screen.getByTestId('custom-amount-input')).toHaveValue('123.45');
-  });
-
-  it('renders amount when quotes are loading but not max amount', () => {
-    mockUseTransactionPayIsMaxAmount.mockReturnValue(false);
-    mockUseIsTransactionPayLoading.mockReturnValue(true);
-
-    const store = mockStore(getMockState());
-
-    renderWithProvider(<CustomAmount amountFiat="123.45" />, store);
-
-    expect(screen.getByTestId('custom-amount-input')).toHaveValue('123.45');
   });
 
   it('renders with error color when hasAlert is true', () => {

--- a/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.tsx
+++ b/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.tsx
@@ -13,10 +13,6 @@ import {
 import { Box, Text } from '../../../../../components/component-library';
 import { getCurrencySymbol } from '../../../../../helpers/utils/common.util';
 import { getCurrentCurrency } from '../../../../../ducks/metamask/metamask';
-import {
-  useIsTransactionPayLoading,
-  useTransactionPayIsMaxAmount,
-} from '../../../hooks/pay/useTransactionPayData';
 
 export type CustomAmountProps = {
   amountFiat: string;
@@ -90,8 +86,6 @@ export const CustomAmount = React.memo(
     isLoading,
     onChange,
   }: CustomAmountProps) => {
-    const isMaxAmount = useTransactionPayIsMaxAmount();
-    const isQuotesLoading = useIsTransactionPayLoading();
     const selectedCurrency = useSelector(getCurrentCurrency);
     const currency = currencyProp ?? selectedCurrency;
     const fiatSymbol = getCurrencySymbol(currency);
@@ -104,8 +98,6 @@ export const CustomAmount = React.memo(
     const amountWidth = amountLength - decimalSeparatorCount * 0.5;
     const displayWidth = amountWidth + Math.max(1, fiatSymbol.length);
 
-    const showLoader = isLoading || (isMaxAmount && isQuotesLoading);
-
     const handleChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         const { value } = e.target;
@@ -116,7 +108,7 @@ export const CustomAmount = React.memo(
       [onChange],
     );
 
-    if (showLoader) {
+    if (isLoading) {
       return <CustomAmountSkeleton />;
     }
 

--- a/ui/pages/confirmations/hooks/transactions/useDepositPrefillAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useDepositPrefillAmount.test.ts
@@ -539,12 +539,20 @@ describe('useDepositPrefillAmount', () => {
   });
 
   describe('isLoading', () => {
-    it('false when enabled but no pay token is selected', () => {
+    it('true while no pay token has been auto-selected yet', () => {
       setupMocks({ payToken: null });
 
       const { result } = runHook();
 
-      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('true while the funding account tokens are still loading', () => {
+      setupMocks({ payToken: null, isAccountTokensLoading: true });
+
+      const { result } = runHook();
+
+      expect(result.current.isLoading).toBe(true);
     });
 
     it('false when the selected pay token has a zero balance', () => {

--- a/ui/pages/confirmations/hooks/transactions/useDepositPrefillAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useDepositPrefillAmount.ts
@@ -217,9 +217,13 @@ export function useDepositPrefillAmount(): DepositPrefillResult {
   }, [committedKey, enabled, readyToCommit, tokenKey]);
 
   const hasPrefilled = committedKey === tokenKey;
-  // No pay token means auto-select found nothing to prefill — do not keep
-  // the amount skeleton up forever waiting for a token that will not come.
-  const isLoading = enabled && Boolean(payToken) && !hasPrefilled;
+  // Loading until the prefill commits, including before a pay token exists.
+  // The pay token, the funding account's tokens and their fiat rates all
+  // arrive asynchronously, and reporting "not loading" in any of those gaps
+  // paints $0 in the field before the prefilled amount lands. A funding
+  // account that holds nothing never commits, so consumers release the
+  // skeleton on the blocking no-funds alert instead.
+  const isLoading = enabled && !hasPrefilled;
 
   return {
     prefillAmount,

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -73,6 +73,7 @@ function runHook({
   balanceUsdOverride,
   isNoFeePayToken = true,
   isMaxAmount = false,
+  isQuotesLoading = false,
   requiredTokens = [],
   totals,
   updateTokenAmountMock = jest.fn(),
@@ -97,6 +98,7 @@ function runHook({
   balanceUsdOverride?: number;
   isNoFeePayToken?: boolean;
   isMaxAmount?: boolean;
+  isQuotesLoading?: boolean;
   requiredTokens?: { amountUsd?: string; skipIfBalance?: boolean }[];
   totals?: TransactionPayTotals;
   updateTokenAmountMock?: jest.Mock;
@@ -121,6 +123,9 @@ function runHook({
   jest
     .mocked(useTransactionPayDataModule.useTransactionPayIsMaxAmount)
     .mockReturnValue(isMaxAmount);
+  jest
+    .mocked(useTransactionPayDataModule.useIsTransactionPayLoading)
+    .mockReturnValue(isQuotesLoading);
   jest
     .mocked(useTransactionPayDataModule.useTransactionPayTotals)
     .mockReturnValue(
@@ -300,6 +305,53 @@ describe('useTransactionCustomAmount', () => {
       });
 
       expect(result.current.amountFiat).toBe('123.46');
+    });
+  });
+
+  describe('isQuoteDerivedAmountLoading', () => {
+    it('reports loading while an output-based Max quote is pending', () => {
+      const { result } = runHook({
+        isMaxAmount: true,
+        isQuotesLoading: true,
+        totals: {
+          isInputBased: false,
+          targetAmount: { usd: '123.456' },
+        } as TransactionPayTotals,
+      });
+
+      expect(result.current.isQuoteDerivedAmountLoading).toBe(true);
+    });
+
+    it('does not report loading while a money account deposit quote is pending', () => {
+      const { result } = runHook({
+        transactionMeta: {
+          ...MOCK_TRANSACTION_META,
+          type: TransactionType.moneyAccountDeposit,
+        } as TransactionMeta,
+        isMaxAmount: true,
+        isQuotesLoading: true,
+      });
+
+      expect(result.current.isQuoteDerivedAmountLoading).toBe(false);
+    });
+
+    it('does not report loading while an input-based Max quote is pending', () => {
+      const { result } = runHook({
+        isMaxAmount: true,
+        isQuotesLoading: true,
+        totals: {
+          isInputBased: true,
+          sourceAmount: { usd: '100' },
+        } as TransactionPayTotals,
+      });
+
+      expect(result.current.isQuoteDerivedAmountLoading).toBe(false);
+    });
+
+    it('does not report loading when Max is not armed', () => {
+      const { result } = runHook({ isQuotesLoading: true });
+
+      expect(result.current.isQuoteDerivedAmountLoading).toBe(false);
     });
   });
 
@@ -1110,6 +1162,72 @@ describe('useTransactionCustomAmount', () => {
       expect(result.current.isDepositPrefilled).toBe(true);
     });
 
+    it('keeps the amount skeleton up while a prefilled Max waits for the funding account tokens', () => {
+      const updateTokenAmountMock = jest.fn();
+      const { result, rerender } = runHook({
+        transactionMeta: moneyAccountDepositMeta,
+        payTokenBalanceUsd: 55.709,
+        payTokenBalanceRaw: '55709000',
+        livePayTokenBalanceRaw: '55709000',
+        isAccountTokensLoading: true,
+        updateTokenAmountMock,
+        depositPrefill: {
+          enabled: true,
+          isUncappedMaxPrefill: true,
+          hasPrefilled: true,
+          isLoading: false,
+          prefillAmount: '55.70',
+        },
+      });
+
+      // The held Max has not written the amount yet, so the field must stay
+      // behind the skeleton instead of showing $0.
+      expect(result.current.amountFiat).toBe('0');
+      expect(result.current.isDepositPrefillLoading).toBe(true);
+      expect(updateTokenAmountMock).not.toHaveBeenCalled();
+
+      jest.mocked(useAccountTokensLoading).mockReturnValue(false);
+      act(() => {
+        rerender();
+      });
+
+      expect(result.current.amountFiat).toBe('55.7');
+      expect(result.current.isDepositPrefillLoading).toBe(false);
+      expect(updateTokenAmountMock).toHaveBeenCalledWith('55.709');
+    });
+
+    it('applies a held prefill as a prefill, not a manual edit', () => {
+      const { result, rerender } = runHook({
+        transactionMeta: moneyAccountDepositMeta,
+        payTokenBalanceUsd: 55.709,
+        payTokenBalanceRaw: '55709000',
+        livePayTokenBalanceRaw: '55709000',
+        isAccountTokensLoading: true,
+        depositPrefill: {
+          enabled: true,
+          isUncappedMaxPrefill: true,
+          hasPrefilled: true,
+          isLoading: false,
+          prefillAmount: '55.70',
+        },
+      });
+
+      jest.mocked(useAccountTokensLoading).mockReturnValue(false);
+      act(() => {
+        rerender();
+      });
+
+      expect(result.current.amountFiat).toBe('55.7');
+      expect(upsertTransactionUIMetricsFragment).toHaveBeenCalledWith(
+        moneyAccountDepositMeta.id,
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            mm_pay_amount_input_type: 'prefilled_max',
+          }),
+        }),
+      );
+    });
+
     it('does not set max amount mode for capped or partial deposit prefill', () => {
       runHook({
         transactionMeta: moneyAccountDepositMeta,
@@ -1267,6 +1385,39 @@ describe('useTransactionCustomAmount', () => {
       });
 
       expect(result.current.isDepositPrefillLoading).toBe(true);
+    });
+
+    it('stops reporting prefill loading once the committed amount is in the field', () => {
+      const { result } = runHook({
+        transactionMeta: moneyAccountDepositMeta,
+        payTokenBalanceUsd: 1000,
+        depositPrefill: {
+          enabled: true,
+          isUncappedMaxPrefill: false,
+          hasPrefilled: true,
+          isLoading: false,
+          prefillAmount: '500',
+        },
+      });
+
+      expect(result.current.amountFiat).toBe('500');
+      expect(result.current.isDepositPrefillLoading).toBe(false);
+    });
+
+    it('does not report prefill loading when nothing can be prefilled', () => {
+      const { result } = runHook({
+        transactionMeta: moneyAccountDepositMeta,
+        payTokenBalanceUsd: 0,
+        depositPrefill: {
+          enabled: true,
+          isUncappedMaxPrefill: false,
+          hasPrefilled: false,
+          isLoading: false,
+          prefillAmount: undefined,
+        },
+      });
+
+      expect(result.current.isDepositPrefillLoading).toBe(false);
     });
 
     it('does not report prefill loading after a manual edit', () => {

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -25,6 +25,7 @@ import { usePayWithNoFeeToken } from '../pay/usePayWithNoFeeToken';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { usePayTokenAccountBalance } from '../pay/usePayTokenAccountBalance';
 import {
+  useIsTransactionPayLoading,
   useTransactionPayIsMaxAmount,
   useTransactionPayPrimaryRequiredToken,
   useTransactionPayTotals,
@@ -72,6 +73,7 @@ export function useTransactionCustomAmount({
   const { chainId, id: transactionId } = transactionMeta ?? {};
 
   const isMaxAmount = useTransactionPayIsMaxAmount();
+  const isQuotesLoading = useIsTransactionPayLoading();
   const isMoneyAccountDeposit = hasTransactionType(transactionMeta, [
     TransactionType.moneyAccountDeposit,
   ]);
@@ -128,10 +130,11 @@ export function useTransactionCustomAmount({
   // wallet holds. The controller's isMaxAmount path uses the same raw
   // payment-token balance for 100%.
   const depositMaxHumanRef = useRef<string | null>(null);
-  // Max clicked while override assets are still loading. Prefill already
-  // waits for that fetch; Max must too — `balanceRaw` can still be the
-  // previous account's snapshot while TPC's isMaxAmount path uses live raw.
-  const pendingDepositMaxRef = useRef(false);
+  // Max held until override assets finish loading — `balanceRaw` can still be
+  // the previous account's snapshot while TPC's isMaxAmount path uses live raw.
+  // Records whether the hold came from prefill so applying it later keeps the
+  // prefill semantics (no manual-edit guard, prefill metrics).
+  const pendingDepositMaxRef = useRef<{ isPrefill: boolean } | null>(null);
   // Mirrors `userEditedRef` for render-time use: the ref is needed to block
   // prefill synchronously, before the next render, while the state is what the
   // loading flag below can safely read. Stored as the edited transaction id so
@@ -145,6 +148,11 @@ export function useTransactionCustomAmount({
   const shouldUseDepositPrefill =
     isMoneyAccountDeposit && depositPrefill.enabled;
   const prevDepositHasPrefilledRef = useRef(depositPrefill.hasPrefilled);
+  // The prefill amount is written by an effect, one commit after prefill
+  // reports `hasPrefilled`. Without tracking that gap the field paints "$0"
+  // between the skeleton coming down and the amount arriving.
+  const [hasAppliedDepositPrefill, setHasAppliedDepositPrefill] =
+    useState(false);
 
   // Create and update debounced function
   useEffect(() => {
@@ -230,6 +238,16 @@ export function useTransactionCustomAmount({
     totals?.targetAmount?.usd,
   ]);
 
+  // Only the Max display above is driven by the quote, so only it goes stale
+  // while a quote is in flight. The flows excluded from that branch keep the
+  // committed amount, and blanking the field for them flickers the value the
+  // user (or prefill) just set.
+  const isQuoteDerivedAmount =
+    isMaxAmount &&
+    !isInputBased &&
+    !isMoneyAccountDeposit &&
+    !isMoneyAccountWithdraw;
+
   const amountHuman = useMemo(
     () =>
       getAmountHumanFromFiat(amountFiat, tokenFiatRate, hasBalanceUsdOverride),
@@ -281,7 +299,7 @@ export function useTransactionCustomAmount({
     prevPayTokenKeyRef.current = payTokenKey;
 
     depositMaxHumanRef.current = null;
-    pendingDepositMaxRef.current = false;
+    pendingDepositMaxRef.current = null;
     userEditedRef.current = false;
     setEditedTransactionId(undefined);
 
@@ -355,7 +373,7 @@ export function useTransactionCustomAmount({
       }
 
       depositMaxHumanRef.current = null;
-      pendingDepositMaxRef.current = false;
+      pendingDepositMaxRef.current = null;
 
       if (transactionId) {
         upsertTransactionUIMetricsFragment(transactionId, {
@@ -382,7 +400,7 @@ export function useTransactionCustomAmount({
       // Hold Max until the override-account fetch completes, matching prefill.
       // Applying now would send a stale `balanceRaw` while TPC uses live raw.
       if (isDepositMax && isAccountTokensLoading) {
-        pendingDepositMaxRef.current = true;
+        pendingDepositMaxRef.current = { isPrefill };
         if (!isPrefill) {
           userEditedRef.current = true;
           setEditedTransactionId(transactionId);
@@ -390,7 +408,7 @@ export function useTransactionCustomAmount({
         return;
       }
 
-      pendingDepositMaxRef.current = false;
+      pendingDepositMaxRef.current = null;
 
       const balanceUsdValue = new BigNumber(String(balanceUsd ?? 0));
 
@@ -528,16 +546,27 @@ export function useTransactionCustomAmount({
   useEffect(() => {
     hasPrefilledMaxRef.current = false;
     userEditedRef.current = false;
-    pendingDepositMaxRef.current = false;
+    pendingDepositMaxRef.current = null;
   }, [transactionId]);
 
-  // Apply a Max that was clicked while override assets were still loading.
+  // Apply a Max (clicked or prefilled) that was held while override assets
+  // were still loading.
   useEffect(() => {
-    if (isAccountTokensLoading || !pendingDepositMaxRef.current) {
+    const pendingDepositMax = pendingDepositMaxRef.current;
+
+    if (isAccountTokensLoading || !pendingDepositMax) {
       return;
     }
-    pendingDepositMaxRef.current = false;
-    updatePendingAmountPercentage(100);
+    pendingDepositMaxRef.current = null;
+    updatePendingAmountPercentage(100, {
+      isPrefill: pendingDepositMax.isPrefill,
+    });
+
+    if (pendingDepositMax.isPrefill) {
+      // The prefilled amount is only now in the field, so the amount skeleton
+      // it was held behind can come down.
+      setHasAppliedDepositPrefill(true);
+    }
   }, [isAccountTokensLoading, updatePendingAmountPercentage]);
 
   const applyDepositPrefillAmount = useCallback(
@@ -624,6 +653,8 @@ export function useTransactionCustomAmount({
     // (from tokenKey changes) must not overwrite their input.
     if (userEditedRef.current) {
       prevDepositHasPrefilledRef.current = depositPrefill.hasPrefilled;
+      // Nothing left to apply — the manual input owns the field.
+      setHasAppliedDepositPrefill(true);
       return;
     }
 
@@ -637,8 +668,16 @@ export function useTransactionCustomAmount({
       } else {
         applyDepositPrefillAmount(depositPrefill.prefillAmount ?? '0');
       }
-    } else if (prevDepositHasPrefilledRef.current) {
-      setAmountFiat('0.0');
+
+      // A Max held for the funding-account fetch has not written the amount
+      // yet — keep the skeleton up so the field does not show $0 until the
+      // effect above applies it.
+      setHasAppliedDepositPrefill(pendingDepositMaxRef.current === null);
+    } else {
+      if (prevDepositHasPrefilledRef.current) {
+        setAmountFiat('0.0');
+      }
+      setHasAppliedDepositPrefill(false);
     }
 
     prevDepositHasPrefilledRef.current = depositPrefill.hasPrefilled;
@@ -678,13 +717,16 @@ export function useTransactionCustomAmount({
     isDepositPrefillEnabled: shouldUseDepositPrefill,
     // Hide the skeleton after a manual edit on the *current* token. A pay
     // token / funding account change clears the edit guard so loading (and
-    // the new prefill) can show again.
+    // the new prefill) can show again. A committed prefill that has not been
+    // written to the field yet still counts as loading.
     isDepositPrefillLoading:
       shouldUseDepositPrefill &&
-      depositPrefill.isLoading &&
+      (depositPrefill.isLoading ||
+        (depositPrefill.hasPrefilled && !hasAppliedDepositPrefill)) &&
       !hasUserEditedAmount,
     isDepositPrefilled: shouldUseDepositPrefill && depositPrefill.hasPrefilled,
     isInputChanged,
+    isQuoteDerivedAmountLoading: isQuoteDerivedAmount && isQuotesLoading,
     updatePendingAmount,
     updatePendingAmountPercentage,
   };


### PR DESCRIPTION
## **Description**

Opening a Money Account deposit confirmation flickered through several states before settling on the prefilled amount: the field showed `$0`, then an amount, then a skeleton, then the amount again 1-2 seconds later.

Three separate gaps caused it:

1. `CustomAmount` raised its own skeleton whenever `isMaxAmount` was armed and a quote was loading. Deposit prefill arms `isMaxAmount`, but the deposit field displays the committed amount, not the quote target, so the skeleton hid an amount that was never going to change. That loading state now lives in `useTransactionCustomAmount`, which knows whether the displayed amount is quote-derived, and `CustomAmount` renders the skeleton purely from its `isLoading` prop. Flows whose Max display does come from the quote (perps/mUSD deposits) keep the skeleton.
2. `useDepositPrefillAmount` reported "not loading" until a pay token existed, so the field painted `$0` while the pay token, funding-account tokens and fiat rates were still arriving. It now reports loading until the prefill commits; a funding account that holds nothing releases the skeleton through the existing blocking no-funds alert.
3. The prefill is applied in an effect one commit after it reports `hasPrefilled`, and a prefilled Max is held while the funding account's assets load. Both gaps released the skeleton before the amount was in the field. The loading flag now stays true until the amount has actually been written, and a held prefill is applied as a prefill (previously it was re-applied as a manual edit, which also mislabelled the `mm_pay_amount_input_type` metric as `100%` instead of `prefilled_max`).

## **Changelog**

CHANGELOG entry: Fixed a bug that was causing the deposit amount to flicker between $0, a loading skeleton and the prefilled amount

## **Related issues**

Fixes: [CONF-1956](https://consensyssoftware.atlassian.net/browse/CONF-1956)

## **Manual testing steps**

1. Run the extension with the Money Account deposit flow and `confirmations_pay_extended.prefilledAmount` enabled.
2. Use an account that holds a stablecoin funding balance (uncapped 100% prefill) and open the Money Account deposit confirmation.
3. Verify the amount field shows a single loading skeleton and then the prefilled amount — no `$0` before it, and no second skeleton once the quote is fetched.
4. Repeat with a non-stablecoin funding token (50% prefill) and with a deposit limit configured, so the prefill is a capped/partial amount.
5. Switch the funding account in the "From" row to an account whose balances have not been loaded yet, and verify the field stays on the skeleton until the new prefilled amount appears.
6. Switch the funding account to one with no funds, and verify the field falls back to `$0` with the "no funds" alert rather than a stuck skeleton.
7. Type an amount manually, then verify it is never replaced by a skeleton or a prefill.
8. On a Perps deposit (or mUSD conversion) confirmation, press Max and verify the amount is still replaced by a skeleton while the quote loads, then shows the quote total.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[CONF-1956]: https://consensyssoftware.atlassian.net/browse/CONF-1956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes loading and prefill timing across confirmation pay amount UI and analytics labels; wrong gating could hide amounts or show stuck skeletons on deposits and Max flows.
> 
> **Overview**
> Fixes **Money Account deposit** amount flicker ($0 → amount → skeleton → amount) by centralizing when the confirmation amount field shows a skeleton.
> 
> **Loading ownership moves up:** `CustomAmount` no longer infers loading from Max + quote hooks; it only skeletons on **`isLoading`**. `useTransactionCustomAmount` exposes **`isQuoteDerivedAmountLoading`** (output-based Max on Perps/mUSD-style flows while quotes are in flight) and **`CustomAmountInfo`** drives the skeleton from deposit prefill loading **or** that flag.
> 
> **Deposit prefill gaps:** `useDepositPrefillAmount` stays **loading until prefill commits**, including before a pay token is auto-selected, so the field does not flash **$0** while tokens and rates load. Prefill application tracks **`hasAppliedDepositPrefill`** so the skeleton stays up until the amount is written, including when a prefilled **Max** is **held** until funding-account tokens finish loading. Held Max is re-applied with **`isPrefill: true`** so metrics stay **`prefilled_max`** instead of a manual **100%** edit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d41e38ec59b47437357f8987f5e2d5d4afa31a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->