### PR TITLE
fix(money): correct info popover colors

### DIFF
--- a/ui/components/app/money/money-account-balance/money-account-balance.test.tsx
+++ b/ui/components/app/money/money-account-balance/money-account-balance.test.tsx
@@ -218,6 +218,10 @@ describe('MoneyAccountBalance', () => {
 
     expect(getByText(tEn('moneyBalanceInfoBody'))).toBeInTheDocument();
     expect(getByText(tEn('moneyBalanceInfoWithdrawals'))).toBeInTheDocument();
+    expect(getByText(tEn('moneyBalanceInfoBody'))).toHaveClass('text-default');
+    expect(getByText(tEn('moneyBalanceInfoWithdrawals'))).toHaveClass(
+      'text-default',
+    );
   });
 
   it('initiates a generic deposit when Add is clicked', () => {

--- a/ui/components/app/money/money-account-balance/money-account-balance.tsx
+++ b/ui/components/app/money/money-account-balance/money-account-balance.tsx
@@ -151,10 +151,10 @@ export const MoneyAccountBalance = () => {
             }}
           >
             <Box flexDirection={BoxFlexDirection.Column} gap={4}>
-              <Text variant={TextVariant.BodyMd} color={TextColor.InfoInverse}>
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
                 {t('moneyBalanceInfoBody')}
               </Text>
-              <Text variant={TextVariant.BodyMd} color={TextColor.InfoInverse}>
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
                 {t('moneyBalanceInfoWithdrawals')}
               </Text>
             </Box>

--- a/ui/components/app/musd/info-popover/info-popover.test.tsx
+++ b/ui/components/app/musd/info-popover/info-popover.test.tsx
@@ -32,6 +32,12 @@ describe('InfoPopover', () => {
     expect(getByTestId('test-tooltip')).toBeInTheDocument();
     expect(getByTestId('test-tooltip')).toHaveTextContent('Tooltip content');
     expect(getByTestId('test-tooltip')).toHaveStyle({ maxWidth: '250px' });
+    expect(getByTestId('test-tooltip')).toHaveClass(
+      'mm-box--background-color-background-elevated2',
+    );
+    expect(getByTestId('test-tooltip')).not.toHaveStyle({
+      backgroundColor: 'var(--color-text-default)',
+    });
   });
 
   it('closes the popover when clicking outside', async () => {

--- a/ui/components/app/musd/info-popover/info-popover.test.tsx
+++ b/ui/components/app/musd/info-popover/info-popover.test.tsx
@@ -35,9 +35,7 @@ describe('InfoPopover', () => {
     expect(getByTestId('test-tooltip')).toHaveClass(
       'mm-box--background-color-background-elevated2',
     );
-    expect(getByTestId('test-tooltip')).not.toHaveStyle({
-      backgroundColor: 'var(--color-text-default)',
-    });
+    expect(getByTestId('test-tooltip').style.backgroundColor).toBe('');
   });
 
   it('closes the popover when clicking outside', async () => {

--- a/ui/components/app/musd/info-popover/info-popover.tsx
+++ b/ui/components/app/musd/info-popover/info-popover.tsx
@@ -14,12 +14,12 @@ import {
 import { Popover, PopoverPosition } from '../../../component-library';
 
 /**
- * Default panel styles — matches confirmations InfoPopoverTooltip for visual parity.
+ * Default panel styles — matches confirmations InfoPopoverTooltip for visual
+ * parity. The Popover supplies its theme-aware elevated background.
  * Z-index above extension chrome (see ui/css/design-system/_z-index.scss).
  */
 const POPOVER_STYLE = {
   zIndex: 1050,
-  backgroundColor: 'var(--color-text-default)',
   paddingTop: '6px',
   paddingBottom: '6px',
   paddingLeft: '16px',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The Money balance info popover overrode the standard theme-aware elevated background with the text-color token, causing the panel colors to appear inverted. This restores the standard popover background and uses the default text color for the Money balance copy.

## **Changelog**

CHANGELOG entry: Fixed the Money balance info popover colors

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Build and load the extension, then open an account with a Money balance on the wallet home page.
2. Select the info icon beside “Money balance • mUSD”.
3. Verify the popover uses the elevated surface color with default-color text in both light and dark themes.

## **Screenshots/Recordings**

### **Before**

<img width="375" height="420" alt="Screenshot 2026-09-10 at 12 33 42 PM" src="https://github.com/user-attachments/assets/f15ca23d-a201-4520-8930-c391eff1b488" />


### **After**
<img width="374" height="358" alt="Screenshot 2026-09-10 at 1 13 53 PM" src="https://github.com/user-attachments/assets/45b09a55-39c0-4efa-90bd-29e90595ccd0" />
<img width="364" height="418" alt="Screenshot 2026-09-10 at 1 13 36 PM" src="https://github.com/user-attachments/assets/07922b8b-cfa9-4523-9a86-c9134979d075" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e420155a-4ce4-4494-85c1-1a81a766879f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e420155a-4ce4-4494-85c1-1a81a766879f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

