### PR TITLE
refactor(metametrics): move uninstall URL off MetaMetricsController

### DIFF
--- a/app/scripts/controllers/analytics/analytics.test.ts
+++ b/app/scripts/controllers/analytics/analytics.test.ts
@@ -19,6 +19,7 @@ import type {
   NetworkControllerGetStateAction,
 } from '@metamask/network-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import type { Browser } from 'webextension-polyfill';
 import { ENVIRONMENT } from '../../../../shared/constants/build';
 import { createEventBuilder } from '../../../../shared/lib/analytics/create-event-builder';
 import type { PreferencesControllerGetStateAction } from '../preferences-controller';
@@ -27,7 +28,6 @@ import type {
   MetaMetricsControllerClearTracesAfterMetricsOptInAction,
   MetaMetricsControllerSetMarketingCampaignCookieIdAction,
   MetaMetricsControllerTrackTracesAfterMetricsOptInAction,
-  MetaMetricsControllerUpdateExtensionUninstallUrlAction,
 } from '../metametrics-controller-method-action-types';
 import { getAnalyticsControllerInitMessenger } from '../../messenger-client-init/messengers/analytics-controller-messenger';
 import {
@@ -78,7 +78,12 @@ function createConfiguredMessenger({
   const trackTracesHandler = jest.fn();
   const clearTracesHandler = jest.fn();
   const setMarketingCampaignCookieIdHandler = jest.fn();
-  const updateExtensionUninstallUrlHandler = jest.fn();
+  const setUninstallURL = jest.fn();
+  const mockExtension = {
+    runtime: {
+      setUninstallURL,
+    },
+  } as unknown as Browser;
   const rootMessenger = new Messenger<
     MockAnyNamespace,
     | PreferencesControllerGetStateAction
@@ -90,7 +95,6 @@ function createConfiguredMessenger({
     | MetaMetricsControllerTrackTracesAfterMetricsOptInAction
     | MetaMetricsControllerClearTracesAfterMetricsOptInAction
     | MetaMetricsControllerSetMarketingCampaignCookieIdAction
-    | MetaMetricsControllerUpdateExtensionUninstallUrlAction
     | AnalyticsControllerGetStateAction
     | AnalyticsControllerTrackEventAction
     | AnalyticsControllerIdentifyAction
@@ -163,10 +167,6 @@ function createConfiguredMessenger({
     }) as never,
   );
   rootMessenger.registerActionHandler(
-    'MetaMetricsController:updateExtensionUninstallUrl',
-    updateExtensionUninstallUrlHandler as never,
-  );
-  rootMessenger.registerActionHandler(
     'AnalyticsController:getState',
     () => analyticsControllerState as never,
   );
@@ -199,6 +199,7 @@ function createConfiguredMessenger({
 
   configureAnalytics({
     messenger: analyticsMessenger,
+    extension: mockExtension,
   });
 
   return {
@@ -211,7 +212,7 @@ function createConfiguredMessenger({
     trackTracesHandler,
     clearTracesHandler,
     setMarketingCampaignCookieIdHandler,
-    updateExtensionUninstallUrlHandler,
+    setUninstallURL,
     analyticsControllerState,
     metaMetricsControllerState,
   };
@@ -411,73 +412,81 @@ describe('analytics', () => {
     describe('the extension uninstall URL', () => {
       const originalEnvironment = process.env.METAMASK_ENVIRONMENT;
       const originalBuildType = process.env.METAMASK_BUILD_TYPE;
+      const originalVersion = process.env.METAMASK_VERSION;
+      const testVersion = '13.0.0';
+      const encodedAnalyticsId =
+        Buffer.from(TEST_ANALYTICS_ID).toString('base64');
+
+      beforeEach(() => {
+        process.env.METAMASK_VERSION = testVersion;
+      });
 
       afterEach(() => {
         process.env.METAMASK_ENVIRONMENT = originalEnvironment;
         process.env.METAMASK_BUILD_TYPE = originalBuildType;
+        process.env.METAMASK_VERSION = originalVersion;
       });
 
       it('updates it when opting in on a main production build', async () => {
         process.env.METAMASK_BUILD_TYPE = 'main';
         process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.PRODUCTION;
-        const { updateExtensionUninstallUrlHandler } =
-          createConfiguredMessenger();
+        const { setUninstallURL } = createConfiguredMessenger();
 
         await setParticipateInMetaMetrics(true);
 
-        expect(updateExtensionUninstallUrlHandler).toHaveBeenCalledTimes(1);
-        expect(updateExtensionUninstallUrlHandler).toHaveBeenCalledWith(
-          true,
-          TEST_ANALYTICS_ID,
+        expect(setUninstallURL).toHaveBeenCalledTimes(1);
+        expect(setUninstallURL).toHaveBeenCalledWith(
+          `https://metamask.io/uninstalled?${new URLSearchParams({
+            av: testVersion,
+            mmi: encodedAnalyticsId,
+            env: ENVIRONMENT.PRODUCTION,
+          }).toString()}`,
         );
       });
 
       it('updates it when opting out on a main production build', async () => {
         process.env.METAMASK_BUILD_TYPE = 'main';
         process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.PRODUCTION;
-        const { updateExtensionUninstallUrlHandler } =
-          createConfiguredMessenger();
+        const { setUninstallURL } = createConfiguredMessenger();
 
         await setParticipateInMetaMetrics(false);
 
-        expect(updateExtensionUninstallUrlHandler).toHaveBeenCalledTimes(1);
-        expect(updateExtensionUninstallUrlHandler).toHaveBeenCalledWith(
-          false,
-          TEST_ANALYTICS_ID,
+        expect(setUninstallURL).toHaveBeenCalledTimes(1);
+        expect(setUninstallURL).toHaveBeenCalledWith(
+          `https://metamask.io/uninstalled?${new URLSearchParams({
+            av: testVersion,
+          }).toString()}`,
         );
       });
 
       it('does not update it when participation is reset to null', async () => {
         process.env.METAMASK_BUILD_TYPE = 'main';
         process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.PRODUCTION;
-        const { updateExtensionUninstallUrlHandler } =
-          createConfiguredMessenger();
+        const { setUninstallURL } = createConfiguredMessenger();
 
         await setParticipateInMetaMetrics(null);
 
-        expect(updateExtensionUninstallUrlHandler).not.toHaveBeenCalled();
+        expect(setUninstallURL).not.toHaveBeenCalled();
       });
 
       it('does not update it in development', async () => {
         process.env.METAMASK_BUILD_TYPE = 'main';
         process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.DEVELOPMENT;
-        const { updateExtensionUninstallUrlHandler } =
-          createConfiguredMessenger();
+        const { setUninstallURL } = createConfiguredMessenger();
 
         await setParticipateInMetaMetrics(true);
 
-        expect(updateExtensionUninstallUrlHandler).not.toHaveBeenCalled();
+        expect(setUninstallURL).not.toHaveBeenCalled();
       });
 
       it('does not update it for a non-main build', async () => {
         process.env.METAMASK_BUILD_TYPE = 'flask';
         process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.PRODUCTION;
-        const { updateExtensionUninstallUrlHandler } =
-          createConfiguredMessenger();
+        const { setUninstallURL } = createConfiguredMessenger();
 
         await setParticipateInMetaMetrics(true);
 
-        expect(updateExtensionUninstallUrlHandler).not.toHaveBeenCalled();
+        expect(setUninstallURL).not.toHaveBeenCalled();
       });
     });
   });

--- a/app/scripts/controllers/analytics/analytics.ts
+++ b/app/scripts/controllers/analytics/analytics.ts
@@ -8,6 +8,7 @@ import type {
 import type { AuthenticationController } from '@metamask/profile-sync-controller';
 import type { Json } from '@metamask/utils';
 import { omitBy } from 'lodash';
+import type { Browser } from 'webextension-polyfill';
 import type {
   AnalyticsEvent,
   AnalyticsEventBuildOptions,
@@ -34,6 +35,8 @@ import { trackSegmentEventWhileOptedOut } from '../../lib/segment/custom-segment
 import { getPlatform } from '../../lib/util';
 import { ANONYMOUS_EVENT_PROPERTY } from './platform-adapter';
 
+const EXTENSION_UNINSTALL_URL = 'https://metamask.io/uninstalled';
+
 type SegmentTrackPayload = Omit<
   SegmentEventPayload,
   'properties' | 'timestamp'
@@ -50,9 +53,11 @@ type SegmentPagePayload = {
 
 type ConfigureAnalyticsOptions = {
   messenger: AnalyticsControllerInitMessenger;
+  extension?: Browser;
 };
 
 let messenger: AnalyticsControllerInitMessenger | undefined;
+let extension: Browser | undefined;
 let cachedProfileIdentity:
   | {
       profileId?: string;
@@ -72,11 +77,49 @@ function getMessenger(): AnalyticsControllerInitMessenger {
  *
  * @param options - Configuration options.
  * @param options.messenger - Messenger with analytics state and delivery access.
+ * @param options.extension - webextension-polyfill, used to set the uninstall URL.
  */
 export function configureAnalytics({
   messenger: configuredMessenger,
+  extension: configuredExtension,
 }: ConfigureAnalyticsOptions): void {
   messenger = configuredMessenger;
+  extension = configuredExtension;
+}
+
+/**
+ * Sets an uninstall URL ("Sorry to see you go!" page), which is opened if a
+ * user uninstalls the extension. Call only after a MetaMetrics consent decision.
+ *
+ * @param participateInMetaMetrics - Whether the user opted into metrics.
+ * @param analyticsId - The current analytics id.
+ */
+function updateExtensionUninstallUrl(
+  participateInMetaMetrics: boolean,
+  analyticsId: string,
+): void {
+  const version = process.env.METAMASK_VERSION as string;
+  const environment = process.env.METAMASK_ENVIRONMENT as string;
+  const appVersion =
+    environment === 'production' ? version : `${version}-${environment}`;
+  const query: {
+    mmi?: string;
+    env?: string;
+    av: string;
+  } = {
+    av: appVersion,
+  };
+  if (participateInMetaMetrics) {
+    query.mmi = Buffer.from(analyticsId).toString('base64');
+    query.env = environment;
+  }
+  const queryString = new URLSearchParams(query);
+
+  if (extension?.runtime) {
+    extension.runtime.setUninstallURL(
+      `${EXTENSION_UNINSTALL_URL}?${queryString}`,
+    );
+  }
 }
 
 /**
@@ -378,8 +421,8 @@ export function identify(
 /**
  * Set whether the user participates in MetaMetrics.
  *
- * Consent is owned by AnalyticsController. Buffered traces, the marketing
- * campaign cookie, and the extension uninstall URL remain on MetaMetricsController.
+ * Consent is owned by AnalyticsController. Buffered traces and the marketing
+ * campaign cookie remain on MetaMetricsController.
  *
  * @param participateInMetaMetrics - Whether the user wants to participate, or `null` to reset to undecided.
  * @returns The current analytics id.
@@ -426,11 +469,7 @@ export async function setParticipateInMetaMetrics(
     process.env.METAMASK_ENVIRONMENT !== ENVIRONMENT.DEVELOPMENT &&
     participateInMetaMetrics !== null
   ) {
-    analyticsMessenger.call(
-      'MetaMetricsController:updateExtensionUninstallUrl',
-      participateInMetaMetrics === true,
-      analyticsId,
-    );
+    updateExtensionUninstallUrl(participateInMetaMetrics === true, analyticsId);
   }
 
   return analyticsId;

--- a/app/scripts/controllers/metametrics-controller-method-action-types.ts
+++ b/app/scripts/controllers/metametrics-controller-method-action-types.ts
@@ -5,11 +5,6 @@
 
 import type { MetaMetricsController } from './metametrics-controller';
 
-export type MetaMetricsControllerUpdateExtensionUninstallUrlAction = {
-  type: `MetaMetricsController:updateExtensionUninstallUrl`;
-  handler: MetaMetricsController['updateExtensionUninstallUrl'];
-};
-
 export type MetaMetricsControllerSetDataCollectionForMarketingAction = {
   type: `MetaMetricsController:setDataCollectionForMarketing`;
   handler: MetaMetricsController['setDataCollectionForMarketing'];
@@ -61,7 +56,6 @@ export type MetaMetricsControllerBufferedEndTraceAction = {
  * Union of all MetaMetricsController action types.
  */
 export type MetaMetricsControllerMethodActions =
-  | MetaMetricsControllerUpdateExtensionUninstallUrlAction
   | MetaMetricsControllerSetDataCollectionForMarketingAction
   | MetaMetricsControllerSetMarketingCampaignCookieIdAction
   | MetaMetricsControllerTrackTracesAfterMetricsOptInAction

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -14,7 +14,6 @@ import type {
   AnalyticsEventProperties,
   AnalyticsUserTraits,
 } from '@metamask/analytics-controller';
-import { Browser } from 'webextension-polyfill';
 import { deriveStateFromMetadata } from '@metamask/base-controller';
 import {
   MOCK_ANY_NAMESPACE,
@@ -119,14 +118,6 @@ const MOCK_ANALYTICS_CONTROLLER_OPTED_IN: AnalyticsControllerState = {
   consentDecisionMade: true,
   analyticsId: TEST_ANALYTICS_ID,
 };
-const MOCK_EXTENSION_ID = 'testid';
-
-const MOCK_EXTENSION = {
-  runtime: {
-    id: MOCK_EXTENSION_ID,
-    setUninstallURL: () => undefined,
-  },
-} as unknown as Browser;
 
 const MOCK_TRAITS = {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -225,7 +216,6 @@ describe('MetaMetricsController', function () {
     it('should properly initialize', async function () {
       const spy = jest.spyOn(segmentMock, 'track');
       await withController(({ controller, controllerMessenger }) => {
-        expect(controller.version).toStrictEqual(VERSION);
         expect(controller.chainId).toStrictEqual(DEFAULT_CHAIN_ID);
         expect(controller.state.marketingCampaignCookieId).toStrictEqual(null);
         const { analyticsId, consentDecisionMade } = controllerMessenger.call(
@@ -1546,40 +1536,6 @@ describe('MetaMetricsController', function () {
       );
     });
   });
-  describe('updateExtensionUninstallUrl', function () {
-    it('should include extension version in uninstall URL regardless of MetaMetrics participation', async function () {
-      await withController(({ controller }) => {
-        const setUninstallURLSpy = jest.spyOn(
-          MOCK_EXTENSION.runtime,
-          'setUninstallURL',
-        );
-
-        // Test with MetaMetrics disabled
-        controller.updateExtensionUninstallUrl(false, 'test-id');
-        expect(setUninstallURLSpy).toHaveBeenCalledWith(
-          expect.stringContaining(`av=${VERSION}`),
-        );
-        expect(setUninstallURLSpy).toHaveBeenCalledWith(
-          expect.not.stringContaining('mmi='),
-        );
-        expect(setUninstallURLSpy).toHaveBeenCalledWith(
-          expect.not.stringContaining('env='),
-        );
-
-        // Test with MetaMetrics enabled
-        controller.updateExtensionUninstallUrl(true, 'test-id');
-        expect(setUninstallURLSpy).toHaveBeenCalledWith(
-          expect.stringContaining(`av=${VERSION}`),
-        );
-        expect(setUninstallURLSpy).toHaveBeenCalledWith(
-          expect.stringContaining('mmi='),
-        );
-        expect(setUninstallURLSpy).toHaveBeenCalledWith(
-          expect.stringContaining('env='),
-        );
-      });
-    });
-  });
 
   describe('metadata', () => {
     it('includes expected state in debug snapshots', async () => {
@@ -1973,9 +1929,6 @@ async function withController<ReturnValue>(
     return fn({
       controller: new MetaMetricsController({
         messenger: metaMetricsControllerMessenger,
-        version: '0.0.1',
-        environment: 'test',
-        extension: MOCK_EXTENSION,
         ...options,
         state: mmcState,
       }),

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -11,7 +11,6 @@ import type {
 } from '@metamask/network-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type { MultichainNetworkControllerGetStateAction } from '@metamask/multichain-network-controller';
-import type { Browser } from 'webextension-polyfill';
 import {
   BaseController,
   type ControllerGetStateAction,
@@ -40,7 +39,6 @@ import { MetaMetricsControllerMethodActions } from './metametrics-controller-met
 // Unique name for the controller
 const controllerName = 'MetaMetricsController';
 
-const EXTENSION_UNINSTALL_URL = 'https://metamask.io/uninstalled';
 const defaultCaptureException = (err: unknown) => {
   // throw error on clean stack so its captured by platform integrations (eg sentry)
   // but does not interrupt the call stack
@@ -161,9 +159,6 @@ type CaptureException = typeof captureException | ((err: unknown) => void);
 export type MetaMetricsControllerOptions = {
   state?: Partial<MetaMetricsControllerState>;
   messenger: MetaMetricsControllerMessenger;
-  version: string;
-  environment: string;
-  extension: Browser;
   captureException?: CaptureException;
 };
 
@@ -185,7 +180,6 @@ const MESSENGER_EXPOSED_METHODS = [
   'setDataCollectionForMarketing',
   'setMarketingCampaignCookieId',
   'trackTracesAfterMetricsOptIn',
-  'updateExtensionUninstallUrl',
 ] as const;
 
 export class MetaMetricsController extends BaseController<
@@ -199,12 +193,6 @@ export class MetaMetricsController extends BaseController<
 
   locale: string;
 
-  version: MetaMetricsControllerOptions['version'];
-
-  #extension: MetaMetricsControllerOptions['extension'];
-
-  #environment: MetaMetricsControllerOptions['environment'];
-
   #analyticsGetState(): AnalyticsControllerState {
     return this.messenger.call('AnalyticsController:getState');
   }
@@ -213,17 +201,11 @@ export class MetaMetricsController extends BaseController<
    * @param options
    * @param options.state - Initial controller state.
    * @param options.messenger - Messenger used to communicate with BaseV2 controller.
-   * @param options.version - The version of the extension
-   * @param options.environment - The environment the extension is running in
-   * @param options.extension - webextension-polyfill
    * @param options.captureException
    */
   constructor({
     state = {},
     messenger,
-    version,
-    environment,
-    extension,
     captureException = defaultCaptureException,
   }: MetaMetricsControllerOptions) {
     super({
@@ -249,10 +231,6 @@ export class MetaMetricsController extends BaseController<
       'PreferencesController:getState',
     );
     this.locale = preferencesControllerState.currentLocale.replace('_', '-');
-    this.version =
-      environment === 'production' ? version : `${version}-${environment}`;
-    this.#extension = extension;
-    this.#environment = environment;
 
     // Register A/B test analytics mappings so that matching events are
     // enriched with their `active_ab_tests` assignment.
@@ -295,35 +273,6 @@ export class MetaMetricsController extends BaseController<
       selectedNetworkClientId,
     );
     return chainId;
-  }
-
-  // It sets an uninstall URL ("Sorry to see you go!" page),
-  // which is opened if a user uninstalls the extension.
-  // This method should only be called after the user has made a decision about MetaMetrics participation.
-  updateExtensionUninstallUrl(
-    participateInMetaMetrics: boolean,
-    analyticsId: string,
-  ): void {
-    const query: {
-      mmi?: string;
-      env?: string;
-      av: string;
-    } = {
-      av: this.version,
-    };
-    if (participateInMetaMetrics) {
-      // We only want to track these things if a user opted into metrics.
-      query.mmi = Buffer.from(analyticsId).toString('base64');
-      query.env = this.#environment;
-    }
-    const queryString = new URLSearchParams(query);
-
-    // this.extension not currently defined in tests
-    if (this.#extension && this.#extension.runtime) {
-      this.#extension.runtime.setUninstallURL(
-        `${EXTENSION_UNINSTALL_URL}?${queryString}`,
-      );
-    }
   }
 
   setDataCollectionForMarketing(dataCollectionForMarketing: boolean): string {

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
@@ -225,10 +225,6 @@ messenger.registerActionHandler(
   'MetaMetricsController:setMarketingCampaignCookieId',
   () => undefined,
 );
-messenger.registerActionHandler(
-  'MetaMetricsController:updateExtensionUninstallUrl',
-  () => undefined,
-);
 
 messenger.registerActionHandler('MultichainNetworkController:getState', () => ({
   isEvmSelected: true,

--- a/app/scripts/messenger-client-init/analytics-controller-init.ts
+++ b/app/scripts/messenger-client-init/analytics-controller-init.ts
@@ -24,13 +24,14 @@ import { MessengerClientInitFunction } from './types';
  * @param request.persistedState - The persisted state to use for the
  * controller.
  * @param request.initMessenger
+ * @param request.extension - The webextension polyfill instance.
  * @returns The initialized controller.
  */
 export const AnalyticsControllerInit: MessengerClientInitFunction<
   AnalyticsController,
   AnalyticsControllerMessenger,
   AnalyticsControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, persistedState }) => {
+> = ({ controllerMessenger, initMessenger, persistedState, extension }) => {
   const persisted = {
     ...persistedState.AnalyticsController,
   };
@@ -65,6 +66,7 @@ export const AnalyticsControllerInit: MessengerClientInitFunction<
 
   configureAnalytics({
     messenger: initMessenger,
+    extension,
   });
 
   return { messengerClient: controller };

--- a/app/scripts/messenger-client-init/messengers/analytics-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/analytics-controller-messenger.ts
@@ -29,7 +29,6 @@ import type {
   MetaMetricsControllerClearTracesAfterMetricsOptInAction,
   MetaMetricsControllerSetMarketingCampaignCookieIdAction,
   MetaMetricsControllerTrackTracesAfterMetricsOptInAction,
-  MetaMetricsControllerUpdateExtensionUninstallUrlAction,
 } from '../../controllers/metametrics-controller-method-action-types';
 import type { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 import type { RootMessenger } from '../../lib/messenger';
@@ -44,7 +43,6 @@ type InitActions =
   | MetaMetricsControllerTrackTracesAfterMetricsOptInAction
   | MetaMetricsControllerClearTracesAfterMetricsOptInAction
   | MetaMetricsControllerSetMarketingCampaignCookieIdAction
-  | MetaMetricsControllerUpdateExtensionUninstallUrlAction
   | AnalyticsControllerGetStateAction
   | AnalyticsControllerTrackEventAction
   | AnalyticsControllerIdentifyAction
@@ -121,7 +119,6 @@ export function getAnalyticsControllerInitMessenger(
       'MetaMetricsController:trackTracesAfterMetricsOptIn',
       'MetaMetricsController:clearTracesAfterMetricsOptIn',
       'MetaMetricsController:setMarketingCampaignCookieId',
-      'MetaMetricsController:updateExtensionUninstallUrl',
       'AnalyticsController:getState',
       'AnalyticsController:trackEvent',
       'AnalyticsController:identify',

--- a/app/scripts/messenger-client-init/metametrics-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/metametrics-controller-init.test.ts
@@ -38,9 +38,6 @@ describe('MetaMetricsControllerInit', () => {
       messenger: expect.any(Object),
       state: undefined,
       captureException: expect.any(Function),
-      environment: 'testing',
-      extension: expect.any(Object),
-      version: 'MOCK_VERSION',
     });
   });
 });

--- a/app/scripts/messenger-client-init/metametrics-controller-init.ts
+++ b/app/scripts/messenger-client-init/metametrics-controller-init.ts
@@ -15,19 +15,15 @@ import { MessengerClientInitFunction } from './types';
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.persistedState - The persisted state of the extension.
- * @param request.extension - The webextension polyfill instance.
  * @returns The initialized controller.
  */
 export const MetaMetricsControllerInit: MessengerClientInitFunction<
   MetaMetricsController,
   MetaMetricsControllerMessenger
-> = ({ controllerMessenger, extension, persistedState }) => {
+> = ({ controllerMessenger, persistedState }) => {
   const messengerClient = new MetaMetricsController({
     state: persistedState.MetaMetricsController,
     messenger: controllerMessenger,
-    version: process.env.METAMASK_VERSION as string,
-    environment: process.env.METAMASK_ENVIRONMENT as string,
-    extension,
     captureException,
   });
 


### PR DESCRIPTION
## **Description**

### Context

`MetaMetricsController` is being deprecated in favor of `@metamask/analytics-controller` plus the Extension analytics facade. Consent already lives in `setParticipateInMetaMetrics`, but Chrome uninstall URL updates still went through a MetaMetricsController messenger action.

### Problem

Keeping `updateExtensionUninstallUrl` on MetaMetricsController blocks further deprecation and leaves an unnecessary messenger RPC for an Extension-only browser API call.

### Solution

- Move uninstall URL construction into a private helper in the analytics facade
- Pass `extension` through `configureAnalytics` from `AnalyticsControllerInit`
- Call the helper directly from `setParticipateInMetaMetrics` after a non-null consent decision on main non-development builds
- Remove the MetaMetricsController method, constructor deps (`version`, `environment`, `extension`), and messenger action
- Keep query behavior unchanged: always `av`, and when opted in also `mmi` (base64 analytics id) and `env`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Chrome does not expose a getter for the current uninstall URL, and LavaMoat scuttling blocks wrapping `chrome.runtime.setUninstallURL` from the service worker console on `yarn dist` builds. Verify by removing the extension and checking the page Chrome opens.

1. Download the build from this PR (development builds skip uninstall URL updates).
2. Complete onboarding and opt into MetaMetrics.
3. On `chrome://extensions`, remove the unpacked MetaMask extension.
4. Confirm Chrome opens an uninstall page on `metamask.io` (the site may redirect to a locale path such as `/en-GB/uninstalled`) with query params including:
   - `av=` (version, or `${version}-${environment}` when the build env is not `production`)
   - `mmi=` (base64 analytics id)
   - `env=` (build environment, for example `production` or `pull-request`)
5. Reload `dist/chrome` as an unpacked extension, unlock or finish setup, then turn MetaMetrics off in Settings.
6. Remove the extension again from `chrome://extensions`.
7. Confirm Chrome opens the uninstall page with `av=` only, and without `mmi=` or `env=`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.