### PR TITLE
fix(activity): align add funds icons

### DIFF
--- a/ui/components/multichain/funding-method-modal/funding-method-item.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-item.tsx
@@ -11,6 +11,7 @@ import {
 
 type FundingMethodItemProps = {
   icon: IconName;
+  iconSize: IconSize;
   title: string;
   description: string;
   onClick: () => void;
@@ -18,6 +19,7 @@ type FundingMethodItemProps = {
 
 const FundingMethodItem = ({
   icon,
+  iconSize,
   title,
   description,
   onClick,
@@ -30,7 +32,9 @@ const FundingMethodItem = ({
     className="funding-method-item"
     padding={4}
   >
-    <Icon name={icon} size={IconSize.Md} />
+    <span className="funding-method-item__icon">
+      <Icon name={icon} size={iconSize} />
+    </span>
     <Box display={[Display.Flex]} flexDirection={FlexDirection.Column}>
       <Text variant={TextVariant.bodyMdMedium}>{title}</Text>
       <Text variant={TextVariant.bodySm} color={TextColor.textAlternative}>

--- a/ui/components/multichain/funding-method-modal/funding-method-item.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-item.tsx
@@ -32,7 +32,7 @@ const FundingMethodItem = ({
     className="funding-method-item"
     padding={4}
   >
-    <span className="funding-method-item__icon">
+    <span className="flex h-6 w-6 shrink-0 items-center justify-center">
       <Icon name={icon} size={iconSize} />
     </span>
     <Box display={[Display.Flex]} flexDirection={FlexDirection.Column}>

--- a/ui/components/multichain/funding-method-modal/funding-method-item.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-item.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Icon, IconName } from '@metamask/design-system-react';
+import { Icon, IconName, IconSize } from '@metamask/design-system-react';
 import { Box, Text } from '../../component-library';
 import {
   Display,
@@ -24,13 +24,13 @@ const FundingMethodItem = ({
 }: FundingMethodItemProps) => (
   <Box
     display={[Display.Flex]}
-    gap={2}
+    gap={3}
     alignItems={AlignItems.center}
     onClick={onClick}
     className="funding-method-item"
     padding={4}
   >
-    <Icon name={icon} />
+    <Icon name={icon} size={IconSize.Md} />
     <Box display={[Display.Flex]} flexDirection={FlexDirection.Column}>
       <Text variant={TextVariant.bodyMdMedium}>{title}</Text>
       <Text variant={TextVariant.bodySm} color={TextColor.textAlternative}>

--- a/ui/components/multichain/funding-method-modal/funding-method-item.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-item.tsx
@@ -11,7 +11,6 @@ import {
 
 type FundingMethodItemProps = {
   icon: IconName;
-  iconSize: IconSize;
   title: string;
   description: string;
   onClick: () => void;
@@ -19,7 +18,6 @@ type FundingMethodItemProps = {
 
 const FundingMethodItem = ({
   icon,
-  iconSize,
   title,
   description,
   onClick,
@@ -33,7 +31,7 @@ const FundingMethodItem = ({
     padding={4}
   >
     <span className="funding-method-item__icon">
-      <Icon name={icon} size={iconSize} />
+      <Icon name={icon} size={IconSize.Md} />
     </span>
     <Box display={[Display.Flex]} flexDirection={FlexDirection.Column}>
       <Text variant={TextVariant.bodyMdMedium}>{title}</Text>

--- a/ui/components/multichain/funding-method-modal/funding-method-item.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-item.tsx
@@ -11,6 +11,7 @@ import {
 
 type FundingMethodItemProps = {
   icon: IconName;
+  iconSize?: IconSize;
   title: string;
   description: string;
   onClick: () => void;
@@ -18,6 +19,7 @@ type FundingMethodItemProps = {
 
 const FundingMethodItem = ({
   icon,
+  iconSize = IconSize.Md,
   title,
   description,
   onClick,
@@ -31,7 +33,7 @@ const FundingMethodItem = ({
     padding={4}
   >
     <span className="funding-method-item__icon">
-      <Icon name={icon} size={IconSize.Md} />
+      <Icon name={icon} size={iconSize} />
     </span>
     <Box display={[Display.Flex]} flexDirection={FlexDirection.Column}>
       <Text variant={TextVariant.bodyMdMedium}>{title}</Text>

--- a/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { CaipChainId, Hex } from '@metamask/utils';
 import {
   IconName,
+  IconSize,
   Modal,
   ModalOverlay,
   ModalHeader,
@@ -149,7 +150,8 @@ export const FundingMethodModal = ({
           onClick={handleBuyCryptoClick}
         />
         <FundingMethodItem
-          icon={IconName.Receive}
+          icon={IconName.Received}
+          iconSize={IconSize.Lg}
           title={t('receiveCrypto')}
           description={t('depositCrypto')}
           onClick={onClickReceive}

--- a/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import { CaipChainId, Hex } from '@metamask/utils';
 import {
   IconName,
-  IconSize,
   Modal,
   ModalOverlay,
   ModalHeader,
@@ -145,21 +144,18 @@ export const FundingMethodModal = ({
         </ModalHeader>
         <FundingMethodItem
           icon={IconName.Card}
-          iconSize={IconSize.Sm}
           title={t('tokenMarketplace')}
           description={t('debitCreditPurchaseOptions')}
           onClick={handleBuyCryptoClick}
         />
         <FundingMethodItem
-          icon={IconName.Received}
-          iconSize={IconSize.Lg}
+          icon={IconName.Receive}
           title={t('receiveCrypto')}
           description={t('depositCrypto')}
           onClick={onClickReceive}
         />
         <FundingMethodItem
           icon={IconName.Link}
-          iconSize={IconSize.Md}
           title={t('transferCrypto')}
           description={t('linkCentralizedExchanges')}
           onClick={handleTransferCryptoClick}

--- a/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { CaipChainId, Hex } from '@metamask/utils';
 import {
   IconName,
+  IconSize,
   Modal,
   ModalOverlay,
   ModalHeader,
@@ -144,18 +145,21 @@ export const FundingMethodModal = ({
         </ModalHeader>
         <FundingMethodItem
           icon={IconName.Card}
+          iconSize={IconSize.Sm}
           title={t('tokenMarketplace')}
           description={t('debitCreditPurchaseOptions')}
           onClick={handleBuyCryptoClick}
         />
         <FundingMethodItem
           icon={IconName.Received}
+          iconSize={IconSize.Lg}
           title={t('receiveCrypto')}
           description={t('depositCrypto')}
           onClick={onClickReceive}
         />
         <FundingMethodItem
           icon={IconName.Link}
+          iconSize={IconSize.Md}
           title={t('transferCrypto')}
           description={t('linkCentralizedExchanges')}
           onClick={handleTransferCryptoClick}

--- a/ui/components/multichain/funding-method-modal/index.scss
+++ b/ui/components/multichain/funding-method-modal/index.scss
@@ -1,6 +1,14 @@
 .funding-method-item {
   cursor: pointer;
 
+  &__icon {
+    align-items: center;
+    display: flex;
+    flex: 0 0 24px;
+    height: 24px;
+    justify-content: center;
+  }
+
   &:hover {
     background-color: var(--color-background-hover);
   }

--- a/ui/components/multichain/funding-method-modal/index.scss
+++ b/ui/components/multichain/funding-method-modal/index.scss
@@ -1,14 +1,6 @@
 .funding-method-item {
   cursor: pointer;
 
-  &__icon {
-    align-items: center;
-    display: flex;
-    flex: 0 0 24px;
-    height: 24px;
-    justify-content: center;
-  }
-
   &:hover {
     background-color: var(--color-background-hover);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Aligned the Add funds icons in consistent 24px slots, optically increased the Received icon, and increased icon-to-text spacing from 8px to 12px.

## **Changelog**

CHANGELOG entry: Fixed inconsistent icon sizing and spacing in the Add funds menu

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Open MetaMask with an account that has no transaction activity.
2. Go to Activity and click **Add funds** in the empty state.
3. Verify Token marketplace uses a card icon, Receive crypto uses an inbound arrow, and Transfer crypto uses a link icon.
4. Verify all icons appear consistently sized and have comfortable spacing from their title and description.

## **Screenshots/Recordings**

### **Before**
<img width="375" height="752" alt="Screenshot 2026-09-10 at 12 11 54 PM" src="https://github.com/user-attachments/assets/89eae696-132f-4165-92b4-587ba4ed08f1" />

### **After**
<img width="345" height="346" alt="Screenshot 2026-09-10 at 3 47 11 PM" src="https://github.com/user-attachments/assets/d702b1e6-1c94-4169-96d3-35d8108e34f6" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47e19d00-1544-41ad-bd39-03c533fae811?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47e19d00-1544-41ad-bd39-03c533fae811&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

