### PR TITLE
chore(assets): remove legacy controller state

### DIFF
--- a/app/scripts/migrations/227.test.ts
+++ b/app/scripts/migrations/227.test.ts
@@ -1,0 +1,93 @@
+import { cloneDeep } from 'lodash';
+import { migrate, version } from './227';
+
+const VERSION = version;
+const PREVIOUS_VERSION = VERSION - 1;
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+const removedControllerStateKeys = [
+  'AccountTracker',
+  'CurrencyController',
+  'MultichainAssetsController',
+  'MultichainAssetsRatesController',
+  'MultichainBalancesController',
+  'TokenBalancesController',
+  'TokenListController',
+  'TokenRatesController',
+];
+
+describe(`migration #${VERSION}`, () => {
+  it('bumps the version', async () => {
+    const oldStorage: VersionedData = {
+      meta: { version: PREVIOUS_VERSION },
+      data: {},
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    await migrate(versionedData, new Set<string>());
+
+    expect(versionedData.meta.version).toBe(VERSION);
+  });
+
+  it('deletes state for removed legacy asset controllers', async () => {
+    const oldStorage: VersionedData = {
+      meta: { version: PREVIOUS_VERSION },
+      data: Object.fromEntries(
+        removedControllerStateKeys.map((controllerName) => [
+          controllerName,
+          { legacy: true },
+        ]),
+      ),
+    };
+    oldStorage.data.OtherController = { retained: true };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.data).toStrictEqual({
+      OtherController: { retained: true },
+    });
+    expect(changedControllers).toStrictEqual(
+      new Set(removedControllerStateKeys),
+    );
+  });
+
+  it('retains TokensController state for ASSETS-3346 metadata healing', async () => {
+    const oldStorage: VersionedData = {
+      meta: { version: PREVIOUS_VERSION },
+      data: {
+        TokensController: {
+          allTokens: { '0x1': {} },
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.data).toStrictEqual(oldStorage.data);
+    expect(changedControllers.size).toBe(0);
+  });
+
+  it('does nothing when removed controller state is missing', async () => {
+    const oldStorage: VersionedData = {
+      meta: { version: PREVIOUS_VERSION },
+      data: {
+        OtherController: { retained: true },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.data).toStrictEqual(oldStorage.data);
+    expect(changedControllers.size).toBe(0);
+  });
+});

--- a/app/scripts/migrations/227.ts
+++ b/app/scripts/migrations/227.ts
@@ -1,0 +1,40 @@
+import { hasProperty } from '@metamask/utils';
+import type { Migrate } from './types';
+
+export const version = 227;
+
+const removedControllerStateKeys = [
+  'AccountTracker',
+  'CurrencyController',
+  'MultichainAssetsController',
+  'MultichainAssetsRatesController',
+  'MultichainBalancesController',
+  'TokenBalancesController',
+  'TokenListController',
+  'TokenRatesController',
+] as const;
+
+/**
+ * Deletes persisted state for legacy asset controllers that are no longer
+ * initialized.
+ *
+ * TokensController is intentionally retained because the temporary ASSETS-3346
+ * metadata-healing path still reads its persisted state.
+ *
+ * @param versionedData - The versioned data object to migrate.
+ * @param changedControllers - A set used to record controllers that were modified.
+ */
+export const migrate = (async (versionedData, changedControllers) => {
+  versionedData.meta.version = version;
+
+  const state = versionedData.data;
+
+  for (const controllerName of removedControllerStateKeys) {
+    if (hasProperty(state, controllerName)) {
+      delete state[controllerName];
+      changedControllers.add(controllerName);
+    }
+  }
+}) satisfies Migrate;
+
+export default migrate;

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -263,6 +263,7 @@ const migrations = [
   require('./224.1'),
   require('./225'),
   require('./226'),
+  require('./227'),
 ];
 
 export default migrations;

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -114,7 +114,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 226,
+      "currentMigrationVersion": 227,
       "firstTimeInfo": {},
       "previousAppVersion": "",
       "previousMigrationVersion": 0,
@@ -1128,6 +1128,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 226
+    "version": 227
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -49,7 +49,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 226,
+      "currentMigrationVersion": 227,
       "firstTimeInfo": {
         "date": 0,
         "version": "13.17.0"
@@ -2224,6 +2224,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 226
+    "version": 227
   }
 }

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -341,6 +341,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 226
+    "version": 227
   }
 }


### PR DESCRIPTION
## **Description**

Stacked on [#46284](https://github.com/MetaMask/metamask-extension/pull/46284) as the final PR in the controller-removal stack.

Adds migration 227 to delete orphaned persisted state for `AccountTracker`, `CurrencyController`, `MultichainAssetsController`, `MultichainAssetsRatesController`, `MultichainBalancesController`, `TokenBalancesController`, `TokenListController`, and `TokenRatesController`.

`TokensController` persisted state is intentionally retained because the temporary ASSETS-3346 metadata-healing path still reads it.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Build and load the extension using a migration-226 wallet state containing legacy asset-controller state.
2. Unlock the wallet and verify onboarding/home initialization completes without errors.
3. Verify native and token balances, token prices, and the selected fiat currency remain available.
4. Inspect persisted state and verify the removed controller keys are absent while `TokensController` remains available for ASSETS-3346 healing.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)