### PR TITLE
fix(benchmarks): pause startupPowerUserHome and the CUF timing gates

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -23,14 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         # Preset names are defined in test/e2e/benchmarks/utils/constants.ts
-        # and must stay in sync with benchmark-command (startupPowerUserHome uses extra flags).
+        # and must stay in sync with benchmark-command.
         #
         # Startup + interaction + user journeys: chrome/firefox × webpack × preset (test build: build-test-webpack / build-test-mv2-webpack).
         browser: [chrome, firefox]
         buildType: [webpack]
         pageType:
           - startupStandardHome
-          - startupPowerUserHome
           - interactionUserActions
           - userJourneyOnboardingImport
           - userJourneyOnboardingNew
@@ -82,7 +81,7 @@ jobs:
         timeout-minutes: 25
         id: run-benchmark
         run: >-
-          ${{ matrix.pageType == 'startupPowerUserHome' && format('yarn test:e2e:benchmark --preset startupPowerUserHome --browserLoads 15 --pageLoads 7 --out test-artifacts/benchmarks/benchmark-{0}-{1}-startupPowerUserHome.json --retries 2', matrix.browser, matrix.buildType) || format('yarn test:e2e:benchmark --preset {2} --out test-artifacts/benchmarks/benchmark-{0}-{1}-{2}.json --retries 2', matrix.browser, matrix.buildType, matrix.pageType) }}
+          ${{ format('yarn test:e2e:benchmark --preset {2} --out test-artifacts/benchmarks/benchmark-{0}-{1}-{2}.json --retries 2', matrix.browser, matrix.buildType, matrix.pageType) }}
         shell: bash
 
       - name: Send benchmark results to Sentry (main/release only)

--- a/development/metamaskbot-build-announce/compare-benchmarks.test.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.test.ts
@@ -191,9 +191,34 @@ describe('compare-benchmarks', () => {
       });
     }
 
