### PR TITLE
fix: remove text-center from Hyperliquid prompt description

### DIFF
--- a/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
+++ b/ui/components/app/hyperliquid-deposit-prompt/hyperliquid-deposit-prompt.tsx
@@ -360,7 +360,7 @@ export const HyperliquidDepositPrompt: React.FC<
         <Text
           variant={TextVariant.BodySm}
           color={TextColor.TextAlternative}
-          className="mt-2 text-center"
+          className="mt-2"
         >
           {t('hyperliquidDepositPromptDescription')}
         </Text>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Removes the `text-center` class from the `Text` element that renders the `hyperliquidDepositPromptDescription` label in the Hyperliquid deposit prompt, so the description no longer forces centered text alignment.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the Hyperliquid deposit prompt.
2. Verify the description text under the title is no longer center-aligned.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/D0AD7VDJ3U0/p1782396245326519?thread_ts=1782396245.326519&cid=D0AD7VDJ3U0)

<div><a href="https://cursor.com/agents/bc-48a266b5-b8e5-59bb-882e-0193a9cfdf4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48a266b5-b8e5-59bb-882e-0193a9cfdf4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

