### PR TITLE
feat: pair social identifiers when Basic Functionality is consolidated

### DIFF
--- a/app/scripts/messenger-client-init/identity/authentication-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/identity/authentication-controller-init.test.ts
@@ -1,19 +1,43 @@
 import { Controller as AuthenticationController } from '@metamask/profile-sync-controller/auth';
 import { Env } from '@metamask/profile-sync-controller/sdk';
+import type { FeatureFlags } from '@metamask/remote-feature-flag-controller';
+import { BFT_CHILD_PREFERENCES } from '../../../../shared/lib/basic-functionality-consolidation';
+import { getManifestFlags } from '../../../../shared/lib/manifestFlags';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
 import {
   getAuthenticationControllerMessenger,
   AuthenticationControllerMessenger,
   AuthenticationControllerInitMessenger,
-  getAuthenticationControllerInitMessenger,
 } from '../messengers/identity';
 import { getRootMessenger } from '../../lib/messenger';
 import { AuthenticationControllerInit } from './authentication-controller-init';
 
 jest.mock('@metamask/profile-sync-controller/auth');
+jest.mock('../../../../shared/lib/manifestFlags');
 
-function buildInitRequestMock(): jest.Mocked<
+const mockGetManifestFlags = jest.mocked(getManifestFlags);
+
+function buildChildPreferences(alignedWithBasicFunctionality: boolean) {
+  return Object.fromEntries(
+    BFT_CHILD_PREFERENCES.map((preference) => [
+      preference,
+      alignedWithBasicFunctionality,
+    ]),
+  );
+}
+
+function buildInitRequestMock({
+  useExternalServices = true,
+  isBasicFunctionalityConsolidatedEnabled = false,
+  mixedChildren = false,
+  remoteFeatureFlags = {},
+}: {
+  useExternalServices?: boolean;
+  isBasicFunctionalityConsolidatedEnabled?: boolean;
+  mixedChildren?: boolean;
+  remoteFeatureFlags?: FeatureFlags;
+} = {}): jest.Mocked<
   MessengerClientInitRequest<
     AuthenticationControllerMessenger,
     AuthenticationControllerInitMessenger
