### PR TITLE
fix: update useNftImageUrl hook to handle non-strings

### DIFF
--- a/ui/pages/confirmations/hooks/useNftImageUrl.test.ts
+++ b/ui/pages/confirmations/hooks/useNftImageUrl.test.ts
@@ -52,12 +52,12 @@ describe('useNftImageUrl', () => {
     );
   });
 
-  it('returns processed imageUrl when imageUrl is empty', () => {
+  it('returns empty string when imageUrl is empty', () => {
     const emptyImageUrl = '';
 
     const { result } = renderHook(() => useNftImageUrl(emptyImageUrl));
 
-    expect(result.current).toBe(mockProcessedImageUrl);
+    expect(result.current).toBe('');
     expect(mockUseSelector).toHaveBeenCalledTimes(1);
     expect(mockUseGetAssetImageUrl).toHaveBeenCalledWith(
       emptyImageUrl,
@@ -76,6 +76,14 @@ describe('useNftImageUrl', () => {
       undefined,
       mockIpfsGateway,
     );
+  });
+
+  it('returns processed imageUrl when imageUrl is not a string', () => {
+    const { result } = renderHook(() =>
+      useNftImageUrl(['ipfs://QmTest123/image.png'] as unknown as string),
+    );
+
+    expect(result.current).toBe(mockProcessedImageUrl);
   });
 
   it('calls useGetAssetImageUrl with correct parameters', () => {

--- a/ui/pages/confirmations/hooks/useNftImageUrl.ts
+++ b/ui/pages/confirmations/hooks/useNftImageUrl.ts
@@ -2,11 +2,12 @@ import { useSelector } from 'react-redux';
 import { getIpfsGateway } from '../../../selectors';
 import useGetAssetImageUrl from '../../../hooks/useGetAssetImageUrl';
 
-export function useNftImageUrl(imageUrl: string) {
+export function useNftImageUrl(imageUrl?: string) {
   const ipfsGateway = useSelector(getIpfsGateway);
   const nftImageURL = useGetAssetImageUrl(imageUrl, ipfsGateway);
 
-  const isImageHosted = imageUrl && !imageUrl.startsWith('ipfs:');
+  const isImageHosted =
+    typeof imageUrl === 'string' && !imageUrl.startsWith('ipfs:');
   const nftItemSrc = isImageHosted ? imageUrl : nftImageURL;
 
   return nftItemSrc;


### PR DESCRIPTION
## **Description**

- Changed the behavior of the `useNftImageUrl` hook to return an empty string when the `imageUrl` is empty.
- Added a new test case to ensure that the hook returns the processed imageUrl when the input is not a string.
- Updated the test descriptions for clarity and accuracy.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: update useNftImageUrl hook to handle non-strings

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3965

## **Manual testing steps**

Was unable to replicate even with the examples provided in ticket. Was only able to test via checking existing code guards.

See code and test changes.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display hook change in confirmation NFT asset UI with unit test coverage; no auth or transaction logic.
> 
> **Overview**
> **`useNftImageUrl`** now treats only real string URLs as “hosted” by checking `typeof imageUrl === 'string'` before using `startsWith('ipfs:')`, so malformed values (e.g. arrays) fall through to the IPFS/processed path from **`useGetAssetImageUrl`** instead of blowing up or mis-routing.
> 
> **Empty `imageUrl`** is no longer returned via the hosted branch in a way that surfaced a processed placeholder—the hook returns **`''`** for an empty string, matching updated tests. The parameter is typed as optional (`imageUrl?: string`).
> 
> Tests were renamed for the empty-string case and a new case covers non-string inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de5eba7a30bdab88286cc0bb877fd30aee041c9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->