### PR TITLE
chore: use the correct colour for icon backgrounds in money info section

### DIFF
--- a/ui/pages/money/components/money-condensed-info-cards.tsx
+++ b/ui/pages/money/components/money-condensed-info-cards.tsx
@@ -37,11 +37,11 @@ export function MoneyCondensedInfoCards() {
           key={key}
           type="button"
           disabled
-          className="flex min-h-[110px] w-full items-center gap-4 rounded-xl bg-background-muted p-4 text-left disabled:cursor-default disabled:opacity-100"
+          className="flex min-h-[110px] w-full items-center gap-4 rounded-xl bg-background-section p-4 text-left disabled:cursor-default disabled:opacity-100"
           data-testid={`money-condensed-info-card-${key}`}
         >
           <span
-            className="flex h-[78px] w-[78px] shrink-0 items-center justify-center rounded-xl bg-background-subsection"
+            className="flex h-[78px] w-[78px] shrink-0 items-center justify-center rounded-xl bg-background-muted"
             data-testid={`money-condensed-info-card-${key}-image`}
           >
             <img

--- a/ui/pages/money/money-home-page.test.tsx
+++ b/ui/pages/money/money-home-page.test.tsx
@@ -359,7 +359,7 @@ describe('MoneyHomePage', () => {
     ['growth', 'musd', 'benefits'].forEach((card) => {
       expect(
         screen.getByTestId(`money-condensed-info-card-${card}-image`),
-      ).toHaveClass('rounded-xl', 'bg-background-subsection');
+      ).toHaveClass('rounded-xl');
     });
     expect(screen.queryByText('Earn up to 4.2% APY')).not.toBeInTheDocument();
     expect(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Spotted in a design review - the colours in this section were slightly off.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: use correct colours in money info section

## **Related issues**

Fixes: N/A

## **Manual testing steps**
N/A
## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="631" height="401" alt="Screenshot 2026-09-11 at 15 36 38" src="https://github.com/user-attachments/assets/363452b9-fa45-4969-b3f5-e2f309d9945b" />
<img width="629" height="390" alt="Screenshot 2026-09-11 at 15 36 21" src="https://github.com/user-attachments/assets/de30e972-00a4-410a-be40-32483569ad7e" />


<!-- [screenshots/recordings] -->

### **After**
<img width="637" height="410" alt="Screenshot 2026-09-11 at 15 35 29" src="https://github.com/user-attachments/assets/7ac6f258-55e4-4939-a46f-1616f8069173" />
<img width="626" height="396" alt="Screenshot 2026-09-11 at 15 36 03" src="https://github.com/user-attachments/assets/05612d00-53cd-4d1b-b9f5-8c5594f0457f" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only Tailwind token swaps on disabled info cards; no logic, data, or auth changes.
> 
> **Overview**
> Aligns **Money** funded-state condensed info cards with design tokens from a design review.
> 
> Each card row now uses **`bg-background-section`** instead of **`bg-background-muted`**, and the icon wrapper uses **`bg-background-muted`** instead of **`bg-background-subsection`**. The funded-state home page test no longer asserts the old **`bg-background-subsection`** class on card image containers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bacd5c5756ac786dd4c531a0dca80900015a83aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->