@@ -21,15 +45,48 @@ function buildInitRequestMock(): jest.Mocked<
 > {
   const baseControllerMessenger = getRootMessenger();
 
-  return {
+  const preferencesState = {
+    useExternalServices,
+    ...buildChildPreferences(useExternalServices),
+    ...(mixedChildren
+      ? { [BFT_CHILD_PREFERENCES[0]]: !useExternalServices }
+      : {}),
+    preferences: {
+      isBasicFunctionalityConsolidatedEnabled,
+    },
+  };
+
+  const requestMock = {
     ...buildControllerInitRequestMock(),
     controllerMessenger: getAuthenticationControllerMessenger(
       baseControllerMessenger,
     ),
-    initMessenger: getAuthenticationControllerInitMessenger(
-      baseControllerMessenger,
-    ),
+    initMessenger: {
+      call: jest.fn((action: string) => {
+        if (action === 'RemoteFeatureFlagController:getState') {
+          return { remoteFeatureFlags: { ...remoteFeatureFlags } };
+        }
+        if (action === 'AnalyticsController:getState') {
+          return { analyticsId: 'test-id' };
+        }
+        throw new Error(`Unexpected init messenger action: ${action}`);
+      }),
+    } as unknown as AuthenticationControllerInitMessenger,
   };
+
+  requestMock.getMessengerClient.mockImplementation((name) => {
+    if (name === 'PreferencesController') {
+      return { state: preferencesState } as never;
+    }
+    throw new Error(`Unexpected messenger client: ${name}`);
+  });
+
+  return requestMock;
+}
+
+function getIsSocialPairingEnabled() {
+  return jest.mocked(AuthenticationController).mock.calls[0][0].config
+    ?.isSocialPairingEnabled;
 }
 
 describe('AuthenticationControllerInit', () => {
@@ -39,6 +96,9 @@ describe('AuthenticationControllerInit', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    mockGetManifestFlags.mockReturnValue({
+      remoteFeatureFlags: {},
+    });
   });
 
   it('returns controller instance', () => {
@@ -62,8 +122,77 @@ describe('AuthenticationControllerInit', () => {
       },
       config: {
         env: Env.PRD,
+        isSocialPairingEnabled: expect.any(Function),
       },
     });
+  });
+
+  it('does not evaluate isSocialPairingEnabled at init', () => {
+    const requestMock = buildInitRequestMock();
+    AuthenticationControllerInit(requestMock);
+
+    expect(requestMock.initMessenger.call).not.toHaveBeenCalledWith(
+      'RemoteFeatureFlagController:getState',
+    );
+    expect(requestMock.getMessengerClient).toHaveBeenCalledWith(
+      'PreferencesController',
+    );
+  });
+
+  it('returns false when the remote flag is off and there is no cohort', () => {
+    AuthenticationControllerInit(
+      buildInitRequestMock({
+        remoteFeatureFlags: { extensionBasicFunctionalityToggle: false },
+      }),
+    );
+
+    expect(getIsSocialPairingEnabled()?.()).toBe(false);
+  });
+
+  it('returns true when the cohort marker is set and the remote flag is off', () => {
+    AuthenticationControllerInit(
+      buildInitRequestMock({
+        isBasicFunctionalityConsolidatedEnabled: true,
+        remoteFeatureFlags: { extensionBasicFunctionalityToggle: false },
+      }),
+    );
+
+    expect(getIsSocialPairingEnabled()?.()).toBe(true);
+  });
+
+  it('returns true when the remote flag is on and prefs are consistent all-on', () => {
+    AuthenticationControllerInit(
+      buildInitRequestMock({
+        remoteFeatureFlags: { extensionBasicFunctionalityToggle: true },
+      }),
+    );
+
+    expect(getIsSocialPairingEnabled()?.()).toBe(true);
+  });
+
+  it('returns false when the remote flag is on, prefs are mixed, and there is no cohort', () => {
+    AuthenticationControllerInit(
+      buildInitRequestMock({
+        mixedChildren: true,
+        remoteFeatureFlags: { extensionBasicFunctionalityToggle: true },
+      }),
+    );
+
+    expect(getIsSocialPairingEnabled()?.()).toBe(false);
+  });
+
+  it('returns true when a manifest override turns the remote flag on', () => {
+    mockGetManifestFlags.mockReturnValue({
+      remoteFeatureFlags: { extensionBasicFunctionalityToggle: true },
+    });
+
+    AuthenticationControllerInit(
+      buildInitRequestMock({
+        remoteFeatureFlags: { extensionBasicFunctionalityToggle: false },
+      }),
+    );
+
+    expect(getIsSocialPairingEnabled()?.()).toBe(true);
   });
 
   it('wires getAppVersion to process.env.METAMASK_VERSION', () => {

--- a/app/scripts/messenger-client-init/identity/authentication-controller-init.ts
+++ b/app/scripts/messenger-client-init/identity/authentication-controller-init.ts
@@ -3,28 +3,54 @@ import {
   Controller as AuthenticationController,
 } from '@metamask/profile-sync-controller/auth';
 import { Platform } from '@metamask/profile-sync-controller/sdk';
+import { loadAuthenticationConfig } from '../../../../shared/lib/authentication';
+import { getIsBasicFunctionalityConsolidationGateEnabled } from '../../../../shared/lib/basic-functionality-consolidation-gate';
+import { getRemoteFeatureFlags } from '../../../../shared/lib/selectors/remote-feature-flags';
 import { MessengerClientInitFunction } from '../types';
 import {
   AuthenticationControllerInitMessenger,
   AuthenticationControllerMessenger,
 } from '../messengers/identity';
-import { loadAuthenticationConfig } from '../../../../shared/lib/authentication';
 
 /**
  * Initialize the Authentication controller.
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
- * @param request.persistedState - The persisted state of the extension.
  * @param request.initMessenger - The messenger to use for initialization.
+ * @param request.persistedState - The persisted state of the extension.
+ * @param request.getMessengerClient - A function to get other initialized controllers.
  * @returns The initialized controller.
  */
 export const AuthenticationControllerInit: MessengerClientInitFunction<
   AuthenticationController,
   AuthenticationControllerMessenger,
   AuthenticationControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, persistedState }) => {
+> = ({
+  controllerMessenger,
+  initMessenger,
+  persistedState,
+  getMessengerClient,
+}) => {
   const env = loadAuthenticationConfig();
+  const preferencesController = getMessengerClient('PreferencesController');
+
+  const isSocialPairingEnabled = () => {
+    const { remoteFeatureFlags } = initMessenger.call(
+      'RemoteFeatureFlagController:getState',
+    );
+    // Resolve through the same manifest-merged path as the UI selector so
+    // `.manifest-overrides.json` / e2e manifestFlags cannot enable consolidation
+    // in the UI while the background gate ignores them.
+    const mergedFlags = getRemoteFeatureFlags({
+      metamask: { remoteFeatureFlags },
+    });
+    return getIsBasicFunctionalityConsolidationGateEnabled({
+      remoteFeatureFlags: mergedFlags,
+      preferencesState: preferencesController.state,
+    });
+  };
+
   const messengerClient = new AuthenticationController({
     messenger: controllerMessenger,
     state:
@@ -37,6 +63,7 @@ export const AuthenticationControllerInit: MessengerClientInitFunction<
     },
     config: {
       env,
+      isSocialPairingEnabled,
     },
   });
 

--- a/app/scripts/messenger-client-init/messengers/identity/authentication-controller-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/identity/authentication-controller-messenger.test.ts
@@ -68,4 +68,19 @@ describe('getAuthenticationControllerInitMessenger', () => {
 
     expect(authenticationControllerInitMessenger).toBeInstanceOf(Messenger);
   });
+
+  it('delegates RemoteFeatureFlagController:getState', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getAuthenticationControllerInitMessenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: expect.arrayContaining([
+          'RemoteFeatureFlagController:getState',
+        ]),
+      }),
+    );
+  });
 });

