### PR TITLE
fix: forced refresh of arc balances after a confirmed transaction cp-13.48.0

### DIFF
--- a/app/scripts/messenger-client-init/assets/assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.test.ts
@@ -16,6 +16,8 @@ import { ASSETS_UNIFY_STATE_FLAG } from '../../../../shared/lib/assets-unify-sta
 import { traceAsControllerCallback } from '../../../../shared/lib/trace';
 import { AssetsControllerInit } from './assets-controller-init';
 
+const mockAssetsControllerGetAssets = jest.fn();
+
 jest.mock('../../../../shared/lib/trace', () => ({
   traceAsControllerCallback: jest.fn((_req, fn) =>
     Promise.resolve(fn?.('traced-context')),
@@ -25,6 +27,7 @@ jest.mock('../../../../shared/lib/trace', () => ({
 jest.mock('@metamask/assets-controller', () => ({
   AssetsController: jest.fn().mockImplementation(() => ({
     state: {},
+    getAssets: mockAssetsControllerGetAssets,
   })),
 }));
 
@@ -126,6 +129,7 @@ function buildSubscribeTestSetup(
 describe('AssetsControllerInit', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAssetsControllerGetAssets.mockResolvedValue({});
   });
 
   it('initializes the controller', () => {
@@ -579,6 +583,95 @@ describe('AssetsControllerInit', () => {
       expect(migrationState.AccountsController).toBe(
         persistedState.AccountsController,
       );
+    });
+  });
+
+  describe('Arc transaction confirmed refresh', () => {
+    function initWithCapturedTransactionConfirmedListener() {
+      const requestMock = getInitRequestMock();
+      const listeners: Record<string, (transactionMeta: unknown) => void> = {};
+      const account = {
+        id: 'account-id-1',
+        address: '0x0000000000000000000000000000000000000001',
+      };
+
+      requestMock.controllerMessenger.subscribe = jest
+        .fn()
+        .mockImplementation((event, listener) => {
+          listeners[event as string] = listener;
+        });
+      requestMock.controllerMessenger.call = jest
+        .fn()
+        .mockImplementation((action) => {
+          if (
+            action ===
+            'AccountTreeController:getAccountsFromSelectedAccountGroup'
+          ) {
+            return [account];
+          }
+          throw new Error(`Unexpected action: ${String(action)}`);
+        });
+
+      AssetsControllerInit(requestMock);
+
+      const listener = listeners['TransactionController:transactionConfirmed'];
+      if (!listener) {
+        throw new Error(
+          'Expected TransactionController:transactionConfirmed listener',
+        );
+      }
+
+      return { account, listener };
+    }
+
+    it('forces a full Arc assets refresh for the transaction sender after confirmation', async () => {
+      const { account, listener } =
+        initWithCapturedTransactionConfirmedListener();
+
+      listener({
+        chainId: '0x13b2',
+        txParams: {
+          from: '0x0000000000000000000000000000000000000001',
+        },
+      });
+
+      await Promise.resolve();
+
+      expect(mockAssetsControllerGetAssets).toHaveBeenCalledWith([account], {
+        chainIds: ['eip155:5042'],
+        forceUpdate: true,
+        bypassServerCache: true,
+      });
+    });
+
+    it('does not refresh assets for non-Arc confirmed transactions', async () => {
+      const { listener } = initWithCapturedTransactionConfirmedListener();
+
+      listener({
+        chainId: '0x1',
+        txParams: {
+          from: '0x0000000000000000000000000000000000000001',
+        },
+      });
+
+      await Promise.resolve();
+
+      expect(mockAssetsControllerGetAssets).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh assets when the transaction sender is not in the selected account group', async () => {
+      const { listener } = initWithCapturedTransactionConfirmedListener();
+
+      listener({
+        chainId: '0x13b2',
+        txParams: {
+          from: '0x0000000000000000000000000000000000000002',
+        },
+      });
+
+      await Promise.resolve();
+
+      expect(mockAssetsControllerGetAssets).not.toHaveBeenCalled();
     });
   });
 

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../../shared/lib/environment';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import { ARC_NATIVE_CAIP_CHAIN_ID } from '#ui/components/app/assets/enablement/arc';
+import { ARC_NATIVE_CAIP_CHAIN_ID } from '../../../../ui/components/app/assets/enablement/arc';
 
 /**
  * Cached API client instance.

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.ts
@@ -5,6 +5,8 @@ import {
 } from '@metamask/assets-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
 import { createApiPlatformClient } from '@metamask/core-backend';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import type {
   TraceCallback as ControllerTraceCallback,
   TraceContext as ControllerTraceContext,
@@ -21,6 +23,8 @@ import {
   type AssetsUnifyStateFeatureFlag,
 } from '../../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../../shared/lib/environment';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { ARC_NATIVE_CAIP_CHAIN_ID } from '#ui/components/app/assets/enablement/arc';
 
 /**
  * Cached API client instance.
@@ -161,6 +165,56 @@ function getApiClient(
 }
 
 /**
+ * Forces a full Arc assets refresh after a confirmed transaction.
+ *
+ * Arc USDC is represented as a native asset in the wallet, but the
+ * AccountActivity incremental balance update can miss that native USDC balance
+ * after swaps while updating ERC-20 balances such as EURC correctly. A full
+ * account asset scan resolves the native USDC balance, matching the manual
+ * recovery path of reloading the extension or switching accounts.
+ *
+ * @param controllerMessenger - The AssetsController messenger.
+ * @param assetsController - The initialized AssetsController instance.
+ */
+function subscribeToArcTransactionConfirmedRefresh(
+  controllerMessenger: AssetsControllerMessenger,
+  assetsController: AssetsController,
+): void {
+  controllerMessenger.subscribe(
+    'TransactionController:transactionConfirmed',
+    (transactionMeta: TransactionMeta) => {
+      if (transactionMeta.chainId?.toLowerCase() !== CHAIN_IDS.ARC) {
+        return;
+      }
+
+      const fromAddress = transactionMeta.txParams.from?.toLowerCase();
+      if (!fromAddress) {
+        return;
+      }
+
+      const matchedAccount = controllerMessenger
+        .call('AccountTreeController:getAccountsFromSelectedAccountGroup')
+        .find(
+          (account: InternalAccount) =>
+            account.address.toLowerCase() === fromAddress,
+        );
+
+      if (!matchedAccount) {
+        return;
+      }
+
+      assetsController
+        .getAssets([matchedAccount], {
+          chainIds: [ARC_NATIVE_CAIP_CHAIN_ID],
+          forceUpdate: true,
+          bypassServerCache: true,
+        })
+        .catch(() => undefined);
+    },
+  );
+}
+
+/**
  * Init function for the AssetsController.
  *
  * @param request - The request object.
@@ -255,6 +309,11 @@ export const AssetsControllerInit: MessengerClientInitFunction<
     }),
     trace: createAssetsControllerTrace(initMessenger),
   });
+
+  subscribeToArcTransactionConfirmedRefresh(
+    controllerMessenger,
+    messengerClient,
+  );
 
   return { messengerClient };
 };

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.ts
@@ -194,6 +194,7 @@ function subscribeToArcTransactionConfirmedRefresh(
         return;
       }
 
+      // TODO: should be moved to the controller (comment on PR#46259)
       const matchedAccount = controllerMessenger
         .call('AccountTreeController:getAccountsFromSelectedAccountGroup')
         .find(

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.ts
@@ -7,6 +7,7 @@ import type { PreferencesState } from '@metamask/preferences-controller';
 import { createApiPlatformClient } from '@metamask/core-backend';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { TransactionMeta } from '@metamask/transaction-controller';
+import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import type {
   TraceCallback as ControllerTraceCallback,
   TraceContext as ControllerTraceContext,
@@ -24,7 +25,8 @@ import {
 } from '../../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../../shared/lib/environment';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import { ARC_NATIVE_CAIP_CHAIN_ID } from '../../../../ui/components/app/assets/enablement/arc';
+
+const ARC_CAIP_CHAIN_ID = toEvmCaipChainId(CHAIN_IDS.ARC);
 
 /**
  * Cached API client instance.
@@ -205,7 +207,7 @@ function subscribeToArcTransactionConfirmedRefresh(
 
       assetsController
         .getAssets([matchedAccount], {
-          chainIds: [ARC_NATIVE_CAIP_CHAIN_ID],
+          chainIds: [ARC_CAIP_CHAIN_ID],
           forceUpdate: true,
           bypassServerCache: true,
         })


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an Arc USDC balance refresh issue after confirmed Arc transactions, such as swaps.
Arc USDC is represented as a native asset in unified assets state.
In some flows, for example swapping EURC -> USDC, the incremental balance update refreshes EURC correctly but leaves the native Arc USDC balance stale until a full asset scan is triggered by reloading the extension or switching accounts.

To address this, the AssetsController now subscribes to `TransactionController:transactionConfirmed`.
When an Arc transaction confirms, it finds the matching account in the selected account group and forces an Arc asset refresh.

Unit coverage was added for:
- refreshing Arc assets after an Arc transaction confirmation
- ignoring non-Arc confirmed transactions
- ignoring Arc transactions from accounts outside the selected account group

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix stale balance for USDC on Arc after a swap

## **Related issues**

Fixes:

## **Manual testing steps**

1. Load the extension in Chrome.
2. Import or use an account that has Arc assets available.
3. Make sure Arc is enabled and the account has both:
    - EURC
    - USDC
4. Record the current EURC and USDC balances.
5. Perform a swap on Arc: EURC -> USDC
6. Wait until the swap transaction is confirmed.
7. Do not reload the extension and do not switch accounts.
8. Verify that:
    - EURC balance decreases/updates
    - USDC balance increases/updates automatically after confirmation
    - the USDC balance does not require a page reload or account switch
9. Optional extra check:
    - Trigger a non-Arc transaction and confirm it does not cause an Arc-only asset refresh side effect.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-confirmation asset fetching for Arc only, but incorrect matching or refresh timing could cause extra API load or missed balance updates in swap flows.
> 
> **Overview**
> Fixes **stale native Arc USDC** after swaps (e.g. EURC → USDC) when incremental AccountActivity updates ERC-20 balances but not native USDC.
> 
> **AssetsController init** now listens for `TransactionController:transactionConfirmed`. On **Arc-only** confirmations, it resolves the sender against the **selected account group** and calls `getAssets` for the Arc CAIP chain with **`forceUpdate`** and **`bypassServerCache`**, mirroring a full rescan without reload or account switch. Non-Arc txs and senders outside the selected group are ignored; refresh errors are swallowed.
> 
> **Unit tests** cover the happy path and both skip conditions; the mock **`AssetsController`** exposes **`getAssets`** for assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752ffed71a0a3c99f24d7c0e50fcd3a5634fb8e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->