### PR TITLE
test: fix flaky test custom token success toast

### DIFF
--- a/test/e2e/page-objects/pages/home/tokens-tab.ts
+++ b/test/e2e/page-objects/pages/home/tokens-tab.ts
@@ -167,6 +167,9 @@ class TokensTab extends HomePage {
   private readonly tokenManagementCustomTokenSuccessToast =
     '[data-testid="token-management-custom-token-success-toast"]';
 
+  private readonly tokenManagementCustomTokenSuccessToastClose =
+    '[data-testid="toast-close-button"]';
+
   private readonly tokenManagementPage =
     '[data-testid="parent-selector-token-management-page"]';
 
@@ -853,11 +856,10 @@ class TokensTab extends HomePage {
     await this.driver.waitForSelector(
       this.tokenManagementCustomTokenSuccessToast,
     );
-    await this.returnFromTokenManagementToHome();
-    await this.driver.assertElementNotPresent(
-      this.tokenManagementCustomTokenSuccessToast,
-      { findElementGuard: this.tokenListItem },
+    await this.driver.clickElementAndWaitToDisappear(
+      this.tokenManagementCustomTokenSuccessToastClose,
     );
+    await this.returnFromTokenManagementToHome();
   }
 
   /**

--- a/ui/components/ui/toast/toast.tsx
+++ b/ui/components/ui/toast/toast.tsx
@@ -78,6 +78,7 @@ export function Toaster() {
                 iconName={IconName.Close}
                 size={ButtonIconSize.Sm}
                 className="relative z-10 self-start"
+                data-testid="toast-close-button"
                 onClick={() => {
                   (item as ToastWithClose).onClose?.();
                   toast.dismiss(item.id);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Stabilizes custom token import E2E so the success toast is closed before any test that uses `importCustomTokenByChain` returns to Home.

This is the same flake in several specs. All of them import a token through that shared helper, then fail with `token-management-custom-token-success-toast` still present:

- `test/e2e/tests/settings/hide-token-without-balance.spec.ts` (`user can activate hide tokens without balance feature via settings`)
- `test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts` (`submits an ERC20 approve transaction`)
- `test/e2e/tests/tokens/import-tokens.spec.ts` (`allows importing using contract address and not current network`)

The same helper is also used by asset-list and ERC20 send specs, so those pick up the fix too.

**Root cause:**

- Each of these tests imports a custom token from Manage tokens, then waits for the green success toast.
- That toast stays on screen after Back, because the toaster lives on the app shell, not on the Manage tokens page.
- Home then loads with the toast still at the bottom center, over the Low value tokens control.
- Next, the shared helper waits for the toast to leave the page on its own.
- The toast often stays visible for the whole wait, so hide-tokens, ERC20 approve, and import-tokens all fail with the same "element that should not be present" error.

**Solution:**

- Add a `toast-close-button` test id on the toaster close control so the helper can click that button directly.
- After the success toast appears, click close and wait for it to leave, so Home is not covered by the toast.
- Then go back to Home. Later list checks and send/approve steps can run without the toast in the way.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Start a test build with `yarn start:test` if one is not already running.
2. Run each of these specs. Confirm each one imports a custom token, closes the success toast, returns to Home, then continues the rest of the test:

```bash
SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/settings/hide-token-without-balance.spec.ts --debug --leave-running
```

```bash
SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts --debug --leave-running
```

```bash
SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/tokens/import-tokens.spec.ts --debug --leave-running
```

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test the code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a test id on the toast close button and adjusts E2E flow only; no production behavior change beyond making the close button discoverable in tests.
> 
> **Overview**
> Fixes flaky E2E around **Manage tokens → custom token import** by dismissing the success toast instead of hoping it disappears after navigation.
> 
> The shared **`importCustomTokenByChain`** helper now clicks the toast close control and waits for the toast to leave **before** going back to Home. It no longer navigates home first and asserts the toast is gone (which often timed out because the shell-level toaster stayed visible over Home UI).
> 
> To support that, the toast **`ButtonIcon`** close control gets **`data-testid="toast-close-button"`**, and the tokens tab page object targets that selector after the custom-token success toast appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e53b96870f66aa805fdad42cfd9537b0e4aef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->