### PR TITLE
fix(build): use Terser minify for AMO-deterministic Flask builds

### DIFF
--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -104,21 +104,17 @@ export const extensionToJs = (filename: string) =>
 /**
  * It gets minimizers for the webpack build.
  *
- * TerserPlugin's default `parallel` mode uses jest-worker to spawn a minifier
- * process per CPU core. Worker assignment is not guaranteed to be stable across
- * runs, which can change SWC mangling frequency analysis and produce different
- * `runtime.[contenthash].js` filenames. That breaks Firefox AMO reviewer
- * rebuild comparisons (mtree) even when the bundles are otherwise equivalent.
- * Disabling parallel minify keeps that step deterministic and has also been a
- * small wall-clock win in local `yarn dist:mv2` timings.
+ * SWC minify can still assign different short names across Linux rebuilds for
+ * larger Flask bundles (`c`/`l` swaps in `runtime.[contenthash].js`), even with
+ * TerserPlugin `parallel: false`. Classic Terser minify is slower but was
+ * deterministic across 10/10 local Ubuntu Docker Flask rebuilds.
  */
 export function getMinimizers() {
   const TerserPlugin: typeof TerserPluginType = require('terser-webpack-plugin');
   return [
     new TerserPlugin({
-      // use SWC to minify (about 7x faster than Terser)
-      minify: TerserPlugin.swcMinify,
-      // Determinism (and a small local build-time win): one minifier process.
+      // Classic Terser for AMO rebuild determinism (slower than SWC).
+      minify: TerserPlugin.terserMinify,
       parallel: false,
       // do not minify snow.
       exclude: /snow\.prod/u,

--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -104,16 +104,17 @@ export const extensionToJs = (filename: string) =>
 /**
  * It gets minimizers for the webpack build.
  *
- * SWC minify can still assign different short names across Linux rebuilds for
- * larger Flask bundles (`c`/`l` swaps in `runtime.[contenthash].js`), even with
- * TerserPlugin `parallel: false`. Classic Terser minify is slower but was
- * deterministic across 10/10 local Ubuntu Docker Flask rebuilds.
+ * Prefer classic Terser over SWC here. SWC mangling can still produce
+ * different `runtime.[contenthash].js` output across Linux rebuilds for Flask
+ * (short-name swaps such as `c`/`l`), even with TerserPlugin `parallel: false`.
+ * That breaks Firefox AMO reviewer `mtree` comparisons. Classic Terser is
+ * slower but keeps minify output stable for those rebuilds.
  */
 export function getMinimizers() {
   const TerserPlugin: typeof TerserPluginType = require('terser-webpack-plugin');
   return [
     new TerserPlugin({
-      // Classic Terser for AMO rebuild determinism (slower than SWC).
+      // Classic Terser for stable AMO rebuilds (slower than SWC).
       minify: TerserPlugin.terserMinify,
       parallel: false,
       // do not minify snow.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Context
Firefox AMO packaging compares the published Firefox zip to a Linux rebuild (`mtree`). On `13.47.1`, **main matched** with `parallel: false`, but **Flask still flaked** on SWC short-name mangling (`c`/`l` swaps in `runtime.[contenthash].js`).

### Problem
`TerserPlugin.swcMinify` + `parallel: false` is not enough for Flask. Local Ubuntu Docker Flask rebuilds flipped between two runtime hashes (~40% match vs published).

### Solution (option A)
Switch production minify to classic **`TerserPlugin.terserMinify`** (keep `parallel: false`).

Local evidence (Flask MV2, Ubuntu Docker, 10 cold rebuilds):
- **10/10** identical `runtime.552cc2ea…`
- Avg wall clock ~**154s** (slower than SWC)

Pros: deterministic + still mangles (smaller than no-mangle).
Cons: slower builds than SWC.

Sibling option: SWC with `mangle: false` (faster, larger bundles).

## **Changelog**
CHANGELOG entry: null

## **Related issues**
Fixes: INFRA-3920

## **Manual testing steps**
1. Build Firefox Flask production (`yarn webpack:lavamoat:build:mv2 --type flask --env production` or release AMO prepare path).
2. Rebuild from the same source on Linux.
3. Confirm `runtime.[contenthash].js` matches between builds.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**
- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)