### PR TITLE
test: MMQA-2029 - Remove deeplink flow anti-pattern

### DIFF
--- a/test/e2e/page-objects/flows/deep-link.flow.ts
+++ b/test/e2e/page-objects/flows/deep-link.flow.ts
@@ -1,24 +1,6 @@
-import assert from 'node:assert/strict';
 import { Driver } from '../../webdriver/driver';
 import DeepLink from '../pages/security/deep-link-page';
 import LoginPage from '../pages/onboarding/login-page';
-
-async function continueFromDeepLinkInterstitial(
-  driver: Driver,
-  shouldShowCheckbox: boolean,
-): Promise<void> {
-  const deepLink = new DeepLink(driver);
-  console.log('Checking if deep link page is loaded');
-  await deepLink.checkPageIsLoaded();
-
-  // we should render the checkbox when the link is "signed"
-  console.log('Checking if deep link interstitial checkbox exists');
-  const hasCheckbox = await deepLink.hasSkipDeepLinkInterstitialCheckBox();
-  assert.equal(hasCheckbox, shouldShowCheckbox, 'Checkbox presence mismatch');
-
-  console.log('Clicking continue button');
-  await deepLink.clickContinueButton();
-}
 
 /**
  * Opens a deep link URL, verifies the checkbox, navigates through the interstitial page,
@@ -45,7 +27,8 @@ export const navigateDeepLinkToDestination = async (
   console.log('Opening deep link URL');
   await driver.openNewURL(deepLinkUrl);
 
-  await continueFromDeepLinkInterstitial(driver, shouldShowCheckbox);
+  const deepLink = new DeepLink(driver);
+  await deepLink.continueFromInterstitial(shouldShowCheckbox);
 
   // If wallet is locked, handle the login flow
   if (locked === 'locked') {
@@ -81,7 +64,8 @@ export const navigateDeepLinkToExternalRedirect = async (
   console.log('Opening external redirect deep link URL');
   await driver.openNewURL(deepLinkUrl);
 
-  await continueFromDeepLinkInterstitial(driver, shouldShowCheckbox);
+  const deepLink = new DeepLink(driver);
+  await deepLink.continueFromInterstitial(shouldShowCheckbox);
 
   console.log(`Waiting for external redirect to ${expectedUrl}`);
   await driver.waitForUrl({ url: expectedUrl });

--- a/test/e2e/page-objects/pages/security/deep-link-page.ts
+++ b/test/e2e/page-objects/pages/security/deep-link-page.ts
@@ -1,5 +1,3 @@
-import assert from 'assert';
-import { By } from 'selenium-webdriver';
 import { Driver } from '../../../webdriver/driver';
 import { regularDelayMs } from '../../../helpers';
 
@@ -47,50 +45,57 @@ export default class DeepLink {
   }
 
   async checkPageIsLoaded(): Promise<void> {
-    try {
-      await this.driver.waitForMultipleSelectors([
-        this.descriptionBox,
-        this.parentSelector,
-      ]);
-      // loading indicator should not be present when the page is loaded
-      await this.driver.assertElementNotPresent(this.loadingIndicator, {
-        waitAtLeastGuard: regularDelayMs,
-      });
-    } catch (e) {
-      console.log('Timeout while waiting for Deep Link page to be loaded', e);
-      throw e;
-    }
+    await this.driver.waitForMultipleSelectors([
+      this.descriptionBox,
+      this.parentSelector,
+    ]);
+    // loading indicator should not be present when the page is loaded
+    await this.driver.assertElementNotPresent(this.loadingIndicator, {
+      waitAtLeastGuard: regularDelayMs,
+    });
     console.log('Deep Link page is loaded');
   }
 
-  async clickContinueButton() {
-    try {
-      await this.driver.clickElementAndWaitToDisappear(this.continueButton);
-    } catch (e) {
-      console.log('Error clicking continue button on Deep Link page', e);
-      throw e;
+  /**
+   * Waits for the skip-interstitial checkbox to be present or absent.
+   *
+   * @param shouldBeDisplayed - Whether the checkbox should be shown.
+   */
+  async checkSkipDeepLinkInterstitialCheckBoxIsDisplayed(
+    shouldBeDisplayed: boolean,
+  ): Promise<void> {
+    if (shouldBeDisplayed) {
+      await this.driver.waitForSelector(this.checkbox);
+    } else {
+      await this.driver.assertElementNotPresent(this.checkbox);
     }
   }
 