--- a/app/scripts/messenger-client-init/messengers/identity/authentication-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/identity/authentication-controller-messenger.ts
@@ -11,6 +11,7 @@ import type {
   SeedlessOnboardingControllerGetStateAction,
 } from '@metamask/seedless-onboarding-controller';
 import type { AnalyticsControllerGetStateAction } from '@metamask/analytics-controller';
+import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { RootMessenger } from '../../../lib/messenger';
 
 type MessengerActions =
@@ -60,7 +61,9 @@ export function getAuthenticationControllerMessenger(
   return controllerMessenger;
 }
 
-export type AllowedInitializationActions = AnalyticsControllerGetStateAction;
+export type AllowedInitializationActions =
+  | AnalyticsControllerGetStateAction
+  | RemoteFeatureFlagControllerGetStateAction;
 
 export type AuthenticationControllerInitMessenger = ReturnType<
   typeof getAuthenticationControllerInitMessenger
@@ -88,7 +91,10 @@ export function getAuthenticationControllerInitMessenger(
   });
   messenger.delegate({
     messenger: controllerInitMessenger,
-    actions: ['AnalyticsController:getState'],
+    actions: [
+      'AnalyticsController:getState',
+      'RemoteFeatureFlagController:getState',
+    ],
   });
   return controllerInitMessenger;
 }

