### PR TITLE
docs: fix dead Infura and skills links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you are not a MetaMask Internal Developer, or are otherwise developing on a f
   - If you are using [nvm](https://github.com/nvm-sh/nvm#installing-and-updating) (recommended) running `nvm use` will automatically choose the right node version for you.
 - Enable Corepack by executing the command `corepack enable` within the metamask-extension project. Corepack is a utility included with Node.js by default. It manages Yarn on a per-project basis, using the version specified by the `packageManager` property in the project's package.json file. Please note that modern releases of [Yarn](https://yarnpkg.com/getting-started/install) are not intended to be installed globally or via npm.
 - Duplicate `.metamaskrc.dist` within the root and rename it to `.metamaskrc` by running `cp .metamaskrc{.dist,}`.
-  - Replace the `INFURA_PROJECT_ID` value with your own personal [Infura API Key](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/project-id).
+  - Replace the `INFURA_PROJECT_ID` value with your own personal [Infura API Key](https://docs.metamask.io/developer-tools/dashboard/how-to/secure-an-api/).
     - If you don't have an Infura account, you can create one for free on the [Infura website](https://app.infura.io/register).
   - If debugging MetaMetrics, you'll need to add a value for `SEGMENT_WRITE_KEY` [Segment write key](https://segment.com/docs/connections/find-writekey/), see [Developing on MetaMask - Segment](./development/README.md#segment).
   - If debugging unhandled exceptions, you'll need to add a value for `SENTRY_DSN` [Sentry Dsn](https://docs.sentry.io/product/sentry-basics/dsn-explainer/), see [Developing on MetaMask - Sentry](./development/README.md#sentry).
@@ -80,7 +80,7 @@ If you are not a MetaMask Internal Developer, or are otherwise developing on a f
 
 ## AI Agent Skills (`yarn skills`)
 
-AI coding agents (Cursor, Claude Code, Codex) consume shared skills from the [MetaMask/skills](https://github.com/MetaMask/skills) repo, with an optional private overlay from [Consensys/skills](https://github.com/Consensys/skills). Per [ADR #57](https://github.com/MetaMask/decisions/pull/162) this content is **not committed here** — `yarn skills` syncs it on demand into local-only paths under `.cursor/`, `.claude/`, and `.agents/`.
+AI coding agents (Cursor, Claude Code, Codex) consume shared skills from the [MetaMask/skills](https://github.com/MetaMask/skills) repo (with an optional private Consensys overlay when available). Per ADR #57 this content is **not committed here** — `yarn skills` syncs it on demand into local-only paths under `.cursor/`, `.claude/`, and `.agents/`.
 
 Zero-config setup:
 


### PR DESCRIPTION
## Summary
README links to a removed Infura docs path and two other dead public URLs around the skills section.

## Repro
1. https://docs.infura.io/networks/ethereum/how-to/secure-a-project/project-id → **404**
2. Replacement that covers securing an API key: https://docs.metamask.io/developer-tools/dashboard/how-to/secure-an-api/ → **200**
3. https://github.com/Consensys/skills → **404** (public)
4. https://github.com/MetaMask/decisions/pull/162 → **404** (public)

## Change
- Point the Infura API key docs link at the live MetaMask developer-tools secure-an-API guide.
- Keep `MetaMask/skills`; drop the dead public Consensys/skills and decisions PR hyperlinks (leave ADR #57 as plain text).

## Notes
Docs-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and wording updates; no runtime or build behavior changes.
> 
> **Overview**
> Updates **README** onboarding docs so links resolve again and the skills blurb does not point at removed public URLs.
> 
> In **Building on your local machine**, the **Infura API Key** anchor now targets MetaMask’s live [secure an API](https://docs.metamask.io/developer-tools/dashboard/how-to/secure-an-api/) guide instead of the old Infura docs path that 404s.
> 
> In **AI Agent Skills (`yarn skills`)**, the intro keeps **MetaMask/skills** but rephrases the optional Consensys overlay (no **Consensys/skills** or **decisions** PR links) and cites **ADR #57** as plain text only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102937906bce86f4ec3c478df6dba02b228dc918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->