-    it('still fails on onboardingImportWallet.total, which is unimodal and stays gated', () => {
-      // The control for the three cases above: the same flow's total absorbs
-      // the slow step into a following one, so it keeps its gate.
+    it('still fails on startupStandardHome.uiStartup, which stays gated', () => {
+      // The control for the cases above: at least one metric must still block,
+      // or every one of them would pass against an allowlist that gates
+      // nothing. Re-pointed from `onboardingImportWallet.total` when #46078
+      // paused the CUF-derived timing metrics.
+      const benchmarks = [
+        {
+          name: 'benchmark-chrome-webpack-startupStandardHome',
+          data: {
+            startupStandardHome: makeBenchmarkResults('uiStartup', {
+              p75: { uiStartup: 99999 },
+              p95: { uiStartup: 99999 },
+              mean: { uiStartup: 99999 },
+            }),
+          },
+        },
+      ];
+
+      const result = runComparison(benchmarks, {});
+      expect(result.anyFailed).toBe(true);
+      expect(result.comparisons[0].absoluteFailed).toBe(true);
+    });
+
+    it('no longer blocks on onboardingImportWallet.total, paused per #46078', () => {
+      // It was the only metric that has ever blocked a pull request: 27 of 116
+      // Chrome runs on `main`, 2026-08-27 to 09-03. Its clock runs in the Node
+      // test process (#46006) and its value is the sum of those step timers
+      // rather than a measurement of the flow (#45452), so a breach now warns.
       const benchmarks = [
         {
           name: 'benchmark-chrome-webpack-userJourneyOnboardingImport',
@@ -208,8 +233,9 @@ describe('compare-benchmarks', () => {
       ];
 
       const result = runComparison(benchmarks, {});
-      expect(result.anyFailed).toBe(true);
-      expect(result.comparisons[0].absoluteFailed).toBe(true);
+      expect(result.anyFailed).toBe(false);
+      expect(result.comparisons[0].absoluteFailed).toBe(false);
+      expect(result.comparisons[0].hasWarning).toBe(true);
     });
 
     it('includes relative metrics when baseline is available', () => {

--- a/test/e2e/benchmarks/utils/gated-metrics.ts
+++ b/test/e2e/benchmarks/utils/gated-metrics.ts
@@ -37,39 +37,55 @@ const GATED_METRIC_VALUES = [
   METRIC.assetDetails.cls,
   METRIC.solanaAssetDetails.cls,
 
-  // Onboarding form-to-form transitions
+  // PAUSED — the nine CUF-derived timing metrics, per #46078.
   //
-  // Demoted per the procedure above, restore condition #45266:
+  // Left the allowlist: `importSrpHome.loginToHomeScreen`,
+  // `importSrpHome.homeAfterImportWithNewWallet`, `importSrpHome.total`,
+  // `onboardingImportWallet.total`,
+  // `onboardingImportWallet.metricsToWalletReadyScreen`,
+  // `onboardingNewWallet.agreeButtonToOnboardingSuccess`, `swap.total`,
+  // `swap.fetchAndDisplaySwapQuotes`, `sendTransactions.openSendPageFromHome`.
+  //
+  // These are not demotions under the procedure above, and no threshold value
+  // would fix them. Each is timed by `TimerHelper` in the Node test process, so
+  // the value is application work plus WebDriver round-trip plus poll interval,
+  // inseparably, and a wait-terminated step cannot resolve finer than 200ms
+  // (#46006). A `.total` is the sum of those step timers rather than a
+  // measurement of its flow (#45452), so it inherits every one of their
+  // defects by construction.
+  //
+  // `onboardingImportWallet.total` is among them and is the only metric that
+  // has ever blocked a pull request — 27 of 116 Chrome runs on `main`,
+  // 2026-08-27 to 09-03. The gate therefore stops blocking on timing entirely.
+  //
+  // The flows themselves keep running. Only the timing entries leave the
+  // allowlist, because seven of the eight CLS canaries above are produced by
+  // these same flows, and CLS is unaffected by the step-timer defects — it is
+  // read in-page by `web-vitals` rather than timed from the driver.
+  //
+  // Restore condition per flow. Every ticket listed for a flow must close, and
+  // restoring is not a revert: a metric returns by qualifying under the
+  // procedure above against data produced after those fixes, never by being
+  // added back.
+  //
+  //   all paused flows  #46006 step clock · #45452 step partition and `.total`
+  //                     · #45205 ceilings derived from the gated population
+  //                     · #7204 percentiles averaged independently
+  //                     · #45431 a failed iteration emits nothing
+  //   onboarding        + #45266 bimodal ~37% slow path · #7280 password
+  //                     transition timers measuring a near-empty window
+  //   swap, send        + #7281 sub-50ms steps below the detection floor
+  //                     · #7202 deterministic render-complete waits
+  //   import-srp        + #7202
+  //
+  // Previously demoted under the procedure above, and unaffected by the pause:
   // `onboardingNewWallet.doneButtonToAssetList` and the import flow's
-  // `doneButtonToHomeScreen` are the same ~37% per-iteration slow path
-  // (24/65 and 30/80 slow draws), so each is a coin flip rather than a
-  // measurement of one thing. No threshold value is correct against a
-  // bimodal null.
-  METRIC.importSrpHome.loginToHomeScreen,
-
-  // Flow totals
-  //
-  // `onboardingNewWallet.total` demoted per the procedure above, restore
-  // condition #45266. Its `doneButtonToAssetList` step is terminal, so the
-  // slow path propagates into the total instead of being absorbed by a
-  // following step: CV 41.8% (demote at >35%) and an FP rate of 11/14 = 79%
-  // (demote at >10%), against a run-level p75 that splits into a 2257–2300ms
-  // cluster and a 6858–10478ms cluster with the 5460ms fail ceiling sitting
-  // inside the gap.
-  //
-  // `onboardingImportWallet.total` stays gated: a step follows its slow one
-  // and absorbs the spill, leaving a unimodal 8.2% CV. It is the calibration
-  // target in #45205.
-  METRIC.onboardingImportWallet.total,
-  METRIC.importSrpHome.total,
-  METRIC.swap.total,
-
-  // Moderate-variance entries (calibrated via `CI_MULTIPLIER.TIER_2`)
-  METRIC.onboardingImportWallet.metricsToWalletReadyScreen,
-  METRIC.onboardingNewWallet.agreeButtonToOnboardingSuccess,
-  METRIC.importSrpHome.homeAfterImportWithNewWallet,
-  METRIC.swap.fetchAndDisplaySwapQuotes,
-  METRIC.sendTransactions.openSendPageFromHome,
+  // `doneButtonToHomeScreen` are the same ~37% per-iteration slow path (24/65
+  // and 30/80 slow draws), so each is a coin flip rather than a measurement of
+  // one thing; `onboardingNewWallet.total` carries that slow path into the sum
+  // because its slow step is terminal, at CV 41.8% against a demote bar of 35%
+  // and an 11/14 false-positive rate against a bar of 10%. Restore condition
+  // for all three: #45266.
 ] as const satisfies readonly MetricKey[];
 
 /**

--- a/test/e2e/benchmarks/utils/gated-metrics.ts
+++ b/test/e2e/benchmarks/utils/gated-metrics.ts
@@ -29,14 +29,22 @@ const GATED_METRIC_VALUES = [
 
   // CLS canary — extension pages should produce CLS ≈ 0
   METRIC.startupStandardHome.cls,
-  METRIC.onboardingImportWallet.cls,
-  METRIC.onboardingNewWallet.cls,
   METRIC.importSrpHome.cls,
   METRIC.sendTransactions.cls,
   METRIC.swap.cls,
   METRIC.assetDetails.cls,
   METRIC.solanaAssetDetails.cls,
 
+  // Removed with them: `onboardingImportWallet.cls` and `onboardingNewWallet.cls`.
+  // Both emit no `cls` at all — absent from the p95 map in 60 of 60 runs for the
+  // import flow and 3 of 3 sampled for the new-wallet flow, while the other six
+  // canaries emit every run. `compare-benchmarks.ts` skips an entry missing
+  // p75/p95 with a warn and a continue, so each has been scoring as a pass
+  // rather than as a measurement. They are the only two onboarding canaries and
+  // the only two that are dark, which is a collection defect rather than a
+  // gating decision — restoring them means making the flows emit CLS, not
+  // adding the keys back.
+  //
   // PAUSED — the nine CUF-derived timing metrics, per #46078.
   //
   // Left the allowlist: `importSrpHome.loginToHomeScreen`,


### PR DESCRIPTION
## **Changelog**

CHANGELOG entry: null

## **Description**

Implements the pause decided in [#46078 ([P1] Pause the benchmarks that cannot produce trustworthy data, and re-scope the measurement approach)](https://github.com/MetaMask/metamask-extension/issues/46078): `startupPowerUserHome` stops running per commit, and the CUF flows' timing metrics leave the gate. The CUF flows themselves keep running.

- **`startupPowerUserHome` leaves the per-commit matrix.** Its Chrome and Firefox legs are removed, so the matrix goes from 16 legs to 14, and the conditional that gave them `--browserLoads 15 --pageLoads 7` goes too. Neither leg carries a gated metric, and either can exit 0 having measured nothing ([#45945 ([P1] startupPowerUserHome exits 0 with no measurements, and the gate scores 24 of 25)](https://github.com/MetaMask/metamask-extension/issues/45945)). The preset and flow stay, so it still runs locally, and matching CI takes those two flags. Its restore condition sits beside the matrix: #45945 closes, and the flow's data graduates under the procedure in `gated-metrics.ts`.
- **Nine timing metrics leave `GATED_METRIC_VALUES`:** `onboardingImportWallet.total`, `onboardingImportWallet.metricsToWalletReadyScreen`, `onboardingNewWallet.agreeButtonToOnboardingSuccess`, `importSrpHome.total`, `importSrpHome.loginToHomeScreen`, `importSrpHome.homeAfterImportWithNewWallet`, `swap.total`, `swap.fetchAndDisplaySwapQuotes` and `sendTransactions.openSendPageFromHome`. Each is timed in the Node test process, so its value mixes app work, WebDriver round trips and a 200 ms poll interval ([#46006 ([P0] Benchmark step timers measure the test harness, not the browser)](https://github.com/MetaMask/metamask-extension/issues/46006)), and the three `.total` values are sums of those step timers ([#45452 ([P1] Benchmark step timers are not a disjoint partition of the flow they measure)](https://github.com/MetaMask/metamask-extension/issues/45452)). No threshold fixes that. Removing them works like a demotion, since a breach warns, but they are not demotions under the graduation procedure: `gated-metrics.ts` lists, per flow, the tickets that must close first, and a metric returns by graduating against data produced after those fixes, not by being added back.
- **No timing metric that has failed the gate stays gated.** `onboardingImportWallet.total` is one of the nine. #46078 measured it as the only gated metric to fail the gate on `main` from 2026-08-27 to 09-03, in 27 of 116 Chrome runs. In the same runs, every other gated timing metric, including the three startup metrics that stay, had its highest per-run p75 1.4x to 147x below its fail ceiling. After this PR, a breach of `onboardingImportWallet.total` warns.
- **Two CLS canaries leave the allowlist because they emit no value.** `onboardingImportWallet.cls` and `onboardingNewWallet.cls` are missing from every Chrome artifact in 60 `main` push runs from 2026-09-08 to 09-11 ([run 34287914617](https://github.com/MetaMask/metamask-extension/actions/runs/34287914617) to [run 34611604157](https://github.com/MetaMask/metamask-extension/actions/runs/34611604157)), while the other six gated CLS canaries are present in all 60. The newest `main` run shows the same: in [run 34846253276](https://github.com/MetaMask/metamask-extension/actions/runs/34846253276), the Chrome `onboardingImportWallet` and `onboardingNewWallet` entries carry no `cls`, while `swap` and `sendTransactions` do. The gate checks a percentile only when the metric is present ([`statistics.ts` L641-L655](https://github.com/MetaMask/metamask-extension/blob/31cd78a3647d914e08d0b3188a7367ea205b0e3a/test/e2e/benchmarks/utils/statistics.ts#L641-L655)), so a missing metric raises no violation and no warning, and both have been scoring as passes. Removing them changes no verdict. Bringing them back means making the onboarding flows emit CLS.
- **The CUF flows keep running, and CLS is their only gated entry.** Five of the six remaining CLS canaries come from these flows: `importSrpHome.cls`, `sendTransactions.cls`, `swap.cls`, `assetDetails.cls` and `solanaAssetDetails.cls`. #46078's "What keeps running" section keeps them, so this PR does not meet its criterion "run report-only with no gated entries".

### What still gates

| entry | why the measurement can be trusted |
|---|---|
| `startupStandardHome.load` | `loadEventEnd` from Navigation Timing, read in the page ([#7869 (Add benchmark script)](https://github.com/MetaMask/metamask-extension/pull/7869)) |
| `startupStandardHome.loadScripts`, `startupStandardHome.uiStartup` | the app's own `trace()` durations, read in the page through `stateHooks.getCustomTraces()` ([#27701 (perf: include custom traces in benchmark results)](https://github.com/MetaMask/metamask-extension/pull/27701)) |
| `startupStandardHome.cls`, `importSrpHome.cls`, `sendTransactions.cls`, `swap.cls`, `assetDetails.cls`, `solanaAssetDetails.cls` | read in the page by `web-vitals`; present in all 60 Chrome `main` runs from 2026-09-08 to 09-11, and missing from all 60 Firefox runs |

Two limits this PR does not change. The startup ceilings were calibrated locally and scaled by a fixed multiplier rather than derived from the runs they gate, so they are not load-bearing until [#45205 ([P2] Restore benchmark gate signal: publish a mocked series and re-derive ceilings from CI data)](https://github.com/MetaMask/metamask-extension/issues/45205) re-derives them. And on Firefox the six remaining canaries check nothing, because no Firefox run carries `cls`.

### Runner time

Over the 10 most recent completed `main` push runs, 2026-09-11 to 09-14 ([run 34625531467](https://github.com/MetaMask/metamask-extension/actions/runs/34625531467) to [run 34846253276](https://github.com/MetaMask/metamask-extension/actions/runs/34846253276)), the 19 `run-benchmarks` jobs (17 benchmark legs, `quality-gate` and `store-benchmark-stats`) took 1,124.8 job-minutes, and the two `startupPowerUserHome` legs took 322.5 of them (28.7%).

A `startupPowerUserHome` leg was also the last leg to finish in all 10 runs, and `quality-gate` started within 5 seconds of it. The next-latest leg finished 6.0 to 11.7 minutes earlier, so without these legs `quality-gate` can start that much sooner, if the other legs run as they did.

### Test plan

- [x] `development/metamaskbot-build-announce/compare-benchmarks.test.ts` passes, 36 of 36, at 2057ca0f110. The test that used `onboardingImportWallet.total` as the control for the bimodal-demotion tests now uses `startupStandardHome.uiStartup`, which stays gated. Without a control that still blocks, those tests would pass against an allowlist that gates nothing. A new test asserts that an `onboardingImportWallet.total` breach warns instead of failing.
- [x] Putting `onboardingImportWallet.total` back into the allowlist fails exactly one test, the new one: `no longer blocks on onboardingImportWallet.total, paused per #46078`.
- [x] `run-benchmarks.yml` parses, and its benchmark matrix resolves to 14 legs.
- [x] A CI run with fresh builds shows 14 benchmark legs, no `startupPowerUserHome`, and a passing gate. This PR's own CI reuses `main`'s builds and skips the benchmark legs, so this ran on a fork at 2057ca0f110 ([fork run 34854195665](https://github.com/consensys-test/metamask-extension-test-majorlift/actions/runs/34854195665)): 14 matrix legs plus the page-load benchmark, none of them `startupPowerUserHome`, and `quality-gate` passed with `Total: 23 benchmarks | 0 failed | 12 warnings`. In the same run, `onboardingImportWallet.total` breached its Chrome ceiling (p75 8,281 ms against a 5,460 ms limit) and was reported as a warning.

## **Related issues**

Part of [MetaMask-planning#6944 ([Epic][P0] Performance Quality Gates)](https://github.com/MetaMask/MetaMask-planning/issues/6944). This does not close #46078: its "Reconsidering the approach" section stays open, and the CUF flows keep gated CLS entries, which its second acceptance criterion rules out.

## **Manual testing steps**

Not applicable: this changes which benchmarks run in CI and which metrics the quality gate enforces. The checks that were run are under Test plan above.

## **Screenshots/Recordings**

Not applicable.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
