### PR TITLE
fix(sentry): use SDK debug logger in integrateLogging

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -1,6 +1,6 @@
 import { createModuleLogger } from '@metamask/utils';
 import * as Sentry from '@sentry/browser';
-import { logger } from '@sentry/core';
+import { debug as sentrySdkLogger } from '@sentry/core';
 import { cloneDeep, escapeRegExp } from 'lodash';
 import browser from 'webextension-polyfill';
 import { BROWSER_SHUTTING_DOWN_ERROR } from '../../../shared/constants/errors';
@@ -744,10 +744,9 @@ function integrateLogging() {
     return;
   }
 
-  // Sentry exposes a mutable logger singleton. In debug mode we intentionally
-  // override its methods so SDK-internal logs flow through our module logger.
-  const sentrySdkLogger = logger;
-
+  // `debug` is the SDK-internal logger and is a mutable singleton. Do not use
+  // the `logger` export: that is the user-facing Logs API, whose members are
+  // getter-only module bindings and throw on assignment.
   for (const loggerType of ['log', 'error']) {
     sentrySdkLogger[loggerType] = (...args) => {
       const message = args[0].replace(`Sentry Logger [${loggerType}]: `, '');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

1. What is the reason for the change?
Local `yarn start --sentry` builds set `METAMASK_DEBUG` and `ENABLE_SENTRY`. During Sentry setup, `integrateLogging()` assigned to `@sentry/core`'s `logger` export. After the Sentry v10 upgrade that export is the user-facing Logs API with getter-only bindings, so assignment threw `TypeError: Cannot set property error of #<Object> which has only a getter`. That exception ran during service-worker evaluation (`kErrorScriptEvaluateFailed`, status 15) and left the extension with "Background connection unresponsive".

2. What is the improvement/solution?
Import the SDK-internal mutable `debug` logger from `@sentry/core` (aliased as `sentrySdkLogger`) and override `log`/`error` on that singleton instead. Production builds are unchanged: `integrateLogging()` still returns immediately when `METAMASK_DEBUG` is false.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-484

## **Manual testing steps**

1. From repo root, run `yarn start --sentry`.
2. In Chrome, reload the unpacked extension from `dist/chrome` (or load it if it is not already loaded).
3. Open `chrome://extensions`, confirm the extension is enabled and that the service worker is running (no "service worker registration failed" / status 15 / "Background connection unresponsive").
4. Click "service worker" / "Inspect views: service worker" and confirm the console has no `TypeError` from `integrateLogging` / `setupSentry`.
5. Open the extension UI (popup or full screen) and confirm it connects to the background instead of hanging on a connection error.

## **Screenshots/Recordings**

No UI change. Before: MV3 service worker failed to register (`Status code: 15`) with `TypeError` at `integrateLogging`. After: service worker starts and the UI can talk to the background with Sentry enabled in a debug build.

### **Before**

Service worker registration failed; Chrome Extensions page showed "Background connection unresponsive"; service-worker console threw `TypeError: Cannot set property error of #<Object> which has only a getter` in `setupSentry.js` `integrateLogging`.

### **After**

`yarn start --sentry` loads; service worker stays running; no `integrateLogging` TypeError.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only Sentry logging hook; production paths are untouched and the change is limited to one import and comment updates in setupSentry.
> 
> **Overview**
> After the Sentry v10 upgrade, **`integrateLogging()`** in `setupSentry.js` no longer assigns to `@sentry/core`'s **`logger`** export. That export is now the user-facing Logs API with getter-only **`log`** / **`error`** properties, which caused a **`TypeError`** during service worker startup when **`METAMASK_DEBUG`** and Sentry were enabled (e.g. `yarn start --sentry`), leaving the extension with an unresponsive background.
> 
> The fix imports the SDK-internal mutable **`debug`** singleton (as **`sentrySdkLogger`**) and overrides **`log`** and **`error`** on that object so internal Sentry messages still route through MetaMask's module logger. **Production behavior is unchanged**—**`integrateLogging()`** still exits immediately when **`METAMASK_DEBUG`** is false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cbe7c10b417e9e9ce091b957cca9cd5bfa0fa75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->