-  async clickSkipDeepLinkInterstitialCheckBox() {
-    try {
-      await this.driver.clickElement(this.checkbox);
-    } catch (e) {
-      console.log(
-        'Error clicking skip deep link interstitial checkbox on Deep Link page',
-        e,
-      );
-      throw e;
-    }
+  async clickContinueButton(): Promise<void> {
+    await this.driver.clickElementAndWaitToDisappear(this.continueButton);
   }
 
-  async getDescriptionText(): Promise<string> {
-    const routeBox = await this.driver.driver.findElement(
-      By.css(this.descriptionBox),
+  async clickSkipDeepLinkInterstitialCheckBox(): Promise<void> {
+    await this.driver.clickElement(this.checkbox);
+  }
+
+  /**
+   * Loads the interstitial, asserts skip-checkbox presence, and continues.
+   *
+   * @param shouldShowCheckbox - Whether the skip checkbox should be rendered
+   * (signed links show it; unsigned/invalid links do not).
+   */
+  async continueFromInterstitial(shouldShowCheckbox: boolean): Promise<void> {
+    console.log('Checking if deep link page is loaded');
+    await this.checkPageIsLoaded();
+
+    console.log('Checking if deep link interstitial checkbox exists');
+    await this.checkSkipDeepLinkInterstitialCheckBoxIsDisplayed(
+      shouldShowCheckbox,
     );
-    assert.strictEqual(await routeBox.isDisplayed(), true);
-    const routeText = await routeBox.getText();
-    return routeText;
+
+    console.log('Clicking continue button');
+    await this.clickContinueButton();
   }
 
   async getSkipDeepLinkInterstitialCheckBoxState(): Promise<boolean> {
@@ -98,13 +103,6 @@ export default class DeepLink {
       '#dont-remind-me-checkbox',
     );
     return await skipCheckbox.isSelected();
-  }
-
-  async hasSkipDeepLinkInterstitialCheckBox(): Promise<boolean> {
-    const skipCheckbox = await this.driver.driver.findElements(
-      By.css(this.checkbox),
-    );
-    return skipCheckbox.length > 0;
   }
 
   async setSkipDeepLinkInterstitialCheckBox(skip: boolean): Promise<void> {

--- a/test/e2e/tests/deep-link/deep-link-route-invalid.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link-route-invalid.spec.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert/strict';
 import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import DeepLink from '../../page-objects/pages/security/deep-link-page';
@@ -70,22 +69,22 @@ describe('Deep Link - Invalid Route', function () {
 
           // we should NOT render the checkbox for invalid routes
           console.log('Checking if deep link interstitial checkbox exists');
-          const hasCheckbox =
-            await deepLink.hasSkipDeepLinkInterstitialCheckBox();
-          assert.equal(hasCheckbox, false, 'Checkbox presence mismatch');
-
-          console.log('Getting error text for invalid route');
-          const text = await deepLink.getDescriptionText();
-          assert.equal(
-            text,
-            `We can't find the page you are looking for.${
-              isSigned
-                ? `
-Update to the latest version of MetaMask
-and we'll take you to the right place.`
-                : ''
-            }`,
+          await deepLink.checkSkipDeepLinkInterstitialCheckBoxIsDisplayed(
+            false,
           );
+
+          console.log('Checking error text for invalid route');
+          await deepLink.checkDescriptionTextIsDisplayed(
+            `We can't find the page you are looking for.`,
+          );
+          if (isSigned) {
+            await deepLink.checkDescriptionTextIsDisplayed(
+              'Update to the latest version of MetaMask',
+            );
+            await deepLink.checkDescriptionTextIsDisplayed(
+              `and we'll take you to the right place.`,
+            );
+          }
 
           console.log('Clicking continue button');
           await deepLink.clickContinueButton();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Deep-link E2E helpers used a racey presence check: `findElements` with no wait, then `assert.equal` on whether the skip-interstitial checkbox existed. That can pass or fail depending on whether the interstitial has painted yet, which is the POM anti-pattern we are removing.

This change replaces that check with a wait-based page-object method (`checkSkipDeepLinkInterstitialCheckBoxIsDisplayed`) that either `waitForSelector`s the checkbox or `assertElementNotPresent`s it. Interstitial continue (load + checkbox check + continue click) now lives on the `DeepLink` page object, because it only uses that one class. The exported `navigateDeepLinkToDestination` and `navigateDeepLinkToExternalRedirect` flows still orchestrate interstitial + login + destination / external URL. Callers still pass `shouldRenderCheckbox(signed)`; signed links still expect the checkbox and unsigned/invalid links still do not. Product interstitial behavior is unchanged.

Follow-up: unsigned invalid-route 404 extra-copy absence is restored without bringing back `getDescriptionText()` + `assert.equal`. Signed invalid routes still `waitForSelector` the extra CTA (“Update to the latest version of MetaMask” / “we'll take you to the right place.”). Unsigned routes wait for the 404 sentence, then `assertElementNotPresent` those strings with `waitAtLeastGuard: regularDelayMs`, so the check cannot pass before async `verify(url)` finishes. The extra copy lives inside `[data-testid="deep-link-description"]` and can appear after `checkPageIsLoaded`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MMQA-2029

## **Manual testing steps**

1. Build and load the extension (`yarn start` or an existing test build), then unlock a wallet.
2. Open an **unsigned** `https://link.metamask.io/home` (or `metamask://home`) URL in the same browser. Confirm the security interstitial appears **without** a “don’t remind me” / skip checkbox. Click Continue and confirm you land on Home.
3. Open a **signed** production `link.metamask.io` home (or swap/asset) URL that MetaMask treats as signed. Confirm the same interstitial **shows** the skip checkbox. Click Continue and confirm you reach the destination.
4. Optionally open an **unsigned** invalid route such as `https://link.metamask.io/INVALID`. Confirm the interstitial still has **no** skip checkbox, shows “We can't find the page you are looking for.”, and does **not** show the extra CTA (“Update to the latest version of MetaMask” / “we'll take you to the right place.”). Continue lands on Home.
5. Optionally open a **signed** invalid route. Confirm the same 404 sentence **plus** the extra CTA copy, still with **no** skip checkbox, then Continue lands on Home.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test the code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only E2E and page-object changes; no production deep-link or wallet behavior is modified.
> 
> **Overview**
> Refactors deep-link E2E page objects to **stop using immediate DOM presence checks** (e.g. `findElements` + `assert`) for the skip-interstitial checkbox, which could flake before the interstitial painted.
> 
> The **`DeepLink` page object** now owns interstitial continuation via `continueFromInterstitial` (load, wait-based checkbox assertion, Continue). Shared flows `navigateDeepLinkToDestination` and `navigateDeepLinkToExternalRedirect` call that instead of a local flow helper. Checkbox expectations use **`checkSkipDeepLinkInterstitialCheckBoxIsDisplayed`**, which either waits for the checkbox or asserts it is absent.
> 
> Invalid-route coverage drops **`getDescriptionText()` + full-string asserts** in favor of **`checkDescriptionTextIsDisplayed` / `checkDescriptionTextIsNotDisplayed`**, with a **`waitAtLeastGuard`** on absence checks so unsigned invalid links do not pass before async 404 extra CTA copy appears. Several redundant try/catch and direct Selenium reads on the page object are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f4e54703c947dc97bd620a5febd9fdb84f810cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->