### PR TITLE
fix(ci): stop blocking cws publish when upload draft is absent from fetchStatus

### DIFF
--- a/.github/scripts/cws-publish-plan.sh
+++ b/.github/scripts/cws-publish-plan.sh
@@ -69,14 +69,16 @@ if [[ "${submitted_state}" == "PENDING_REVIEW" && "${submitted_crx}" == "${CRX_V
   exit 1
 fi
 
-# After upload-only, submittedItemRevisionStatus is usually unset until :publish; lastAsyncUploadState=SUCCEEDED is the draft signal.
-draft_ready=false
-if [[ "${async_state}" == "SUCCEEDED" && -z "${submitted_crx}" ]]; then
-  draft_ready=true
+if [[ "${submitted_state}" == "STAGED" && "${submitted_crx}" == "${CRX_VERSION}" ]]; then
+  echo "::error::Version ${CRX_VERSION} is already STAGED (approved, not live). Use publish-staged operation."
+  exit 1
 fi
 
-if [[ "${draft_ready}" != "true" ]]; then
-  echo "::error::No uploaded draft for version ${CRX_VERSION} (submitted state=${submitted_state:-<none>}, submitted crx=${submitted_crx:-<none>}, lastAsyncUploadState=${async_state:-<none>}). Run upload-extension-to-cws.yml first."
+# Upload-only drafts are not reliably visible in :fetchStatus before :publish
+# (submittedItemRevisionStatus stays unset; lastAsyncUploadState is async-only and often absent
+# after sync :upload). Proceed with :publish; cws-publish.yml verifies crxVersion after submit.
+if [[ -n "${submitted_crx}" && "${submitted_crx}" != "${CRX_VERSION}" ]]; then
+  echo "::error::Another revision is already submitted (submitted crx=${submitted_crx}, expected ${CRX_VERSION}). Resolve in CWS console before submitting ${CRX_VERSION}."
   cat "${FETCH_STATUS_JSON}"
   exit 1
 fi
@@ -90,5 +92,5 @@ fi
 {
   echo "action=submit-for-review"
   echo "api_publish_type=${api_publish_type}"
-  echo "branch=Submit ${CRX_VERSION} for review (${PUBLISH_TYPE}, ${PERCENTAGE}%)"
+  echo "branch=Submit ${CRX_VERSION} for review (${PUBLISH_TYPE}, ${PERCENTAGE}%; pre-publish fetchStatus lastAsyncUploadState=${async_state:-none})"
 } >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## **Description**

After Runway Phase 2a upload succeeds, `cws-publish.yml` submit-for-review was failing in `cws-publish-plan.sh` with "No uploaded draft" even though the CWSS dashboard shows the draft (e.g. 13.48.0 vs live 13.47.0).

**Reason:** Upload-only packages are often invisible in `:fetchStatus` before `:publish`. `submittedItemRevisionStatus` stays unset until submit, and `lastAsyncUploadState` is documented for async uploads only (often absent after sync `:upload` returning `SUCCEEDED`).

**Fix:** Remove the pre-flight `lastAsyncUploadState` draft gate for submit-for-review. Keep guards for already-live, already pending review, already staged, and conflicting submitted revision. Rely on existing post-`:publish` verification in `cws-publish.yml` (checks `submittedItemRevisionStatus.crxVersion`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: INFRA-3881

## **Manual testing steps**

1. Merge to `main` (or run workflow from branch if testing pre-merge).
2. Confirm prod listing has an upload-only draft in CWSS (Draft 13.48.0 / Published 13.47.0).
3. Dispatch **CWS publish (submit or publish staged)** on `main` with:
   - operation: `submit-for-review`
   - version: `13.48.0`
   - target: `production`
   - publish_type: `deferred`
   - percentage: `1`
4. Approve `cws-rollout-production` environment.
5. Verify plan step passes (no "No uploaded draft" error) and `:publish` runs.
6. Verify post-submit step reports `submittedItemRevisionStatus.crxVersion=13.48.0.0` and state `PENDING_REVIEW` or `STAGED`.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.


Made with [Cursor](https://cursor.com)