### PR TITLE
feat: update hyperliquid prompt ui

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4795,6 +4795,14 @@
   "honeypotTitle": {
     "message": "Honey pot"
   },
+  "hyperliquidDepositPromptDescription": {
+    "message": "Deposit any token. We'll swap it and send it to your Hyperliquid account automatically—no MetaMask fee.",
+    "description": "The description of the Hyperliquid deposit prompt screen shown after enabling trading on Hyperliquid"
+  },
+  "hyperliquidDepositPromptNoThanks": {
+    "message": "No thanks, deposit manually",
+    "description": "The label of the dismiss button in the Hyperliquid deposit prompt screen"
+  },
   "hyperliquidDepositPromptTitle": {
     "message": "Fund Hyperliquid with MetaMask",
     "description": "The title of the Hyperliquid deposit prompt screen shown after enabling trading on Hyperliquid"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4795,6 +4795,14 @@
   "honeypotTitle": {
     "message": "Honey pot"
   },
+  "hyperliquidDepositPromptDescription": {
+    "message": "Deposit any token. We'll swap it and send it to your Hyperliquid account automatically—no MetaMask fee.",
+    "description": "The description of the Hyperliquid deposit prompt screen shown after enabling trading on Hyperliquid"
+  },
+  "hyperliquidDepositPromptNoThanks": {
+    "message": "No thanks, deposit manually",
+    "description": "The label of the dismiss button in the Hyperliquid deposit prompt screen"
+  },
   "hyperliquidDepositPromptTitle": {
     "message": "Fund Hyperliquid with MetaMask",
     "description": "The title of the Hyperliquid deposit prompt screen shown after enabling trading on Hyperliquid"

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
@@ -175,11 +175,14 @@ describe('HyperliquidDepositPrompt', () => {
     mockGetEnvironmentType.mockReturnValue('notification');
   });
 
-  it('renders the title, logos, default token and continue button', () => {
+  it('renders the title, description, logos, default token and action buttons', () => {
     renderComponent();
 
     expect(
       screen.getByText(messages.hyperliquidDepositPromptTitle.message),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.hyperliquidDepositPromptDescription.message),
     ).toBeInTheDocument();
     expect(screen.getByText(messages.payWith.message)).toBeInTheDocument();
     expect(
@@ -194,6 +197,9 @@ describe('HyperliquidDepositPrompt', () => {
     expect(
       screen.getByTestId('hyperliquid-deposit-prompt-continue'),
     ).toBeEnabled();
+    expect(
+      screen.getByTestId('hyperliquid-deposit-prompt-no-thanks'),
+    ).toHaveTextContent(messages.hyperliquidDepositPromptNoThanks.message);
   });
 
   it('tracks Hyperliquid Deposit Prompt Viewed on render', () => {
@@ -212,6 +218,24 @@ describe('HyperliquidDepositPrompt', () => {
     const { onActionComplete } = renderComponent();
 
     fireEvent.click(screen.getByTestId('hyperliquid-deposit-prompt-close'));
+
+    expect(onActionComplete).toHaveBeenCalledWith({ action: 'dismiss' });
+    expect(mockStartPerpsDeposit).not.toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: MetaMetricsEventName.HyperliquidDepositPromptInteracted,
+      properties: {
+        category: MetaMetricsEventCategory.Confirmations,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        interaction_type: 'dismiss',
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('resolves the approval without starting a deposit when No thanks is clicked', () => {
+    const { onActionComplete } = renderComponent();
+
+    fireEvent.click(screen.getByTestId('hyperliquid-deposit-prompt-no-thanks'));
 
     expect(onActionComplete).toHaveBeenCalledWith({ action: 'dismiss' });
     expect(mockStartPerpsDeposit).not.toHaveBeenCalled();
@@ -308,6 +332,9 @@ describe('HyperliquidDepositPrompt', () => {
     expect(
       screen.getByTestId('hyperliquid-deposit-prompt-continue'),
     ).toBeDisabled();
+    expect(
+      screen.getByTestId('hyperliquid-deposit-prompt-no-thanks'),
+    ).toBeEnabled();
   });
 
   it('uses the wallet home perps tab as goBackTo when bottom nav is disabled', async () => {

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.test.tsx
@@ -31,9 +31,10 @@ import { HyperliquidDepositPrompt } from './hyperliquid-deposit-prompt';
 jest.mock('../../../pages/confirmations/hooks/send/useSendTokens');
 
 const mockStartPerpsDeposit = jest.fn();
+let mockIsStartingDeposit = false;
 jest.mock('../perps/hooks/usePerpsDepositConfirmation', () => ({
   usePerpsDepositConfirmation: () => ({
-    isLoading: false,
+    isLoading: mockIsStartingDeposit,
     trigger: mockStartPerpsDeposit,
   }),
 }));
@@ -162,6 +163,7 @@ const renderComponent = (
 describe('HyperliquidDepositPrompt', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsStartingDeposit = false;
     mockSelectBlockedPayTokens.mockReturnValue({
       chainIds: [],
       tokens: [],
@@ -248,6 +250,16 @@ describe('HyperliquidDepositPrompt', () => {
       },
       sensitiveProperties: {},
     });
+  });
+
+  it('disables No thanks while a deposit is being started', () => {
+    mockIsStartingDeposit = true;
+
+    renderComponent();
+
+    expect(
+      screen.getByTestId('hyperliquid-deposit-prompt-no-thanks'),
+    ).toBeDisabled();
   });
 
   it('updates the selected token when one is picked from the modal', () => {

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
@@ -399,6 +399,7 @@ export const HyperliquidDepositPrompt: React.FC<
           data-testid="hyperliquid-deposit-prompt-no-thanks"
           variant={ButtonVariant.Tertiary}
           onClick={handleClose}
+          isDisabled={isStartingDeposit}
           isFullWidth
         >
           {t('hyperliquidDepositPromptNoThanks')}

--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
@@ -18,6 +18,7 @@ import {
   Button,
   ButtonBase,
   ButtonIcon,
+  ButtonVariant,
   Icon,
   IconColor,
   IconName,
@@ -356,8 +357,15 @@ export const HyperliquidDepositPrompt: React.FC<
         >
           {t('hyperliquidDepositPromptTitle')}
         </Text>
+        <Text
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
+          className="mt-2 text-center"
+        >
+          {t('hyperliquidDepositPromptDescription')}
+        </Text>
       </Box>
-      <Box flexDirection={BoxFlexDirection.Column} gap={2} className="pt-14">
+      <Box flexDirection={BoxFlexDirection.Column} gap={2} className="pt-8">
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {t('payWith')}
         </Text>
@@ -377,15 +385,25 @@ export const HyperliquidDepositPrompt: React.FC<
           {t('somethingWentWrong')}
         </Text>
       )}
-      <Button
-        data-testid="hyperliquid-deposit-prompt-continue"
-        onClick={handleContinue}
-        isLoading={isStartingDeposit}
-        isDisabled={!displayToken || isStartingDeposit}
-        isFullWidth
-      >
-        {t('continue')}
-      </Button>
+      <Box flexDirection={BoxFlexDirection.Column} gap={4}>
+        <Button
+          data-testid="hyperliquid-deposit-prompt-continue"
+          onClick={handleContinue}
+          isLoading={isStartingDeposit}
+          isDisabled={!displayToken || isStartingDeposit}
+          isFullWidth
+        >
+          {t('continue')}
+        </Button>
+        <Button
+          data-testid="hyperliquid-deposit-prompt-no-thanks"
+          variant={ButtonVariant.Tertiary}
+          onClick={handleClose}
+          isFullWidth
+        >
+          {t('hyperliquidDepositPromptNoThanks')}
+        </Button>
+      </Box>
       <Modal
         isOpen={isPickerOpen}
         onClose={() => setIsPickerOpen(false)}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds description and a dismiss button

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update Hyperliquid deposit prompt UI with a description and dismiss button

## **Related issues**

Fixes:

## **Manual testing steps**

yarn storybook and look for Hyperliquid Deposit Prompt

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="280" height="417" alt="image" src="https://github.com/user-attachments/assets/601aa886-44b1-43c7-8027-e40f23b8340a" />


### **After**

<img width="421" height="772" alt="image" src="https://github.com/user-attachments/assets/27cc2a66-94ae-41d1-81b3-0433afcf6f0a" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and copy changes with dismiss wired to existing close handling; deposit flow logic is unchanged aside from an extra dismiss entry point.
> 
> **Overview**
> The **Hyperliquid deposit prompt** now shows explanatory copy under the title (any-token deposit, automatic swap, no MetaMask fee) and a tertiary **“No thanks, deposit manually”** action alongside **Continue**.
> 
> Choosing **No thanks** uses the same dismiss path as the close control: it resolves the approval with `action: 'dismiss'`, fires the existing dismiss analytics, and does **not** start a perps deposit. **No thanks** is disabled while a deposit is starting; it stays enabled when **Continue** is disabled (e.g. no selectable token). Layout spacing above the pay-with section is tightened slightly.
> 
> New strings are added in **en** and **en_GB**; unit tests cover the new UI and dismiss/loading behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 378749b040f76cd4915adbc02719f1aa4b554d60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->