### PR TITLE
fix(build): disable SWC mangling on the runtime chunk for AMO determinism

### DIFF
--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -104,11 +104,11 @@ export const extensionToJs = (filename: string) =>
 /**
  * It gets minimizers for the webpack build.
  *
- * SWC minify can still assign different short names across Linux rebuilds for
- * larger Flask bundles (`c`/`l` swaps in `runtime.[contenthash].js`), even with
- * TerserPlugin `parallel: false`. Disabling SWC mangling keeps compress and was
- * deterministic across 10/10 local Ubuntu Docker Flask rebuilds, while staying
- * faster than classic Terser.
+ * Keep SWC compress, but disable mangling. SWC mangling can still produce
+ * different `runtime.[contenthash].js` output across Linux rebuilds for Flask
+ * (short-name swaps such as `c`/`l`), even with TerserPlugin `parallel: false`.
+ * That breaks Firefox AMO reviewer `mtree` comparisons. Skipping mangling keeps
+ * minify output stable while preserving most of SWC's speed.
  */
 export function getMinimizers() {
   const TerserPlugin: typeof TerserPluginType = require('terser-webpack-plugin');
@@ -118,7 +118,7 @@ export function getMinimizers() {
       minify: TerserPlugin.swcMinify,
       parallel: false,
       terserOptions: {
-        // Avoid nondeterministic SWC short-name assignment for AMO rebuilds.
+        // Disable mangling so AMO Linux rebuilds stay content-stable.
         mangle: false,
       },
       // do not minify snow.

--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -104,13 +104,11 @@ export const extensionToJs = (filename: string) =>
 /**
  * It gets minimizers for the webpack build.
  *
- * TerserPlugin's default `parallel` mode uses jest-worker to spawn a minifier
- * process per CPU core. Worker assignment is not guaranteed to be stable across
- * runs, which can change SWC mangling frequency analysis and produce different
- * `runtime.[contenthash].js` filenames. That breaks Firefox AMO reviewer
- * rebuild comparisons (mtree) even when the bundles are otherwise equivalent.
- * Disabling parallel minify keeps that step deterministic and has also been a
- * small wall-clock win in local `yarn dist:mv2` timings.
+ * SWC minify can still assign different short names across Linux rebuilds for
+ * larger Flask bundles (`c`/`l` swaps in `runtime.[contenthash].js`), even with
+ * TerserPlugin `parallel: false`. Disabling SWC mangling keeps compress and was
+ * deterministic across 10/10 local Ubuntu Docker Flask rebuilds, while staying
+ * faster than classic Terser.
  */
 export function getMinimizers() {
   const TerserPlugin: typeof TerserPluginType = require('terser-webpack-plugin');
@@ -118,8 +116,11 @@ export function getMinimizers() {
     new TerserPlugin({
       // use SWC to minify (about 7x faster than Terser)
       minify: TerserPlugin.swcMinify,
-      // Determinism (and a small local build-time win): one minifier process.
       parallel: false,
+      terserOptions: {
+        // Avoid nondeterministic SWC short-name assignment for AMO rebuilds.
+        mangle: false,
+      },
       // do not minify snow.
       exclude: /snow\.prod/u,
     }),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Reason for the change

Firefox AMO rebuilds MetaMask from source and checks that every file matches the published zip (`mtree` / content hashes). That check was failing because `runtime.[contenthash].js` was not byte-identical across Linux builds: SWC mangling sometimes picks different short names (for example `c` vs `l`) even with `parallel: false`.

### Solution

Disable SWC mangling only for the webpack `runtime.*` chunk. Keep mangling on for every other chunk.

Turning mangling off for the whole bundle broke the extension at runtime (LavaMoat errors such as `Cannot set properties of undefined (setting 'LavaDome')`). Scoping `mangle: false` to the runtime chunk keeps AMO builds stable without that breakage.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3920](https://consensyssoftware.atlassian.net/browse/INFRA-3920)

## **Manual testing steps**

1. Build a production Firefox MV2 bundle (`yarn webpack:lavamoat:build:mv2` or the usual dist MV2 command).
2. Build again on the same machine (or compare against a second Linux rebuild of the same source).
3. Confirm `runtime.[contenthash].js` has the same content hash across builds.
4. Load the built extension and confirm it opens past the loading screen (no LavaMoat / `LavaDome` console errors).
5. Optionally repeat for a Flask build.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time minification only; scoped to the webpack runtime chunk with mangling unchanged elsewhere.
> 
> **Overview**
> Fixes **Firefox AMO `mtree` failures** where `runtime.[contenthash].js` differed byte-for-byte across Linux rebuilds because SWC mangling could pick different short names even with **`parallel: false`**.
> 
> **`getMinimizers()`** now uses **two `TerserPlugin` (SWC) passes**: one keeps **mangling on** for all chunks except `@lavamoat/snow` and the runtime asset (matched by `runtimeChunkRe`), and a second applies **`mangle: false` only** to `runtime.*` chunks while still minifying them. Other bundles stay mangled so the extension avoids the **LavaMoat / `LavaDome`** breakage seen when mangling was disabled globally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c4232e805dede00210c67081e531a1e0c6ab997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[INFRA-3920]: https://consensyssoftware.atlassian.net/browse/INFRA-3920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