### PR TITLE
feat: add advanced charts feature flag

### DIFF
--- a/.github/scripts/known-feature-flag-constants.mts
+++ b/.github/scripts/known-feature-flag-constants.mts
@@ -76,6 +76,11 @@ const FILE_SOURCES: Array<{
     exportName: 'EXTENSION_TRUST_AND_SECURITY_TDP_FLAG',
   },
   {
+    key: 'TOKEN_DETAILS_ADVANCED_CHARTS_FLAG',
+    file: 'shared/lib/assets/advanced-charts-feature-flags.ts',
+    exportName: 'TOKEN_DETAILS_ADVANCED_CHARTS_FLAG',
+  },
+  {
     key: 'MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME',
     file: 'shared/lib/money/feature-flags.ts',
     exportName: 'MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME',

--- a/shared/lib/assets/advanced-charts-feature-flags.ts
+++ b/shared/lib/assets/advanced-charts-feature-flags.ts
@@ -3,5 +3,4 @@
  * uses kebab-case `token-details-advanced-charts`, which is converted
  * before it reaches extension state.
  */
-export const TOKEN_DETAILS_ADVANCED_CHARTS_FLAG =
-  'tokenDetailsAdvancedCharts';
+export const TOKEN_DETAILS_ADVANCED_CHARTS_FLAG = 'tokenDetailsAdvancedCharts';

--- a/shared/lib/assets/advanced-charts-feature-flags.ts
+++ b/shared/lib/assets/advanced-charts-feature-flags.ts
@@ -1,0 +1,7 @@
+/**
+ * Client-config / RemoteFeatureFlagController key (camelCase). LaunchDarkly
+ * uses kebab-case `token-details-advanced-charts`, which is converted
+ * before it reaches extension state.
+ */
+export const TOKEN_DETAILS_ADVANCED_CHARTS_FLAG =
+  'tokenDetailsAdvancedCharts';

--- a/test/e2e/feature-flags/feature-flag-registry.ts
+++ b/test/e2e/feature-flags/feature-flag-registry.ts
@@ -3488,6 +3488,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
   },
 