--- a/test/e2e/tests/identity/mocks.ts
+++ b/test/e2e/tests/identity/mocks.ts
@@ -30,6 +30,7 @@ export async function mockIdentityServices(
   mockAPICall(server, AuthMocks.getMockAuthLoginResponse());
   mockAPICall(server, AuthMocks.getMockAuthAccessTokenResponse());
   mockAPICall(server, AuthMocks.getMockAuthPairResponse());
+  mockAPICall(server, AuthMocks.getMockAuthPairSocialIdentifierResponse());
   mockAPICall(server, AuthMocks.getMockCustomerServiceTokenResponse());
 
   // Storage

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -482,7 +482,7 @@
       "MetaMask: Background connection not initialized": 13
     },
     "ui/hooks/identity/useAuthentication/useAutoSignIn.test.tsx": {
-      "MetaMask: Background connection not initialized": 12
+      "MetaMask: Background connection not initialized": 15
     },
     "ui/hooks/identity/useAuthentication/useAutoSignOut.test.tsx": {
       "MetaMask: Background connection not initialized": 2

--- a/ui/hooks/identity/useAuthentication/useAutoSignIn.test.tsx
+++ b/ui/hooks/identity/useAuthentication/useAutoSignIn.test.tsx
@@ -1,5 +1,8 @@
 import { act } from '@testing-library/react';
 import { renderHookWithProviderTyped } from '../../../../test/lib/render-helpers-navigate';
+import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
+import * as Environment from '../../../../shared/lib/environment';
+import { UPDATE_METAMASK_STATE } from '../../../store/actionConstants';
 import * as actions from '../../../store/actions';
 import { MetamaskIdentityProvider } from '../../../contexts/identity';
 import { useAutoSignIn } from './useAutoSignIn';
@@ -10,6 +13,9 @@ type ArrangeMocksMetamaskStateOverrides = {
   isSignedIn: boolean;
   completedOnboarding: boolean;
   needsProfilePairing: boolean;
+  needsSocialPairing?: boolean;
+  firstTimeFlowType?: FirstTimeFlowType;
+  isBasicFunctionalityConsolidatedEnabled?: boolean;
 };
 
 const arrangeMockState = (
@@ -20,10 +26,17 @@ const arrangeMockState = (
     metadata: { id: string };
   }[] = [],
 ) => {
+  const { isBasicFunctionalityConsolidatedEnabled, ...metamaskOverrides } =
+    stateOverrides;
+
   return {
     metamask: {
-      ...stateOverrides,
+      ...metamaskOverrides,
       keyrings,
+      preferences: {
+        isBasicFunctionalityConsolidatedEnabled:
+          isBasicFunctionalityConsolidatedEnabled ?? false,
+      },
     },
   };
 };
@@ -191,5 +204,148 @@ describe('useAutoSignIn', () => {
     // Initial mount baselines the keyring count via `useRef`; no dispatch
     // should fire until the count actually changes between renders.
     expect(mockRequestProfilePairing).not.toHaveBeenCalled();
+  });
+
+  describe('social identifier pairing', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(Environment, 'getIsSeedlessOnboardingFeatureEnabled')
+        .mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const socialPairingReadyState = {
+      isUnlocked: true,
+      useExternalServices: true,
+      completedOnboarding: true,
+      isSignedIn: true,
+      needsProfilePairing: false,
+    };
+
+    it('forces sign-in for a social-login user when pairing is needed and consolidation is on', async () => {
+      const state = arrangeMockState({
+        ...socialPairingReadyState,
+        needsSocialPairing: true,
+        firstTimeFlowType: FirstTimeFlowType.socialCreate,
+        isBasicFunctionalityConsolidatedEnabled: true,
+      });
+      const { mockPerformSignInAction } = arrangeMocks();
+      const hook = renderHookWithProviderTyped(
+        () => useAutoSignIn(),
+        state,
+        undefined,
+        MetamaskIdentityProvider,
+      );
+
+      await act(async () => {
+        await hook.result.current.autoSignIn();
+      });
+
+      expect(mockPerformSignInAction).toHaveBeenCalled();
+    });
+
+    it('does not force sign-in for an SRP user when pairing is needed and consolidation is on', async () => {
+      const state = arrangeMockState({
+        ...socialPairingReadyState,
+        needsSocialPairing: true,
+        firstTimeFlowType: FirstTimeFlowType.create,
+        isBasicFunctionalityConsolidatedEnabled: true,
+      });
+      const { mockPerformSignInAction } = arrangeMocks();
+      const hook = renderHookWithProviderTyped(
+        () => useAutoSignIn(),
+        state,
+        undefined,
+        MetamaskIdentityProvider,
+      );
+
+      await act(async () => {
+        await hook.result.current.autoSignIn();
+      });
+
+      expect(mockPerformSignInAction).not.toHaveBeenCalled();
+    });
+
+    it('does not force sign-in for a social-login user when consolidation is off', async () => {
+      const state = arrangeMockState({
+        ...socialPairingReadyState,
+        needsSocialPairing: true,
+        firstTimeFlowType: FirstTimeFlowType.socialCreate,
+        isBasicFunctionalityConsolidatedEnabled: false,
+      });
+      const { mockPerformSignInAction } = arrangeMocks();
+      const hook = renderHookWithProviderTyped(
+        () => useAutoSignIn(),
+        state,
+        undefined,
+        MetamaskIdentityProvider,
+      );
+
+      await act(async () => {
+        await hook.result.current.autoSignIn();
+      });
+
+      expect(mockPerformSignInAction).not.toHaveBeenCalled();
+    });
+
+    it('does not force sign-in for a social-login user when pairing is not needed', async () => {
+      const state = arrangeMockState({
+        ...socialPairingReadyState,
+        needsSocialPairing: false,
+        firstTimeFlowType: FirstTimeFlowType.socialCreate,
+        isBasicFunctionalityConsolidatedEnabled: true,
+      });
+      const { mockPerformSignInAction } = arrangeMocks();
+      const hook = renderHookWithProviderTyped(
+        () => useAutoSignIn(),
+        state,
+        undefined,
+        MetamaskIdentityProvider,
+      );
+
+      await act(async () => {
+        await hook.result.current.autoSignIn();
+      });
+
+      expect(mockPerformSignInAction).not.toHaveBeenCalled();
+    });
+
+    it('forces sign-in when consolidation flips on for a social-login user that still needs pairing', async () => {
+      const state = arrangeMockState({
+        ...socialPairingReadyState,
+        needsSocialPairing: true,
+        firstTimeFlowType: FirstTimeFlowType.socialCreate,
+        isBasicFunctionalityConsolidatedEnabled: false,
+      });
+      const { mockPerformSignInAction } = arrangeMocks();
+      const hook = renderHookWithProviderTyped(
+        () => useAutoSignIn(),
+        state,
+        undefined,
+        MetamaskIdentityProvider,
+      );
+
+      await act(async () => {
+        await hook.result.current.autoSignIn();
+      });
+      expect(mockPerformSignInAction).not.toHaveBeenCalled();
+
+      await act(async () => {
+        hook.store.dispatch({
+          type: UPDATE_METAMASK_STATE,
+          value: {
+            preferences: {
+              isBasicFunctionalityConsolidatedEnabled: true,
+            },
+          },
+        });
+        await hook.result.current.autoSignIn();
+      });
+
+      expect(mockPerformSignInAction).toHaveBeenCalled();
+    });
   });
 });

