### PR TITLE
fix: defi controller fetch behaviour change

### DIFF
--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
     "@metamask/announcement-controller": "^8.0.0",
     "@metamask/approval-controller": "^9.0.0",
     "@metamask/assets-controller": "^15.0.0",
-    "@metamask/assets-controllers": "111.3.0",
+    "@metamask/assets-controllers": "^111.3.0",
     "@metamask/authenticated-user-storage": "^3.0.2",
     "@metamask/base-controller": "^9.0.1",
     "@metamask/base-data-service": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
     "@metamask/announcement-controller": "^8.0.0",
     "@metamask/approval-controller": "^9.0.0",
     "@metamask/assets-controller": "^15.0.0",
-    "@metamask/assets-controllers": "^111.1.2",
+    "@metamask/assets-controllers": "111.3.0",
     "@metamask/authenticated-user-storage": "^3.0.2",
     "@metamask/base-controller": "^9.0.1",
     "@metamask/base-data-service": "^1.0.0",

--- a/test/e2e/fixtures/fixture-validation.ts
+++ b/test/e2e/fixtures/fixture-validation.ts
@@ -58,16 +58,6 @@ const getFixtureIgnoredKeys = (): string[] => [
   'data.AppStateController.onboardingDate',
   'data.AppStateController.recoveryPhraseReminderLastShown',
   'data.AppStateController.termsOfUseLastAgreed',
-  'data.CurrencyController.currencyRates.BNB.conversionDate',
-  'data.CurrencyController.currencyRates.BNB.conversionRate',
-  'data.CurrencyController.currencyRates.BNB.usdConversionRate',
-  'data.CurrencyController.currencyRates.ETH.conversionDate',
-  'data.CurrencyController.currencyRates.ETH.conversionRate',
-  'data.CurrencyController.currencyRates.POL.conversionDate',
-  'data.CurrencyController.currencyRates.POL.conversionRate',
-  'data.CurrencyController.currencyRates.POL.usdConversionRate',
-  'data.MultichainAssetsRatesController.conversionRates.bip122:000000000019d6689c085ae165831e93/slip44:0.conversionTime',
-  'data.MultichainAssetsRatesController.conversionRates.bip122:000000000019d6689c085ae165831e93/slip44:0.expirationTime',
   'data.NetworkController.networkConfigurationsByChainId.0x539.lastUpdatedAt',
   'data.NotificationServicesController.metamaskNotificationsList',
   'data.PhishingController.c2DomainBlocklistLastFetched',
@@ -81,6 +71,16 @@ const getFixtureIgnoredKeys = (): string[] => [
   // Threshold group selection is derived from the (random) analyticsId, so it
   // is non-deterministic per run, like the other flags above.
   'data.RemoteFeatureFlagController.featureFlagThresholdGroups',
+  // Legacy assets controllers set `persist: false` in `@metamask/assets-controllers`
+  // v111.2.0, so they are absent from persisted state. The fixtures still seed them
+  // because controllers are constructed from the fixture state at boot, but there is
+  // nothing to validate against.
+  'data.CurrencyController',
+  'data.MultichainAssetsRatesController',
+  'data.MultichainAssetsController',
+  'data.MultichainBalancesController',
+  'data.TokenRatesController',
+  'data.TokensController',
   // Entire objects/controllers ignored (dynamic or impractical to validate)
   'data.AccountTreeController.selectedAccountGroup', // Entropy source is random and non-deterministic, and the selected group can change on each run.
   'data.AccountsController.internalAccounts.accounts',
@@ -88,7 +88,6 @@ const getFixtureIgnoredKeys = (): string[] => [
   'data.AssetsController',
   'data.AuthenticationController',
   'data.MetaMetricsController',
-  'data.MultichainAssetsController',
   'data.TokenBalancesController',
   // Environment-specific values that differ per machine
   'data.AppStateController.browserEnvironment.os',
@@ -102,8 +101,6 @@ const getFixtureIgnoredKeys = (): string[] => [
   // Random ids
   'data.AnalyticsController.analyticsId',
   'data.AnalyticsController.preConsentEventQueue',
-  'data.MultichainBalancesController',
-  'data.MultichainBalancesController.balances',
   'data.MultichainTransactionsController.nonEvmTransactions',
   'data.NetworkController.networkConfigurationsByChainId.0x539.rpcEndpoints[0].networkClientId',
   'data.NetworkController.networkConfigurationsByChainId.0x1.rpcEndpoints[0].failoverUrls',

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -4,9 +4,7 @@
       "hiddenAccountList": "object",
       "pinnedAccountList": "object"
     },
-    "AccountTracker": {
-      "accountsByChainId": "object"
-    },
+    "AccountTracker": {},
     "AccountTreeController": {
       "accountGroupsMetadata": "object",
       "accountTree": "object",
@@ -107,10 +105,7 @@
       "lastFetched": null,
       "version": null
     },
-    "CurrencyController": {
-      "currencyRates": {},
-      "currentCurrency": "usd"
-    },
+    "CurrencyController": {},
     "DeFiPositionsControllerV2": "object",
     "GasFeeController": {
       "estimatedGasFeeTimeBounds": {},
@@ -137,17 +132,9 @@
     },
     "MoneyAccountController": { "moneyAccounts": "object" },
     "MoneyAccountUpgradeController": { "upgradedAccounts": "object" },
-    "MultichainAssetsController": {
-      "accountsAssets": "object",
-      "allIgnoredAssets": "object",
-      "assetsMetadata": "object"
-    },
-    "MultichainAssetsRatesController": {
-      "conversionRates": "object"
-    },
-    "MultichainBalancesController": {
-      "balances": "object"
-    },
+    "MultichainAssetsController": {},
+    "MultichainAssetsRatesController": {},
+    "MultichainBalancesController": {},
     "MultichainNetworkController": "object",
     "MultichainRatesController": {
       "cryptocurrencies": ["btc", "sol"],
@@ -340,17 +327,9 @@
       "subjectMetadata": "object"
     },
     "SubscriptionController": "object",
-    "TokenBalancesController": {
-      "tokenBalances": "object"
-    },
-    "TokenRatesController": {
-      "marketData": "object"
-    },
-    "TokensController": {
-      "allDetectedTokens": {},
-      "allIgnoredTokens": {},
-      "allTokens": {}
-    },
+    "TokenBalancesController": {},
+    "TokenRatesController": {},
+    "TokensController": {},
     "TransactionController": {
       "lastFetchedBlockNumbers": "object",
       "methodData": "object",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5782,9 +5782,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^111.1.2, @metamask/assets-controllers@npm:^111.1.3":
-  version: 111.1.3
-  resolution: "@metamask/assets-controllers@npm:111.1.3"
+"@metamask/assets-controllers@npm:111.3.0, @metamask/assets-controllers@npm:^111.1.3":
+  version: 111.3.0
+  resolution: "@metamask/assets-controllers@npm:111.3.0"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
@@ -5793,13 +5793,13 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^8.0.0"
+    "@metamask/account-tree-controller": "npm:^9.0.0"
     "@metamask/accounts-controller": "npm:^39.1.1"
     "@metamask/approval-controller": "npm:^9.0.2"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/contract-metadata": "npm:^2.4.0"
     "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/core-backend": "npm:^9.0.0"
+    "@metamask/core-backend": "npm:^9.1.1"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/keyring-api": "npm:^24.0.0"
     "@metamask/keyring-controller": "npm:^27.1.1"
@@ -5809,18 +5809,18 @@ __metadata:
     "@metamask/network-controller": "npm:^36.0.0"
     "@metamask/network-enablement-controller": "npm:^6.0.5"
     "@metamask/permission-controller": "npm:^13.1.1"
-    "@metamask/phishing-controller": "npm:^17.4.0"
+    "@metamask/phishing-controller": "npm:^17.4.1"
     "@metamask/polling-controller": "npm:^16.0.9"
     "@metamask/preferences-controller": "npm:^23.1.0"
-    "@metamask/profile-sync-controller": "npm:^29.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^6.0.0"
+    "@metamask/profile-sync-controller": "npm:^30.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^6.1.1"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/snaps-sdk": "npm:^11.0.0"
     "@metamask/snaps-utils": "npm:^12.1.2"
     "@metamask/storage-service": "npm:^1.0.2"
-    "@metamask/transaction-controller": "npm:^69.6.1"
-    "@metamask/utils": "npm:^11.11.0"
+    "@metamask/transaction-controller": "npm:^69.8.1"
+    "@metamask/utils": "npm:^11.12.0"
     "@tanstack/query-core": "npm:^5.62.16"
     "@types/bn.js": "npm:^5.1.5"
     "@types/uuid": "npm:^8.3.0"
@@ -5836,7 +5836,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/b25f4dd77a05e75ba6a5c1fd85c81a2f5f43c233e4c6e1648baa64f50a317fd108bb6b2eddd2ac98027b4b6425eb3946efd1ae5d1f6400d75f56b8127720e6f9
+  checksum: 10/5f421aee39729d0f594dd9109ca9c020841367dad718c57a9875998babd4faf63c787a6a7c27152393101b21af1eaf349517f886b55091b6681f7bd1dd307f80
   languageName: node
   linkType: hard
 
@@ -31890,7 +31890,7 @@ __metadata:
     "@metamask/api-specs": "npm:^0.13.0"
     "@metamask/approval-controller": "npm:^9.0.0"
     "@metamask/assets-controller": "npm:^15.0.0"
-    "@metamask/assets-controllers": "npm:^111.1.2"
+    "@metamask/assets-controllers": "npm:111.3.0"
     "@metamask/authenticated-user-storage": "npm:^3.0.2"
     "@metamask/auto-changelog": "npm:^6.2.0"
     "@metamask/base-controller": "npm:^9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5782,7 +5782,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:111.3.0, @metamask/assets-controllers@npm:^111.1.3":
+"@metamask/assets-controllers@npm:^111.1.3, @metamask/assets-controllers@npm:^111.3.0":
   version: 111.3.0
   resolution: "@metamask/assets-controllers@npm:111.3.0"
   dependencies:
@@ -31890,7 +31890,7 @@ __metadata:
     "@metamask/api-specs": "npm:^0.13.0"
     "@metamask/approval-controller": "npm:^9.0.0"
     "@metamask/assets-controller": "npm:^15.0.0"
-    "@metamask/assets-controllers": "npm:111.3.0"
+    "@metamask/assets-controllers": "npm:^111.3.0"
     "@metamask/authenticated-user-storage": "npm:^3.0.2"
     "@metamask/auto-changelog": "npm:^6.2.0"
     "@metamask/base-controller": "npm:^9.0.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Upgrades assets controllers package to implement a behaviour change in the new defi controller, so that number of fetches to the new api are reduced.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrade touches core asset/DeFi controller behavior and persisted state shape; risk is mainly regression in balances, rates, tokens, or DeFi fetch cadence rather than auth or payments.
> 
> **Overview**
> Upgrades **`@metamask/assets-controllers`** from `111.1.x` to **`111.3.0`** (and lockfile) to pick up a **DeFi controller fetch behavior** change that reduces calls to the new DeFi API.
> 
> That release also leaves several **legacy asset-related controllers** with **`persist: false`**, so they no longer appear in persisted wallet state. E2E **fixture validation** now ignores whole controllers (`CurrencyController`, token/multichain asset and balance/rates controllers, etc.) instead of flaky per-field currency rate paths, with a comment pointing at v111.2.0+ behavior. The **metrics state snapshot** JSON is updated so those controllers are represented as **empty objects** rather than nested shapes that are no longer persisted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e459fd2d5edaa3f98e827546db40461f97a1c2e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->