+  tokenDetailsAdvancedCharts: {
+    inProd: true,
+    name: 'tokenDetailsAdvancedCharts',
+    productionDefault: {
+      enabled: true,
+      minimumVersion: '13.49.0',
+    },
+    status: FeatureFlagStatus.Active,
+    type: FeatureFlagType.Remote,
+  },
+
   tronAccounts: {
     inProd: true,
     name: 'tronAccounts',

--- a/test/e2e/feature-flags/feature-flag-registry.ts
+++ b/test/e2e/feature-flags/feature-flag-registry.ts
@@ -3492,7 +3492,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     inProd: true,
     name: 'tokenDetailsAdvancedCharts',
     productionDefault: {
-      enabled: true,
+      enabled: false,
       minimumVersion: '13.49.0',
     },
     status: FeatureFlagStatus.Active,

--- a/ui/selectors/multichain/feature-flags.test.ts
+++ b/ui/selectors/multichain/feature-flags.test.ts
@@ -1,6 +1,8 @@
 import { EXTENSION_TRUST_AND_SECURITY_TDP_FLAG } from '../../../shared/lib/assets/security-trust-feature-flags';
+import { TOKEN_DETAILS_ADVANCED_CHARTS_FLAG } from '../../../shared/lib/assets/advanced-charts-feature-flags';
 import {
   BFT_CHILD_PREFERENCES,
+  getIsAdvancedChartsEnabled,
   getIsBasicFunctionalityConsolidationEnabled,
   getIsBasicFunctionalityToggleEnabled,
   getIsNetworkManagementEnabled,
@@ -388,5 +390,80 @@ describe('getIsSecurityTrustTdpEnabled', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       getIsSecurityTrustTdpEnabled(buildState() as any),
     ).toBe(false);
+  });
+});
+
+describe('getIsAdvancedChartsEnabled', () => {
+  it('returns true for a version-gated flag whose minimumVersion is satisfied', () => {
+    expect(
+      getIsAdvancedChartsEnabled(
+        buildState({
+          [TOKEN_DETAILS_ADVANCED_CHARTS_FLAG]: {
+            enabled: true,
+            minimumVersion: '0.0.0',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a version-gated flag whose minimumVersion is in the future', () => {
+    expect(
+      getIsAdvancedChartsEnabled(
+        buildState({
+          [TOKEN_DETAILS_ADVANCED_CHARTS_FLAG]: {
+            enabled: true,
+            minimumVersion: '999.0.0',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when the version-gated flag is explicitly disabled', () => {
+    expect(
+      getIsAdvancedChartsEnabled(
+        buildState({
+          [TOKEN_DETAILS_ADVANCED_CHARTS_FLAG]: {
+            enabled: false,
+            minimumVersion: '0.0.0',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for malformed objects missing the minimumVersion field', () => {
+    expect(
+      getIsAdvancedChartsEnabled(
+        buildState({
+          [TOKEN_DETAILS_ADVANCED_CHARTS_FLAG]: {
+            enabled: true,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when the flag is missing', () => {
+    expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getIsAdvancedChartsEnabled(buildState() as any),
+    ).toBe(false);
+  });
+
+  it('handles backward-compatible boolean shape', () => {
+    expect(
+      getIsAdvancedChartsEnabled(
+        buildState({
+          [TOKEN_DETAILS_ADVANCED_CHARTS_FLAG]: true,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(true);
   });
 });

--- a/ui/selectors/multichain/feature-flags.ts
+++ b/ui/selectors/multichain/feature-flags.ts
@@ -4,6 +4,7 @@ import { createSelector } from 'reselect';
 import { isMultichainFeatureEnabled } from '../../../shared/lib/multichain-feature-flags';
 import { getBooleanFeatureFlag } from '../../../shared/lib/remote-feature-flag-utils';
 import { EXTENSION_TRUST_AND_SECURITY_TDP_FLAG } from '../../../shared/lib/assets/security-trust-feature-flags';
+import { TOKEN_DETAILS_ADVANCED_CHARTS_FLAG } from '../../../shared/lib/assets/advanced-charts-feature-flags';
 import { getRemoteFeatureFlags } from '../../../shared/lib/selectors/remote-feature-flags';
 
 export {
@@ -173,4 +174,22 @@ export const getIsSecurityTrustTdpEnabled = createSelector(
 export const getIsDiscoverSearchEnabled = createSelector(
   getRemoteFeatureFlags,
   ({ extensionUXSearch }) => getBooleanFeatureFlag(extensionUXSearch, false),
+);
+
+/**
+ * Selector that returns whether the TradingView advanced charts integration
+ * should be shown on the Token Details Page.
+ *
+ * When enabled, the Token Details Page renders the TradingView advanced chart
+ * iframe instead of the legacy Chart.js line chart.
+ *
+ * @param _state - The MetaMask state object
+ * @returns boolean - True when the advanced chart integration should be shown.
+ */
+export const getIsAdvancedChartsEnabled = createSelector(
+  getRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const rawFlagValue = remoteFeatureFlags[TOKEN_DETAILS_ADVANCED_CHARTS_FLAG];
+    return getBooleanFeatureFlag(rawFlagValue, false);
+  },
 );


### PR DESCRIPTION
## **Description**

Introduces the LaunchDarkly feature flag `tokenDetailsAdvancedCharts` for gating the TradingView Advanced Charts integration on the Token Details Page (TDP).

This is a foundational PR that adds only the flag infrastructure — no TDP changes yet. The chart integration will follow in a separate PR that depends on this one.

### What this PR adds

- **Flag constant** (`shared/lib/assets/advanced-charts-feature-flags.ts`) — Defines `TOKEN_DETAILS_ADVANCED_CHARTS_FLAG`
- **Selector** (`ui/selectors/multichain/feature-flags.ts`) — `getIsAdvancedChartsEnabled` with version-gating support
- **Tests** (`ui/selectors/multichain/feature-flags.test.ts`) — 6 test cases covering enabled/disabled, version gating, malformed flags
- **Registry entry** (`test/e2e/feature-flags/feature-flag-registry.ts`) — Local dev default with `minimumVersion: 13.49.0`
- **CI validation** (`.github/scripts/known-feature-flag-constants.mts`) — Ensures flag constant is tracked

### LaunchDarkly flag

- **Key**: `token-details-advanced-charts` (kebab-case in LD, converted to camelCase in extension state)
- **Shape**: Version-gated (`{ enabled: boolean, minimumVersion: string }`)
- **Default**: Disabled

## **Changelog**

CHANGELOG entry: Added `tokenDetailsAdvancedCharts` feature flag for gating advanced charts on the Token Details Page.

## **Related issues**

Related: https://consensyssoftware.atlassian.net/browse/ASSETS-3667
Fixes: https://consensyssoftware.atlassian.net/jira/software/c/projects/ASSETS/boards/1567?assignee=61a5edc8b0b630006a140ec1&selectedIssue=ASSETS-3969

## **Manual testing steps**


## **Screenshots/Recordings**

N/A — infrastructure only, no UI changes.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag-only change with production default disabled; no UI or chart integration wired yet.
> 
> **Overview**
> Adds **infrastructure only** for the remote flag `tokenDetailsAdvancedCharts` (LaunchDarkly `token-details-advanced-charts`), intended to gate TradingView advanced charts on the Token Details Page in a follow-up PR.
> 
> Introduces `TOKEN_DETAILS_ADVANCED_CHARTS_FLAG` and **`getIsAdvancedChartsEnabled`**, which reads remote flags via `getBooleanFeatureFlag` (version-gated `{ enabled, minimumVersion }` and legacy booleans). Registers the flag in the **E2E feature-flag registry** (default off, `minimumVersion: 13.49.0`) and **CI known-flag constants**, with **six unit tests** for the selector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a17f3a9cfc56d76ac9910c9987677f94417a03c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->