--- a/ui/hooks/identity/useAuthentication/useAutoSignIn.test.tsx
+++ b/ui/hooks/identity/useAuthentication/useAutoSignIn.test.tsx
@@ -53,7 +53,14 @@ const arrangeMocks = () => {
   };
 };
 
-const prerequisitesStateKeys = [
+type CombinatorialOverrideKey =
+  | 'isUnlocked'
+  | 'useExternalServices'
+  | 'isSignedIn'
+  | 'completedOnboarding'
+  | 'needsProfilePairing';
+
+const prerequisitesStateKeys: CombinatorialOverrideKey[] = [
   'isUnlocked',
   'useExternalServices',
   'isSignedIn',
@@ -65,15 +72,13 @@ const shouldAutoSignInTestCases: ArrangeMocksMetamaskStateOverrides[] = [];
 const shouldNotAutoSignInTestCases: ArrangeMocksMetamaskStateOverrides[] = [];
 
 // We generate all possible combinations of the prerequisites here
-const generateCombinations = (keys: string[]) => {
+const generateCombinations = (keys: CombinatorialOverrideKey[]) => {
   const result: ArrangeMocksMetamaskStateOverrides[] = [];
   const total = 2 ** keys.length;
   for (let i = 0; i < total; i++) {
     const state = {} as ArrangeMocksMetamaskStateOverrides;
     keys.forEach((key, index) => {
-      state[key as keyof ArrangeMocksMetamaskStateOverrides] = Boolean(
-        Math.floor(i / 2 ** index) % 2,
-      );
+      state[key] = Boolean(Math.floor(i / 2 ** index) % 2);
     });
     result.push(state);
   }

--- a/ui/hooks/identity/useAuthentication/useAutoSignIn.ts
+++ b/ui/hooks/identity/useAuthentication/useAutoSignIn.ts
@@ -9,7 +9,10 @@ import {
 import {
   selectIsSignedIn,
   selectNeedsProfilePairing,
+  selectNeedsSocialPairing,
 } from '../../../selectors/identity/authentication';
+import { getIsSocialLoginFlow } from '../../../selectors/first-time-flow';
+import { getIsBasicFunctionalityConsolidationEnabled } from '../../../selectors/multichain/basic-functionality';
 import { requestProfilePairing } from '../../../store/actions';
 import { useDispatch } from '../../../store/hooks';
 import { useSignIn } from './useSignIn';
@@ -21,7 +24,9 @@ import { useSignIn } from './useSignIn';
  * `requestProfilePairing()` so the controller's `needsProfilePairing` flag
  * flips to `true`. That, in turn, re-arms the gate below and triggers a
  * forced `performSignIn` (`signIn(true)`) which re-runs the pairing logic
- * inside the controller.
+ * inside the controller. The same forced sign-in path is used for social
+ * identifier pairing when a social-login user still needs pairing and the
+ * Basic Functionality consolidation experience is on.
  *
  * @returns An object containing:
  * - `autoSignIn`: A function to automatically sign in the user if necessary.
@@ -43,6 +48,13 @@ export function useAutoSignIn(): {
   const completedOnboarding = Boolean(useSelector(getCompletedOnboarding));
   const isSignedIn = useSelector(selectIsSignedIn);
   const needsProfilePairing = useSelector(selectNeedsProfilePairing);
+  const needsSocialPairing = useSelector(selectNeedsSocialPairing);
+  const isSocialLoginFlow = Boolean(useSelector(getIsSocialLoginFlow));
+  const isBftConsolidationEnabled = Boolean(
+    useSelector(getIsBasicFunctionalityConsolidationEnabled),
+  );
+  const shouldSocialPair =
+    needsSocialPairing && isSocialLoginFlow && isBftConsolidationEnabled;
 
   const keyrings = useSelector(getMetaMaskKeyrings);
   const previousKeyringsLength = useRef(keyrings.length);
@@ -62,7 +74,10 @@ export function useAutoSignIn(): {
 
   const shouldAutoSignIn = useMemo(
     () =>
-      (!isSignedIn || hasNewKeyrings || needsProfilePairing) &&
+      (!isSignedIn ||
+        hasNewKeyrings ||
+        needsProfilePairing ||
+        shouldSocialPair) &&
       isUnlocked &&
       isBasicFunctionalityEnabled &&
       completedOnboarding,
@@ -73,6 +88,7 @@ export function useAutoSignIn(): {
       completedOnboarding,
       hasNewKeyrings,
       needsProfilePairing,
+      shouldSocialPair,
     ],
   );
 
@@ -82,14 +98,20 @@ export function useAutoSignIn(): {
       // keyring) or pairing has not yet succeeded for the current SRP set.
       // `signIn()` (no force) is the steady-state initial-sign-in path used
       // when the user is simply not signed in yet.
-      if (hasNewKeyrings || needsProfilePairing) {
+      if (hasNewKeyrings || needsProfilePairing || shouldSocialPair) {
         await signIn(true);
         setHasNewKeyrings(false);
       } else {
         await signIn();
       }
     }
-  }, [shouldAutoSignIn, signIn, hasNewKeyrings, needsProfilePairing]);
+  }, [
+    shouldAutoSignIn,
+    signIn,
+    hasNewKeyrings,
+    needsProfilePairing,
+    shouldSocialPair,
+  ]);
 
   return {
     autoSignIn,

--- a/ui/selectors/identity/authentication.test.ts
+++ b/ui/selectors/identity/authentication.test.ts
@@ -1,4 +1,9 @@
-import { selectIsSignedIn, selectSessionData } from './authentication';
+import {
+  selectIsSignedIn,
+  selectNeedsProfilePairing,
+  selectNeedsSocialPairing,
+  selectSessionData,
+} from './authentication';
 
 describe('Authentication Selectors', () => {
   const mockState = {
@@ -43,5 +48,29 @@ describe('Authentication Selectors', () => {
     expect(selectSessionData(mockState)).toEqual(
       mockState.metamask.srpSessionData.entropySourceId1,
     );
+  });
+
+  it('selectNeedsProfilePairing returns the persisted value when present', () => {
+    expect(
+      selectNeedsProfilePairing({
+        metamask: { ...mockState.metamask, needsProfilePairing: false },
+      }),
+    ).toBe(false);
+  });
+
+  it('selectNeedsProfilePairing defaults to true when the field is absent', () => {
+    expect(selectNeedsProfilePairing(mockState)).toBe(true);
+  });
+
+  it('selectNeedsSocialPairing returns the persisted value when present', () => {
+    expect(
+      selectNeedsSocialPairing({
+        metamask: { ...mockState.metamask, needsSocialPairing: false },
+      }),
+    ).toBe(false);
+  });
+
+  it('selectNeedsSocialPairing defaults to true when the field is absent', () => {
+    expect(selectNeedsSocialPairing(mockState)).toBe(true);
   });
 });

--- a/ui/selectors/identity/authentication.ts
+++ b/ui/selectors/identity/authentication.ts
@@ -44,6 +44,24 @@ export const selectNeedsProfilePairing = createSelector(
 );
 
 /**
+ * Selector that exposes the `needsSocialPairing` flag from the
+ * `AuthenticationController` state.
+ *
+ * Used by `useAutoSignIn` to force a sign-in when a social-login wallet
+ * still needs its social identifier paired to the SRP profile.
+ *
+ * Defaults to `true` when the field is absent from state — this mirrors the
+ * controller's `defaultState` and matches `selectNeedsProfilePairing`.
+ *
+ * @param state - The current state of the Redux store.
+ * @returns `true` if social identifier pairing is needed, `false` otherwise.
+ */
+export const selectNeedsSocialPairing = createSelector(
+  [getMetamask],
+  (metamask) => metamask.needsSocialPairing ?? true,
+);
+
+/**
  * Selector to retrieve the primary SRP session data.
  *
  * This selector fetches the `srpSessionData` from the `metamask` state using the `createSelector` function, and gets the first entry.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Related to: https://consensyssoftware.atlassian.net/browse/MUL-2200

## **Manual testing steps**

1. Add to `.manifest-overrides.json` at repo root: `{ "_flags": { "remoteFeatureFlags": { "extensionBasicFunctionalityToggle": true } } }` and `MANIFEST_OVERRIDES=.manifest-overrides.json; MM_DEV_API_ENV=dev` in `.metamaskrc`
2. Onboard with social login
3. Verify in the network tab that a call to `POST /api/v2/profile/pair/identifier` has been made and returned either `200` or `409` (in case it's already paired)
4. If it's returning `401`, you likely did not update your dev env files correctly. Return to step 1.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto sign-in and authentication init gating for social pairing, but behavior is feature-flag and preference gated with broad unit coverage.
> 
> **Overview**
> When **Basic Functionality consolidation** is on, social-login wallets that still need identifier pairing now get a **forced sign-in** path (same idea as profile re-pairing), so the background controller can call **`POST /api/v2/profile/pair/identifier`**.
> 
> **Background:** `AuthenticationControllerInit` passes a lazy **`isSocialPairingEnabled`** callback that uses the same manifest-merged remote flags and preferences gate as the UI (`getIsBasicFunctionalityConsolidationGateEnabled`), and the init messenger now delegates **`RemoteFeatureFlagController:getState`**.
> 
> **UI:** `useAutoSignIn` treats **`needsSocialPairing` + social onboarding flow + consolidation** as **`shouldSocialPair`**, which extends **`shouldAutoSignIn`** and triggers **`signIn(true)`**. A new **`selectNeedsSocialPairing`** selector (default **`true`** when missing) exposes controller state to the hook.
> 
> Tests cover gate matrix for init, hook behavior, and selectors; identity e2e mocks add the social pair identifier auth response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6557b76aee1fa461961c9dcd7a04fde464ec5a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->